### PR TITLE
[master] added a virtual destructor to fix memory leak in gbt

### DIFF
--- a/algorithms/kernel/dtrees/dtrees_feature_type_helper.i
+++ b/algorithms/kernel/dtrees/dtrees_feature_type_helper.i
@@ -40,6 +40,7 @@ struct ColIndexTask
 {
     DAAL_NEW_DELETE();
     ColIndexTask(size_t nRows) : _index(nRows), maxNumDiffValues(1) {}
+    virtual ~ColIndexTask() {}
     bool isValid() const { return _index.get(); }
 
     struct FeatureIdx


### PR DESCRIPTION
I detected a memory leak in GBT.
This was due to the fact that the destructor of the ColIndexTaskBins object is not called.
I added a virtual destructor  for the parent ColIndexTask object to fix this.