### PR TITLE
Removing icc and gnu compiler usage from sycl_examples

### DIFF
--- a/examples/cpp_sycl/makefile_lnx
+++ b/examples/cpp_sycl/makefile_lnx
@@ -42,11 +42,6 @@ help:
 ##                                 of Intel(R) DAAL for
 ##                                 64-bit applications, dynamic linking
 ##
-## make libintel64 compiler=clang  - build by Intel(R) oneAPI Compiler and run all example
-##                                 of Intel(R) DAAL for
-##                                 Intel(R) 64 processor family applications,
-##                                 static linking
-##
 ## make sointel64                - build by Intel(R) oneAPI Compiler (as default)
 ##                                 and run all examples for Intel(R)64 processor
 ##                                 family  applications, dynamic linking
@@ -102,18 +97,6 @@ ifeq ($(compiler),clang)
     CC = clang++
     COPTS += -fsycl
     EXT_LIB += -foffload-static-lib=$(DAAL_PATH)/libdaal_sycl.a
-endif
-
-ifeq ($(compiler),intel)
-    CC = icc
-    COPTS += $(if $(COVFILE), -m64) -DONEAPI_DAAL_NO_MKL_GPU_FUNC
-    EXT_LIB += -lComputeCpp
-endif
-
-ifeq ($(compiler),gnu)
-    CC = g++
-    COPTS += -m64 -DONEAPI_DAAL_NO_MKL_GPU_FUNC
-    EXT_LIB += -lComputeCpp
 endif
 
 LOPTS := -Wl,--start-group $(DAAL_LIB) $(EXT_LIB) -Wl,--end-group

--- a/examples/cpp_sycl/makefile_lnx
+++ b/examples/cpp_sycl/makefile_lnx
@@ -24,7 +24,7 @@ help:
 	@echo
 	@echo "name              - example name. Please see daal.lst file."
 	@echo
-	@echo "compiler_name     - can be clang, gnu or intel. Default value is clang."
+	@echo "compiler_name     - can be clang. Default value is clang."
 	@echo "                    Intel(R) oneAPI Compiler as default"
 	@echo
 	@echo "threading_name    - can be parallel or sequential. Default value is parallel."
@@ -38,11 +38,11 @@ help:
 ##                                 and run pca example for 64-bit
 ##                                 applications, static linking
 ##
-## make sointel64 compiler=gnu   - build by GNU C++ compiler and run all examples
+## make sointel64 compiler=clang   - build by Intel(R) oneAPI Compiler and run all examples
 ##                                 of Intel(R) DAAL for
 ##                                 64-bit applications, dynamic linking
 ##
-## make libintel64 compiler=gnu  - build by GNU C++ compiler and run all example
+## make libintel64 compiler=clang  - build by Intel(R) oneAPI Compiler and run all example
 ##                                 of Intel(R) DAAL for
 ##                                 Intel(R) 64 processor family applications,
 ##                                 static linking
@@ -65,11 +65,10 @@ ifndef example
     example = $(DAAL)
 endif
 
-ifneq ($(compiler),gnu)
-    ifneq ($(compiler),intel)
-        override compiler = clang
-    endif
-endif
+ifndef compiler
+    compiler = clang
+ifndef
+
 
 ifneq ($(mode),build)
     override mode = run

--- a/examples/cpp_sycl/makefile_lnx
+++ b/examples/cpp_sycl/makefile_lnx
@@ -62,8 +62,7 @@ endif
 
 ifndef compiler
     compiler = clang
-ifndef
-
+endif
 
 ifneq ($(mode),build)
     override mode = run

--- a/examples/cpp_sycl/makefile_win
+++ b/examples/cpp_sycl/makefile_win
@@ -24,8 +24,8 @@ help:
 	@echo
 	@echo "name              - example name."
 	@echo
-	@echo "compiler_name     - can be clang. Default value is clang."
-	@echo "                    Intel(R) oneAPI Compiler as default."
+	@echo "compiler_name     - the only supported compiler is clang (default value)"
+	@echo "                    Intel(R) oneAPI DPC++ compiler"
 	@echo
 	@echo "threading_name    - can be parallel or sequential. Default value is parallel."
 	@echo


### PR DESCRIPTION
# Description
Currently icc and gnu compilers supported only together with computeCPP compiler that we have been used at initial stages of oneDAL development. 
We never supported this configuration officially and now removing remaining parts of it's usage. 