### PR TITLE
Remove c++11 features from headers

### DIFF
--- a/examples/cpp/makefile_lnx
+++ b/examples/cpp/makefile_lnx
@@ -97,7 +97,12 @@ endif
 
 DAAL_LIB := $(DAAL_PATH)/libdaal_core.$(RES_EXT) $(DAAL_LIB_T)
 
-COPTS := -std=c++11 -pedantic -Wall -Wextra -Werror=return-type -Werror=uninitialized -Werror=unknown-pragmas -Werror -I./source/utils
+COPTS := -pedantic -Wall -Wextra -Werror \
+         -Werror=return-type \
+         -Werror=uninitialized \
+         -Werror=unknown-pragmas \
+         -I./source/utils
+
 LOPTS := -Wl,--start-group $(DAAL_LIB) $(EXT_LIB) -Wl,--end-group
 
 RES_DIR=_results/$(compiler)_$(_IA)_$(threading)_$(RES_EXT)
@@ -110,7 +115,9 @@ endif
 
 ifeq ($(compiler),gnu)
     CC = g++
-    COPTS += $(if $(filter ia32, $(_IA)), -m32, -m64)
+    # Add extra flags to check if DAAL headers can be used in C++03 mode
+    COPTS += $(if $(filter ia32, $(_IA)), -m32, -m64) \
+             -std=c++03 -Wno-variadic-macros -Wno-long-long
 endif
 
 ifeq ($(compiler),clang)

--- a/include/algorithms/boosting/adaboost_model.h
+++ b/include/algorithms/boosting/adaboost_model.h
@@ -153,7 +153,7 @@ typedef services::SharedPtr<Model> ModelPtr;
  */
 enum ResultToComputeId
 {
-    computeWeakLearnersErrors = 0x00000001ULL,
+    computeWeakLearnersErrors = 0x00000001ULL
 };
 /**
  * \brief Contains version 2.0 of Intel(R) Data Analytics Acceleration Library (Intel(R) DAAL) interface.

--- a/include/algorithms/classifier/classifier_model.h
+++ b/include/algorithms/classifier/classifier_model.h
@@ -46,7 +46,7 @@ enum ResultToComputeId
 {
     computeClassLabels           = 0x00000001ULL, /*!< Numeric table of size n x 1 with the predicted labels >*/
     computeClassProbabilities    = 0x00000002ULL, /*!< Numeric table of size n x p with the predicted class probabilities for each observation >*/
-    computeClassLogProbabilities = 0x00000004ULL, /*!< Numeric table of size n x p with the predicted class probabilities for each observation >*/
+    computeClassLogProbabilities = 0x00000004ULL  /*!< Numeric table of size n x p with the predicted class probabilities for each observation >*/
 };
 
 /**

--- a/include/algorithms/dbscan/dbscan_types.h
+++ b/include/algorithms/dbscan/dbscan_types.h
@@ -51,7 +51,7 @@ const int undefined = -2;
  */
 enum Method
 {
-    defaultDense = 0, /*!< Default: performance-oriented method */
+    defaultDense = 0 /*!< Default: performance-oriented method */
 };
 
 /**

--- a/include/algorithms/elastic_net/elastic_net_training_types.h
+++ b/include/algorithms/elastic_net/elastic_net_training_types.h
@@ -56,7 +56,7 @@ namespace training
  */
 enum Method
 {
-    defaultDense = 0, /*!< Normal equations method */
+    defaultDense = 0 /*!< Normal equations method */
 };
 
 /**

--- a/include/algorithms/gradient_boosted_trees/gbt_training_parameter.h
+++ b/include/algorithms/gradient_boosted_trees/gbt_training_parameter.h
@@ -74,7 +74,7 @@ enum VariableImportanceModes
     totalCover = 0x002ULL,
     cover      = 0x004ULL,
     totalGain  = 0x008ULL,
-    gain       = 0x010ULL,
+    gain       = 0x010ULL
 };
 
 /**

--- a/include/algorithms/lasso_regression/lasso_regression_training_types.h
+++ b/include/algorithms/lasso_regression/lasso_regression_training_types.h
@@ -56,7 +56,7 @@ namespace training
  */
 enum Method
 {
-    defaultDense = 0, /*!< Normal equations method */
+    defaultDense = 0 /*!< Normal equations method */
 };
 
 /**

--- a/include/algorithms/normalization/minmax_types.h
+++ b/include/algorithms/normalization/minmax_types.h
@@ -63,7 +63,7 @@ namespace minmax
  */
 enum Method
 {
-    defaultDense = 0, /*!< Default: performance-oriented method. Works with all types of numeric tables */
+    defaultDense = 0 /*!< Default: performance-oriented method. Works with all types of numeric tables */
 };
 
 /**

--- a/include/algorithms/normalization/zscore_types.h
+++ b/include/algorithms/normalization/zscore_types.h
@@ -64,7 +64,7 @@ namespace zscore
 enum Method
 {
     defaultDense = 0, /*!< Default: performance-oriented method. Works with all types of numeric tables */
