### PR TITLE
[mnt] Train test split optimizations

### DIFF
--- a/algorithms/threading/threading.h
+++ b/algorithms/threading/threading.h
@@ -319,15 +319,15 @@ inline bool is_in_parallel()
 }
 
 template <typename Func>
-void runBlocks(const bool inParallel, const size_t nBlocks, Func func)
+void conditional_threader_for(const bool inParallel, const size_t n, Func func)
 {
     if (inParallel)
     {
-        threader_for(nBlocks, nBlocks, [&](size_t i) { func(i); });
+        threader_for(n, n, [&](size_t i) { func(i); });
     }
     else
     {
-        for (size_t i = 0; i < nBlocks; ++i)
+        for (size_t i = 0; i < n; ++i)
         {
             func(i);
         }

--- a/algorithms/threading/threading.h
+++ b/algorithms/threading/threading.h
@@ -318,6 +318,22 @@ inline bool is_in_parallel()
     return _daal_is_in_parallel();
 }
 
+template <typename Func>
+void runBlocks(const bool inParallel, const size_t nBlocks, Func func)
+{
+    if (inParallel)
+    {
+        threader_for(nBlocks, nBlocks, [&](size_t i) { func(i); });
+    }
+    else
+    {
+        for (size_t i = 0; i < nBlocks; ++i)
+        {
+            func(i);
+        }
+    }
+}
+
 } // namespace daal
 
 #endif

--- a/include/data_management/data/internal/train_test_split.h
+++ b/include/data_management/data/internal/train_test_split.h
@@ -1,0 +1,38 @@
+/* file: train_test_split.h */
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef __DATA_MANAGEMENT_DATA_INTERNAL_TRAIN_TEST_SPLIT_H__
+#define __DATA_MANAGEMENT_DATA_INTERNAL_TRAIN_TEST_SPLIT_H__
+
+#include "data_management/data/numeric_table.h"
+#include "services/daal_defines.h"
+
+namespace daal
+{
+namespace data_management
+{
+namespace internal
+{
+template <typename IdxType>
+DAAL_EXPORT void trainTestSplit(NumericTable & inputTable, NumericTable & trainTable, NumericTable & testTable,
+                                NumericTable & trainIdxTable, NumericTable & testIdxTable, NumericTable & columnTypesTable);
+
+} // namespace internal
+} // namespace data_management
+} // namespace daal
+
+#endif

--- a/include/data_management/data/internal/train_test_split.h
+++ b/include/data_management/data/internal/train_test_split.h
@@ -28,8 +28,8 @@ namespace data_management
 namespace internal
 {
 template <typename IdxType>
-DAAL_EXPORT void trainTestSplit(const NumericTablePtr inputTable, const NumericTablePtr trainTable, const NumericTablePtr testTable,
-                                const NumericTablePtr trainIdxTable, const NumericTablePtr testIdxTable);
+DAAL_EXPORT void trainTestSplit(const NumericTablePtr & inputTable, const NumericTablePtr & trainTable, const NumericTablePtr & testTable,
+                                const NumericTablePtr & trainIdxTable, const NumericTablePtr & testIdxTable);
 
 } // namespace internal
 } // namespace data_management

--- a/include/data_management/data/internal/train_test_split.h
+++ b/include/data_management/data/internal/train_test_split.h
@@ -28,8 +28,8 @@ namespace data_management
 namespace internal
 {
 template <typename IdxType>
-DAAL_EXPORT void trainTestSplit(NumericTable & inputTable, NumericTable & trainTable, NumericTable & testTable,
-                                NumericTable & trainIdxTable, NumericTable & testIdxTable);
+DAAL_EXPORT void trainTestSplit(NumericTable & inputTable, NumericTable & trainTable, NumericTable & testTable, NumericTable & trainIdxTable,
+                                NumericTable & testIdxTable);
 
 } // namespace internal
 } // namespace data_management

--- a/include/data_management/data/internal/train_test_split.h
+++ b/include/data_management/data/internal/train_test_split.h
@@ -29,7 +29,7 @@ namespace internal
 {
 template <typename IdxType>
 DAAL_EXPORT void trainTestSplit(NumericTable & inputTable, NumericTable & trainTable, NumericTable & testTable,
-                                NumericTable & trainIdxTable, NumericTable & testIdxTable, NumericTable & columnTypesTable);
+                                NumericTable & trainIdxTable, NumericTable & testIdxTable);
 
 } // namespace internal
 } // namespace data_management

--- a/include/data_management/data/internal/train_test_split.h
+++ b/include/data_management/data/internal/train_test_split.h
@@ -28,8 +28,8 @@ namespace data_management
 namespace internal
 {
 template <typename IdxType>
-DAAL_EXPORT void trainTestSplit(NumericTable & inputTable, NumericTable & trainTable, NumericTable & testTable, NumericTable & trainIdxTable,
-                                NumericTable & testIdxTable);
+DAAL_EXPORT void trainTestSplit(const NumericTablePtr inputTable, const NumericTablePtr trainTable, const NumericTablePtr testTable,
+                                const NumericTablePtr trainIdxTable, const NumericTablePtr testIdxTable);
 
 } // namespace internal
 } // namespace data_management

