### PR TITLE
Move definition of __int from makefile to defines

### DIFF
--- a/build/cmplr.clang.mk
+++ b/build/cmplr.clang.mk
@@ -28,9 +28,9 @@ CORE.SERV.COMPILER.clang = generic
 -Zl.clang =
 -DEBC.clang = -g
 
-COMPILER.mac.clang = clang++ -D__int64="long long" -D__int32="int" -m64 -fgnu-runtime -stdlib=libc++ -mmacosx-version-min=10.11 -fwrapv
-COMPILER.fbsd.clang = clang++ -D__int64="long long" -D__int32="int" $(if $(IA_is_ia32),-m32,-m64) -fgnu-runtime -Wno-inconsistent-missing-override -nostdinc++ -I/usr/include/c++/v1 -I/usr/local/include
-COMPILER.lnx.clang = clang++ -D__int64="long long" -D__int32="int" $(if $(IA_is_ia32),-m32,-m64)
+COMPILER.mac.clang = clang++ -m64 -fgnu-runtime -stdlib=libc++ -mmacosx-version-min=10.11 -fwrapv
+COMPILER.fbsd.clang = clang++ $(if $(IA_is_ia32),-m32,-m64) -fgnu-runtime -Wno-inconsistent-missing-override -nostdinc++ -I/usr/include/c++/v1 -I/usr/local/include
+COMPILER.lnx.clang = clang++ $(if $(IA_is_ia32),-m32,-m64)
 
 link.dynamic.mac.clang = clang++ -m64
 link.dynamic.fbsd.clang = clang++ $(if $(IA_is_ia32),-m32,-m64)

--- a/build/cmplr.gnu.mk
+++ b/build/cmplr.gnu.mk
@@ -27,7 +27,7 @@ CORE.SERV.COMPILER.gnu = generic
 -Zl.gnu =
 -DEBC.gnu = -g
 
-COMPILER.lnx.gnu =  ${CXX} -D__int64="long long" -D__int32="int" $(if $(IA_is_ia32),-m32,-m64) -fwrapv -fno-strict-overflow -fno-delete-null-pointer-checks
+COMPILER.lnx.gnu =  ${CXX} $(if $(IA_is_ia32),-m32,-m64) -fwrapv -fno-strict-overflow -fno-delete-null-pointer-checks
 
 link.dynamic.lnx.gnu = ${CXX} $(if $(IA_is_ia32),-m32,-m64)
 

--- a/include/services/daal_defines.h
+++ b/include/services/daal_defines.h
@@ -28,6 +28,11 @@
 
 #include <cstddef> // for size_t
 
+#if !(defined(_MSC_VER) || defined(__INTEL_COMPILER))
+    #define __int32 int
+    #define __int64 long long int
+#endif
+
 #if defined(_WIN32) || defined(_WIN64)
     #ifdef __DAAL_IMPLEMENTATION
         #define DAAL_EXPORT __declspec(dllexport)


### PR DESCRIPTION
This minor step towards preparation to new interface integration. The change is needed to **have more or less conformant build parameters for both interfaces**.

Testing: http://intel-ci.intel.com/ea95d390-ea3e-f188-bb5e-8cdcd4b723a1