### PR TITLE
[Beta 07]Fix for Random Forest deserialization in daal4py.

### DIFF
--- a/algorithms/kernel/dtrees/forest/classification/df_classification_model.cpp
+++ b/algorithms/kernel/dtrees/forest/classification/df_classification_model.cpp
@@ -288,14 +288,22 @@ void ModelImpl::traverseBFS(size_t iTree, tree_utils::classification::interface1
 services::Status ModelImpl::serializeImpl(data_management::InputDataArchive * arch)
 {
     auto s = daal::algorithms::classifier::Model::serialImpl<data_management::InputDataArchive, false>(arch);
-    return s.add(ImplType::serialImpl<data_management::InputDataArchive, false>(arch));
+    s.add(ImplType::serialImpl<data_management::InputDataArchive, false>(arch));
+    arch->set(daal::algorithms::classifier::internal::ModelInternal::_nFeatures);
+    return s;
 }
 
 services::Status ModelImpl::deserializeImpl(const data_management::OutputDataArchive * arch)
 {
-    auto s = daal::algorithms::classifier::Model::serialImpl<const data_management::OutputDataArchive, true>(arch);
-    return s.add(ImplType::serialImpl<const data_management::OutputDataArchive, true>(
-        arch, COMPUTE_DAAL_VERSION(arch->getMajorVersion(), arch->getMinorVersion(), arch->getUpdateVersion())));
+    auto s                = daal::algorithms::classifier::Model::serialImpl<const data_management::OutputDataArchive, true>(arch);
+    const int daalVersion = COMPUTE_DAAL_VERSION(arch->getMajorVersion(), arch->getMinorVersion(), arch->getUpdateVersion());
+    s.add(ImplType::serialImpl<const data_management::OutputDataArchive, true>(arch, daalVersion));
+    if ((daalVersion >= COMPUTE_DAAL_VERSION(2020, 0, 1)))
+    {
+        arch->set(daal::algorithms::classifier::internal::ModelInternal::_nFeatures);
+    }
+
+    return s;
 }
 
 bool ModelImpl::add(const TreeType & tree, size_t nClasses)

--- a/algorithms/kernel/dtrees/forest/classification/df_classification_predict_dense_default_batch_impl.i
+++ b/algorithms/kernel/dtrees/forest/classification/df_classification_predict_dense_default_batch_impl.i
@@ -813,14 +813,14 @@ Status PredictClassificationTask<float, avx512>::predictOneRowByAllTrees(size_t 
                 for (size_t i = 0; i < 16; ++i)
                 {
                     prob_ptr[iTree + i] = const_cast<double *>(_model->getProbas(iTree + i));
-                    prob_pd = _mm512_add_pd(prob_pd, _mm512_mask_load_pd(zero_pd, tail_mask, prob_ptr[iTree + i] + displaces[i] * _nClasses));
+                    prob_pd = _mm512_add_pd(prob_pd, _mm512_mask_loadu_pd(zero_pd, tail_mask, prob_ptr[iTree + i] + displaces[i] * _nClasses));
                 }
             }
             else
             {
                 for (size_t i = 0; i < 16; ++i)
                 {
-                    prob_pd = _mm512_add_pd(prob_pd, _mm512_mask_load_pd(zero_pd, tail_mask, prob_ptr[iTree + i] + displaces[i] * _nClasses));
+                    prob_pd = _mm512_add_pd(prob_pd, _mm512_mask_loadu_pd(zero_pd, tail_mask, prob_ptr[iTree + i] + displaces[i] * _nClasses));
                 }
             }
         }
@@ -839,16 +839,16 @@ Status PredictClassificationTask<float, avx512>::predictOneRowByAllTrees(size_t 
             {
                 for (size_t i = 0; i < 16; ++i)
                 {
-                    prob_pd = _mm512_add_pd(prob_pd, _mm512_load_pd(prob_ptr[iTree + i] + displaces[i] * _nClasses + iBlock * 8));
+                    prob_pd = _mm512_add_pd(prob_pd, _mm512_loadu_pd(prob_ptr[iTree + i] + displaces[i] * _nClasses + iBlock * 8));
                 }
-                _mm512_store_pd(prob_d + iBlock * 8, _mm512_add_pd(prob_pd, _mm512_mask_load_pd(zero_pd, tail_mask, prob_d + iBlock * 8)));
+                _mm512_store_pd(prob_d + iBlock * 8, _mm512_add_pd(prob_pd, _mm512_load_pd(prob_d + iBlock * 8)));
                 prob_pd = _mm512_set1_pd(0);
             }
             if (tailSize != 0)
             {
-                for (size_t i = 0; i < 16; i++)
+                for (size_t i = 0; i < 16; ++i)
                     prob_pd =
-                        _mm512_add_pd(prob_pd, _mm512_mask_load_pd(zero_pd, tail_mask, prob_ptr[iTree + i] + displaces[i] * _nClasses + iBlock * 8));
+                        _mm512_add_pd(prob_pd, _mm512_mask_loadu_pd(zero_pd, tail_mask, prob_ptr[iTree + i] + displaces[i] * _nClasses + iBlock * 8));
                 _mm512_mask_store_pd(prob_d + iBlock * 8, tail_mask,
                                      _mm512_add_pd(prob_pd, _mm512_mask_load_pd(zero_pd, tail_mask, prob_d + iBlock * 8)));
                 prob_pd = _mm512_set1_pd(0);


### PR DESCRIPTION
There is difference between master and rls/daal-2020-mnt branches which leads to failing serialization tests in daal4py. https://github.com/oneapi-src/oneDAL/pull/603

* merge difference with mnt branch

* Fix for 32bit ssystem: without aligned memory support (#376)

Co-authored-by: ShvetsKS <33296480+ShvetsKS@users.noreply.github.com>