### PR TITLE
[daal-2020-mnt] kNN predict optimizations

### DIFF
--- a/algorithms/kernel/k_nearest_neighbors/kdtree_knn_classification_predict_dense_default_batch.h
+++ b/algorithms/kernel/k_nearest_neighbors/kdtree_knn_classification_predict_dense_default_batch.h
@@ -67,7 +67,8 @@ public:
 protected:
     void findNearestNeighbors(const algorithmFpType * query, Heap<GlobalNeighbors<algorithmFpType, cpu>, cpu> & heap,
                               kdtree_knn_classification::internal::Stack<SearchNode<algorithmFpType>, cpu> & stack, size_t k, algorithmFpType radius,
-                              const KDTreeTable & kdTreeTable, size_t rootTreeNodeIndex, const NumericTable & data);
+                              const KDTreeTable & kdTreeTable, size_t rootTreeNodeIndex, const NumericTable & data, const bool isHomogenSOA,
+                              services::internal::TArrayScalable<algorithmFpType *, cpu> & soa_arrays);
 
     services::Status predict(algorithmFpType & predictedClass, const Heap<GlobalNeighbors<algorithmFpType, cpu>, cpu> & heap, const NumericTable & labels,
                  size_t k);

--- a/algorithms/kernel/k_nearest_neighbors/kdtree_knn_classification_predict_dense_default_batch_impl.i
+++ b/algorithms/kernel/k_nearest_neighbors/kdtree_knn_classification_predict_dense_default_batch_impl.i
@@ -26,6 +26,7 @@
 
 #include "threading.h"
 #include "daal_defines.h"
+#include "data_management/data/internal/conversion.h"
 #include "algorithm.h"
 #include "daal_atomic_int.h"
 #include "service_memory.h"
@@ -185,9 +186,63 @@ struct SearchNode
     algorithmFpType minDistance;
 };
 
