### PR TITLE
Fix logreg predict instance for GPU

### DIFF
--- a/algorithms/kernel/logistic_regression/logistic_regression_predict_container.h
+++ b/algorithms/kernel/logistic_regression/logistic_regression_predict_container.h
@@ -25,10 +25,9 @@
 
 #include "algorithms/logistic_regression/logistic_regression_predict.h"
 #include "algorithms/classifier/classifier_model.h"
-#include "algorithms/kernel/logistic_regression/logistic_regression_predict_kernel.h"
 #include "service/kernel/service_algo_utils.h"
-
-#include "algorithms/kernel/logistic_regression/oneapi/logistic_regression_predict_kernel_oneapi_instance.h"
+#include "algorithms/kernel/logistic_regression/logistic_regression_predict_kernel.h"
+#include "algorithms/kernel/logistic_regression/oneapi/logistic_regression_predict_kernel_oneapi.h"
 
 namespace daal
 {
@@ -52,7 +51,7 @@ BatchContainer<algorithmFPType, method, cpu>::BatchContainer(daal::services::Env
     }
     else
     {
-        __DAAL_INITIALIZE_KERNELS(internal::PredictBatchKernelOneAPI, algorithmFPType, method);
+        __DAAL_INITIALIZE_KERNELS_SYCL(internal::PredictBatchKernelOneAPI, algorithmFPType, method);
     }
 }
 
@@ -90,8 +89,8 @@ services::Status BatchContainer<algorithmFPType, method, cpu>::compute()
     }
     else
     {
-        __DAAL_CALL_KERNEL(env, internal::PredictBatchKernelOneAPI, __DAAL_KERNEL_ARGUMENTS(algorithmFPType, method), compute,
-                           daal::services::internal::hostApp(*input), a, m, par->nClasses, r, prob, logProb);
+        __DAAL_CALL_KERNEL_SYCL(env, internal::PredictBatchKernelOneAPI, __DAAL_KERNEL_ARGUMENTS(algorithmFPType, method), compute,
+                                daal::services::internal::hostApp(*input), a, m, par->nClasses, r, prob, logProb);
     }
 }
 

--- a/algorithms/kernel/logistic_regression/logistic_regression_predict_dense_default_batch_oneapi_fpt.cpp
+++ b/algorithms/kernel/logistic_regression/logistic_regression_predict_dense_default_batch_oneapi_fpt.cpp
@@ -1,6 +1,6 @@
-/* file: logistic_regression_predict_kernel_oneapi_instance.h */
+/* file: logistic_regression_predict_dense_default_batch_oneapi_fpt.cpp */
 /*******************************************************************************
-* Copyright 2014-2020 Intel Corporation
+* Copyright 2020 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -17,14 +17,26 @@
 
 /*
 //++
-//  Implementation of logistic regression Batch Kernel Adapter for GPU.
+//  Implementation of prediction stage of logistic regression classification algorithm.
 //--
 */
-
-#ifndef __LOGISTIC_REGRESSION_TRAIN_KERNEL_ONEAPI_INSTANCE_H__
-#define __LOGISTIC_REGRESSION_TRAIN_KERNEL_ONEAPI_INSTANCE_H__
 
 #include "algorithms/kernel/logistic_regression/oneapi/logistic_regression_predict_kernel_oneapi.h"
 #include "algorithms/kernel/logistic_regression/oneapi/logistic_regression_predict_dense_default_batch_oneapi_impl.i"
 
-#endif
+namespace daal
+{
+namespace algorithms
+{
+namespace logistic_regression
+{
+namespace prediction
+{
+namespace internal
+{
+template class PredictBatchKernelOneAPI<DAAL_FPTYPE, defaultDense>;
+}
+} // namespace prediction
+} // namespace logistic_regression
+} // namespace algorithms
+} // namespace daal

--- a/algorithms/kernel/logistic_regression/oneapi/logistic_regression_predict_dense_default_batch_oneapi_impl.i
+++ b/algorithms/kernel/logistic_regression/oneapi/logistic_regression_predict_dense_default_batch_oneapi_impl.i
@@ -40,9 +40,9 @@ namespace internal
 using namespace daal::oneapi::internal;
 
 // Heaviside step function
