### PR TITLE
Fix of xgemm call.

### DIFF
--- a/algorithms/kernel/linear_model/oneapi/linear_model_predict_dense_default_batch_oneapi_impl.i
+++ b/algorithms/kernel/linear_model/oneapi/linear_model_predict_dense_default_batch_oneapi_impl.i
@@ -124,8 +124,7 @@ services::Status PredictKernelOneAPI<algorithmFPType, defaultDense>::compute(con
 
         /* SYRK: Compute beta*xTable for each block */
         status = BlasGpu<algorithmFPType>::xgemm(math::Layout::RowMajor, math::Transpose::NoTrans, math::Transpose::Trans, xNRows, yNCols, xNCols,
-                                                 algorithmFPType(1.0), xBuf, xNCols, 0, betaBuf, nBetas, 1, algorithmFPType(0.0),
-                                                 yBuf, yNCols, 0);
+                                                 algorithmFPType(1.0), xBuf, xNCols, 0, betaBuf, nBetas, 1, algorithmFPType(0.0), yBuf, yNCols, 0);
 
         DAAL_CHECK_STATUS_VAR(status);
 

--- a/algorithms/kernel/linear_model/oneapi/linear_model_predict_dense_default_batch_oneapi_impl.i
+++ b/algorithms/kernel/linear_model/oneapi/linear_model_predict_dense_default_batch_oneapi_impl.i
@@ -124,7 +124,7 @@ services::Status PredictKernelOneAPI<algorithmFPType, defaultDense>::compute(con
 
         /* SYRK: Compute beta*xTable for each block */
         status = BlasGpu<algorithmFPType>::xgemm(math::Layout::RowMajor, math::Transpose::NoTrans, math::Transpose::Trans, xNRows, yNCols, xNCols,
-                                                 algorithmFPType(1.0), xBuf, xNCols, 0, betaBuf, nBetas, algorithmFPType(1), algorithmFPType(0.0),
+                                                 algorithmFPType(1.0), xBuf, xNCols, 0, betaBuf, nBetas, 1, algorithmFPType(0.0),
                                                  yBuf, yNCols, 0);
 
         DAAL_CHECK_STATUS_VAR(status);


### PR DESCRIPTION
Small fix of ```BlasGpu<algorithmFPType>::xgemm``` call signature. The value "1" in this context should be ```uint32_t```, not ```algorithmFPType```.