--- a/service/kernel/data_management/finiteness_checker.cpp
+++ b/service/kernel/data_management/finiteness_checker.cpp
@@ -94,15 +94,6 @@ bool checkFiniteness(const size_t nElements, size_t nDataPtrs, size_t nElementsP
 const size_t BLOCK_SIZE       = 8192;
 const size_t THREADING_BORDER = 262144;
 
-template <typename Func>
-void runBlocks(bool inParallel, size_t nBlocks, Func func)
-{
-    if (inParallel)
-        daal::threader_for(nBlocks, nBlocks, [&](size_t i) { func(i); });
-    else
-        for (size_t i = 0; i < nBlocks; ++i) func(i);
-}
-
 template <typename DataType>
 DataType sumWithAVX512(size_t n, const DataType * dataPtr)
 {
@@ -143,7 +134,7 @@ DataType computeSumAVX512Impl(size_t nDataPtrs, size_t nElementsPerPtr, const Da
     if (!pSums) return getInf<DataType>();
     for (size_t iBlock = 0; iBlock < nTotalBlocks; ++iBlock) pSums[iBlock] = 0;
 
-    runBlocks(inParallel, nTotalBlocks, [&](size_t iBlock) {
+    daal::runBlocks(inParallel, nTotalBlocks, [&](size_t iBlock) {
         size_t ptrIdx        = iBlock / nBlocksPerPtr;
         size_t blockIdxInPtr = iBlock - nBlocksPerPtr * ptrIdx;
         size_t start         = blockIdxInPtr * nPerBlock;
@@ -177,7 +168,7 @@ services::Status checkFinitenessInBlocks(const float ** dataPtrs, bool inParalle
     DAAL_CHECK_MALLOC(notFinitePtr);
     for (size_t iBlock = 0; iBlock < nTotalBlocks; ++iBlock) notFinitePtr[iBlock] = false;
 
-    runBlocks(inParallel, nTotalBlocks, [&](size_t iBlock) {
+    daal::runBlocks(inParallel, nTotalBlocks, [&](size_t iBlock) {
         size_t ptrIdx        = iBlock / nBlocksPerPtr;
         size_t blockIdxInPtr = iBlock - nBlocksPerPtr * ptrIdx;
         size_t start         = blockIdxInPtr * nPerBlock;
@@ -232,7 +223,7 @@ services::Status checkFinitenessInBlocks(const double ** dataPtrs, bool inParall
     DAAL_CHECK_MALLOC(notFinitePtr);
     for (size_t iBlock = 0; iBlock < nTotalBlocks; ++iBlock) notFinitePtr[iBlock] = false;
 
-    runBlocks(inParallel, nTotalBlocks, [&](size_t iBlock) {
+    daal::runBlocks(inParallel, nTotalBlocks, [&](size_t iBlock) {
         size_t ptrIdx        = iBlock / nBlocksPerPtr;
         size_t blockIdxInPtr = iBlock - nBlocksPerPtr * ptrIdx;
         size_t start         = blockIdxInPtr * nPerBlock;

--- a/service/kernel/data_management/finiteness_checker.cpp
+++ b/service/kernel/data_management/finiteness_checker.cpp
@@ -134,7 +134,7 @@ DataType computeSumAVX512Impl(size_t nDataPtrs, size_t nElementsPerPtr, const Da
     if (!pSums) return getInf<DataType>();
     for (size_t iBlock = 0; iBlock < nTotalBlocks; ++iBlock) pSums[iBlock] = 0;
 
-    daal::runBlocks(inParallel, nTotalBlocks, [&](size_t iBlock) {
+    daal::conditional_threader_for(inParallel, nTotalBlocks, [&](size_t iBlock) {
         size_t ptrIdx        = iBlock / nBlocksPerPtr;
         size_t blockIdxInPtr = iBlock - nBlocksPerPtr * ptrIdx;
         size_t start         = blockIdxInPtr * nPerBlock;
@@ -168,7 +168,7 @@ services::Status checkFinitenessInBlocks(const float ** dataPtrs, bool inParalle
     DAAL_CHECK_MALLOC(notFinitePtr);
     for (size_t iBlock = 0; iBlock < nTotalBlocks; ++iBlock) notFinitePtr[iBlock] = false;
 
-    daal::runBlocks(inParallel, nTotalBlocks, [&](size_t iBlock) {
+    daal::conditional_threader_for(inParallel, nTotalBlocks, [&](size_t iBlock) {
         size_t ptrIdx        = iBlock / nBlocksPerPtr;
         size_t blockIdxInPtr = iBlock - nBlocksPerPtr * ptrIdx;
         size_t start         = blockIdxInPtr * nPerBlock;
@@ -223,7 +223,7 @@ services::Status checkFinitenessInBlocks(const double ** dataPtrs, bool inParall
     DAAL_CHECK_MALLOC(notFinitePtr);
     for (size_t iBlock = 0; iBlock < nTotalBlocks; ++iBlock) notFinitePtr[iBlock] = false;
 
-    daal::runBlocks(inParallel, nTotalBlocks, [&](size_t iBlock) {
+    daal::conditional_threader_for(inParallel, nTotalBlocks, [&](size_t iBlock) {
         size_t ptrIdx        = iBlock / nBlocksPerPtr;
         size_t blockIdxInPtr = iBlock - nBlocksPerPtr * ptrIdx;
         size_t start         = blockIdxInPtr * nPerBlock;

--- a/service/kernel/data_management/train_test_split.cpp
+++ b/service/kernel/data_management/train_test_split.cpp
@@ -190,18 +190,22 @@ services::Status trainTestSplitImpl(const NumericTablePtr inputTable, const Nume
         DAAL_CHECK_MALLOC(trainIdx);
         DAAL_CHECK_MALLOC(testIdx);
 
-        daal::runBlocks(nColumns > 1 && nColumns * (nTrainRows + nTestRows) > THREADING_BORDER && nThreads > 1, nColumns, [&](size_t iCol) {
-            switch ((*tableFeaturesDict)[iCol].getIndexType())
-            {
-            case daal::data_management::features::IndexNumType::DAAL_FLOAT32:
-                s |= splitColumn<float, IdxType, cpu>(inputTable, trainTable, testTable, trainIdx, testIdx, nTrainRows, nTestRows, iCol, nThreads);
-                break;
-            case daal::data_management::features::IndexNumType::DAAL_FLOAT64:
-                s |= splitColumn<double, IdxType, cpu>(inputTable, trainTable, testTable, trainIdx, testIdx, nTrainRows, nTestRows, iCol, nThreads);
-                break;
-            default: s |= splitColumn<int, IdxType, cpu>(inputTable, trainTable, testTable, trainIdx, testIdx, nTrainRows, nTestRows, iCol, nThreads);
-            }
-        });
+        daal::conditional_threader_for(
+            nColumns > 1 && nColumns * (nTrainRows + nTestRows) > THREADING_BORDER && nThreads > 1, nColumns, [&](size_t iCol) {
+                switch ((*tableFeaturesDict)[iCol].getIndexType())
+                {
+                case daal::data_management::features::IndexNumType::DAAL_FLOAT32:
+                    s |=
+                        splitColumn<float, IdxType, cpu>(inputTable, trainTable, testTable, trainIdx, testIdx, nTrainRows, nTestRows, iCol, nThreads);
+                    break;
+                case daal::data_management::features::IndexNumType::DAAL_FLOAT64:
+                    s |= splitColumn<double, IdxType, cpu>(inputTable, trainTable, testTable, trainIdx, testIdx, nTrainRows, nTestRows, iCol,
+                                                           nThreads);
+                    break;
+                default:
+                    s |= splitColumn<int, IdxType, cpu>(inputTable, trainTable, testTable, trainIdx, testIdx, nTrainRows, nTestRows, iCol, nThreads);
+                }
+            });
     }
     else
     {

--- a/service/kernel/data_management/train_test_split.cpp
+++ b/service/kernel/data_management/train_test_split.cpp
@@ -55,6 +55,8 @@ services::Status assignColumnValues(const DataType * origDataPtr, const NumericT
         dataPtr[i] = origDataPtr[idxPtr[i]];
     }
 
+    dataTable->releaseBlockOfColumnValues(dataBlock);
+
     return services::Status();
 }
 
@@ -96,6 +98,8 @@ services::Status splitColumn(const NumericTablePtr & inputTable, const NumericTa
     s |= assignColumnSubset<DataType, IdxType, cpu>(origDataPtr, trainTable, trainIdx, nTrainRows, iCol, nThreads);
     s |= assignColumnSubset<DataType, IdxType, cpu>(origDataPtr, testTable, testIdx, nTestRows, iCol, nThreads);
 
+    inputTable->releaseBlockOfColumnValues(origBlock);
+
     return s;
 }
 
@@ -121,6 +125,10 @@ services::Status assignRows(const DataType * origDataPtr, const NumericTablePtr 
             dataPtr[i * nColumns + j] = origDataPtr[idxPtr[i] * nColumns + j];
         }
     }
+
+    dataTable->releaseBlockOfRows(dataBlock);
+    idxTable->releaseBlockOfColumnValues(idxBlock);
+
     return services::Status();
 }
 
@@ -161,6 +169,8 @@ services::Status splitRows(const NumericTablePtr & inputTable, const NumericTabl
 
     s |= assignRowsSubset<DataType, IdxType, cpu>(origDataPtr, trainTable, trainIdxTable, nTrainRows, nColumns, nThreads, blockSize);
     s |= assignRowsSubset<DataType, IdxType, cpu>(origDataPtr, testTable, testIdxTable, nTestRows, nColumns, nThreads, blockSize);
+
+    inputTable->releaseBlockOfRows(origBlock);
 
     return s;
 }
@@ -205,6 +215,10 @@ services::Status trainTestSplitImpl(const NumericTablePtr & inputTable, const Nu
                     s |= splitColumn<int, IdxType, cpu>(inputTable, trainTable, testTable, trainIdx, testIdx, nTrainRows, nTestRows, iCol, nThreads);
                 }
             });
+
+        trainIdxTable->releaseBlockOfColumnValues(trainIdxBlock);
+        testIdxTable->releaseBlockOfColumnValues(testIdxBlock);
+
         return s.detach();
     }
     else

--- a/service/kernel/data_management/train_test_split.cpp
+++ b/service/kernel/data_management/train_test_split.cpp
@@ -196,15 +196,13 @@ services::Status trainTestSplitImpl(NumericTable & inputTable, NumericTable & tr
         runBlocks(nColumns > 1 && nColumns * (nTrainRows + nTestRows) > THREADING_BORDER && nThreads > 1, nColumns, [&](size_t iCol) {
             switch ((*tableFeaturesDict)[iCol].getIndexType())
             {
-            case daal::data_management::features::IndexNumType::DAAL_INT32_S:
-                s |= splitColumn<int, IdxType, cpu>(inputTable, trainTable, testTable, trainIdx, testIdx, nTrainRows, nTestRows, iCol, nThreads);
-                break;
             case daal::data_management::features::IndexNumType::DAAL_FLOAT32:
                 s |= splitColumn<float, IdxType, cpu>(inputTable, trainTable, testTable, trainIdx, testIdx, nTrainRows, nTestRows, iCol, nThreads);
                 break;
             case daal::data_management::features::IndexNumType::DAAL_FLOAT64:
                 s |= splitColumn<double, IdxType, cpu>(inputTable, trainTable, testTable, trainIdx, testIdx, nTrainRows, nTestRows, iCol, nThreads);
                 break;
+            default: s |= splitColumn<int, IdxType, cpu>(inputTable, trainTable, testTable, trainIdx, testIdx, nTrainRows, nTestRows, iCol, nThreads);
             }
         });
     }
@@ -212,10 +210,6 @@ services::Status trainTestSplitImpl(NumericTable & inputTable, NumericTable & tr
     {
         switch ((*tableFeaturesDict)[0].getIndexType())
         {
-        case daal::data_management::features::IndexNumType::DAAL_INT32_S:
-            s |= splitRows<int, IdxType, cpu>(inputTable, trainTable, testTable, trainIdxTable, testIdxTable, nTrainRows, nTestRows, nColumns,
-                                              nThreads);
-            break;
         case daal::data_management::features::IndexNumType::DAAL_FLOAT32:
             s |= splitRows<float, IdxType, cpu>(inputTable, trainTable, testTable, trainIdxTable, testIdxTable, nTrainRows, nTestRows, nColumns,
                                                 nThreads);
@@ -224,6 +218,9 @@ services::Status trainTestSplitImpl(NumericTable & inputTable, NumericTable & tr
             s |= splitRows<double, IdxType, cpu>(inputTable, trainTable, testTable, trainIdxTable, testIdxTable, nTrainRows, nTestRows, nColumns,
                                                  nThreads);
             break;
+        default:
+            s |= splitRows<int, IdxType, cpu>(inputTable, trainTable, testTable, trainIdxTable, testIdxTable, nTrainRows, nTestRows, nColumns,
+                                              nThreads);
         }
     }
     return s;

--- a/service/kernel/data_management/train_test_split.cpp
+++ b/service/kernel/data_management/train_test_split.cpp
@@ -71,12 +71,11 @@ services::Status assignColumnSubset(const DataType * origDataPtr, NumericTable &
 
     if (nRows > THREADING_BORDER && nThreads > 1)
     {
-        const size_t nBlocks = daal::services::internal::max<cpu, size_t>(nRows / BLOCK_CONST, 1);
-        const int nSurplus   = nRows - BLOCK_CONST * nBlocks;
+        const size_t nBlocks = nRows / BLOCK_CONST + !!(nRows % BLOCK_CONST);
 
         daal::threader_for(nBlocks, nBlocks, [&](size_t iBlock) {
             const size_t start = iBlock * BLOCK_CONST;
-            const size_t end   = iBlock == nBlocks - 1 ? start + BLOCK_CONST + nSurplus : start + BLOCK_CONST;
+            const size_t end   = daal::services::internal::min<cpu, size_t>(start + BLOCK_CONST, nRows);
 
             s |= assignColumnValues<DataType, IdxType>(origDataPtr, dataTable, idxPtr, start, end - start, iCol);
         });
@@ -136,12 +135,11 @@ services::Status assignRowsSubset(const DataType * origDataPtr, NumericTable & d
 
     if (nRows * nColumns > THREADING_BORDER && nThreads > 1)
     {
-        const size_t nBlocks = daal::services::internal::max<cpu, size_t>(nRows / blockSize, 1);
-        const int nSurplus   = nRows - blockSize * nBlocks;
+        const size_t nBlocks = nRows / blockSize + !!(nRows % blockSize);
 
         daal::threader_for(nBlocks, nBlocks, [&](size_t iBlock) {
             const size_t start = iBlock * blockSize;
-            const size_t end   = iBlock == nBlocks - 1 ? start + blockSize + nSurplus : start + blockSize;
+            const size_t end   = daal::services::internal::min<cpu, size_t>(start + blockSize, nRows);
 
             s |= assignRows<DataType, IdxType>(origDataPtr, dataTable, idxTable, start, end - start, nColumns);
         });

--- a/service/kernel/data_management/train_test_split.cpp
+++ b/service/kernel/data_management/train_test_split.cpp
@@ -22,6 +22,7 @@
 #include "externals/service_dispatch.h"
 #include "service/kernel/service_data_utils.h"
 #include "service/kernel/service_utils.h"
+#include "service/kernel/service_defines.h"
 #include "algorithms/threading/threading.h"
 #include "service/kernel/data_management/service_numeric_table.h"
 #include "data_management/features/defines.h"
@@ -244,14 +245,20 @@ services::Status trainTestSplitImpl(NumericTable & inputTable, NumericTable & tr
 }
 
 template <typename IdxType>
+void trainTestSplitDispImpl(NumericTable & inputTable, NumericTable & trainTable, NumericTable & testTable, NumericTable & trainIdxTable,
+                            NumericTable & testIdxTable)
+{
+#define DAAL_TTS(cpuId, ...) trainTestSplitImpl<IdxType, cpuId>(__VA_ARGS__);
+    DAAL_DISPATCH_FUNCTION_BY_CPU(DAAL_TTS, inputTable, trainTable, testTable, trainIdxTable, testIdxTable);
+#undef DAAL_TTS
+}
+
+template <typename IdxType>
 DAAL_EXPORT void trainTestSplit(NumericTable & inputTable, NumericTable & trainTable, NumericTable & testTable, NumericTable & trainIdxTable,
                                 NumericTable & testIdxTable)
 {
-#define DAAL_TTS(cpuId, ...) trainTestSplitImpl<IdxType, cpuId>(__VA_ARGS__);
-
-    DAAL_DISPATCH_FUNCTION_BY_CPU(DAAL_TTS, inputTable, trainTable, testTable, trainIdxTable, testIdxTable);
-
-#undef DAAL_TTS
+    DAAL_SAFE_CPU_CALL((trainTestSplitDispImpl<IdxType>(inputTable, trainTable, testTable, trainIdxTable, testIdxTable)),
+                       (trainTestSplitImpl<IdxType, daal::CpuType::sse2>(inputTable, trainTable, testTable, trainIdxTable, testIdxTable)));
 }
 
 template DAAL_EXPORT void trainTestSplit<int>(NumericTable & inputTable, NumericTable & trainTable, NumericTable & testTable,

--- a/service/kernel/data_management/train_test_split.cpp
+++ b/service/kernel/data_management/train_test_split.cpp
@@ -34,7 +34,7 @@ namespace internal
 {
 typedef daal::data_management::NumericTable::StorageLayout NTLayout;
 
-const size_t BLOCK_CONST = 2048;
+const size_t BLOCK_CONST      = 2048;
 const size_t THREADING_BORDER = 8388608;
 
 template <typename Func>
@@ -47,9 +47,8 @@ void runBlocks(const bool inParallel, const size_t nBlocks, Func func)
 }
 
 template <typename DataType, typename IdxType, daal::CpuType cpu>
-services::Status splitColumn(NumericTable & inputTable, NumericTable & trainTable, NumericTable & testTable,
-                             const IdxType * trainIdx, const IdxType * testIdx,
-                             const size_t nTrainRows, const size_t nTestRows, const size_t iCol, const size_t nThreads)
+services::Status splitColumn(NumericTable & inputTable, NumericTable & trainTable, NumericTable & testTable, const IdxType * trainIdx,
+                             const IdxType * testIdx, const size_t nTrainRows, const size_t nTestRows, const size_t iCol, const size_t nThreads)
 {
     services::Status s;
     const size_t BLOCK_SIZE = BLOCK_CONST;
@@ -59,63 +58,59 @@ services::Status splitColumn(NumericTable & inputTable, NumericTable & trainTabl
     trainTable.getBlockOfColumnValues(iCol, 0, nTrainRows, readWrite, trainBlock);
     testTable.getBlockOfColumnValues(iCol, 0, nTestRows, readWrite, testBlock);
     const DataType * origDataPtr = origBlock.getBlockPtr();
-    DataType * trainDataPtr = trainBlock.getBlockPtr();
-    DataType * testDataPtr = testBlock.getBlockPtr();
+    DataType * trainDataPtr      = trainBlock.getBlockPtr();
+    DataType * testDataPtr       = testBlock.getBlockPtr();
     DAAL_CHECK_MALLOC(origDataPtr);
     DAAL_CHECK_MALLOC(trainDataPtr);
     DAAL_CHECK_MALLOC(testDataPtr);
 
-    if ( nTrainRows > THREADING_BORDER && nThreads > 1 )
+    if (nTrainRows > THREADING_BORDER && nThreads > 1)
     {
         const size_t nTrainBlocks = daal::services::internal::max<cpu, size_t>(nTrainRows / BLOCK_SIZE, 1);
-        const int nTrainSurplus = nTrainRows - BLOCK_SIZE * nTrainBlocks;
+        const int nTrainSurplus   = nTrainRows - BLOCK_SIZE * nTrainBlocks;
 
         daal::threader_for(nTrainBlocks, nTrainBlocks, [&](size_t iBlock) {
             const size_t start = iBlock * BLOCK_SIZE;
             const size_t end   = iBlock == nTrainBlocks - 1 ? start + BLOCK_SIZE + nTrainSurplus : start + BLOCK_SIZE;
 
-            for (size_t i = start; i < end; ++i)
-                trainDataPtr[i] = origDataPtr[trainIdx[i]];
+            for (size_t i = start; i < end; ++i) trainDataPtr[i] = origDataPtr[trainIdx[i]];
         });
     }
     else
     {
-        for (size_t i = 0; i < nTrainRows; ++i)
-            trainDataPtr[i] = origDataPtr[trainIdx[i]];
+        for (size_t i = 0; i < nTrainRows; ++i) trainDataPtr[i] = origDataPtr[trainIdx[i]];
     }
 
-    if ( nTestRows > THREADING_BORDER && nThreads > 1 )
+    if (nTestRows > THREADING_BORDER && nThreads > 1)
     {
         const size_t nTestBlocks = daal::services::internal::max<cpu, size_t>(nTestRows / BLOCK_SIZE, 1);
-        const int nTestSurplus = nTestRows - BLOCK_SIZE * nTestBlocks;
+        const int nTestSurplus   = nTestRows - BLOCK_SIZE * nTestBlocks;
 
         daal::threader_for(nTestBlocks, nTestBlocks, [&](size_t iBlock) {
             const size_t start = iBlock * BLOCK_SIZE;
             const size_t end   = iBlock == nTestBlocks - 1 ? start + BLOCK_SIZE + nTestSurplus : start + BLOCK_SIZE;
 
-            for (size_t i = start; i < end; ++i)
-                testDataPtr[i] = origDataPtr[testIdx[i]];
+            for (size_t i = start; i < end; ++i) testDataPtr[i] = origDataPtr[testIdx[i]];
         });
     }
     else
     {
-        for (size_t i = 0; i < nTestRows; ++i)
-            testDataPtr[i] = origDataPtr[testIdx[i]];
+        for (size_t i = 0; i < nTestRows; ++i) testDataPtr[i] = origDataPtr[testIdx[i]];
     }
 
     return s;
 }
 
 template <typename DataType, typename IdxType, daal::CpuType cpu>
-services::Status assignRows(const DataType * origDataPtr, NumericTable & dataTable, NumericTable & idxTable,
-                            const size_t startRow, const size_t nRows, const size_t nColumns)
+services::Status assignRows(const DataType * origDataPtr, NumericTable & dataTable, NumericTable & idxTable, const size_t startRow,
+                            const size_t nRows, const size_t nColumns)
 {
     services::Status s;
     BlockDescriptor<DataType> dataBlock;
     BlockDescriptor<IdxType> idxBlock;
     dataTable.getBlockOfRows(startRow, startRow + nRows, readWrite, dataBlock);
     idxTable.getBlockOfColumnValues(0, startRow, nRows, readOnly, idxBlock);
-    DataType * dataPtr = dataBlock.getBlockPtr();
+    DataType * dataPtr     = dataBlock.getBlockPtr();
     const IdxType * idxPtr = idxBlock.getBlockPtr();
     DAAL_CHECK_MALLOC(dataPtr);
     DAAL_CHECK_MALLOC(idxPtr);
@@ -125,16 +120,14 @@ services::Status assignRows(const DataType * origDataPtr, NumericTable & dataTab
         const IdxType idx = idxPtr[i];
         PRAGMA_IVDEP
         PRAGMA_VECTOR_ALWAYS
-        for (size_t j = 0; j < nColumns; ++j)
-            dataPtr[i * nColumns + j] = origDataPtr[idxPtr[i] * nColumns + j];
+        for (size_t j = 0; j < nColumns; ++j) dataPtr[i * nColumns + j] = origDataPtr[idxPtr[i] * nColumns + j];
     }
     return s;
 }
 
 template <typename DataType, typename IdxType, daal::CpuType cpu>
-services::Status splitRows(NumericTable & inputTable, NumericTable & trainTable, NumericTable & testTable,
-                           NumericTable & trainIdxTable, NumericTable & testIdxTable,
-                           const size_t nTrainRows, const size_t nTestRows, const size_t nColumns, const size_t nThreads)
+services::Status splitRows(NumericTable & inputTable, NumericTable & trainTable, NumericTable & testTable, NumericTable & trainIdxTable,
+                           NumericTable & testIdxTable, const size_t nTrainRows, const size_t nTestRows, const size_t nColumns, const size_t nThreads)
 {
     services::Status s;
     const size_t BLOCK_SIZE = daal::services::internal::max<cpu, size_t>(BLOCK_CONST / nColumns, 1);
@@ -143,10 +136,10 @@ services::Status splitRows(NumericTable & inputTable, NumericTable & trainTable,
     const DataType * origDataPtr = origBlock.getBlockPtr();
     DAAL_CHECK_MALLOC(origDataPtr);
 
-    if ( nTrainRows * nColumns > THREADING_BORDER && nThreads > 1 )
+    if (nTrainRows * nColumns > THREADING_BORDER && nThreads > 1)
     {
         const size_t nTrainBlocks = daal::services::internal::max<cpu, size_t>(nTrainRows / BLOCK_SIZE, 1);
-        const int nTrainSurplus = nTrainRows - BLOCK_SIZE * nTrainBlocks;
+        const int nTrainSurplus   = nTrainRows - BLOCK_SIZE * nTrainBlocks;
 
         daal::threader_for(nTrainBlocks, nTrainBlocks, [&](size_t iBlock) {
             const size_t start = iBlock * BLOCK_SIZE;
@@ -160,10 +153,10 @@ services::Status splitRows(NumericTable & inputTable, NumericTable & trainTable,
         s |= assignRows<DataType, IdxType, cpu>(origDataPtr, trainTable, trainIdxTable, 0, nTrainRows, nColumns);
     }
 
-    if ( nTestRows * nColumns > THREADING_BORDER && nThreads > 1 )
+    if (nTestRows * nColumns > THREADING_BORDER && nThreads > 1)
     {
         const size_t nTestBlocks = daal::services::internal::max<cpu, size_t>(nTestRows / BLOCK_SIZE, 1);
-        const int nTestSurplus = nTestRows - BLOCK_SIZE * nTestBlocks;
+        const int nTestSurplus   = nTestRows - BLOCK_SIZE * nTestBlocks;
 
         daal::threader_for(nTestBlocks, nTestBlocks, [&](size_t iBlock) {
             const size_t start = iBlock * BLOCK_SIZE;
@@ -181,15 +174,15 @@ services::Status splitRows(NumericTable & inputTable, NumericTable & trainTable,
 }
 
 template <typename IdxType, daal::CpuType cpu>
-services::Status trainTestSplitImpl(NumericTable & inputTable, NumericTable & trainTable, NumericTable & testTable,
-                                    NumericTable & trainIdxTable, NumericTable & testIdxTable)
+services::Status trainTestSplitImpl(NumericTable & inputTable, NumericTable & trainTable, NumericTable & testTable, NumericTable & trainIdxTable,
+                                    NumericTable & testIdxTable)
 {
     services::Status s;
-    const size_t nThreads = threader_get_threads_number();
-    const NTLayout layout  = inputTable.getDataLayout();
-    const size_t nColumns = trainTable.getNumberOfColumns();
+    const size_t nThreads   = threader_get_threads_number();
+    const NTLayout layout   = inputTable.getDataLayout();
+    const size_t nColumns   = trainTable.getNumberOfColumns();
     const size_t nTrainRows = trainTable.getNumberOfRows();
-    const size_t nTestRows = testTable.getNumberOfRows();
+    const size_t nTestRows  = testTable.getNumberOfRows();
     DAAL_OVERFLOW_CHECK_BY_MULTIPLICATION(size_t, nTrainRows + nTestRows, nColumns);
 
     NumericTableDictionaryPtr tableFeaturesDict = inputTable.getDictionarySharedPtr();
@@ -200,22 +193,22 @@ services::Status trainTestSplitImpl(NumericTable & inputTable, NumericTable & tr
         trainIdxTable.getBlockOfColumnValues(0, 0, nTrainRows, readOnly, trainIdxBlock);
         testIdxTable.getBlockOfColumnValues(0, 0, nTestRows, readOnly, testIdxBlock);
         const IdxType * trainIdx = trainIdxBlock.getBlockPtr();
-        const IdxType * testIdx = testIdxBlock.getBlockPtr();
+        const IdxType * testIdx  = testIdxBlock.getBlockPtr();
         DAAL_CHECK_MALLOC(trainIdx);
         DAAL_CHECK_MALLOC(testIdx);
 
         runBlocks(nColumns > 1 && nColumns * (nTrainRows + nTestRows) > THREADING_BORDER && nThreads > 1, nColumns, [&](size_t iCol) {
             switch ((*tableFeaturesDict)[iCol].getIndexType())
             {
-                case daal::data_management::features::IndexNumType::DAAL_INT32_S:
-                    s |= splitColumn<int, IdxType, cpu>(inputTable, trainTable, testTable, trainIdx, testIdx, nTrainRows, nTestRows, iCol, nThreads);
-                    break;
-                case daal::data_management::features::IndexNumType::DAAL_FLOAT32:
-                    s |= splitColumn<float, IdxType, cpu>(inputTable, trainTable, testTable, trainIdx, testIdx, nTrainRows, nTestRows, iCol, nThreads);
-                    break;
-                case daal::data_management::features::IndexNumType::DAAL_FLOAT64:
-                    s |= splitColumn<double, IdxType, cpu>(inputTable, trainTable, testTable, trainIdx, testIdx, nTrainRows, nTestRows, iCol, nThreads);
-                    break;
+            case daal::data_management::features::IndexNumType::DAAL_INT32_S:
+                s |= splitColumn<int, IdxType, cpu>(inputTable, trainTable, testTable, trainIdx, testIdx, nTrainRows, nTestRows, iCol, nThreads);
+                break;
+            case daal::data_management::features::IndexNumType::DAAL_FLOAT32:
+                s |= splitColumn<float, IdxType, cpu>(inputTable, trainTable, testTable, trainIdx, testIdx, nTrainRows, nTestRows, iCol, nThreads);
+                break;
+            case daal::data_management::features::IndexNumType::DAAL_FLOAT64:
+                s |= splitColumn<double, IdxType, cpu>(inputTable, trainTable, testTable, trainIdx, testIdx, nTrainRows, nTestRows, iCol, nThreads);
+                break;
             }
         });
     }
@@ -223,23 +216,26 @@ services::Status trainTestSplitImpl(NumericTable & inputTable, NumericTable & tr
     {
         switch ((*tableFeaturesDict)[0].getIndexType())
         {
-            case daal::data_management::features::IndexNumType::DAAL_INT32_S:
-                s |= splitRows<int, IdxType, cpu>(inputTable, trainTable, testTable, trainIdxTable, testIdxTable, nTrainRows, nTestRows, nColumns, nThreads);
-                break;
-            case daal::data_management::features::IndexNumType::DAAL_FLOAT32:
-                s |= splitRows<float, IdxType, cpu>(inputTable, trainTable, testTable, trainIdxTable, testIdxTable, nTrainRows, nTestRows, nColumns, nThreads);
-                break;
-            case daal::data_management::features::IndexNumType::DAAL_FLOAT64:
-                s |= splitRows<double, IdxType, cpu>(inputTable, trainTable, testTable, trainIdxTable, testIdxTable, nTrainRows, nTestRows, nColumns, nThreads);
-                break;
+        case daal::data_management::features::IndexNumType::DAAL_INT32_S:
+            s |= splitRows<int, IdxType, cpu>(inputTable, trainTable, testTable, trainIdxTable, testIdxTable, nTrainRows, nTestRows, nColumns,
+                                              nThreads);
+            break;
+        case daal::data_management::features::IndexNumType::DAAL_FLOAT32:
+            s |= splitRows<float, IdxType, cpu>(inputTable, trainTable, testTable, trainIdxTable, testIdxTable, nTrainRows, nTestRows, nColumns,
+                                                nThreads);
+            break;
+        case daal::data_management::features::IndexNumType::DAAL_FLOAT64:
+            s |= splitRows<double, IdxType, cpu>(inputTable, trainTable, testTable, trainIdxTable, testIdxTable, nTrainRows, nTestRows, nColumns,
+                                                 nThreads);
+            break;
         }
     }
     return s;
 }
 
 template <typename IdxType>
-DAAL_EXPORT void trainTestSplit(NumericTable & inputTable, NumericTable & trainTable, NumericTable & testTable,
-                                NumericTable & trainIdxTable, NumericTable & testIdxTable)
+DAAL_EXPORT void trainTestSplit(NumericTable & inputTable, NumericTable & trainTable, NumericTable & testTable, NumericTable & trainIdxTable,
+                                NumericTable & testIdxTable)
 {
 #define DAAL_TTS(cpuId, ...) trainTestSplitImpl<IdxType, cpuId>(__VA_ARGS__);
 

--- a/service/kernel/data_management/train_test_split.cpp
+++ b/service/kernel/data_management/train_test_split.cpp
@@ -1,0 +1,203 @@
+/** file train_test_split.cpp */
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "data_management/data/internal/train_test_split.h"
+#include "data_management/data/numeric_table.h"
+#include "services/env_detect.h"
+#include "service_dispatch.h"
+#include "service_data_utils.h"
+#include "threading.h"
+#include "service_numeric_table.h"
+
+namespace daal
+{
+namespace data_management
+{
+namespace internal
+{
+typedef daal::data_management::NumericTable::StorageLayout NTLayout;
+
+const size_t BLOCK_CONST = 10240;
+const size_t THREADING_BORDER = 12800000;
+
+template <typename Func>
+void runBlocks(const bool inParallel, const size_t nBlocks, Func func)
+{
+    if (inParallel)
+        daal::threader_for(nBlocks, nBlocks, [&](size_t i) { func(i); });
+    else
+        for (size_t i = 0; i < nBlocks; ++i) func(i);
+}
+
+template <typename DataType, typename IdxType>
+services::Status splitColumn(NumericTable & inputTable, NumericTable & trainTable, NumericTable & testTable,
+                             const IdxType * trainIdx, const IdxType * testIdx,
+                             const size_t nTrainRows, const size_t nTestRows, const size_t iCol)
+{
+    services::Status s;
+    BlockDescriptor<DataType> origBlock, trainBlock, testBlock;
+    inputTable.getBlockOfColumnValues(iCol, 0, nTrainRows + nTestRows, readOnly, origBlock);
+    trainTable.getBlockOfColumnValues(iCol, 0, nTrainRows, readWrite, trainBlock);
+    testTable.getBlockOfColumnValues(iCol, 0, nTestRows, readWrite, testBlock);
+    const DataType * origDataPtr = origBlock.getBlockPtr();
+    DataType * trainDataPtr = trainBlock.getBlockPtr();
+    DataType * testDataPtr = testBlock.getBlockPtr();
+    DAAL_CHECK_MALLOC(origDataPtr);
+    DAAL_CHECK_MALLOC(trainDataPtr);
+    DAAL_CHECK_MALLOC(testDataPtr);
+
+    const size_t BLOCK_SIZE = BLOCK_CONST;
+    const size_t nTrainBlocks = nTrainRows / BLOCK_SIZE ? nTrainRows / BLOCK_SIZE : 1;
+    const size_t nTestBlocks = nTestRows / BLOCK_SIZE ? nTestRows / BLOCK_SIZE : 1;
+    const int nTrainSurplus = nTrainRows / BLOCK_SIZE ? nTrainRows % BLOCK_SIZE : nTrainRows - BLOCK_SIZE;
+    const int nTestSurplus = nTestRows / BLOCK_SIZE ? nTestRows % BLOCK_SIZE : nTestRows - BLOCK_SIZE;
+
+    runBlocks(nTrainRows > THREADING_BORDER, nTrainBlocks, [&](size_t iBlock) {
+        const size_t start = iBlock * BLOCK_SIZE;
+        const size_t end   = iBlock == nTrainBlocks - 1 ? start + BLOCK_SIZE + nTrainSurplus : start + BLOCK_SIZE;
+
+        for (size_t i = start; i < end; ++i)
+            trainDataPtr[i] = origDataPtr[trainIdx[i]];
+    });
+
+    runBlocks(nTestRows > THREADING_BORDER, nTestBlocks, [&](size_t iBlock) {
+        const size_t start = iBlock * BLOCK_SIZE;
+        const size_t end   = iBlock == nTestBlocks - 1 ? start + BLOCK_SIZE + nTestSurplus : start + BLOCK_SIZE;
+
+        for (size_t i = start; i < end; ++i)
+            testDataPtr[i] = origDataPtr[testIdx[i]];
+    });
+
+    return s;
+}
+
+template <typename DataType, typename IdxType>
+services::Status splitRows(NumericTable & inputTable, NumericTable & trainTable, NumericTable & testTable,
+                           const IdxType * trainIdx, const IdxType * testIdx,
+                           const size_t nTrainRows, const size_t nTestRows, const size_t nColumns)
+{
+    services::Status s;
+    const size_t BLOCK_SIZE = BLOCK_CONST / nColumns ? BLOCK_CONST / nColumns : 1;
+    const size_t nTrainBlocks = nTrainRows / BLOCK_SIZE ? nTrainRows / BLOCK_SIZE : 1;
+    const size_t nTestBlocks = nTestRows / BLOCK_SIZE ? nTestRows / BLOCK_SIZE : 1;
+    const int nTrainSurplus = nTrainRows / BLOCK_SIZE ? nTrainRows % BLOCK_SIZE : nTrainRows - BLOCK_SIZE;
+    const int nTestSurplus = nTestRows / BLOCK_SIZE ? nTestRows % BLOCK_SIZE : nTestRows - BLOCK_SIZE;
+
+    BlockDescriptor<DataType> origBlock, trainBlock, testBlock;
+    inputTable.getBlockOfRows(0, nTrainRows + nTestRows, readOnly, origBlock);
+    trainTable.getBlockOfRows(0, nTrainRows, readWrite, trainBlock);
+    testTable.getBlockOfRows(0, nTestRows, readWrite, testBlock);
+    const DataType * origDataPtr = origBlock.getBlockPtr();
+    DataType * trainDataPtr = trainBlock.getBlockPtr();
+    DataType * testDataPtr = testBlock.getBlockPtr();
+    DAAL_CHECK_MALLOC(origDataPtr);
+    DAAL_CHECK_MALLOC(trainDataPtr);
+    DAAL_CHECK_MALLOC(testDataPtr);
+
+    runBlocks(nTrainRows * nColumns > THREADING_BORDER, nTrainBlocks, [&](size_t iBlock) {
+        const size_t start = iBlock * BLOCK_SIZE;
+        const size_t end   = iBlock == nTrainBlocks - 1 ? start + BLOCK_SIZE + nTrainSurplus : start + BLOCK_SIZE;
+
+        for (size_t i = start; i < end; ++i)
+            for (size_t j = 0; j < nColumns; ++j)
+                trainDataPtr[i * nColumns + j] = origDataPtr[trainIdx[i] * nColumns + j];
+    });
+
+    runBlocks(nTestRows * nColumns > THREADING_BORDER, nTestBlocks, [&](size_t iBlock) {
+        const size_t start = iBlock * BLOCK_SIZE;
+        const size_t end   = iBlock == nTestBlocks - 1 ? start + BLOCK_SIZE + nTestSurplus : start + BLOCK_SIZE;
+
+        for (size_t i = start; i < end; ++i)
+            for (size_t j = 0; j < nColumns; ++j)
+                testDataPtr[i * nColumns + j] = origDataPtr[testIdx[i] * nColumns + j];
+    });
+    return s;
+}
+
+
+template <typename IdxType>
+services::Status trainTestSplitImpl(NumericTable & inputTable, NumericTable & trainTable, NumericTable & testTable,
+                                    NumericTable & trainIdxTable, NumericTable & testIdxTable, NumericTable & columnTypesTable)
+{
+    services::Status s;
+    const NTLayout layout  = inputTable.getDataLayout();
+    const size_t nColumns = trainTable.getNumberOfColumns();
+    const size_t nTrainRows = trainTable.getNumberOfRows();
+    const size_t nTestRows = testTable.getNumberOfRows();
+    DAAL_OVERFLOW_CHECK_BY_MULTIPLICATION(size_t, nTrainRows + nTestRows, nColumns);
+
+    BlockDescriptor<int> columnTypesBlock;
+    columnTypesTable.getBlockOfRows(0, nColumns, readOnly, columnTypesBlock);
+    const int * columnTypesPtr = columnTypesBlock.getBlockPtr();
+    DAAL_CHECK_MALLOC(columnTypesPtr);
+
+    BlockDescriptor<IdxType> trainIdxBlock, testIdxBlock;
+    trainIdxTable.getBlockOfColumnValues(0, 0, nTrainRows, readOnly, trainIdxBlock);
+    testIdxTable.getBlockOfColumnValues(0, 0, nTestRows, readOnly, testIdxBlock);
+    const IdxType * trainIdx = trainIdxBlock.getBlockPtr();
+    const IdxType * testIdx = testIdxBlock.getBlockPtr();
+    DAAL_CHECK_MALLOC(trainIdx);
+    DAAL_CHECK_MALLOC(testIdx);
+
+    if (layout == NTLayout::soa)
+    {
+        runBlocks(nColumns > 1 && nColumns * (nTrainRows + nTestRows) > THREADING_BORDER, nColumns, [&](size_t iCol) {
+            switch (columnTypesPtr[iCol])
+            {
+                case 0:
+                    splitColumn<int, IdxType>(inputTable, trainTable, testTable, trainIdx, testIdx, nTrainRows, nTestRows, iCol);
+                    break;
+                case 1:
+                    splitColumn<float, IdxType>(inputTable, trainTable, testTable, trainIdx, testIdx, nTrainRows, nTestRows, iCol);
+                    break;
+                case 2:
+                    splitColumn<double, IdxType>(inputTable, trainTable, testTable, trainIdx, testIdx, nTrainRows, nTestRows, iCol);
+                    break;
+            }
+        });
+    }
+    else
+    {
+        switch (columnTypesPtr[0])
+        {
+            case 0:
+                splitRows<int, IdxType>(inputTable, trainTable, testTable, trainIdx, testIdx, nTrainRows, nTestRows, nColumns);
+                break;
+            case 1:
+                splitRows<float, IdxType>(inputTable, trainTable, testTable, trainIdx, testIdx, nTrainRows, nTestRows, nColumns);
+                break;
+            case 2:
+                splitRows<double, IdxType>(inputTable, trainTable, testTable, trainIdx, testIdx, nTrainRows, nTestRows, nColumns);
+                break;
+        }
+    }
+    return s;
+}
+
+template <typename IdxType>
+DAAL_EXPORT void trainTestSplit(NumericTable & inputTable, NumericTable & trainTable, NumericTable & testTable,
+                                NumericTable & trainIdxTable, NumericTable & testIdxTable, NumericTable & columnTypesTable)
+{
+    services::Status s = trainTestSplitImpl<IdxType>(inputTable, trainTable, testTable, trainIdxTable, testIdxTable, columnTypesTable);
+}
+
+template DAAL_EXPORT void trainTestSplit<int>(NumericTable & inputTable, NumericTable & trainTable, NumericTable & testTable,
+                                              NumericTable & trainIdxTable, NumericTable & testIdxTable, NumericTable & columnTypesTable);
+
+} // namespace internal
+} // namespace data_management
+} // namespace daal

--- a/service/kernel/data_management/train_test_split.cpp
+++ b/service/kernel/data_management/train_test_split.cpp
@@ -105,7 +105,7 @@ services::Status assignRows(const DataType * origDataPtr, const NumericTablePtr 
 {
     BlockDescriptor<DataType> dataBlock;
     BlockDescriptor<IdxType> idxBlock;
-    dataTable->getBlockOfRows(startRow, startRow + nRows, readWrite, dataBlock);
+    dataTable->getBlockOfRows(startRow, nRows, readWrite, dataBlock);
     idxTable->getBlockOfColumnValues(0, startRow, nRows, readOnly, idxBlock);
     DataType * dataPtr     = dataBlock.getBlockPtr();
     const IdxType * idxPtr = idxBlock.getBlockPtr();


### PR DESCRIPTION
# Description
Optimizations for [train_test_split function from scikit-learn](https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.train_test_split.html). Includes separate branches for SOA and AOS layouts.
[daal4py pull request](https://github.com/IntelPython/daal4py/pull/215)