### PR TITLE
kNN predict optimizations

### DIFF
--- a/algorithms/kernel/k_nearest_neighbors/kdtree_knn_classification_predict_dense_default_batch.h
+++ b/algorithms/kernel/k_nearest_neighbors/kdtree_knn_classification_predict_dense_default_batch.h
@@ -30,6 +30,7 @@
 #include "algorithms/kernel/kernel.h"
 #include "data_management/data/numeric_table.h"
 #include "externals/service_blas.h"
+#include "service/kernel/service_arrays.h"
 
 namespace daal
 {
@@ -69,10 +70,20 @@ public:
 protected:
     void findNearestNeighbors(const algorithmFpType * query, Heap<GlobalNeighbors<algorithmFpType, cpu>, cpu> & heap,
                               kdtree_knn_classification::internal::Stack<SearchNode<algorithmFpType>, cpu> & stack, size_t k, algorithmFpType radius,
-                              const KDTreeTable & kdTreeTable, size_t rootTreeNodeIndex, const NumericTable & data);
+                              const KDTreeTable & kdTreeTable, size_t rootTreeNodeIndex, const NumericTable & data, const bool isHomogenSOA, services::internal::TArrayScalable<algorithmFpType*, cpu>& soa_arrays);
 
-    services::Status predict(algorithmFpType & predictedClass, const Heap<GlobalNeighbors<algorithmFpType, cpu>, cpu> & heap,
+    void predict(algorithmFpType & predictedClass, const Heap<GlobalNeighbors<algorithmFpType, cpu>, cpu> & heap,
                              const NumericTable & labels, size_t k);
+
+
+    // bool checkHomogenSOA(const NumericTable & data, services::internal::TArrayScalable<algorithmFpType*, cpu>& soa_arrays);
+
+    // DAAL_FORCEINLINE const algorithmFpType* getNtData(const bool isHomogenSOA, size_t feat_idx, size_t irow, size_t nrows,
+    //                         const NumericTable & data, data_management::BlockDescriptor<algorithmFpType>& xBD, services::internal::TArrayScalable<algorithmFpType*, cpu>& soa_arrays);
+
+    // DAAL_FORCEINLINE void releaseNtData(const bool isHomogenSOA, const NumericTable & data, data_management::BlockDescriptor<algorithmFpType>& xBD);
+
+
 };
 
 } // namespace internal

--- a/algorithms/kernel/k_nearest_neighbors/kdtree_knn_classification_predict_dense_default_batch.h
+++ b/algorithms/kernel/k_nearest_neighbors/kdtree_knn_classification_predict_dense_default_batch.h
@@ -70,7 +70,8 @@ public:
 protected:
     void findNearestNeighbors(const algorithmFpType * query, Heap<GlobalNeighbors<algorithmFpType, cpu>, cpu> & heap,
                               kdtree_knn_classification::internal::Stack<SearchNode<algorithmFpType>, cpu> & stack, size_t k, algorithmFpType radius,
-                              const KDTreeTable & kdTreeTable, size_t rootTreeNodeIndex, const NumericTable & data, const bool isHomogenSOA, services::internal::TArrayScalable<algorithmFpType*, cpu>& soa_arrays);
+                              const KDTreeTable & kdTreeTable, size_t rootTreeNodeIndex, const NumericTable & data, const bool isHomogenSOA,
+                              services::internal::TArrayScalable<algorithmFpType *, cpu> & soa_arrays);
 
     services::Status predict(algorithmFpType & predictedClass, const Heap<GlobalNeighbors<algorithmFpType, cpu>, cpu> & heap,
                              const NumericTable & labels, size_t k);

--- a/algorithms/kernel/k_nearest_neighbors/kdtree_knn_classification_predict_dense_default_batch.h
+++ b/algorithms/kernel/k_nearest_neighbors/kdtree_knn_classification_predict_dense_default_batch.h
@@ -72,18 +72,8 @@ protected:
                               kdtree_knn_classification::internal::Stack<SearchNode<algorithmFpType>, cpu> & stack, size_t k, algorithmFpType radius,
                               const KDTreeTable & kdTreeTable, size_t rootTreeNodeIndex, const NumericTable & data, const bool isHomogenSOA, services::internal::TArrayScalable<algorithmFpType*, cpu>& soa_arrays);
 
-    void predict(algorithmFpType & predictedClass, const Heap<GlobalNeighbors<algorithmFpType, cpu>, cpu> & heap,
+    services::Status predict(algorithmFpType & predictedClass, const Heap<GlobalNeighbors<algorithmFpType, cpu>, cpu> & heap,
                              const NumericTable & labels, size_t k);
-
-
-    // bool checkHomogenSOA(const NumericTable & data, services::internal::TArrayScalable<algorithmFpType*, cpu>& soa_arrays);
-
-    // DAAL_FORCEINLINE const algorithmFpType* getNtData(const bool isHomogenSOA, size_t feat_idx, size_t irow, size_t nrows,
-    //                         const NumericTable & data, data_management::BlockDescriptor<algorithmFpType>& xBD, services::internal::TArrayScalable<algorithmFpType*, cpu>& soa_arrays);
-
-    // DAAL_FORCEINLINE void releaseNtData(const bool isHomogenSOA, const NumericTable & data, data_management::BlockDescriptor<algorithmFpType>& xBD);
-
-
 };
 
 } // namespace internal

--- a/include/data_management/data/soa_numeric_table.h
+++ b/include/data_management/data/soa_numeric_table.h
@@ -196,21 +196,7 @@ public:
      *  \param[in]  idx Feature index
      *  \return Pointer to the array of values
      */
-    void * getArray(size_t idx)
-    {
-
-        if (idx < _ddict->getNumberOfFeatures())
-        {
-            return _arrays[idx].get();
-        }
-        else
-        {
-            this->_status.add(services::ErrorIncorrectNumberOfFeatures);
-            return NULL;
-        }
-
-        // return getArraySharedPtr(idx).get();
-    }
+    void * getArray(size_t idx) { return getArraySharedPtr(idx).get(); }
 
     services::Status getBlockOfRows(size_t vector_idx, size_t vector_num, ReadWriteMode rwflag, BlockDescriptor<double> & block) DAAL_C11_OVERRIDE
     {
@@ -263,7 +249,10 @@ public:
         return s;
     }
 
-    /* the method checks for the fact that all columns have the same data type and this type is double or float. */
+    /**
+     *  Returns 'true' if all features have the same data type, else 'false'
+     *  \return All features have the same data type or not
+     */
     bool isHomogeneousFloatOrDouble() const
     {
         const size_t ncols                                      = getNumberOfColumns();


### PR DESCRIPTION
The PR optimizes knn predict algorithm if training data set in model is represented as a homogen SOA numeric table (default behavior for C++ and only one available for IDP Sklearn).
