### PR TITLE
Patch for #173: Memory Leak for Kmeans example

### DIFF
--- a/cpp/daal/include/algorithms/kmeans/kmeans_init_distributed.h
+++ b/cpp/daal/include/algorithms/kmeans/kmeans_init_distributed.h
@@ -238,7 +238,13 @@ class DAAL_EXPORT DistributedBase : public daal::algorithms::Analysis<distribute
 public:
     typedef algorithms::kmeans::init::Parameter ParameterType;
     /** Default destructor */
-    virtual ~DistributedBase() {}
+    virtual ~DistributedBase()
+    {
+        if (_par)
+        {
+            delete _par;
+        }
+    }
 
 protected:
     DistributedBase() {}


### PR DESCRIPTION
This patch is the minimally possible correction for the identified memory leaks in "kmeans" example.

I verified that all classes in KMeans using the base class DistributedBase do this in the same manner:
: DistributedBase(new ParameterType(...)), parameter(*static_cast<ParameterType *>(_par))

Thus, in the existing code this patch is applicable and correct. Removing the field _par in the deeper base class (like Algorithm<batch>) is not applicable since sometimes _par in classes-successors points out to another class field.

Other memory leaks identified by Valgrind and Inspector are related with:
1) not freed singleton classes that is not interpreted as a real memory leak;
2) with macros DAAL_MKLFN_CALL and DAAL_VSLFN_CALL_NR_WHILE that relate to the layer between DAAL and MKL rather than own DAAL code. 