### PR TITLE
[master] Add ability to use PCA with svdDense method if n_observations < n_features

### DIFF
--- a/algorithms/kernel/pca/pca_input.cpp
+++ b/algorithms/kernel/pca/pca_input.cpp
@@ -102,10 +102,6 @@ Status Input::check(const daal::algorithms::Parameter * par, int method) const
     else
     {
         DAAL_CHECK_STATUS(s, checkNumericTable(dataTable.get(), dataStr()));
-        if (method == svdDense)
-        {
-            DAAL_CHECK_EX(dataTable->getNumberOfColumns() <= dataTable->getNumberOfRows(), ErrorIncorrectNumberOfRows, ArgumentName, dataStr());
-        }
     }
     return s;
 }

--- a/algorithms/kernel/svd/svd_dense_default_batch_impl.i
+++ b/algorithms/kernel/svd/svd_dense_default_batch_impl.i
@@ -119,6 +119,8 @@ Status SVDBatchKernel<algorithmFPType, method, cpu>::compute_seq(const size_t na
         TArray<algorithmFPType, cpu> sigmaPtr(n);
         DAAL_CHECK_MALLOC(sigmaPtr.get());
         algorithmFPType * Sigma = sigmaPtr.get();
+        const algorithmFPType zero(0.0);
+        service_memset<algorithmFPType, cpu>(Sigma, zero, n);
 
         compute_svd_on_one_node<algorithmFPType, cpu>(m, n, AT, m, Sigma, QT, m, VT, n);
 

--- a/algorithms/kernel/svd/svd_dense_default_distr_step2_impl.i
+++ b/algorithms/kernel/svd/svd_dense_default_distr_step2_impl.i
@@ -21,8 +21,8 @@
 //--
 */
 
-#ifndef __SVD_KERNEL_DISTR_IMPL_I__
-#define __SVD_KERNEL_DISTR_IMPL_I__
+#ifndef __SVD_DENSE_DEFAULT_DISTR_STEP2_IMPL_I__
+#define __SVD_DENSE_DEFAULT_DISTR_STEP2_IMPL_I__
 
 #include "externals/service_memory.h"
 #include "externals/service_math.h"

--- a/algorithms/kernel/svd/svd_dense_default_distr_step3_impl.i
+++ b/algorithms/kernel/svd/svd_dense_default_distr_step3_impl.i
@@ -21,8 +21,8 @@
 //--
 */
 
-#ifndef __SVD_KERNEL_DISTR_IMPL_I__
-#define __SVD_KERNEL_DISTR_IMPL_I__
+#ifndef __SVD_DENSE_DEFAULT_DISTR_STEP3_IMPL_I__
+#define __SVD_DENSE_DEFAULT_DISTR_STEP3_IMPL_I__
 
 #include "externals/service_memory.h"
 #include "externals/service_math.h"
@@ -46,134 +46,6 @@ namespace svd
 {
 namespace internal
 {
-template <typename algorithmFPType, daal::algorithms::svd::Method method, CpuType cpu>
-Status SVDDistributedStep2Kernel<algorithmFPType, method, cpu>::compute(const size_t na, const NumericTable * const * a, const size_t nr,
-                                                                        NumericTable * r[], const daal::algorithms::Parameter * par)
-{
-    svd::Parameter defaultParams;
-    const svd::Parameter * svdPar = &defaultParams;
-
-    if (par != 0)
-    {
-        svdPar = static_cast<const svd::Parameter *>(par);
-    }
-
-    const NumericTable * ntAux2_0 = a[0];
-    NumericTable * ntSigma        = const_cast<NumericTable *>(r[0]);
-
-    size_t nBlocks = na;
-
-    size_t n   = ntAux2_0->getNumberOfColumns();
-    size_t nxb = n * nBlocks;
-
-    WriteOnlyRows<algorithmFPType, cpu, NumericTable> sigmaBlock(ntSigma, 0, 1); /* Sigma [1][n]   */
-    DAAL_CHECK_BLOCK_STATUS(sigmaBlock);
-    algorithmFPType * Sigma = sigmaBlock.get();
-
-    DAAL_OVERFLOW_CHECK_BY_MULTIPLICATION(size_t, n, nxb);
-    DAAL_OVERFLOW_CHECK_BY_MULTIPLICATION(size_t, n, n);
-    DAAL_OVERFLOW_CHECK_BY_MULTIPLICATION(size_t, n * n, sizeof(algorithmFPType));
-    DAAL_OVERFLOW_CHECK_BY_MULTIPLICATION(size_t, n * nxb, sizeof(algorithmFPType));
-
-    TArray<algorithmFPType, cpu> Aux2TPtr(n * nxb);
-    TArray<algorithmFPType, cpu> VTPtr(n * n);
-    TArray<algorithmFPType, cpu> Aux3TPtr(n * nxb);
-    algorithmFPType * Aux2T = Aux2TPtr.get();
-    algorithmFPType * VT    = VTPtr.get();
-    algorithmFPType * Aux3T = Aux3TPtr.get();
-
-    DAAL_CHECK(Aux2T && VT && Aux3T, ErrorMemoryAllocationFailed);
-
-    SafeStatus safeStat;
-
-    daal::threader_for(nBlocks, nBlocks, [=, &safeStat](int k) {
-        ReadRows<algorithmFPType, cpu, NumericTable> aux2Block(const_cast<NumericTable *>(a[k]), 0, n); /* Aux2  [nxb][n] */
-        DAAL_CHECK_BLOCK_STATUS_THR(aux2Block);
-        const algorithmFPType * Aux2 = aux2Block.get();
-
-        for (size_t i = 0; i < n; i++)
-        {
-            for (size_t j = 0; j < n; j++)
-            {
-                Aux2T[j * nxb + k * n + i] = Aux2[i * n + j];
-            }
-        }
-    });
-
-    if (!safeStat) return safeStat.detach();
-
-    {
-        DAAL_INT ldAux2 = nxb;
-        DAAL_INT ldAux3 = nxb;
-        DAAL_INT ldV    = n;
-
-        DAAL_INT ldR = n;
-        DAAL_INT ldU = n;
-
-        TArray<algorithmFPType, cpu> RPtr(n * ldR);
-        TArray<algorithmFPType, cpu> UPtr(n * ldU);
-        algorithmFPType * R = RPtr.get();
-        algorithmFPType * U = UPtr.get();
-
-        DAAL_CHECK(U && R, ErrorMemoryAllocationFailed);
-
-        /* By some reason, there was this part in Sample */
-        for (size_t i = 0; i < n * ldR; i++)
-        {
-            R[i] = 0.0;
-        }
-
-        // Rc = P*R
-        const auto ecQr = compute_QR_on_one_node<algorithmFPType, cpu>(nxb, n, Aux2T, ldAux2, R, ldR);
-        if (!ecQr) return ecQr;
-
-        // Qn*R -> Qn*(U*Sigma*V) -> (Qn*U)*Sigma*V
-        const auto ecSvd = compute_svd_on_one_node<algorithmFPType, cpu>(n, n, R, ldR, Sigma, U, ldU, VT, ldV);
-        if (!ecSvd) return ecSvd;
-
-        if (svdPar->leftSingularMatrix == requiredInPackedForm)
-        {
-            const auto ecGemm = compute_gemm_on_one_node<algorithmFPType, cpu>(nxb, n, Aux2T, ldAux2, U, ldU, Aux3T, ldAux3);
-            if (!ecGemm) return ecGemm;
-        }
-    }
-
-    if (svdPar->leftSingularMatrix == requiredInPackedForm)
-    {
-        daal::threader_for(nBlocks, nBlocks, [=, &safeStat](int k) {
-            WriteOnlyRows<algorithmFPType, cpu, NumericTable> aux3Block(r[2 + k], 0, n); /* Aux3  [nxb][n] */
-            DAAL_CHECK_BLOCK_STATUS_THR(aux3Block);
-            algorithmFPType * Aux3 = aux3Block.get();
-
-            for (size_t i = 0; i < n; i++)
-            {
-                for (size_t j = 0; j < n; j++)
-                {
-                    Aux3[i * n + j] = Aux3T[j * nxb + k * n + i];
-                }
-            }
-        });
-        if (!safeStat) return safeStat.detach();
-    }
-
-    if (svdPar->rightSingularMatrix == requiredInPackedForm)
-    {
-        WriteOnlyRows<algorithmFPType, cpu, NumericTable> VBlock(r[1], 0, n); /* V[n][n] */
-        DAAL_CHECK_BLOCK_STATUS(VBlock);
-        algorithmFPType * V = VBlock.get();
-
-        for (size_t i = 0; i < n; i++)
-        {
-            for (size_t j = 0; j < n; j++)
-            {
-                V[i + j * n] = VT[i * n + j];
-            }
-        }
-    }
-
-    return Status();
-}
-
 template <typename algorithmFPType, daal::algorithms::svd::Method method, CpuType cpu>
 Status SVDDistributedStep3Kernel<algorithmFPType, method, cpu>::compute(const size_t na, const NumericTable * const * a, const size_t nr,
                                                                         NumericTable * r[], const daal::algorithms::Parameter * par)

--- a/algorithms/kernel/svd/svd_dense_default_impl.i
+++ b/algorithms/kernel/svd/svd_dense_default_impl.i
@@ -135,9 +135,12 @@ Status compute_svd_on_one_node_seq(DAAL_INT m, DAAL_INT n, algorithmFPType * a, 
   Input:
     a_q at input : a[m][lda_q] -> A (m x n)
   Output:
+  If m >= n:
     a_q at output: q[m][lda_q] -> Qn(m x n) = n leading columns of orthogonal Q
     r   at output: r[n][ldr  ] -> R (n x n) = upper triangular matrix written in lower triangular (fortran is evil)
-
+  else (if m < n):
+    a_q at output: q[m][lda_q] -> Qn(m x m) = m leading columns of orthogonal Q
+    r   at output: r[n][ldr  ] -> R (n x m) = upper trapezoidal matrix written in lower trapezoidal (fortran is evil)
 */
 template <typename algorithmFPType, CpuType cpu>
 Status compute_QR_on_one_node(DAAL_INT m, DAAL_INT n, algorithmFPType * a_q, DAAL_INT lda_q, algorithmFPType * r, DAAL_INT ldr)
@@ -206,7 +209,7 @@ Status compute_QR_on_one_node(DAAL_INT m, DAAL_INT n, algorithmFPType * a_q, DAA
             }
         }
     }
-    
+
     // Get Q of the QR factorization formed by xgeqrf
     Lapack<algorithmFPType, cpu>::xorgqr(m, nColumnsInQ, nColumnsInQ, a_q, lda_q, tau, work, workDim, &mklStatus);
 

--- a/algorithms/kernel/svd/svd_distr_step3_input.cpp
+++ b/algorithms/kernel/svd/svd_distr_step3_input.cpp
@@ -122,7 +122,6 @@ Status DistributedStep3Input::check(const daal::algorithms::Parameter * paramete
         {
             return s;
         }
-        DAAL_CHECK_EX(numTableInQCollection->getNumberOfRows() >= nFeatures, ErrorNullNumericTable, ArgumentName, rCollectionStr());
         s |= checkNumericTable(numTableInRCollection.get(), rCollectionStr(), unexpectedLayouts, 0, nFeatures, nFeatures);
         if (!s)
         {

--- a/algorithms/kernel/svd/svd_input.cpp
+++ b/algorithms/kernel/svd/svd_input.cpp
@@ -99,14 +99,7 @@ Status Input::getNumberOfRows(size_t * nRows) const
 Status Input::check(const daal::algorithms::Parameter * parameter, int method) const
 {
     NumericTablePtr dataTable = get(data);
-    Status s                  = checkNumericTable(dataTable.get(), dataStr());
-    if (!s)
-    {
-        return s;
-    }
-
-    DAAL_CHECK_EX(dataTable->getNumberOfColumns() <= dataTable->getNumberOfRows(), ErrorIncorrectNumberOfRows, ArgumentName, dataStr());
-    return Status();
+    return checkNumericTable(dataTable.get(), dataStr());
 }
 
 } // namespace interface1

--- a/algorithms/kernel/svd/svd_online_partial_result.cpp
+++ b/algorithms/kernel/svd/svd_online_partial_result.cpp
@@ -174,8 +174,6 @@ Status OnlinePartialResult::checkImpl(const daal::algorithms::Parameter * parame
             {
                 return s;
             }
-
-            DAAL_CHECK_EX(nFeatures <= numTableInQCollection->getNumberOfRows(), ErrorIncorrectNumberOfRows, ArgumentName, qCollectionStr());
         }
     }
     return Status();


### PR DESCRIPTION
Input checks for n_observations >= n_features were removed in svdDense method in PCA.
SVD algorithm was modified to let it work with n_observations < n_features in batch, online and distributed compute modes.
SVD is computed using QR decomposition, so I've changed the code of QR decomposition to let it pack the resulting R matrix properly when n_observations < n_features.

Successful CI: http://intel-ci.intel.com/ea734df7-9982-f136-ac5c-8cdcd4b723a1