-    sumDense     = 1, /*!< Precomputed sum: implementation of algorithm in the case of a precomputed sum.
+    sumDense     = 1  /*!< Precomputed sum: implementation of algorithm in the case of a precomputed sum.
                                      Works with all types of numeric tables */
 };
 

--- a/include/algorithms/optimization_solver/adagrad/adagrad_types.h
+++ b/include/algorithms/optimization_solver/adagrad/adagrad_types.h
@@ -54,7 +54,7 @@ namespace adagrad
  */
 enum Method
 {
-    defaultDense = 0, /*!< Default: performance-oriented method */
+    defaultDense = 0 /*!< Default: performance-oriented method */
 };
 
 /**

--- a/include/algorithms/optimization_solver/coordinate_descent/coordinate_descent_types.h
+++ b/include/algorithms/optimization_solver/coordinate_descent/coordinate_descent_types.h
@@ -54,7 +54,7 @@ namespace coordinate_descent
  */
 enum Method
 {
-    defaultDense = 0, /*!< Default: performance-oriented method */
+    defaultDense = 0 /*!< Default: performance-oriented method */
 };
 
 /**

--- a/include/algorithms/optimization_solver/lbfgs/lbfgs_types.h
+++ b/include/algorithms/optimization_solver/lbfgs/lbfgs_types.h
@@ -84,7 +84,7 @@ enum OptionalDataId
                                          row 0 represent average arguments for the previous L iterations and
                                          row 1 represent average arguments for the last L iterations.
                                          These values are required to compute S correction vectors on the next step */
-    lastOptionalData = averageArgumentLIterations,
+    lastOptionalData = averageArgumentLIterations
 };
 
 /**

--- a/include/algorithms/optimization_solver/objective_function/objective_function_types.h
+++ b/include/algorithms/optimization_solver/objective_function/objective_function_types.h
@@ -78,7 +78,7 @@ enum ResultToComputeId
     componentOfHessianDiagonal =
         0x00000080ULL, /*!< Numeric table of size 1 x nDependentVariable with the dioganal element of hession matrix over certain feature of the objective function in the given argument */
     componentOfProximalProjection =
-        0x00000100ULL, /*!< Numeric table of size p x nDependentVariable with proximal projection of certain of the objective function in the given argument */
+        0x00000100ULL /*!< Numeric table of size p x nDependentVariable with proximal projection of certain of the objective function in the given argument */
 };
 
 /**

--- a/include/algorithms/optimization_solver/objective_function/sum_of_functions_types.h
+++ b/include/algorithms/optimization_solver/objective_function/sum_of_functions_types.h
@@ -52,7 +52,7 @@ namespace sum_of_functions
   */
 enum InputId
 {
-    argument = (int)objective_function::argument, /*!< Numeric table of size 1 x p with input argument of the objective function */
+    argument = (int)objective_function::argument /*!< Numeric table of size 1 x p with input argument of the objective function */
 };
 
 /**

--- a/include/algorithms/optimization_solver/saga/saga_types.h
+++ b/include/algorithms/optimization_solver/saga/saga_types.h
@@ -54,7 +54,7 @@ namespace saga
  */
 enum Method
 {
-    defaultDense = 0, /*!< Default: performance-oriented method */
+    defaultDense = 0 /*!< Default: performance-oriented method */
 };
 
 /**

--- a/include/algorithms/ridge_regression/ridge_regression_training_types.h
+++ b/include/algorithms/ridge_regression/ridge_regression_training_types.h
@@ -56,7 +56,7 @@ namespace training
 enum Method
 {
     defaultDense = 0, /*!< Normal equations method */
-    normEqDense  = 0, /*!< Normal equations method */
+    normEqDense  = 0  /*!< Normal equations method */
 };
 
 /**

--- a/include/oneapi/internal/execution_context.h
+++ b/include/oneapi/internal/execution_context.h
@@ -130,7 +130,7 @@ public:
     {
         publicBuffer,
         publicConstant,
-        privateBuffer,
+        privateBuffer
     };
 
 private:

--- a/include/oneapi/internal/math/types.h
+++ b/include/oneapi/internal/math/types.h
@@ -28,19 +28,19 @@ namespace math
 {
 namespace interface1
 {
-enum class Layout
+enum Layout
 {
     ColMajor,
     RowMajor
 };
 
-enum class Transpose
+enum Transpose
 {
     NoTrans,
     Trans
 };
 
-enum class UpLo
+enum UpLo
 {
     Upper,
     Lower


### PR DESCRIPTION
- Remove c++11 features from oneAPI headers exposed in classical DAAL headers
- Add `-std=c++03`, `-Wno-variadic-macros`, `-Wno-long-long` for GCC 
- Fix some ISO C++ 2003 violations in DAAL headers