-template <typename algorithmFPType, prediction::Method method, CpuType cpu>
-services::Status PredictBatchKernelOneAPI<algorithmFPType, method, cpu>::heaviside(const services::Buffer<algorithmFPType> & x,
-                                                                                   services::Buffer<algorithmFPType> & result, const uint32_t n)
+template <typename algorithmFPType, prediction::Method method>
+services::Status PredictBatchKernelOneAPI<algorithmFPType, method>::heaviside(const services::Buffer<algorithmFPType> & x,
+                                                                              services::Buffer<algorithmFPType> & result, const uint32_t n)
 {
     services::Status status;
 
@@ -69,10 +69,10 @@ services::Status PredictBatchKernelOneAPI<algorithmFPType, method, cpu>::heavisi
 }
 
 // Index max elements for each row
-template <typename algorithmFPType, prediction::Method method, CpuType cpu>
-services::Status PredictBatchKernelOneAPI<algorithmFPType, method, cpu>::argMax(const services::Buffer<algorithmFPType> & x,
-                                                                                services::Buffer<algorithmFPType> & result, const uint32_t n,
-                                                                                const uint32_t p)
+template <typename algorithmFPType, prediction::Method method>
+services::Status PredictBatchKernelOneAPI<algorithmFPType, method>::argMax(const services::Buffer<algorithmFPType> & x,
+                                                                           services::Buffer<algorithmFPType> & result, const uint32_t n,
+                                                                           const uint32_t p)
 {
     services::Status status;
 
@@ -99,10 +99,10 @@ services::Status PredictBatchKernelOneAPI<algorithmFPType, method, cpu>::argMax(
     return status;
 }
 
-template <typename algorithmFPType, prediction::Method method, CpuType cpu>
-services::Status PredictBatchKernelOneAPI<algorithmFPType, method, cpu>::compute(services::HostAppIface * pHostApp, NumericTable * x,
-                                                                                 const logistic_regression::Model * m, size_t nClasses,
-                                                                                 NumericTable * pRes, NumericTable * pProb, NumericTable * pLogProb)
+template <typename algorithmFPType, prediction::Method method>
+services::Status PredictBatchKernelOneAPI<algorithmFPType, method>::compute(services::HostAppIface * pHostApp, NumericTable * x,
+                                                                            const logistic_regression::Model * m, size_t nClasses,
+                                                                            NumericTable * pRes, NumericTable * pProb, NumericTable * pLogProb)
 {
     services::Status status;
 

--- a/algorithms/kernel/logistic_regression/oneapi/logistic_regression_predict_kernel_oneapi.h
+++ b/algorithms/kernel/logistic_regression/oneapi/logistic_regression_predict_kernel_oneapi.h
@@ -26,6 +26,7 @@
 #define __LOGISTIC_REGRESSION_PREDICT_KERNEL_ONEAPI_H__
 
 #include "algorithms/logistic_regression/logistic_regression_training_types.h"
+#include "algorithms/logistic_regression/logistic_regression_predict.h"
 #include "algorithms/kernel/objective_function/common/oneapi/objective_function_utils_oneapi.h"
 #include "algorithms/kernel/objective_function/logistic_loss/oneapi/logistic_loss_dense_default_kernel_oneapi.h"
 #include "algorithms/kernel/objective_function/cross_entropy_loss/oneapi/cross_entropy_loss_dense_default_kernel_oneapi.h"
@@ -40,7 +41,7 @@ namespace prediction
 {
 namespace internal
 {
-template <typename algorithmFPType, Method method, CpuType cpu>
+template <typename algorithmFPType, Method method>
 class PredictBatchKernelOneAPI : public daal::algorithms::Kernel
 {
 public:


### PR DESCRIPTION
In windows testing we have inlegal symbols in SVM Predict from Logistic Regression Predict. It changes fixed instance Logistic Regression Predict.