-template<typename algorithmFpType, CpuType cpu>
-Status KNNClassificationPredictKernel<algorithmFpType, defaultDense, cpu>::
-                 compute(const NumericTable * x, const classifier::Model * m, NumericTable * y, const daal::algorithms::Parameter * par)
+template <typename algorithmFpType, CpuType cpu>
+DAAL_FORCEINLINE bool checkHomogenSOA(const NumericTable & data, services::internal::TArrayScalable<algorithmFpType *, cpu> & soa_arrays)
+{
+    if (data.getDataLayout() & NumericTableIface::soa)
+    {
+        if (static_cast<const SOANumericTable &>(data).isHomogeneous())
+        {
+            auto f = (*const_cast<NumericTable &>(data).getDictionary())[0];
+            if ((int)daal::data_management::internal::getConversionDataType<algorithmFpType>() == (int)f.indexType)
+            {
+                const size_t xColumnCount = data.getNumberOfColumns();
+                soa_arrays.reset(xColumnCount);
+
+                for (size_t i = 0; i < xColumnCount; ++i)
+                {
+                    soa_arrays[i] = static_cast<algorithmFpType *>(static_cast<SOANumericTable &>(const_cast<NumericTable &>(data)).getArray(i));
+                    if (!soa_arrays[i])
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+template <typename algorithmFpType, CpuType cpu>
+DAAL_FORCEINLINE const algorithmFpType * getNtData(const bool isHomogenSOA, size_t feat_idx, size_t irow, size_t nrows, const NumericTable & data,
+                                                   data_management::BlockDescriptor<algorithmFpType> & xBD,
+                                                   services::internal::TArrayScalable<algorithmFpType *, cpu> & soa_arrays)
+{
+    if (isHomogenSOA)
+    {
+        return soa_arrays[feat_idx] + irow;
+    }
+    else
+    {
+        const_cast<NumericTable &>(data).getBlockOfColumnValues(feat_idx, irow, nrows, readOnly, xBD);
+        return xBD.getBlockPtr();
+    }
+}
+
+template <typename algorithmFpType, CpuType cpu>
+DAAL_FORCEINLINE void releaseNtData(const bool isHomogenSOA, const NumericTable & data, data_management::BlockDescriptor<algorithmFpType> & xBD)
+{
+    if (!isHomogenSOA)
+    {
+        const_cast<NumericTable &>(data).releaseBlockOfColumnValues(xBD);
+    }
+}
+
+template <typename algorithmFpType, CpuType cpu>
+Status KNNClassificationPredictKernel<algorithmFpType, defaultDense, cpu>::compute(const NumericTable * x, const classifier::Model * m,
+                                                                                   NumericTable * y, const daal::algorithms::Parameter * par)
 {
     Status status;
 
@@ -227,8 +282,7 @@ Status KNNClassificationPredictKernel<algorithmFpType, defaultDense, cpu>::
         MaxHeap heap;
         SearchStack stack;
     };
-    daal::tls<Local *> localTLS([=, &status]()-> Local *
-    {
+    daal::tls<Local *> localTLS([&]() -> Local * {
         Local * const ptr = service_scalable_calloc<Local, cpu>(1);
         if (ptr)
         {
@@ -258,8 +312,11 @@ Status KNNClassificationPredictKernel<algorithmFpType, defaultDense, cpu>::
     const auto rowsPerBlock = (xRowCount + maxThreads - 1) / maxThreads;
     const auto blockCount = (xRowCount + rowsPerBlock - 1) / rowsPerBlock;
     SafeStatus safeStat;
-    daal::threader_for(blockCount, blockCount, [=, &localTLS, &kdTreeTable, &data, &labels, &rowsPerBlock, &k, &safeStat](int iBlock)
-    {
+
+    services::internal::TArrayScalable<algorithmFpType *, cpu> soa_arrays;
+    bool isHomogenSOA = checkHomogenSOA<algorithmFpType, cpu>(data, soa_arrays);
+
+    daal::threader_for(blockCount, blockCount, [&](int iBlock) {
         Local * const local = localTLS.local();
         if (local)
         {
@@ -273,10 +330,12 @@ Status KNNClassificationPredictKernel<algorithmFpType, defaultDense, cpu>::
             data_management::BlockDescriptor<algorithmFpType> yBD;
             y->getBlockOfRows(first, last - first, writeOnly, yBD);
             auto * const dy = yBD.getBlockPtr();
+
             for (size_t i = 0; i < last - first; ++i)
             {
-                findNearestNeighbors(&dx[i * xColumnCount], local->heap, local->stack, k, radius, kdTreeTable, rootTreeNodeIndex, data);
-                services::Status s = predict(dy[i * yColumnCount], local->heap, labels, k);
+                findNearestNeighbors(&dx[i * xColumnCount], local->heap, local->stack, k, radius, kdTreeTable, rootTreeNodeIndex, data, isHomogenSOA,
+                                     soa_arrays);
+                auto s = predict(dy[i * yColumnCount], local->heap, labels, k);
                 DAAL_CHECK_STATUS_THR(s)
             }
             y->releaseBlockOfRows(yBD);
@@ -286,8 +345,7 @@ Status KNNClassificationPredictKernel<algorithmFpType, defaultDense, cpu>::
 
     DAAL_CHECK_SAFE_STATUS()
 
-    localTLS.reduce([=](Local * ptr) -> void
-    {
+    localTLS.reduce([&](Local * ptr) -> void {
         if (ptr)
         {
             ptr->stack.clear();
@@ -298,11 +356,58 @@ Status KNNClassificationPredictKernel<algorithmFpType, defaultDense, cpu>::
     return status;
 }
 
-template<typename algorithmFpType, CpuType cpu>
-void KNNClassificationPredictKernel<algorithmFpType, defaultDense, cpu>::
-    findNearestNeighbors(const algorithmFpType * query, Heap<GlobalNeighbors<algorithmFpType, cpu>, cpu> & heap,
-                         kdtree_knn_classification::internal::Stack<SearchNode<algorithmFpType>, cpu> & stack, size_t k, algorithmFpType radius,
-                         const KDTreeTable & kdTreeTable, size_t rootTreeNodeIndex, const NumericTable & data)
+template <typename algorithmFpType, CpuType cpu>
+DAAL_FORCEINLINE void computeDistance(size_t start, size_t end, algorithmFpType * distance, const algorithmFpType * query, const bool isHomogenSOA,
+                                      const NumericTable & data, data_management::BlockDescriptor<algorithmFpType> xBD[2],
+                                      services::internal::TArrayScalable<algorithmFpType *, cpu> & soa_arrays)
+{
+    for (size_t i = start; i < end; ++i)
+    {
+        distance[i - start] = 0;
+    }
+
+    size_t curBDIdx  = 0;
+    size_t nextBDIdx = 1;
+
+    const size_t xColumnCount = data.getNumberOfColumns();
+
+    const algorithmFpType * nx = nullptr;
+    const algorithmFpType * dx = getNtData(isHomogenSOA, 0, start, end - start, data, xBD[curBDIdx], soa_arrays);
+
+    size_t j;
+    for (j = 1; j < xColumnCount; ++j)
+    {
+        nx = getNtData(isHomogenSOA, j, start, end - start, data, xBD[nextBDIdx], soa_arrays);
+
+        DAAL_PREFETCH_READ_T0(nx);
+        DAAL_PREFETCH_READ_T0(nx + 16);
+
+        for (size_t i = 0; i < end - start; ++i)
+        {
+            distance[i] += (query[j - 1] - dx[i]) * (query[j - 1] - dx[i]);
+        }
+
+        releaseNtData<algorithmFpType, cpu>(isHomogenSOA, data, xBD[curBDIdx]);
+
+        services::internal::swap<cpu, size_t>(curBDIdx, nextBDIdx);
+        services::internal::swap<cpu, const algorithmFpType *>(dx, nx);
+    }
+    {
+        for (size_t i = 0; i < end - start; ++i)
+        {
+            distance[i] += (query[j - 1] - dx[i]) * (query[j - 1] - dx[i]);
+        }
+
+        releaseNtData<algorithmFpType, cpu>(isHomogenSOA, data, xBD[curBDIdx]);
+    }
+}
+
+template <typename algorithmFpType, CpuType cpu>
+void KNNClassificationPredictKernel<algorithmFpType, defaultDense, cpu>::findNearestNeighbors(
+    const algorithmFpType * query, Heap<GlobalNeighbors<algorithmFpType, cpu>, cpu> & heap,
+    kdtree_knn_classification::internal::Stack<SearchNode<algorithmFpType>, cpu> & stack, size_t k, algorithmFpType radius,
+    const KDTreeTable & kdTreeTable, size_t rootTreeNodeIndex, const NumericTable & data, const bool isHomogenSOA,
+    services::internal::TArrayScalable<algorithmFpType *, cpu> & soa_arrays)
 {
     heap.reset();
     stack.reset();
@@ -330,40 +435,7 @@ void KNNClassificationPredictKernel<algorithmFpType, defaultDense, cpu>::
             start = node->leftIndex;
             end = node->rightIndex;
 
-            for (i = start; i < end; ++i)
-            {
-                distance[i - start] = 0;
-            }
-
-            curBDIdx = 0;
-            nextBDIdx = 1;
-            const_cast<NumericTable &>(data).getBlockOfColumnValues(0, start, end - start, readOnly, xBD[curBDIdx]);
-            for (j = 1; j < xColumnCount; ++j)
-            {
-                const algorithmFpType * const dx = xBD[curBDIdx].getBlockPtr();
-
-                const_cast<NumericTable &>(data).getBlockOfColumnValues(j, start, end - start, readOnly, xBD[nextBDIdx]);
-                const algorithmFpType * const nx = xBD[nextBDIdx].getBlockPtr();
-                DAAL_PREFETCH_READ_T0(nx);
-                DAAL_PREFETCH_READ_T0(nx + 16);
-
-                for (i = 0; i < end - start; ++i)
-                {
-                    distance[i] += (query[j - 1] - dx[i]) * (query[j - 1] - dx[i]);
-                }
-
-                const_cast<NumericTable &>(data).releaseBlockOfColumnValues(xBD[curBDIdx]);
-
-                const auto tempBDIdx = curBDIdx; curBDIdx = nextBDIdx; nextBDIdx = tempBDIdx;
-            }
-            {
-                const algorithmFpType * const dx = xBD[curBDIdx].getBlockPtr();
-                for (i = 0; i < end - start; ++i)
-                {
-                    distance[i] += (query[j - 1] - dx[i]) * (query[j - 1] - dx[i]);
-                }
-                const_cast<NumericTable &>(data).releaseBlockOfColumnValues(xBD[curBDIdx]);
-            }
+            computeDistance<algorithmFpType, cpu>(start, end, distance, query, isHomogenSOA, data, xBD, soa_arrays);
 
             for (i = start; i < end; ++i)
             {

--- a/include/data_management/data/soa_numeric_table.h
+++ b/include/data_management/data/soa_numeric_table.h
@@ -281,6 +281,26 @@ public:
         return s;
     }
 
+    /**
+     *  Returns 'true' if all features have the same data type, else 'false'
+     *  \return All features have the same data type or not
+     */
+    bool isHomogeneous() const
+    {
+        const size_t ncols                                      = getNumberOfColumns();
+        const NumericTableFeature & f0                          = (*_ddict)[0];
+        daal::data_management::features::IndexNumType indexType = f0.indexType;
+
+        for (size_t i = 1; i < ncols; ++i)
+        {
+            const NumericTableFeature & f1 = (*_ddict)[i];
+
+            if (f1.indexType != indexType) return false;
+        }
+
+        return (int)indexType == (int)internal::getConversionDataType<float>() || (int)indexType == (int)internal::getConversionDataType<double>();
+    }
+
 protected:
 
     SOANumericTable( size_t nColumns, size_t nRows, DictionaryIface::FeaturesEqual featuresEqual, services::Status &st );
@@ -480,24 +500,6 @@ private:
         }
 
         return services::Status();
-    }
-
-    /* the method checks for the fact that all columns have the same data type. */
-    bool isHomogeneous() const
-    {
-        size_t ncols = getNumberOfColumns();
-
-        NumericTableFeature & f0 = (*_ddict)[0];
-
-        for (size_t i = 0; i < ncols; ++i)
-        {
-            NumericTableFeature & f1 = (*_ddict)[i];
-
-            if (f1.indexType != f0.indexType) return false;
-        }
-
-        return (int)f0.indexType == (int)internal::getConversionDataType<float>()
-               || (int)f0.indexType == (int)internal::getConversionDataType<double>();
     }
 
     template <typename T>


### PR DESCRIPTION
This is a cherry-pick from #518

The PR optimizes knn predict algorithm if training data set in model is represented as a homogen SOA numeric table (default behavior for C++ and only one available for IDP Sklearn).