### PR TITLE
[releases] kNN predict optimizations

### DIFF
--- a/algorithms/kernel/k_nearest_neighbors/kdtree_knn_classification_predict_dense_default_batch.h
+++ b/algorithms/kernel/k_nearest_neighbors/kdtree_knn_classification_predict_dense_default_batch.h
@@ -30,6 +30,7 @@
 #include "algorithms/kernel/kernel.h"
 #include "data_management/data/numeric_table.h"
 #include "externals/service_blas.h"
+#include "service/kernel/service_arrays.h"
 
 namespace daal
 {
@@ -69,7 +70,8 @@ public:
 protected:
     void findNearestNeighbors(const algorithmFpType * query, Heap<GlobalNeighbors<algorithmFpType, cpu>, cpu> & heap,
                               kdtree_knn_classification::internal::Stack<SearchNode<algorithmFpType>, cpu> & stack, size_t k, algorithmFpType radius,
-                              const KDTreeTable & kdTreeTable, size_t rootTreeNodeIndex, const NumericTable & data);
+                              const KDTreeTable & kdTreeTable, size_t rootTreeNodeIndex, const NumericTable & data, const bool isHomogenSOA,
+                              services::internal::TArrayScalable<algorithmFpType *, cpu> & soa_arrays);
 
     services::Status predict(algorithmFpType & predictedClass, const Heap<GlobalNeighbors<algorithmFpType, cpu>, cpu> & heap,
                              const NumericTable & labels, size_t k);

--- a/algorithms/kernel/k_nearest_neighbors/kdtree_knn_classification_predict_dense_default_batch_impl.i
+++ b/algorithms/kernel/k_nearest_neighbors/kdtree_knn_classification_predict_dense_default_batch_impl.i
@@ -26,7 +26,7 @@
 
 #include "algorithms/threading/threading.h"
 #include "services/daal_defines.h"
-#include "service/kernel/service_utils.h"
+#include "data_management/data/internal/conversion.h"
 #include "algorithms/algorithm.h"
 #include "services/daal_atomic_int.h"
 #include "externals/service_memory.h"
@@ -219,10 +219,10 @@ DAAL_FORCEINLINE bool checkHomogenSOA(const NumericTable & data, services::inter
 {
     if (data.getDataLayout() & NumericTableIface::soa)
     {
-        if (static_cast<const SOANumericTable &>(data).isHomogeneousFloatOrDouble())
+        if (static_cast<const SOANumericTable &>(data).isHomogeneous())
         {
             auto f = (*const_cast<NumericTable &>(data).getDictionary())[0];
-            if (daal::data_management::features::getIndexNumType<algorithmFpType>() == f.indexType)
+            if ((int)daal::data_management::internal::getConversionDataType<algorithmFpType>() == (int)f.indexType)
             {
                 const size_t xColumnCount = data.getNumberOfColumns();
                 soa_arrays.reset(xColumnCount);

--- a/include/data_management/data/soa_numeric_table.h
+++ b/include/data_management/data/soa_numeric_table.h
@@ -261,7 +261,7 @@ public:
      *  Returns 'true' if all features have the same data type, else 'false'
      *  \return All features have the same data type or not
      */
-    bool isHomogeneousFloatOrDouble() const
+    bool isHomogeneous() const
     {
         const size_t ncols                                      = getNumberOfColumns();
         const NumericTableFeature & f0                          = (*_ddict)[0];
@@ -273,8 +273,8 @@ public:
             if (f1.indexType != indexType) return false;
         }
 
-        return indexType == daal::data_management::features::getIndexNumType<float>()
-               || indexType == daal::data_management::features::getIndexNumType<double>();
+        return (int)indexType == (int)internal::getConversionDataType<float>()
+               || (int)indexType == (int)internal::getConversionDataType<double>();
     }
 
 protected:

--- a/include/data_management/data/soa_numeric_table.h
+++ b/include/data_management/data/soa_numeric_table.h
@@ -270,11 +270,11 @@ public:
         for (size_t i = 1; i < ncols; ++i)
         {
             const NumericTableFeature & f1 = (*_ddict)[i];
+
             if (f1.indexType != indexType) return false;
         }
 
-        return (int)indexType == (int)internal::getConversionDataType<float>()
-               || (int)indexType == (int)internal::getConversionDataType<double>();
+        return (int)indexType == (int)internal::getConversionDataType<float>() || (int)indexType == (int)internal::getConversionDataType<double>();
     }
 
 protected:

--- a/include/data_management/data/soa_numeric_table.h
+++ b/include/data_management/data/soa_numeric_table.h
@@ -257,6 +257,26 @@ public:
         return s;
     }
 
+    /**
+     *  Returns 'true' if all features have the same data type, else 'false'
+     *  \return All features have the same data type or not
+     */
+    bool isHomogeneousFloatOrDouble() const
+    {
+        const size_t ncols                                      = getNumberOfColumns();
+        const NumericTableFeature & f0                          = (*_ddict)[0];
+        daal::data_management::features::IndexNumType indexType = f0.indexType;
+
+        for (size_t i = 1; i < ncols; ++i)
+        {
+            const NumericTableFeature & f1 = (*_ddict)[i];
+            if (f1.indexType != indexType) return false;
+        }
+
+        return indexType == daal::data_management::features::getIndexNumType<float>()
+               || indexType == daal::data_management::features::getIndexNumType<double>();
+    }
+
 protected:
     SOANumericTable(size_t nColumns, size_t nRows, DictionaryIface::FeaturesEqual featuresEqual, services::Status & st);
 
@@ -453,24 +473,6 @@ private:
         }
 
         return services::Status();
-    }
-
-    /* the method checks for the fact that all columns have the same data type. */
-    bool isHomogeneous() const
-    {
-        size_t ncols = getNumberOfColumns();
-
-        NumericTableFeature & f0 = (*_ddict)[0];
-
-        for (size_t i = 0; i < ncols; ++i)
-        {
-            NumericTableFeature & f1 = (*_ddict)[i];
-
-            if (f1.indexType != f0.indexType) return false;
-        }
-
-        return (int)f0.indexType == (int)internal::getConversionDataType<float>()
-               || (int)f0.indexType == (int)internal::getConversionDataType<double>();
     }
 
     template <typename T>


### PR DESCRIPTION
This is a cherry-pick from #518

The PR optimizes knn predict algorithm if training data set in model is represented as a homogen SOA numeric table (default behavior for C++ and only one available for IDP Sklearn).