### PR TITLE
Added RF classifier for GPU

### DIFF
--- a/algorithms/kernel/dtrees/forest/classification/df_classification_predict_dense_default_batch_fpt_dispatcher.cpp
+++ b/algorithms/kernel/dtrees/forest/classification/df_classification_predict_dense_default_batch_fpt_dispatcher.cpp
@@ -29,7 +29,7 @@ namespace daal
 {
 namespace algorithms
 {
-__DAAL_INSTANTIATE_DISPATCH_CONTAINER(decision_forest::classification::prediction::BatchContainer, batch, DAAL_FPTYPE,
+__DAAL_INSTANTIATE_DISPATCH_CONTAINER_SYCL(decision_forest::classification::prediction::BatchContainer, batch, DAAL_FPTYPE,
                                       decision_forest::classification::prediction::defaultDense)
 namespace decision_forest
 {

--- a/algorithms/kernel/dtrees/forest/classification/df_classification_predict_dense_default_batch_fpt_dispatcher.cpp
+++ b/algorithms/kernel/dtrees/forest/classification/df_classification_predict_dense_default_batch_fpt_dispatcher.cpp
@@ -30,7 +30,7 @@ namespace daal
 namespace algorithms
 {
 __DAAL_INSTANTIATE_DISPATCH_CONTAINER_SYCL(decision_forest::classification::prediction::BatchContainer, batch, DAAL_FPTYPE,
-                                      decision_forest::classification::prediction::defaultDense)
+                                           decision_forest::classification::prediction::defaultDense)
 namespace decision_forest
 {
 namespace classification

--- a/algorithms/kernel/dtrees/forest/classification/df_classification_train_dense_default_impl.i
+++ b/algorithms/kernel/dtrees/forest/classification/df_classification_train_dense_default_impl.i
@@ -27,6 +27,7 @@
 
 #include "algorithms/kernel/dtrees/forest/df_train_dense_default_impl.i"
 #include "algorithms/kernel/dtrees/forest/classification/df_classification_train_kernel.h"
+#include "algorithms/kernel/dtrees/forest/classification/df_classification_train_dense_default_kernel.h"
 #include "algorithms/kernel/dtrees/forest/classification/df_classification_model_impl.h"
 #include "algorithms/kernel/dtrees/dtrees_predict_dense_default_impl.i"
 #include "algorithms/kernel/dtrees/forest/classification/df_classification_training_types_result.h"
@@ -776,8 +777,8 @@ public:
 //////////////////////////////////////////////////////////////////////////////////////////
 // ClassificationTrainBatchKernel
 //////////////////////////////////////////////////////////////////////////////////////////
-template <typename algorithmFPType, Method method, CpuType cpu>
-services::Status ClassificationTrainBatchKernel<algorithmFPType, method, cpu>::compute(
+template <typename algorithmFPType, CpuType cpu>
+services::Status ClassificationTrainBatchKernel<algorithmFPType, defaultDense, cpu>::compute(
     HostAppIface * pHostApp, const NumericTable * x, const NumericTable * y, decision_forest::classification::Model & m, Result & res,
     const decision_forest::classification::training::interface1::Parameter & par)
 {
@@ -797,14 +798,14 @@ services::Status ClassificationTrainBatchKernel<algorithmFPType, method, cpu>::c
     return compute(pHostApp, x, y, m, res, tmpPar);
 }
 
-template <typename algorithmFPType, Method method, CpuType cpu>
-services::Status ClassificationTrainBatchKernel<algorithmFPType, method, cpu>::compute(
+template <typename algorithmFPType, CpuType cpu>
+services::Status ClassificationTrainBatchKernel<algorithmFPType, defaultDense, cpu>::compute(
     HostAppIface * pHostApp, const NumericTable * x, const NumericTable * y, decision_forest::classification::Model & m, Result & res,
     const decision_forest::classification::training::Parameter & par)
 {
     ResultData rd(par, res.get(variableImportance).get(), res.get(outOfBagError).get(), res.get(outOfBagErrorPerObservation).get());
     services::Status s = computeImpl<algorithmFPType, cpu, daal::algorithms::decision_forest::classification::internal::ModelImpl,
-                                     TrainBatchTask<algorithmFPType, method, cpu> >(
+                                     TrainBatchTask<algorithmFPType, defaultDense, cpu> >(
         pHostApp, x, y, *static_cast<daal::algorithms::decision_forest::classification::internal::ModelImpl *>(&m), rd, par, par.nClasses);
     if (s.ok()) res.impl()->setEngine(rd.updatedEngine);
     return s;

--- a/algorithms/kernel/dtrees/forest/classification/df_classification_train_dense_default_kernel.h
+++ b/algorithms/kernel/dtrees/forest/classification/df_classification_train_dense_default_kernel.h
@@ -1,6 +1,6 @@
-/* file: df_classification_train_kernel.h */
+/* file: df_classification_train_dense_default_kernel.h */
 /*******************************************************************************
-* Copyright 2014-2020 Intel Corporation
+* Copyright 2020 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -22,12 +22,12 @@
 //--
 */
 
-#ifndef __DF_CLASSFICATION_TRAIN_KERNEL_H__
-#define __DF_CLASSFICATION_TRAIN_KERNEL_H__
+#ifndef __DF_CLASSIFICATION_TRAIN_DENSE_DEFAULT_KERNEL_H__
+#define __DF_CLASSIFICATION_TRAIN_DENSE_DEFAULT_KERNEL_H__
 
 #include "data_management/data/numeric_table.h"
 #include "algorithms/algorithm_base_common.h"
-#include "algorithms/decision_forest/decision_forest_training_parameter.h"
+#include "algorithms/decision_forest/decision_forest_classification_training_types.h"
 
 using namespace daal::data_management;
 using namespace daal::services;
@@ -44,20 +44,14 @@ namespace training
 {
 namespace internal
 {
-template <typename algorithmFPType, Method method, CpuType cpu>
-class ClassificationTrainBatchKernel : public daal::algorithms::Kernel
+template <typename algorithmFPType, CpuType cpu>
+class ClassificationTrainBatchKernel<algorithmFPType, defaultDense, cpu> : public daal::algorithms::Kernel
 {
 public:
     services::Status compute(HostAppIface * pHostApp, const NumericTable * x, const NumericTable * y, decision_forest::classification::Model & m,
-                             Result & res, const decision_forest::classification::training::interface1::Parameter & par)
-    {
-        return services::ErrorMethodNotImplemented;
-    }
+                             Result & res, const decision_forest::classification::training::interface1::Parameter & par);
     services::Status compute(HostAppIface * pHostApp, const NumericTable * x, const NumericTable * y, decision_forest::classification::Model & m,
-                             Result & res, const decision_forest::classification::training::Parameter & par)
-    {
-        return services::ErrorMethodNotImplemented;
-    }
+                             Result & res, const Parameter & par);
 };
 
 } // namespace internal

--- a/algorithms/kernel/dtrees/forest/classification/df_classification_train_hist_batch_fpt_cpu.cpp
+++ b/algorithms/kernel/dtrees/forest/classification/df_classification_train_hist_batch_fpt_cpu.cpp
@@ -1,0 +1,50 @@
+/* file: df_classification_train_hist_batch_fpt_cpu.cpp */
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+/*
+//++
+//  Implementation of decision forest classification training functions for the hist method
+//--
+*/
+
+#include "algorithms/kernel/dtrees/forest/classification/df_classification_train_container.h"
+#include "algorithms/kernel/dtrees/forest/classification/df_classification_train_kernel.h"
+
+namespace daal
+{
+namespace algorithms
+{
+namespace decision_forest
+{
+namespace classification
+{
+namespace training
+{
+namespace interface2
+{
+template class BatchContainer<DAAL_FPTYPE, hist, DAAL_CPU>;
+}
+namespace internal
+{
+template class ClassificationTrainBatchKernel<DAAL_FPTYPE, hist, DAAL_CPU>;
+}
+
+} // namespace training
+} // namespace classification
+} // namespace decision_forest
+} // namespace algorithms
+} // namespace daal

--- a/algorithms/kernel/dtrees/forest/classification/df_classification_train_hist_batch_fpt_dispatcher.cpp
+++ b/algorithms/kernel/dtrees/forest/classification/df_classification_train_hist_batch_fpt_dispatcher.cpp
@@ -1,0 +1,58 @@
+/* file: df_classification_train_hist_batch_fpt_dispatcher.cpp */
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+/*
+//++
+//  Implementation of decision forest container for the hist method.
+//--
+*/
+
+#include "algorithms/kernel/dtrees/forest/classification/df_classification_train_container.h"
+#include "service/kernel/daal_strings.h"
+
+namespace daal
+{
+namespace algorithms
+{
+__DAAL_INSTANTIATE_DISPATCH_CONTAINER_SYCL(decision_forest::classification::training::BatchContainer, batch, DAAL_FPTYPE,
+                                           decision_forest::classification::training::hist)
+namespace decision_forest
+{
+namespace classification
+{
+namespace training
+{
+namespace interface2
+{
+template <>
+DAAL_EXPORT services::Status Batch<DAAL_FPTYPE, decision_forest::classification::training::hist>::checkComputeParams()
+{
+    services::Status s = classifier::training::Batch::checkComputeParams();
+    if (!s) return s;
+    const auto x         = input.get(classifier::training::data);
+    const auto nFeatures = x->getNumberOfColumns();
+    DAAL_CHECK_EX(parameter.featuresPerNode <= nFeatures, services::ErrorIncorrectParameter, services::ParameterName, featuresPerNodeStr());
+    const size_t nSamplesPerTree(parameter.observationsPerTreeFraction * x->getNumberOfRows());
+    DAAL_CHECK_EX(nSamplesPerTree > 0, services::ErrorIncorrectParameter, services::ParameterName, observationsPerTreeFractionStr());
+    return s;
+}
+} // namespace interface2
+} // namespace training
+} // namespace classification
+} // namespace decision_forest
+} // namespace algorithms
+} // namespace daal

--- a/algorithms/kernel/dtrees/forest/classification/df_classification_train_hist_batch_oneapi_fpt.cpp
+++ b/algorithms/kernel/dtrees/forest/classification/df_classification_train_hist_batch_oneapi_fpt.cpp
@@ -1,0 +1,46 @@
+/* file: df_classification_train_hist_batch_oneapi_fpt.cpp */
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+/*
+//++
+//  Implementation of decision forest classification training functions for the hist method
+//--
+*/
+
+#include "algorithms/kernel/dtrees/forest/classification/oneapi/df_classification_train_hist_kernel_oneapi.h"
+#include "algorithms/kernel/dtrees/forest/classification/oneapi/df_classification_train_hist_oneapi_impl.i"
+
+namespace daal
+{
+namespace algorithms
+{
+namespace decision_forest
+{
+namespace classification
+{
+namespace training
+{
+namespace internal
+{
+template class ClassificationTrainBatchKernelOneAPI<DAAL_FPTYPE, hist>;
+}
+
+} // namespace training
+} // namespace classification
+} // namespace decision_forest
+} // namespace algorithms
+} // namespace daal

--- a/algorithms/kernel/dtrees/forest/classification/oneapi/cl_kernels/df_batch_classification_kernels.cl
+++ b/algorithms/kernel/dtrees/forest/classification/oneapi/cl_kernels/df_batch_classification_kernels.cl
@@ -1,0 +1,578 @@
+/* file: df_batch_classification_kernels.cl */
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+/*
+//++
+//  Implementation of decision forest Batch classification OpenCL kernels.
+//--
+*/
+
+#ifndef __DF_BATCH_CLASSIFICATION_KERNELS_CL__
+#define __DF_BATCH_CLASSIFICATION_KERNELS_CL__
+
+#include <string.h>
+
+#define DECLARE_SOURCE(name, src) static const char * name = #src;
+
+DECLARE_SOURCE(
+    df_batch_classification_kernels,
+
+    inline int fpEq(algorithmFPType a, algorithmFPType b) {
+        return (int)(fabs(a - b) <= algorithmFPTypeAccuracy);
+    } inline int fpGt(algorithmFPType a, algorithmFPType b) { return (int)((a - b) > algorithmFPTypeAccuracy); }
+
+    __kernel void initializeTreeOrder(__global int * treeOrder) {
+        const int id  = get_global_id(0);
+        treeOrder[id] = id;
+    }
+
+    __kernel void computeBestSplitSinglePass(const __global int * data, const __global int * treeOrder, const __global int * selectedFeatures,
+                                             int nSelectedFeatures, const __global algorithmFPType * response, const __global int * binOffsets,
+                                             __global int * nodeList, const __global int * nodeIndices, int nodeIndicesOffset,
+                                             __global algorithmFPType * splitInfo, __global algorithmFPType * nodeImpDecreaseList,
+                                             int updateImpDecreaseRequired, int nFeatures, int minObservationsInLeafNode,
+                                             algorithmFPType impurityThreshold) {
+        // this kernel is targeted for processing nodes with small number of rows
+        // nodeList will be updated with split attributes
+        // spliInfo will contain node impurity and mean
+        const int nProp     = HIST_PROPS;                  // num of classes (i.e. classes)
+        const int nNodeProp = NODE_PROPS;                  // num of node properties in nodeList
+        const int nImpProp  = IMPURITY_PROPS + HIST_PROPS; // impurity + node classes histogram
+        const int leafMark  = -1;
+
+        const int local_id           = get_local_id(0);
+        const int sub_group_local_id = get_sub_group_local_id();
+        const int sub_group_size     = get_sub_group_size();
+        const int local_size         = get_local_size(0);
+        const int n_sub_groups       = local_size / sub_group_size; // num of subgroups for current node processing
+        const int sub_group_id       = local_id / sub_group_size;
+        const int max_sub_groups_num = 16; //replace with define
+
+        const int bufIdx  = get_global_id(1) % (max_sub_groups_num / n_sub_groups); // local buffer is shared between 16 sub groups
+        const int nodeIdx = get_global_id(1);
+        const int nodeId  = nodeIndices[nodeIndicesOffset + nodeIdx];
+
+        const int rowsOffset = nodeList[nodeId * nNodeProp + 0];
+        const int nRows      = nodeList[nodeId * nNodeProp + 1];
+
+        // each sub group will process 16 bins and produce 1 best split for it
+        // expect maximum 16 subgroups only for each node
+        const int maxBinsBlocks = 16;
+        __local algorithmFPType bufI[maxBinsBlocks]; // storage for impurity decrease
+        __local int bufS[maxBinsBlocks * nNodeProp]; // storage for split info
+
+        const algorithmFPType minImpDec = (algorithmFPType)-1e30;
+        const int valNotFound           = 1 << 30;
+
+        algorithmFPType curImpDec = minImpDec;
+        int curFeatureValue       = leafMark;
+        int curFeatureId          = leafMark;
+
+        nodeList[nodeId * nNodeProp + 2] = curFeatureId;
+        nodeList[nodeId * nNodeProp + 3] = curFeatureValue;
+        nodeList[nodeId * nNodeProp + 4] = nRows;
+
+        algorithmFPType mrgN = (algorithmFPType)nRows;
+
+        algorithmFPType bestLN = (algorithmFPType)0;
+
+        algorithmFPType mrgCls[nProp] = { (algorithmFPType)0 };
+
+        algorithmFPType imp = (algorithmFPType)1;
+
+        int totalBins = 0;
+
+        // totalBins is calculated by each subgroup
+        for (int featIdx = sub_group_local_id; featIdx < nSelectedFeatures; featIdx += sub_group_size)
+        {
+            int featId = selectedFeatures[nodeId * nSelectedFeatures + featIdx];
+            int nBins  = binOffsets[featId + 1] - binOffsets[featId];
+            totalBins += sub_group_reduce_add(nBins);
+        }
+        totalBins = sub_group_broadcast(totalBins, 0);
+
+        int currFtrIdx  = 0;
+        int featId      = selectedFeatures[nodeId * nSelectedFeatures + currFtrIdx];
+        int binId       = 0;
+        int currFtrBins = binOffsets[featId + 1] - binOffsets[featId];
+        int passedBins  = 0;
+
+        for (int i = local_id; i < totalBins; i += local_size)
+        {
+            while (i >= passedBins + currFtrBins)
+            {
+                passedBins += currFtrBins;
+                currFtrIdx++;
+                featId      = selectedFeatures[nodeId * nSelectedFeatures + currFtrIdx];
+                currFtrBins = binOffsets[featId + 1] - binOffsets[featId];
+            }
+            binId = i - passedBins;
+
+            algorithmFPType mrgLRN[2]           = { (algorithmFPType)0 };
+            algorithmFPType mrgLRCls[nProp * 2] = { (algorithmFPType)0 };
+
+            // calculating classes histogram
+            for (int row = 0; row < nRows; row++)
+            {
+                int id      = treeOrder[rowsOffset + row];
+                int bin     = data[id * nFeatures + featId];
+                int classId = (int)response[id];
+                mrgLRN[(int)(bin > binId)] += (algorithmFPType)1;
+                mrgLRCls[nProp * (int)(bin > binId) + classId] += (algorithmFPType)1;
+            }
+
+            imp                  = (algorithmFPType)1;
+            algorithmFPType impL = (algorithmFPType)1;
+            algorithmFPType impR = (algorithmFPType)1;
+            algorithmFPType div  = (algorithmFPType)1 / (mrgN * mrgN);
+            algorithmFPType divL = ((algorithmFPType)0 < mrgLRN[0]) ? (algorithmFPType)1 / (mrgLRN[0] * mrgLRN[0]) : (algorithmFPType)0;
+            algorithmFPType divR = ((algorithmFPType)0 < mrgLRN[1]) ? (algorithmFPType)1 / (mrgLRN[1] * mrgLRN[1]) : (algorithmFPType)0;
+
+            for (int prop = 0; prop < nProp; prop++)
+            {
+                impL -= mrgLRCls[prop] * mrgLRCls[prop] * divL;
+                impR -= mrgLRCls[nProp + prop] * mrgLRCls[nProp + prop] * divR;
+                mrgCls[prop] = mrgLRCls[prop] + mrgLRCls[nProp + prop];
+                imp -= mrgCls[prop] * mrgCls[prop] * div;
+            }
+            impL = (algorithmFPType)0 < impL ? impL : (algorithmFPType)0;
+            impR = (algorithmFPType)0 < impR ? impR : (algorithmFPType)0;
+            imp  = (algorithmFPType)0 < imp ? imp : (algorithmFPType)0;
+
+            algorithmFPType impDec = imp - (mrgLRN[0] * impL + mrgLRN[1] * impR) / mrgN;
+
+            if ((algorithmFPType)0 < impDec && (!fpEq(imp, (algorithmFPType)0)) && imp >= impurityThreshold
+                && (curFeatureValue == leafMark || fpGt(impDec, curImpDec) || (fpEq(impDec, curImpDec) && featId < curFeatureId))
+                && mrgLRN[0] >= minObservationsInLeafNode && mrgLRN[1] >= minObservationsInLeafNode)
+            {
+                curFeatureId    = featId;
+                curFeatureValue = binId;
+                curImpDec       = impDec;
+
+                bestLN = mrgLRN[0];
+            }
+        } // for i
+
+        algorithmFPType bestImpDec = sub_group_reduce_max(curImpDec);
+
+        int impDecIsBest     = fpEq(bestImpDec, curImpDec);
+        int bestFeatureId    = sub_group_reduce_min(impDecIsBest ? curFeatureId : valNotFound);
+        int bestFeatureValue = sub_group_reduce_min((bestFeatureId == curFeatureId && impDecIsBest) ? curFeatureValue : valNotFound);
+
+        bool noneSplitFoundBySubGroup = ((leafMark == bestFeatureId) && (0 == sub_group_local_id));
+        bool mySplitIsBest            = (leafMark != bestFeatureId && curFeatureId == bestFeatureId && curFeatureValue == bestFeatureValue);
+        if (noneSplitFoundBySubGroup || mySplitIsBest)
+        {
+            if (1 == n_sub_groups)
+            {
+                __global algorithmFPType * splitNodeInfo = splitInfo + nodeId * nImpProp;
+                __global algorithmFPType * nodeHistInfo  = splitInfo + nodeId * nImpProp + IMPURITY_PROPS;
+                splitNodeInfo[0]                         = imp;
+                algorithmFPType maxVal                   = (algorithmFPType)0;
+                int maxInd                               = 0;
+                for (int i = 0; i < nProp; i++)
+                {
+                    nodeHistInfo[i] = mrgCls[i];
+                    if (mrgCls[i] > maxVal)
+                    {
+                        maxVal = mrgCls[i];
+                        maxInd = i;
+                    }
+                }
+
+                nodeList[nodeId * nNodeProp + 2] = curFeatureId == valNotFound ? leafMark : curFeatureId;
+                nodeList[nodeId * nNodeProp + 3] = curFeatureValue == valNotFound ? leafMark : curFeatureValue;
+                nodeList[nodeId * nNodeProp + 4] = (int)bestLN;
+                nodeList[nodeId * nNodeProp + 5] = maxInd;
+
+                if (updateImpDecreaseRequired) nodeImpDecreaseList[nodeId] = bestImpDec;
+            }
+            else
+            {
+                bufS[(bufIdx + sub_group_id) * nNodeProp + 0] = curFeatureId;
+                bufS[(bufIdx + sub_group_id) * nNodeProp + 1] = curFeatureValue;
+                bufS[(bufIdx + sub_group_id) * nNodeProp + 2] = (int)bestLN;
+
+                bufI[bufIdx + sub_group_id] = curImpDec;
+            }
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+        if (1 < n_sub_groups && 0 == sub_group_id)
+        {
+            // first sub group for current node reduces over local buffer if required
+            algorithmFPType curImpDec = (sub_group_local_id < n_sub_groups) ? bufI[bufIdx + sub_group_local_id] : minImpDec;
+
+            int curFeatureId    = sub_group_local_id < n_sub_groups ? bufS[(bufIdx + sub_group_local_id) * nNodeProp + 0] : valNotFound;
+            int curFeatureValue = sub_group_local_id < n_sub_groups ? bufS[(bufIdx + sub_group_local_id) * nNodeProp + 1] : valNotFound;
+            int LN              = sub_group_local_id < n_sub_groups ? bufS[(bufIdx + sub_group_local_id) * nNodeProp + 2] : 0;
+
+            algorithmFPType bestImpDec = sub_group_reduce_max(curImpDec);
+
+            int impDecIsBest     = fpEq(bestImpDec, curImpDec);
+            int bestFeatureId    = sub_group_reduce_min(impDecIsBest ? curFeatureId : valNotFound);
+            int bestFeatureValue = sub_group_reduce_min((bestFeatureId == curFeatureId && impDecIsBest) ? curFeatureValue : valNotFound);
+
+            bool noneSplitFoundBySubGroup = ((leafMark == bestFeatureId) && (0 == sub_group_local_id));
+            bool mySplitIsBest            = (leafMark != bestFeatureId && curFeatureId == bestFeatureId && curFeatureValue == bestFeatureValue);
+            if (noneSplitFoundBySubGroup || mySplitIsBest)
+            {
+                __global algorithmFPType * splitNodeInfo = splitInfo + nodeId * nImpProp;
+                __global algorithmFPType * nodeHistInfo  = splitInfo + nodeId * nImpProp + IMPURITY_PROPS;
+                splitNodeInfo[0]                         = imp;
+                algorithmFPType maxVal                   = (algorithmFPType)0;
+                int maxInd                               = 0;
+                for (int i = 0; i < nProp; i++)
+                {
+                    nodeHistInfo[i] = mrgCls[i];
+                    if (mrgCls[i] > maxVal)
+                    {
+                        maxVal = mrgCls[i];
+                        maxInd = i;
+                    }
+                }
+
+                nodeList[nodeId * nNodeProp + 2] = curFeatureId == valNotFound ? leafMark : curFeatureId;
+                nodeList[nodeId * nNodeProp + 3] = curFeatureValue == valNotFound ? leafMark : curFeatureValue;
+                nodeList[nodeId * nNodeProp + 4] = (int)LN;
+                nodeList[nodeId * nNodeProp + 5] = maxInd;
+
+                if (updateImpDecreaseRequired) nodeImpDecreaseList[nodeId] = bestImpDec;
+            }
+        }
+    }
+
+    __kernel void computeBestSplitByHistogram(const __global algorithmFPType * histograms, const __global int * selectedFeatures,
+                                              int nSelectedFeatures, const __global int * binOffsets, __global int * nodeList,
+                                              const __global int * nodeIndices, int nodeIndicesOffset, __global algorithmFPType * splitInfo,
+                                              __global algorithmFPType * nodeImpDecreaseList, int updateImpDecreaseRequired, int nMaxBinsAmongFtrs,
+                                              int minObservationsInLeafNode, algorithmFPType impurityThreshold) {
+        // this kernel has almost the same code as computeBestSplitSinglePass
+        // the difference is that here for each potential split point we pass through bins hist instead of rows
+        // nodeList will be updated with split attributes in this kernel
+        // spliInfo will contain node impurity and mean
+        const int nProp              = HIST_PROPS;                  // classes histogram
+        const int nNodeProp          = NODE_PROPS;                  // num of node properties in nodeList
+        const int nImpProp           = IMPURITY_PROPS + HIST_PROPS; // impurity + node classes histogram
+        const int local_id           = get_local_id(0);
+        const int sub_group_local_id = get_sub_group_local_id();
+        const int sub_group_size     = get_sub_group_size();
+        const int nodeIdx            = get_global_id(1);
+        const int nodeId             = nodeIndices[nodeIndicesOffset + nodeIdx];
+        const int leafMark           = -1;
+
+        const int local_size         = get_local_size(0);
+        const int n_sub_groups       = local_size / sub_group_size; // num of subgroups for current node processing
+        const int sub_group_id       = local_id / sub_group_size;
+        const int max_sub_groups_num = 16;                                                     //replace with define
+        const int bufIdx             = get_global_id(1) % (max_sub_groups_num / n_sub_groups); // local buffer is shared between 16 sub groups
+
+        const int rowsOffset = nodeList[nodeId * nNodeProp + 0];
+        const int nRows      = nodeList[nodeId * nNodeProp + 1];
+
+        // each sub group will process 16 bins and produce 1 best split for it
+        // expect maximum 16 subgroups only for each node
+        const int maxBinsBlocks = 16;
+        __local algorithmFPType bufI[maxBinsBlocks]; // storage for impurity decrease
+        __local int bufS[maxBinsBlocks * nNodeProp]; // storage for split info
+
+        int valNotFound     = 1 << 30;
+        int curFeatureValue = leafMark;
+        int curFeatureId    = leafMark;
+
+        const algorithmFPType minImpDec = (algorithmFPType)-1e30;
+        algorithmFPType curImpDec       = minImpDec;
+
+        nodeList[nodeId * nNodeProp + 2] = curFeatureId;
+        nodeList[nodeId * nNodeProp + 3] = curFeatureValue;
+        nodeList[nodeId * nNodeProp + 4] = nRows;
+
+        algorithmFPType mrgN = (algorithmFPType)nRows;
+
+        algorithmFPType mrgLN = (algorithmFPType)0;
+
+        algorithmFPType bestLN        = (algorithmFPType)0;
+        algorithmFPType mrgCls[nProp] = { (algorithmFPType)0 };
+
+        algorithmFPType imp = (algorithmFPType)1;
+
+        int totalBins = 0;
+
+        // totalBins is calculated by each subgroup
+        for (int featIdx = sub_group_local_id; featIdx < nSelectedFeatures; featIdx += sub_group_size)
+        {
+            int featId = selectedFeatures[nodeId * nSelectedFeatures + featIdx];
+            int nBins  = binOffsets[featId + 1] - binOffsets[featId];
+            totalBins += sub_group_reduce_add(nBins);
+        }
+
+        totalBins = sub_group_broadcast(totalBins, 0);
+
+        int currFtrIdx  = 0;
+        int featId      = selectedFeatures[nodeId * nSelectedFeatures + currFtrIdx];
+        int binId       = 0;
+        int currFtrBins = binOffsets[featId + 1] - binOffsets[featId];
+        int passedBins  = 0;
+
+        for (int i = local_id; i < totalBins; i += local_size)
+        {
+            while (i >= passedBins + currFtrBins)
+            {
+                passedBins += currFtrBins;
+                currFtrIdx++;
+                featId      = selectedFeatures[nodeId * nSelectedFeatures + currFtrIdx];
+                currFtrBins = binOffsets[featId + 1] - binOffsets[featId];
+            }
+            binId = i - passedBins;
+
+            const __global algorithmFPType * nodeHistogram       = histograms + nodeIdx * nSelectedFeatures * nMaxBinsAmongFtrs * nProp;
+            const __global algorithmFPType * histogramForFeature = nodeHistogram + currFtrIdx * nMaxBinsAmongFtrs * nProp;
+
+            // calculate merged statistics
+
+            algorithmFPType mrgLRN[2]           = { (algorithmFPType)0 };
+            algorithmFPType mrgLRCls[nProp * 2] = { (algorithmFPType)0 };
+
+            for (int tbin = 0; tbin < currFtrBins; tbin++)
+            {
+                int binOffset = tbin * nProp;
+                for (int prop = 0; prop < nProp; prop++)
+                {
+                    mrgCls[prop] += histogramForFeature[binOffset + prop];
+
+                    mrgLRN[(int)(tbin > binId)] += histogramForFeature[binOffset + prop];
+                    mrgLRCls[nProp * (int)(tbin > binId) + prop] += histogramForFeature[binOffset + prop];
+                }
+            }
+
+            imp                  = (algorithmFPType)1;
+            algorithmFPType impL = (algorithmFPType)1;
+            algorithmFPType impR = (algorithmFPType)1;
+            algorithmFPType div  = (algorithmFPType)1 / (mrgN * mrgN);
+            algorithmFPType divL = ((algorithmFPType)0 < mrgLRN[0]) ? (algorithmFPType)1 / (mrgLRN[0] * mrgLRN[0]) : (algorithmFPType)0;
+            algorithmFPType divR = ((algorithmFPType)0 < mrgLRN[1]) ? (algorithmFPType)1 / (mrgLRN[1] * mrgLRN[1]) : (algorithmFPType)0;
+
+            for (int prop = 0; prop < nProp; prop++)
+            {
+                impL -= mrgLRCls[prop] * mrgLRCls[prop] * divL;
+                impR -= mrgLRCls[nProp + prop] * mrgLRCls[nProp + prop] * divR;
+                mrgCls[prop] = mrgLRCls[prop] + mrgLRCls[nProp + prop];
+                imp -= mrgCls[prop] * mrgCls[prop] * div;
+            }
+            impL = (algorithmFPType)0 < impL ? impL : (algorithmFPType)0;
+            impR = (algorithmFPType)0 < impR ? impR : (algorithmFPType)0;
+            imp  = (algorithmFPType)0 < imp ? imp : (algorithmFPType)0;
+
+            algorithmFPType impDec = imp - (mrgLRN[0] * impL + mrgLRN[1] * impR) / mrgN;
+
+            if ((algorithmFPType)0 < impDec && !fpEq(imp, (algorithmFPType)0) && imp >= impurityThreshold
+                && (curFeatureValue == leafMark || fpGt(impDec, curImpDec) || (fpEq(impDec, curImpDec) && featId < curFeatureId))
+                && mrgLRN[0] >= minObservationsInLeafNode && mrgLRN[1] >= minObservationsInLeafNode)
+            {
+                curFeatureId    = featId;
+                curFeatureValue = binId;
+                curImpDec       = impDec;
+
+                bestLN = mrgLRN[0];
+            }
+        } // for i
+
+        algorithmFPType bestImpDec = sub_group_reduce_max(curImpDec);
+
+        int impDecIsBest     = fpEq(bestImpDec, curImpDec);
+        int bestFeatureId    = sub_group_reduce_min(impDecIsBest ? curFeatureId : valNotFound);
+        int bestFeatureValue = sub_group_reduce_min((bestFeatureId == curFeatureId && impDecIsBest) ? curFeatureValue : valNotFound);
+
+        bool noneSplitFoundBySubGroup = ((leafMark == bestFeatureId) && (0 == sub_group_local_id));
+        bool mySplitIsBest            = (leafMark != bestFeatureId && curFeatureId == bestFeatureId && curFeatureValue == bestFeatureValue);
+        if (noneSplitFoundBySubGroup || mySplitIsBest)
+        {
+            if (1 == n_sub_groups)
+            {
+                __global algorithmFPType * splitNodeInfo = splitInfo + nodeId * nImpProp;
+                __global algorithmFPType * nodeHistInfo  = splitInfo + nodeId * nImpProp + IMPURITY_PROPS;
+
+                splitNodeInfo[0]       = imp;
+                algorithmFPType maxVal = (algorithmFPType)0;
+                int maxInd             = 0;
+                for (int i = 0; i < nProp; i++)
+                {
+                    nodeHistInfo[i] = mrgCls[i];
+                    if (mrgCls[i] > maxVal)
+                    {
+                        maxVal = mrgCls[i];
+                        maxInd = i;
+                    }
+                }
+
+                nodeList[nodeId * nNodeProp + 2] = curFeatureId == valNotFound ? leafMark : curFeatureId;
+                nodeList[nodeId * nNodeProp + 3] = curFeatureValue == valNotFound ? leafMark : curFeatureValue;
+                nodeList[nodeId * nNodeProp + 4] = (int)bestLN;
+                nodeList[nodeId * nNodeProp + 5] = maxInd;
+
+                if (updateImpDecreaseRequired) nodeImpDecreaseList[nodeId] = bestImpDec;
+            }
+            else
+            {
+                bufS[(bufIdx + sub_group_id) * nNodeProp + 0] = curFeatureId;
+                bufS[(bufIdx + sub_group_id) * nNodeProp + 1] = curFeatureValue;
+                bufS[(bufIdx + sub_group_id) * nNodeProp + 2] = (int)bestLN;
+
+                bufI[bufIdx + sub_group_id] = curImpDec;
+            }
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+        if (1 < n_sub_groups && 0 == sub_group_id)
+        {
+            // first sub group for current node reduces over local buffer if required
+            algorithmFPType curImpDec = (sub_group_local_id < n_sub_groups) ? bufI[bufIdx + sub_group_local_id] : minImpDec;
+
+            int curFeatureId    = sub_group_local_id < n_sub_groups ? bufS[(bufIdx + sub_group_local_id) * nNodeProp + 0] : valNotFound;
+            int curFeatureValue = sub_group_local_id < n_sub_groups ? bufS[(bufIdx + sub_group_local_id) * nNodeProp + 1] : valNotFound;
+            int LN              = sub_group_local_id < n_sub_groups ? bufS[(bufIdx + sub_group_local_id) * nNodeProp + 2] : 0;
+
+            algorithmFPType bestImpDec = sub_group_reduce_max(curImpDec);
+
+            int bestFeatureId    = sub_group_reduce_min(bestImpDec == curImpDec ? curFeatureId : valNotFound);
+            int bestFeatureValue = sub_group_reduce_min((bestFeatureId == curFeatureId && bestImpDec == curImpDec) ? curFeatureValue : valNotFound);
+
+            bool noneSplitFoundBySubGroup = ((leafMark == bestFeatureId) && (0 == sub_group_local_id));
+            bool mySplitIsBest            = (leafMark != bestFeatureId && curFeatureId == bestFeatureId && curFeatureValue == bestFeatureValue);
+            if (noneSplitFoundBySubGroup || mySplitIsBest)
+            {
+                __global algorithmFPType * splitNodeInfo = splitInfo + nodeId * nImpProp;
+                __global algorithmFPType * nodeHistInfo  = splitInfo + nodeId * nImpProp + IMPURITY_PROPS;
+
+                splitNodeInfo[0]       = imp;
+                algorithmFPType maxVal = (algorithmFPType)0;
+                int maxInd             = 0;
+                for (int i = 0; i < nProp; i++)
+                {
+                    nodeHistInfo[i] = mrgCls[i];
+                    if (mrgCls[i] > maxVal)
+                    {
+                        maxVal = mrgCls[i];
+                        maxInd = i;
+                    }
+                }
+
+                nodeList[nodeId * nNodeProp + 2] = curFeatureId == valNotFound ? leafMark : curFeatureId;
+                nodeList[nodeId * nNodeProp + 3] = curFeatureValue == valNotFound ? leafMark : curFeatureValue;
+                nodeList[nodeId * nNodeProp + 4] = (int)LN;
+                nodeList[nodeId * nNodeProp + 5] = maxInd;
+
+                if (updateImpDecreaseRequired) nodeImpDecreaseList[nodeId] = bestImpDec;
+            }
+        }
+    }
+
+    __kernel void computePartialHistograms(const __global int * data, const __global int * treeOrder, const __global int * nodeList,
+                                           const __global int * nodeIndices, int nodeIndicesOffset, const __global int * selectedFeatures,
+                                           const __global algorithmFPType * response, const __global int * binOffsets, int nMaxBinsAmongFtrs,
+                                           int nFeatures, __global algorithmFPType * partialHistograms) {
+        const int nProp     = HIST_PROPS; // num of characteristics in histogram (i.e. classes)
+        const int nNodeProp = NODE_PROPS; // num of node properties in nodeOffsets
+
+        const int nodeIdx           = get_global_id(2);
+        const int nodeId            = nodeIndices[nodeIndicesOffset + nodeIdx];
+        const int featIdx           = get_local_id(1);
+        const int nSelectedFeatures = get_local_size(1);
+        const int histIdx           = get_global_id(0);
+        const int nPartHist         = get_global_size(0);
+
+        const int featId     = selectedFeatures[nodeId * nSelectedFeatures + featIdx];
+        const int rowsOffset = nodeList[nodeId * nNodeProp + 0];
+        const int nRows      = nodeList[nodeId * nNodeProp + 1];
+
+        const int nElementsForGroup = nRows / nPartHist + !!(nRows % nPartHist);
+
+        int iStart = histIdx * nElementsForGroup;
+        int iEnd   = (histIdx + 1) * nElementsForGroup;
+
+        iEnd = (iEnd > nRows) ? nRows : iEnd;
+
+        __global algorithmFPType * histogram =
+            partialHistograms + ((nodeIdx * nPartHist + histIdx) * nSelectedFeatures + featIdx) * nMaxBinsAmongFtrs * nProp;
+
+        int nBins = binOffsets[featId + 1] - binOffsets[featId];
+
+        for (int i = 0; i < nProp * nBins; i++)
+        {
+            histogram[i] = (algorithmFPType)0;
+        }
+
+        for (int i = iStart; i < iEnd; i++)
+        {
+            int id      = treeOrder[rowsOffset + i];
+            int bin     = data[id * nFeatures + featId];
+            int classId = (int)response[id];
+
+            histogram[bin * nProp + classId] += (algorithmFPType)1;
+        }
+    }
+
+    __kernel void reducePartialHistograms(const __global algorithmFPType * partialHistograms, __global algorithmFPType * histograms,
+                                          int nPartialHistograms, int nSelectedFeatures, int nMaxBinsAmongFtrs) {
+        const int nProp = HIST_PROPS; // num of characteristics in histogram (i.e. classes)
+        __local algorithmFPType buf[LOCAL_BUFFER_SIZE * nProp];
+
+        const int nodeIdx    = get_global_id(2);
+        const int binId      = get_global_id(0);
+        const int local_id   = get_local_id(1);
+        const int local_size = get_local_size(1);
+
+        for (int prop = 0; prop < nProp; prop++)
+        {
+            buf[local_id * nProp + prop] = (algorithmFPType)0;
+        }
+
+        const __global algorithmFPType * nodePartialHistograms =
+            partialHistograms + nodeIdx * nPartialHistograms * nSelectedFeatures * nMaxBinsAmongFtrs * nProp;
+        __global algorithmFPType * nodeHistogram = histograms + nodeIdx * nSelectedFeatures * nMaxBinsAmongFtrs * nProp;
+
+        for (int i = local_id; i < nPartialHistograms; i += local_size)
+        {
+            int offset = i * nSelectedFeatures * nMaxBinsAmongFtrs * nProp + binId * nProp;
+            for (int prop = 0; prop < nProp; prop++)
+            {
+                buf[local_id * nProp + prop] += nodePartialHistograms[offset + prop];
+            }
+        }
+
+        for (int offset = local_size / 2; offset > 0; offset >>= 1)
+        {
+            barrier(CLK_LOCAL_MEM_FENCE);
+            if (local_id < offset)
+            {
+                for (int prop = 0; prop < nProp; prop++)
+                {
+                    buf[local_id * nProp + prop] += buf[(local_id + offset) * nProp + prop];
+                }
+            }
+        }
+
+        if (local_id == 0)
+        {
+            for (int prop = 0; prop < nProp; prop++)
+            {
+                nodeHistogram[binId * nProp + prop] = buf[local_id + prop];
+            }
+        }
+    });
+
+#endif

--- a/algorithms/kernel/dtrees/forest/classification/oneapi/cl_kernels/df_batch_classification_kernels.cl
+++ b/algorithms/kernel/dtrees/forest/classification/oneapi/cl_kernels/df_batch_classification_kernels.cl
@@ -31,14 +31,9 @@
 DECLARE_SOURCE(
     df_batch_classification_kernels,
 
-    inline int fpEq(algorithmFPType a, algorithmFPType b) {
-        return (int)(fabs(a - b) <= algorithmFPTypeAccuracy);
-    } inline int fpGt(algorithmFPType a, algorithmFPType b) { return (int)((a - b) > algorithmFPTypeAccuracy); }
+    inline int fpEq(algorithmFPType a, algorithmFPType b) { return (int)(fabs(a - b) <= algorithmFPTypeAccuracy); }
 
-    __kernel void initializeTreeOrder(__global int * treeOrder) {
-        const int id  = get_global_id(0);
-        treeOrder[id] = id;
-    }
+    inline int fpGt(algorithmFPType a, algorithmFPType b) { return (int)((a - b) > algorithmFPTypeAccuracy); }
 
     __kernel void computeBestSplitSinglePass(const __global int * data, const __global int * treeOrder, const __global int * selectedFeatures,
                                              int nSelectedFeatures, const __global algorithmFPType * response, const __global int * binOffsets,

--- a/algorithms/kernel/dtrees/forest/classification/oneapi/cl_kernels/df_batch_classification_kernels.cl
+++ b/algorithms/kernel/dtrees/forest/classification/oneapi/cl_kernels/df_batch_classification_kernels.cl
@@ -29,7 +29,7 @@
 #define DECLARE_SOURCE(name, src) static const char * name = #src;
 
 DECLARE_SOURCE(
-    df_batch_classification_kernels,
+    df_batch_classification_kernels_part1,
 
     inline int fpEq(algorithmFPType a, algorithmFPType b) { return (int)(fabs(a - b) <= algorithmFPTypeAccuracy); }
 
@@ -249,7 +249,14 @@ DECLARE_SOURCE(
                 if (updateImpDecreaseRequired) nodeImpDecreaseList[nodeId] = bestImpDec;
             }
         }
-    }
+    });
+
+DECLARE_SOURCE(
+    df_batch_classification_kernels_part2,
+
+    inline int fpEq(algorithmFPType a, algorithmFPType b) { return (int)(fabs(a - b) <= algorithmFPTypeAccuracy); }
+
+    inline int fpGt(algorithmFPType a, algorithmFPType b) { return (int)((a - b) > algorithmFPTypeAccuracy); }
 
     __kernel void computeBestSplitByHistogram(const __global algorithmFPType * histograms, const __global int * selectedFeatures,
                                               int nSelectedFeatures, const __global int * binOffsets, __global int * nodeList,

--- a/algorithms/kernel/dtrees/forest/classification/oneapi/df_classification_train_hist_kernel_oneapi.h
+++ b/algorithms/kernel/dtrees/forest/classification/oneapi/df_classification_train_hist_kernel_oneapi.h
@@ -172,6 +172,7 @@ private:
 
     size_t _nClasses;
     size_t _nMaxBinsAmongFtrs;
+    size_t _totalBins;
 };
 
 } // namespace internal

--- a/algorithms/kernel/dtrees/forest/classification/oneapi/df_classification_train_hist_kernel_oneapi.h
+++ b/algorithms/kernel/dtrees/forest/classification/oneapi/df_classification_train_hist_kernel_oneapi.h
@@ -95,7 +95,8 @@ public:
                              Result & res, const Parameter & par);
 
 private:
-    services::Status buildProgram(oneapi::internal::ClKernelFactoryIface & factory, const char * buildOptions = nullptr);
+    services::Status buildProgram(oneapi::internal::ClKernelFactoryIface & factory, const char * programName, const char * programSrc,
+                                  const char * buildOptions);
 
     services::Status computeBestSplit(const oneapi::internal::UniversalBuffer & data, oneapi::internal::UniversalBuffer & treeOrder,
                                       oneapi::internal::UniversalBuffer & selectedFeatures, size_t nSelectedFeatures,

--- a/algorithms/kernel/dtrees/forest/classification/oneapi/df_classification_train_hist_kernel_oneapi.h
+++ b/algorithms/kernel/dtrees/forest/classification/oneapi/df_classification_train_hist_kernel_oneapi.h
@@ -1,0 +1,184 @@
+/* file: df_classification_train_hist_kernel_oneapi.h */
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+/*
+//++
+//  Declaration of structure containing kernels for decision forest
+//  training for GPU for the hist method.
+//--
+*/
+
+#ifndef __DF_CLASSIFICATION_TRAIN_HIST_KERNEL_ONEAPI_H__
+#define __DF_CLASSIFICATION_TRAIN_HIST_KERNEL_ONEAPI_H__
+
+#include "oneapi/internal/types.h"
+#include "oneapi/internal/execution_context.h"
+#include "data_management/data/numeric_table.h"
+#include "algorithms/algorithm_base_common.h"
+#include "algorithms/kernel/dtrees/forest/classification/df_classification_model_impl.h"
+#include "algorithms/decision_forest/decision_forest_classification_training_types.h"
+#include "algorithms/decision_forest/decision_forest_classification_model.h"
+#include "algorithms/kernel/dtrees/forest/oneapi/df_feature_type_helper_oneapi.h"
+#include "algorithms/kernel/dtrees/forest/oneapi/df_tree_level_build_helper_oneapi.h"
+
+using namespace daal::data_management;
+using namespace daal::services;
+
+namespace daal
+{
+namespace algorithms
+{
+namespace decision_forest
+{
+namespace classification
+{
+namespace training
+{
+namespace internal
+{
+template <typename algorithmFPType, Method method>
+class ClassificationTrainBatchKernelOneAPI : public daal::algorithms::Kernel
+{
+public:
+    ClassificationTrainBatchKernelOneAPI() {}
+    services::Status compute(HostAppIface * pHostApp, const NumericTable * x, const NumericTable * y, decision_forest::classification::Model & m,
+                             Result & res, const Parameter & par)
+    {
+        return services::ErrorMethodNotImplemented;
+    }
+
+    services::Status compute(HostAppIface * pHostApp, const NumericTable * x, const NumericTable * y, decision_forest::classification::Model & m,
+                             Result & res, const decision_forest::classification::training::interface1::Parameter & par)
+    {
+        return services::ErrorMethodNotImplemented;
+    }
+};
+
+template <typename algorithmFPType>
+class ClassificationTrainBatchKernelOneAPI<algorithmFPType, hist> : public daal::algorithms::Kernel
+{
+public:
+    ClassificationTrainBatchKernelOneAPI() {}
+    services::Status compute(HostAppIface * pHostApp, const NumericTable * x, const NumericTable * y, decision_forest::classification::Model & m,
+                             Result & res, const decision_forest::classification::training::interface1::Parameter & par)
+    {
+        Parameter tmpPar(par.nClasses);
+        tmpPar.nTrees                      = par.nTrees;
+        tmpPar.observationsPerTreeFraction = par.observationsPerTreeFraction;
+        tmpPar.featuresPerNode             = par.featuresPerNode;
+        tmpPar.maxTreeDepth                = par.maxTreeDepth;
+        tmpPar.minObservationsInLeafNode   = par.minObservationsInLeafNode;
+        tmpPar.seed                        = par.seed;
+        tmpPar.engine                      = par.engine;
+        tmpPar.impurityThreshold           = par.impurityThreshold;
+        tmpPar.varImportance               = par.varImportance;
+        tmpPar.resultsToCompute            = par.resultsToCompute;
+        tmpPar.memorySavingMode            = par.memorySavingMode;
+        tmpPar.bootstrap                   = par.bootstrap;
+        return compute(pHostApp, x, y, m, res, tmpPar);
+    }
+    services::Status compute(HostAppIface * pHostApp, const NumericTable * x, const NumericTable * y, decision_forest::classification::Model & m,
+                             Result & res, const Parameter & par);
+
+private:
+    services::Status buildProgram(oneapi::internal::ClKernelFactoryIface & factory, const char * buildOptions = nullptr);
+
+    services::Status computeBestSplit(const oneapi::internal::UniversalBuffer & data, oneapi::internal::UniversalBuffer & treeOrder,
+                                      oneapi::internal::UniversalBuffer & selectedFeatures, size_t nSelectedFeatures,
+                                      const services::Buffer<algorithmFPType> & response, oneapi::internal::UniversalBuffer & nodeOffsets,
+                                      oneapi::internal::UniversalBuffer & binOffsets, oneapi::internal::UniversalBuffer & splitInfo,
+                                      oneapi::internal::UniversalBuffer & nodeImpDecreaseList, bool updateImpDecreaseRequired, size_t nFeatures,
+                                      size_t nNodes, size_t minObservationsInLeafNode, algorithmFPType impurityThreshold);
+
+    services::Status computeBestSplitSinglePass(const oneapi::internal::UniversalBuffer & data, oneapi::internal::UniversalBuffer & treeOrder,
+                                                oneapi::internal::UniversalBuffer & selectedFeatures, size_t nSelectedFeatures,
+                                                const services::Buffer<algorithmFPType> & response, oneapi::internal::UniversalBuffer & binOffsets,
+                                                oneapi::internal::UniversalBuffer & nodeList, oneapi::internal::UniversalBuffer & nodeIndices,
+                                                size_t nodeIndicesOffset, oneapi::internal::UniversalBuffer & impList,
+                                                oneapi::internal::UniversalBuffer & nodeImpDecreaseList, bool updateImpDecreaseRequired,
+                                                size_t nFeatures, size_t nNodes, size_t minObservationsInLeafNode, algorithmFPType impurityThreshold);
+
+    services::Status computeBestSplitByHistogram(const oneapi::internal::UniversalBuffer & nodeHistogramList,
+                                                 oneapi::internal::UniversalBuffer & selectedFeatures, size_t nSelectedFeatures,
+                                                 oneapi::internal::UniversalBuffer & nodeList, oneapi::internal::UniversalBuffer & nodeIndices,
+                                                 size_t nodeIndicesOffset, oneapi::internal::UniversalBuffer & binOffsets,
+                                                 oneapi::internal::UniversalBuffer & splitInfo,
+                                                 oneapi::internal::UniversalBuffer & nodeImpDecreaseList, bool updateImpDecreaseRequired,
+                                                 size_t nNodes, size_t nMaxBinsAmongFtrs, size_t minObservationsInLeafNode,
+                                                 algorithmFPType impurityThreshold);
+
+    services::Status computePartialHistograms(const oneapi::internal::UniversalBuffer & data, oneapi::internal::UniversalBuffer & treeOrder,
+                                              oneapi::internal::UniversalBuffer & selectedFeatures, size_t nSelectedFeatures,
+                                              const services::Buffer<algorithmFPType> & response, oneapi::internal::UniversalBuffer & nodeList,
+                                              oneapi::internal::UniversalBuffer & nodeIndices, size_t nodeIndicesOffset,
+                                              oneapi::internal::UniversalBuffer & binOffsets, size_t nMaxBinsAmongFtrs, size_t nFeatures,
+                                              size_t nNodes, oneapi::internal::UniversalBuffer & partialHistograms, size_t nPartialHistograms);
+
+    services::Status reducePartialHistograms(oneapi::internal::UniversalBuffer & partialHistograms, oneapi::internal::UniversalBuffer & histograms,
+                                             size_t nPartialHistograms, size_t nNodes, size_t nSelectedFeatures, size_t nMaxBinsAmongFtrs,
+                                             size_t reduceLocalSize);
+
+    services::Status computeResults(const dtrees::internal::Tree & t, const algorithmFPType * x, const algorithmFPType * y, const size_t nRows,
+                                    const size_t nFeatures, const oneapi::internal::UniversalBuffer & oobIndices, size_t nOOB,
+                                    oneapi::internal::UniversalBuffer & oobBuf, algorithmFPType * varImp, algorithmFPType * varImpVariance,
+                                    size_t nBuiltTrees, const engines::EnginePtr & engine, const Parameter & par);
+
+    algorithmFPType computeOOBError(const dtrees::internal::Tree & t, const algorithmFPType * x, const algorithmFPType * y, const size_t nRows,
+                                    const size_t nFeatures, const oneapi::internal::UniversalBuffer & indices, size_t n,
+                                    oneapi::internal::UniversalBuffer oobBuf, services::Status * status);
+
+    algorithmFPType computeOOBErrorPerm(const dtrees::internal::Tree & t, const algorithmFPType * x, const algorithmFPType * y, const size_t nRows,
+                                        const size_t nFeatures, const oneapi::internal::UniversalBuffer & indices, const int * indicesPerm,
+                                        const size_t testFtrInd, size_t n, services::Status * status);
+
+    services::Status finalizeOOBError(const algorithmFPType * y, const oneapi::internal::UniversalBuffer & oobBuf, const size_t nRows,
+                                      algorithmFPType * res, algorithmFPType * resPerObs);
+
+    services::Status finalizeVarImp(const Parameter & par, algorithmFPType * varImp, algorithmFPType * varImpVariance, size_t nFeatures);
+
+    oneapi::internal::KernelPtr kernelComputePartialHistograms;
+    oneapi::internal::KernelPtr kernelReducePartialHistograms;
+    oneapi::internal::KernelPtr kernelComputeBestSplitByHistogram;
+    oneapi::internal::KernelPtr kernelComputeBestSplitSinglePass;
+
+    decision_forest::internal::TreeLevelBuildHelperOneAPI<algorithmFPType> _treeLevelBuildHelper;
+
+    const uint32_t _maxWorkItemsPerGroup = 256; // should be a power of two for interal needs
+    const uint32_t _preferableSubGroup   = 16;  // preferable maximal sub-group size
+    const uint32_t _maxLocalSize         = 128;
+    const uint32_t _maxLocalSums         = 256;
+    const uint32_t _maxLocalHistograms   = 256;
+    const uint32_t _preferableGroupSize  = 256;
+    const uint32_t _minRowsBlock         = 256;
+    const uint32_t _maxBins              = 256;
+
+    const uint32_t _nHistProps     = 0; // number of properties in bins histogram (i.e. n, mean and var)
+    const uint32_t _nNodesGroups   = 3; // all nodes are split on groups (big, medium, small)
+    const uint32_t _nodeGroupProps = 2; // each nodes Group contains props: numOfNodes, maxNumOfBlocks
+
+    size_t _nClasses;
+    size_t _nMaxBinsAmongFtrs;
+};
+
+} // namespace internal
+} // namespace training
+} // namespace classification
+} // namespace decision_forest
+} // namespace algorithms
+} // namespace daal
+
+#endif

--- a/algorithms/kernel/dtrees/forest/classification/oneapi/df_classification_train_hist_kernel_oneapi.h
+++ b/algorithms/kernel/dtrees/forest/classification/oneapi/df_classification_train_hist_kernel_oneapi.h
@@ -166,7 +166,6 @@ private:
     const uint32_t _minRowsBlock         = 256;
     const uint32_t _maxBins              = 256;
 
-    const uint32_t _nHistProps     = 0; // number of properties in bins histogram (i.e. n, mean and var)
     const uint32_t _nNodesGroups   = 3; // all nodes are split on groups (big, medium, small)
     const uint32_t _nodeGroupProps = 2; // each nodes Group contains props: numOfNodes, maxNumOfBlocks
 

--- a/algorithms/kernel/dtrees/forest/classification/oneapi/df_classification_train_hist_oneapi_impl.i
+++ b/algorithms/kernel/dtrees/forest/classification/oneapi/df_classification_train_hist_oneapi_impl.i
@@ -1,0 +1,930 @@
+/* file: df_classification_train_hist_oneapi_impl.i */
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+/*
+//++
+//  Implementation of auxiliary functions for decision forest classification
+//  hist method.
+//--
+*/
+
+#ifndef __DF_CLASSIFICATION_TRAIN_HIST_ONEAPI_IMPL_I__
+#define __DF_CLASSIFICATION_TRAIN_HIST_ONEAPI_IMPL_I__
+
+#include "algorithms/kernel/dtrees/forest/classification/oneapi/df_classification_train_hist_kernel_oneapi.h"
+#include "algorithms/kernel/dtrees/forest/classification/oneapi/cl_kernels/df_batch_classification_kernels.cl"
+
+#include "algorithms/kernel/dtrees/forest/oneapi/df_feature_type_helper_oneapi.i"
+#include "algorithms/kernel/dtrees/forest/oneapi/df_tree_level_build_helper_oneapi.i"
+#include "algorithms/kernel/dtrees/forest/classification/df_classification_model_impl.h"
+#include "algorithms/kernel/dtrees/forest/classification/oneapi/df_classification_tree_helper_impl.i"
+
+#include "externals/service_ittnotify.h"
+#include "externals/service_rng.h"
+#include "externals/service_math.h" //will remove after migrating finalize MDA to GPU
+#include "services/buffer.h"
+#include "data_management/data/numeric_table.h"
+#include "services/env_detect.h"
+#include "services/error_indexes.h"
+#include "service/kernel/service_data_utils.h"
+#include "service/kernel/service_algo_utils.h"
+#include "service/kernel/service_arrays.h"
+#include "service/kernel/service_utils.h"
+#include "algorithms/kernel/engines/engine_types_internal.h"
+#include "oneapi/internal/types.h"
+
+using namespace daal::algorithms::decision_forest::internal;
+using namespace daal::algorithms::decision_forest::classification::internal;
+
+namespace daal
+{
+namespace algorithms
+{
+namespace decision_forest
+{
+namespace classification
+{
+namespace training
+{
+namespace internal
+{
+template <typename algorithmFPType>
+static services::String getFPTypeAccuracy()
+{
+    if (IsSameType<algorithmFPType, float>::value)
+    {
+        return services::String(" -D algorithmFPTypeAccuracy=(float)1e-5 ");
+    }
+    if (IsSameType<algorithmFPType, double>::value)
+    {
+        return services::String(" -D algorithmFPTypeAccuracy=(double)1e-10 ");
+    }
+    return services::String();
+}
+
+inline char * utoa(uint32_t value, char * buffer, size_t buffer_size)
+{
+    size_t i = 0;
+    while (value && i < buffer_size - 1)
+    {
+        size_t rem  = value % 10;
+        buffer[i++] = 48 + rem;
+        value /= 10;
+    }
+
+    for (size_t j = 0; j < i - j - 1; j++)
+    {
+        char tmp          = buffer[j];
+        buffer[j]         = buffer[i - j - 1];
+        buffer[i - j - 1] = tmp;
+    }
+    buffer[i] = 0;
+    return buffer;
+}
+
+static services::String getBuildOptions(size_t nClasses)
+{
+    const uint32_t valBufSize = 16;
+    static char valBuffer[valBufSize];
+
+    services::String nClassesStr(utoa(static_cast<uint32_t>(nClasses), valBuffer, valBufSize));
+    services::String buildOptions = " -D NODE_PROPS=6 -D IMPURITY_PROPS=1 -D HIST_PROPS=";
+    buildOptions.add(nClassesStr);
+    buildOptions.add(" -D NUM_OF_CLASSES=");
+    buildOptions.add(nClassesStr);
+
+    return buildOptions;
+}
+
+template <typename algorithmFPType>
+services::Status ClassificationTrainBatchKernelOneAPI<algorithmFPType, hist>::buildProgram(ClKernelFactoryIface & factory, const char * buildOptions)
+{
+    services::Status status;
+
+    DAAL_ITTNOTIFY_SCOPED_TASK(compute.buildProgram);
+    {
+        auto fptype_name     = getKeyFPType<algorithmFPType>();
+        auto fptype_accuracy = getFPTypeAccuracy<algorithmFPType>();
+        auto build_options   = fptype_name;
+        build_options.add(fptype_accuracy);
+        build_options.add(" -cl-std=CL1.2 ");
+        build_options.add(" -D LOCAL_BUFFER_SIZE=256 -D MAX_WORK_ITEMS_PER_GROUP=256 ");
+
+        if (buildOptions)
+        {
+            build_options.add(buildOptions);
+        }
+
+        services::String cachekey("__daal_algorithms_df_batch_classification_");
+        cachekey.add(build_options);
+        factory.build(ExecutionTargetIds::device, cachekey.c_str(), df_batch_classification_kernels, build_options.c_str());
+    }
+
+    return status;
+}
+
+template <typename algorithmFPType>
+services::Status ClassificationTrainBatchKernelOneAPI<algorithmFPType, hist>::computeBestSplitByHistogram(
+    const UniversalBuffer & nodeHistogramList, UniversalBuffer & selectedFeatures, size_t nSelectedFeatures, UniversalBuffer & nodeList,
+    UniversalBuffer & nodeIndices, size_t nodeIndicesOffset, UniversalBuffer & binOffsets, UniversalBuffer & impList,
+    UniversalBuffer & nodeImpDecreaseList, bool updateImpDecreaseRequired, size_t nNodes, size_t nMaxBinsAmongFtrs, size_t minObservationsInLeafNode,
+    algorithmFPType impurityThreshold)
+{
+    DAAL_ITTNOTIFY_SCOPED_TASK(compute.computeBestSpitByHistogramLevel);
+
+    services::Status status;
+
+    auto & context = services::Environment::getInstance()->getDefaultExecutionContext();
+
+    auto & kernel = kernelComputeBestSplitByHistogram;
+
+    {
+        KernelArguments args(13);
+        args.set(0, nodeHistogramList, AccessModeIds::read);
+        args.set(1, selectedFeatures, AccessModeIds::read);
+        args.set(2, (int32_t)nSelectedFeatures);
+        args.set(3, binOffsets, AccessModeIds::read);
+        args.set(4, nodeList, AccessModeIds::readwrite); // nodeList will be updated with split attributes
+        args.set(5, nodeIndices, AccessModeIds::read);
+        args.set(6, nodeIndicesOffset);
+        args.set(7, impList, AccessModeIds::write);
+        args.set(8, nodeImpDecreaseList, AccessModeIds::write);
+        args.set(9, (int32_t)updateImpDecreaseRequired);
+        args.set(10, (int32_t)nMaxBinsAmongFtrs);
+        args.set(11, (int32_t)minObservationsInLeafNode);
+        args.set(12, impurityThreshold);
+
+        const size_t numOfSubGroupsPerNode = 4; //add logic for adjusting it in accordance with nNodes
+        size_t localSize                   = _preferableSubGroup * numOfSubGroupsPerNode;
+
+        KernelRange local_range(localSize, 1);
+        KernelRange global_range(localSize, nNodes);
+
+        KernelNDRange range(2);
+        range.local(local_range, &status);
+        DAAL_CHECK_STATUS_VAR(status);
+        range.global(global_range, &status);
+        DAAL_CHECK_STATUS_VAR(status);
+
+        context.run(range, kernel, args, &status);
+        DAAL_CHECK_STATUS_VAR(status);
+    }
+
+    return status;
+}
+
+template <typename algorithmFPType>
+services::Status ClassificationTrainBatchKernelOneAPI<algorithmFPType, hist>::computeBestSplitSinglePass(
+    const UniversalBuffer & data, UniversalBuffer & treeOrder, UniversalBuffer & selectedFeatures, size_t nSelectedFeatures,
+    const services::Buffer<algorithmFPType> & response, UniversalBuffer & binOffsets, UniversalBuffer & nodeList, UniversalBuffer & nodeIndices,
+    size_t nodeIndicesOffset, UniversalBuffer & impList, UniversalBuffer & nodeImpDecreaseList, bool updateImpDecreaseRequired, size_t nFeatures,
+    size_t nNodes, size_t minObservationsInLeafNode, algorithmFPType impurityThreshold)
+{
+    DAAL_ITTNOTIFY_SCOPED_TASK(compute.computeBestSplitSinglePass);
+
+    services::Status status;
+
+    auto & context = services::Environment::getInstance()->getDefaultExecutionContext();
+
+    auto & kernel = kernelComputeBestSplitSinglePass;
+
+    {
+        KernelArguments args(15);
+        args.set(0, data, AccessModeIds::read);
+        args.set(1, treeOrder, AccessModeIds::read);
+        args.set(2, selectedFeatures, AccessModeIds::read);
+        args.set(3, (int32_t)nSelectedFeatures);
+        args.set(4, response, AccessModeIds::read);
+        args.set(5, binOffsets, AccessModeIds::read);
+        args.set(6, nodeList, AccessModeIds::readwrite); // nodeList will be updated with split attributes
+        args.set(7, nodeIndices, AccessModeIds::read);
+        args.set(8, (int32_t)nodeIndicesOffset);
+        args.set(9, impList, AccessModeIds::write);
+        args.set(10, nodeImpDecreaseList, AccessModeIds::write);
+        args.set(11, (int32_t)updateImpDecreaseRequired);
+        args.set(12, (int32_t)nFeatures);
+        args.set(13, (int32_t)minObservationsInLeafNode);
+        args.set(14, impurityThreshold);
+
+        const size_t numOfSubGroupsPerNode = 4; //add logic for adjusting it in accordance with nNodes
+        size_t localSize                   = _preferableSubGroup * numOfSubGroupsPerNode;
+
+        KernelRange local_range(localSize, 1);
+        KernelRange global_range(localSize, nNodes);
+
+        KernelNDRange range(2);
+        range.local(local_range, &status);
+        DAAL_CHECK_STATUS_VAR(status);
+        range.global(global_range, &status);
+        DAAL_CHECK_STATUS_VAR(status);
+
+        context.run(range, kernel, args, &status);
+        DAAL_CHECK_STATUS_VAR(status);
+    }
+
+    return status;
+}
+
+template <typename algorithmFPType>
+services::Status ClassificationTrainBatchKernelOneAPI<algorithmFPType, hist>::computeBestSplit(
+    const UniversalBuffer & data, UniversalBuffer & treeOrder, UniversalBuffer & selectedFeatures, size_t nSelectedFeatures,
+    const services::Buffer<algorithmFPType> & response, UniversalBuffer & nodeList, UniversalBuffer & binOffsets, UniversalBuffer & impList,
+    UniversalBuffer & nodeImpDecreaseList, bool updateImpDecreaseRequired, size_t nFeatures, size_t nNodes, size_t minObservationsInLeafNode,
+    algorithmFPType impurityThreshold)
+{
+    services::Status status;
+
+    auto & context = services::Environment::getInstance()->getDefaultExecutionContext();
+
+    auto nodesGroups = context.allocate(TypeIds::id<int>(), _nNodesGroups * _nodeGroupProps, &status);
+    auto nodeIndices = context.allocate(TypeIds::id<int>(), nNodes, &status);
+    DAAL_CHECK_STATUS_VAR(status);
+
+    DAAL_CHECK_STATUS_VAR(_treeLevelBuildHelper.splitNodeListOnGroupsBySize(nodeList, nNodes, nodesGroups, nodeIndices));
+
+    auto nodesGroupsHost = nodesGroups.template get<int>().toHost(ReadWriteMode::readOnly);
+    DAAL_CHECK_MALLOC(nodesGroupsHost.get());
+
+    size_t nGroupNodes    = 0;
+    size_t processedNodes = 0;
+
+    for (size_t i = 0; i < _nNodesGroups; i++, processedNodes += nGroupNodes)
+    {
+        nGroupNodes = nodesGroupsHost.get()[i * _nodeGroupProps + 0];
+        if (0 == nGroupNodes) continue;
+
+        size_t maxGroupBlocksNum = nodesGroupsHost.get()[i * _nodeGroupProps + 1];
+
+        size_t groupIndicesOffset = processedNodes;
+
+        if (maxGroupBlocksNum > 1)
+        {
+            size_t nPartialHistograms = maxGroupBlocksNum < _maxLocalHistograms / 2 ? maxGroupBlocksNum : _maxLocalHistograms / 2;
+            //_maxLocalHistograms/2 (128) showed better performance than _maxLocalHistograms need to investigate
+            int reduceLocalSize = 16; // add logic for its adjustment
+
+            size_t partHistSize = nSelectedFeatures * _nMaxBinsAmongFtrs * _nClasses;
+
+            auto partialHistograms = context.allocate(TypeIds::id<algorithmFPType>(), nGroupNodes * nPartialHistograms * partHistSize, &status);
+            auto nodesHistograms   = context.allocate(TypeIds::id<algorithmFPType>(), nGroupNodes * partHistSize, &status);
+            DAAL_CHECK_STATUS_VAR(status);
+
+            DAAL_CHECK_STATUS_VAR(computePartialHistograms(data, treeOrder, selectedFeatures, nSelectedFeatures, response, nodeList, nodeIndices,
+                                                           groupIndicesOffset, binOffsets, _nMaxBinsAmongFtrs, nFeatures, nGroupNodes,
+                                                           partialHistograms, nPartialHistograms));
+
+            DAAL_CHECK_STATUS_VAR(reducePartialHistograms(partialHistograms, nodesHistograms, nPartialHistograms, nGroupNodes, nSelectedFeatures,
+                                                          _nMaxBinsAmongFtrs, reduceLocalSize));
+
+            DAAL_CHECK_STATUS_VAR(computeBestSplitByHistogram(nodesHistograms, selectedFeatures, nSelectedFeatures, nodeList, nodeIndices,
+                                                              groupIndicesOffset, binOffsets, impList, nodeImpDecreaseList, updateImpDecreaseRequired,
+                                                              nGroupNodes, _nMaxBinsAmongFtrs, minObservationsInLeafNode, impurityThreshold));
+        }
+        else
+        {
+            DAAL_CHECK_STATUS_VAR(computeBestSplitSinglePass(data, treeOrder, selectedFeatures, nSelectedFeatures, response, binOffsets, nodeList,
+                                                             nodeIndices, groupIndicesOffset, impList, nodeImpDecreaseList, updateImpDecreaseRequired,
+                                                             nFeatures, nGroupNodes, minObservationsInLeafNode, impurityThreshold));
+        }
+    }
+
+    return status;
+}
+
+template <typename algorithmFPType>
+services::Status ClassificationTrainBatchKernelOneAPI<algorithmFPType, hist>::computePartialHistograms(
+    const UniversalBuffer & data, UniversalBuffer & treeOrder, UniversalBuffer & selectedFeatures, size_t nSelectedFeatures,
+    const services::Buffer<algorithmFPType> & response, UniversalBuffer & nodeList, UniversalBuffer & nodeIndices, size_t nodeIndicesOffset,
+    UniversalBuffer & binOffsets, size_t nMaxBinsAmongFtrs, size_t nFeatures, size_t nNodes, UniversalBuffer & partialHistograms,
+    size_t nPartialHistograms)
+{
+    DAAL_ITTNOTIFY_SCOPED_TASK(compute.computePartialHistograms);
+
+    services::Status status;
+
+    auto & context = services::Environment::getInstance()->getDefaultExecutionContext();
+
+    auto & kernel = kernelComputePartialHistograms;
+
+    {
+        KernelArguments args(11);
+        args.set(0, data, AccessModeIds::read);
+        args.set(1, treeOrder, AccessModeIds::read);
+        args.set(2, nodeList, AccessModeIds::read);
+        args.set(3, nodeIndices, AccessModeIds::read);
+        args.set(4, (int32_t)nodeIndicesOffset);
+        args.set(5, selectedFeatures, AccessModeIds::read);
+        args.set(6, response, AccessModeIds::read);
+        args.set(7, binOffsets, AccessModeIds::read);
+        args.set(8, (int32_t)nMaxBinsAmongFtrs); // max num of bins among all ftrs
+        args.set(9, (int32_t)nFeatures);
+        args.set(10, partialHistograms, AccessModeIds::write);
+
+        size_t localSize = nSelectedFeatures < _maxLocalSize ? nSelectedFeatures : _maxLocalSize;
+
+        KernelRange local_range(1, localSize, 1);
+        KernelRange global_range(nPartialHistograms, localSize, nNodes);
+
+        KernelNDRange range(3);
+        range.local(local_range, &status);
+        DAAL_CHECK_STATUS_VAR(status);
+        range.global(global_range, &status);
+        DAAL_CHECK_STATUS_VAR(status);
+
+        context.run(range, kernel, args, &status);
+        DAAL_CHECK_STATUS_VAR(status);
+    }
+
+    return status;
+}
+
+template <typename algorithmFPType>
+services::Status ClassificationTrainBatchKernelOneAPI<algorithmFPType, hist>::reducePartialHistograms(
+    UniversalBuffer & partialHistograms, UniversalBuffer & histograms, size_t nPartialHistograms, size_t nNodes, size_t nSelectedFeatures,
+    size_t nMaxBinsAmongFtrs, size_t reduceLocalSize)
+{
+    DAAL_ITTNOTIFY_SCOPED_TASK(compute.reducePartialHistograms);
+
+    services::Status status;
+
+    auto & context = services::Environment::getInstance()->getDefaultExecutionContext();
+
+    auto & kernel = kernelReducePartialHistograms;
+
+    {
+        KernelArguments args(5);
+        args.set(0, partialHistograms, AccessModeIds::read);
+        args.set(1, histograms, AccessModeIds::write);
+        args.set(2, (int32_t)nPartialHistograms);
+        args.set(3, (int32_t)nSelectedFeatures);
+        args.set(4, (int32_t)nMaxBinsAmongFtrs); // max num of bins among all ftrs
+
+        KernelRange local_range(1, reduceLocalSize, 1);
+        KernelRange global_range(nMaxBinsAmongFtrs * nSelectedFeatures, reduceLocalSize, nNodes);
+
+        KernelNDRange range(3);
+        range.global(global_range, &status);
+        DAAL_CHECK_STATUS_VAR(status);
+        range.local(local_range, &status);
+        DAAL_CHECK_STATUS_VAR(status);
+
+        context.run(range, kernel, args, &status);
+        DAAL_CHECK_STATUS_VAR(status);
+    }
+
+    return status;
+}
+
+template <CpuType cpu>
+static void shuffle(void * state, size_t n, int * dst)
+{
+    RNGs<int, cpu> rng;
+    int idx[2];
+
+    for (size_t i = 0; i < n; ++i)
+    {
+        rng.uniform(2, idx, state, 0, n);
+        daal::services::internal::swap<cpu, int>(dst[idx[0]], dst[idx[1]]);
+    }
+}
+
+template <CpuType cpu>
+services::Status selectParallelizationTechnique(const Parameter & par, engines::internal::ParallelizationTechnique & technique)
+{
+    auto engineImpl = dynamic_cast<engines::internal::BatchBaseImpl *>(par.engine.get());
+
+    engines::internal::ParallelizationTechnique techniques[] = { engines::internal::family, engines::internal::leapfrog,
+                                                                 engines::internal::skipahead };
+
+    for (auto & t : techniques)
+    {
+        if (engineImpl->hasSupport(t))
+        {
+            technique = t;
+            return services::Status();
+        }
+    }
+    return services::Status(ErrorEngineNotSupported);
+}
+
+/* following methods are related to results computation (OBB err, varImportance MDA/MDA_Scaled)*/
+/* they will be migrated on GPU when prediction layer forGPU is ready*/
+template <typename algorithmFPType>
+services::Status ClassificationTrainBatchKernelOneAPI<algorithmFPType, hist>::computeResults(
+    const dtrees::internal::Tree & t, const algorithmFPType * x, const algorithmFPType * y, size_t nRows, size_t nFeatures,
+    const UniversalBuffer & oobIndices, size_t nOOB, UniversalBuffer & oobBuf, algorithmFPType * varImp, algorithmFPType * varImpVariance,
+    size_t nBuiltTrees, const engines::EnginePtr & engine, const Parameter & par)
+{
+    services::Status status;
+    const bool mdaRequired(par.varImportance == decision_forest::training::MDA_Raw || par.varImportance == decision_forest::training::MDA_Scaled);
+
+    if ((par.resultsToCompute & (decision_forest::training::computeOutOfBagError | decision_forest::training::computeOutOfBagErrorPerObservation)
+         || mdaRequired)
+        && nOOB)
+    {
+        const algorithmFPType oobError = computeOOBError(t, x, y, nRows, nFeatures, oobIndices, nOOB, oobBuf, &status);
+
+        if (mdaRequired)
+        {
+            TArray<int, sse2> permutation(nOOB);
+            DAAL_CHECK_MALLOC(permutation.get());
+            for (size_t i = 0; i < nOOB; ++i)
+            {
+                permutation[i] = i;
+            }
+
+            const algorithmFPType div1 = algorithmFPType(1) / algorithmFPType(nBuiltTrees);
+            daal::internal::RNGs<int, sse2> rng;
+            auto engineImpl = dynamic_cast<engines::internal::BatchBaseImpl *>(engine.get());
+
+            for (size_t ftr = 0; ftr < nFeatures; ftr++)
+            {
+                shuffle<sse2>(engineImpl->getState(), nOOB, permutation.get());
+                const algorithmFPType permOOBError =
+                    computeOOBErrorPerm(t, x, y, nRows, nFeatures, oobIndices, permutation.get(), ftr, nOOB, &status);
+
+                const algorithmFPType diff  = (permOOBError - oobError);
+                const algorithmFPType delta = diff - varImp[ftr];
+                varImp[ftr] += div1 * delta;
+                if (varImpVariance)
+                {
+                    varImpVariance[ftr] += delta * (diff - varImp[ftr]);
+                }
+            }
+        }
+        DAAL_CHECK_STATUS_VAR(status);
+    }
+    return status;
+}
+
+template <typename algorithmFPType>
+algorithmFPType ClassificationTrainBatchKernelOneAPI<algorithmFPType, hist>::computeOOBError(const dtrees::internal::Tree & t,
+                                                                                             const algorithmFPType * x, const algorithmFPType * y,
+                                                                                             const size_t nRows, const size_t nFeatures,
+                                                                                             const UniversalBuffer & indices, size_t n,
+                                                                                             UniversalBuffer oobBuf, services::Status * status)
+{
+    typedef DFTreeConverter<algorithmFPType, sse2> DFTreeConverterType;
+    typename DFTreeConverterType::TreeHelperType mTreeHelper;
+
+    auto rowsIndHost = indices.template get<int>().toHost(ReadWriteMode::readOnly);
+    DAAL_CHECK_MALLOC(rowsIndHost.get());
+    auto oobBufHost = oobBuf.template get<uint32_t>().toHost(ReadWriteMode::readWrite);
+    DAAL_CHECK_MALLOC(oobBufHost.get());
+
+    //compute prediction error on each OOB row and get its mean online formulae (Welford)
+    //TODO: can be threader_for() block
+
+    algorithmFPType mean = algorithmFPType(0);
+    for (size_t i = 0; i < n; i++)
+    {
+        int rowInd        = rowsIndHost.get()[i];
+        size_t prediction = mTreeHelper.predict(t, &x[rowInd * nFeatures]);
+        oobBufHost.get()[rowInd * _nClasses + prediction]++;
+        algorithmFPType val = algorithmFPType(prediction != size_t(y[rowInd]));
+        mean += (val - mean) / algorithmFPType(i + 1);
+    }
+
+    return mean;
+}
+
+template <typename algorithmFPType>
+algorithmFPType ClassificationTrainBatchKernelOneAPI<algorithmFPType, hist>::computeOOBErrorPerm(
+    const dtrees::internal::Tree & t, const algorithmFPType * x, const algorithmFPType * y, const size_t nRows, const size_t nFeatures,
+    const UniversalBuffer & indices, const int * indicesPerm, const size_t testFtrInd, size_t n, services::Status * status)
+{
+    typedef DFTreeConverter<algorithmFPType, sse2> DFTreeConverterType;
+    typename DFTreeConverterType::TreeHelperType mTreeHelper;
+
+    auto rowsIndHost = indices.template get<int>().toHost(ReadWriteMode::readOnly);
+    DAAL_CHECK_MALLOC(rowsIndHost.get());
+    TArray<algorithmFPType, sse2> buf(nFeatures);
+    DAAL_CHECK_MALLOC(buf.get());
+
+    algorithmFPType mean = algorithmFPType(0);
+    for (size_t i = 0; i < n; i++)
+    {
+        int rowInd     = rowsIndHost.get()[i];
+        int rowIndPerm = indicesPerm[i];
+        services::internal::tmemcpy<algorithmFPType, sse2>(buf.get(), &x[rowInd * nFeatures], nFeatures);
+        buf[testFtrInd]     = x[rowIndPerm * nFeatures + testFtrInd];
+        size_t prediction   = mTreeHelper.predict(t, buf.get());
+        algorithmFPType val = algorithmFPType(prediction != size_t(y[rowInd]));
+        mean += (val - mean) / algorithmFPType(i + 1);
+    }
+
+    return mean;
+}
+
+template <typename algorithmFPType>
+services::Status ClassificationTrainBatchKernelOneAPI<algorithmFPType, hist>::finalizeOOBError(const algorithmFPType * y,
+                                                                                               const UniversalBuffer & oobBuf, const size_t nRows,
+                                                                                               algorithmFPType * res, algorithmFPType * resPerObs)
+{
+    auto oobBufHost = oobBuf.template get<uint32_t>().toHost(ReadWriteMode::readOnly);
+    DAAL_CHECK_MALLOC(oobBufHost.get());
+
+    size_t nPredicted    = 0;
+    algorithmFPType _res = 0;
+
+    for (size_t i = 0; i < nRows; i++)
+    {
+        size_t prediction = 0;
+        size_t expectation(y[i]);
+        size_t maxVal = 0;
+        for (size_t clsIdx = 0; clsIdx < _nClasses; clsIdx++)
+        {
+            size_t val = oobBufHost.get()[i * _nClasses + clsIdx];
+            if (val > maxVal)
+            {
+                maxVal     = val;
+                prediction = clsIdx;
+            }
+        }
+
+        if (0 < maxVal)
+        {
+            algorithmFPType predictionRes = algorithmFPType(prediction != expectation);
+            if (resPerObs) resPerObs[i] = predictionRes;
+            _res += predictionRes;
+            nPredicted++;
+        }
+        else if (resPerObs)
+            resPerObs[i] = algorithmFPType(-1); //was not in OOB set of any tree and hence not predicted
+    }
+
+    if (res) *res = (0 < nPredicted) ? _res / algorithmFPType(nPredicted) : 0;
+
+    return services::Status();
+}
+
+template <typename algorithmFPType>
+services::Status ClassificationTrainBatchKernelOneAPI<algorithmFPType, hist>::finalizeVarImp(const Parameter & par, algorithmFPType * varImp,
+                                                                                             algorithmFPType * varImpVariance, size_t nFeatures)
+{
+    if (par.varImportance == decision_forest::training::MDA_Scaled)
+    {
+        if (par.nTrees > 1)
+        {
+            const algorithmFPType div = algorithmFPType(1) / algorithmFPType(par.nTrees);
+            for (size_t i = 0; i < nFeatures; i++)
+            {
+                varImpVariance[i] *= div;
+                if (varImpVariance[i] > algorithmFPType(0)) varImp[i] /= daal::internal::Math<algorithmFPType, sse2>::sSqrt(varImpVariance[i] * div);
+            }
+        }
+        else
+        {
+            for (size_t i = 0; i < nFeatures; i++)
+            {
+                varImp[i] = algorithmFPType(0);
+            }
+        }
+    }
+    else if (par.varImportance == decision_forest::training::MDI)
+    {
+        const algorithmFPType div = algorithmFPType(1) / algorithmFPType(par.nTrees);
+        for (size_t i = 0; i < nFeatures; i++) varImp[i] *= div;
+    }
+    return services::Status();
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////
+/* compute method for ClassificationTrainBatchKernelOneAPI */
+///////////////////////////////////////////////////////////////////////////////////////////
+template <typename algorithmFPType>
+services::Status ClassificationTrainBatchKernelOneAPI<algorithmFPType, hist>::compute(HostAppIface * pHostApp, const NumericTable * x,
+                                                                                      const NumericTable * y,
+                                                                                      decision_forest::classification::Model & m, Result & res,
+                                                                                      const Parameter & par)
+{
+    typedef DFTreeConverter<algorithmFPType, sse2> DFTreeConverterType;
+    typedef TreeLevelRecord<algorithmFPType> TreeLevel;
+
+    services::Status status;
+
+    _nClasses = par.nClasses;
+
+    const size_t nRows             = x->getNumberOfRows();
+    const size_t nFeatures         = x->getNumberOfColumns();
+    const size_t nSelectedFeatures = par.featuresPerNode ? par.featuresPerNode : daal::internal::Math<algorithmFPType, sse2>::sSqrt(nFeatures);
+
+    const bool mdaRequired(par.varImportance == decision_forest::training::MDA_Raw || par.varImportance == decision_forest::training::MDA_Scaled);
+    const bool oobRequired =
+        (par.resultsToCompute & (decision_forest::training::computeOutOfBagError | decision_forest::training::computeOutOfBagErrorPerObservation)
+         || mdaRequired);
+
+    decision_forest::classification::internal::ModelImpl & mdImpl =
+        *static_cast<daal::algorithms::decision_forest::classification::internal::ModelImpl *>(&m);
+    DAAL_CHECK_MALLOC(mdImpl.resize(par.nTrees));
+
+    services::String buildOptions = getBuildOptions(_nClasses);
+    DAAL_CHECK_STATUS_VAR(_treeLevelBuildHelper.init(buildOptions.c_str()));
+
+    auto & context        = Environment::getInstance()->getDefaultExecutionContext();
+    auto & kernel_factory = context.getClKernelFactory();
+
+    DAAL_CHECK_STATUS_VAR(buildProgram(kernel_factory, buildOptions.c_str()));
+
+    kernelComputeBestSplitByHistogram = kernel_factory.getKernel("computeBestSplitByHistogram", &status);
+    kernelComputeBestSplitSinglePass  = kernel_factory.getKernel("computeBestSplitSinglePass", &status);
+    kernelComputePartialHistograms    = kernel_factory.getKernel("computePartialHistograms", &status);
+    kernelReducePartialHistograms     = kernel_factory.getKernel("reducePartialHistograms", &status);
+    DAAL_CHECK_STATUS_VAR(status);
+
+    dtrees::internal::BinParams prm(_maxBins, par.minObservationsInLeafNode);
+    decision_forest::internal::IndexedFeaturesOneAPI<algorithmFPType> indexedFeatures;
+    dtrees::internal::FeatureTypes featTypes;
+    DAAL_CHECK_MALLOC(featTypes.init(*x));
+    DAAL_CHECK_STATUS(status, (indexedFeatures.init(*const_cast<NumericTable *>(x), &featTypes, &prm)));
+
+    /* calculating the maximal number of bins for feature among all features */
+    {
+        auto binOffsetsHost = indexedFeatures.binOffsets().template get<int>().toHost(ReadWriteMode::readOnly);
+        DAAL_CHECK_MALLOC(binOffsetsHost.get());
+        _nMaxBinsAmongFtrs = 0;
+        for (size_t i = 0; i < nFeatures; i++)
+        {
+            auto nFtrBins      = static_cast<size_t>(binOffsetsHost.get()[i + 1] - binOffsetsHost.get()[i]);
+            _nMaxBinsAmongFtrs = (_nMaxBinsAmongFtrs < nFtrBins) ? nFtrBins : _nMaxBinsAmongFtrs;
+        }
+    }
+
+    const size_t nSelectedRows = par.observationsPerTreeFraction * nRows;
+    daal::services::internal::TArray<int, sse2> selectedRowsHost(nSelectedRows);
+    DAAL_CHECK_MALLOC(selectedRowsHost.get());
+
+    auto treeOrderLev    = context.allocate(TypeIds::id<int>(), nSelectedRows, &status);
+    auto treeOrderLevBuf = context.allocate(TypeIds::id<int>(), nSelectedRows, &status);
+
+    BlockDescriptor<algorithmFPType> dataBlock;
+    DAAL_CHECK_STATUS_VAR(const_cast<NumericTable *>(x)->getBlockOfRows(0, nRows, readOnly, dataBlock));
+
+    /* blocks for varImp MDI calculation */
+    bool mdiRequired         = (par.varImportance == decision_forest::training::MDI);
+    auto nodeImpDecreaseList = context.allocate(TypeIds::id<algorithmFPType>(), 1, &status); // holder will be reallocated in loop
+    BlockDescriptor<algorithmFPType> varImpBlock;
+    NumericTablePtr varImpResPtr = res.get(variableImportance);
+
+    if (mdiRequired || mdaRequired)
+    {
+        DAAL_CHECK_STATUS_VAR(varImpResPtr->getBlockOfRows(0, 1, writeOnly, varImpBlock));
+        context.fill(varImpBlock.getBuffer(), (algorithmFPType)0, &status);
+        DAAL_CHECK_STATUS_VAR(status);
+    }
+
+    /* blocks for OutOfBag error calculation */
+    UniversalBuffer oobBufferPerObs;
+    if (oobRequired)
+    {
+        // oobBufferPerObs contains nClassed counters for all out of bag observations for all trees
+        oobBufferPerObs = context.allocate(TypeIds::id<uint32_t>(), nRows * _nClasses, &status);
+        context.fill(oobBufferPerObs, 0, &status);
+        DAAL_CHECK_STATUS_VAR(status);
+    }
+
+    /* blocks for MDA scaled error calculation */
+    bool mdaScaledRequired = (par.varImportance == decision_forest::training::MDA_Scaled);
+    daal::services::internal::TArrayCalloc<algorithmFPType, sse2> varImpVariance; // for now it is calculated on host
+    if (mdaScaledRequired)
+    {
+        varImpVariance.reset(nFeatures);
+    }
+
+    /*init engines*/
+    engines::internal::ParallelizationTechnique technique = engines::internal::family;
+    selectParallelizationTechnique<sse2>(par, technique);
+    engines::internal::Params<sse2> params(par.nTrees);
+    for (size_t i = 0; i < par.nTrees; i++)
+    {
+        params.nSkip[i] = i * par.nTrees * x->getNumberOfRows() * (par.featuresPerNode + 1);
+    }
+    DAAL_OVERFLOW_CHECK_BY_MULTIPLICATION(size_t, par.nTrees, sizeof(engines::EnginePtr));
+    daal::services::internal::TArray<engines::EnginePtr, sse2> engines(par.nTrees);
+    engines::internal::EnginesCollection<sse2> enginesCollection(par.engine, technique, params, engines, &status);
+    DAAL_CHECK_STATUS_VAR(status);
+
+    if (!par.bootstrap)
+    {
+        DAAL_CHECK_STATUS_VAR(_treeLevelBuildHelper.initializeTreeOrder(nSelectedRows, treeOrderLev));
+    }
+
+    for (size_t iter = 0; (iter < par.nTrees) && !algorithms::internal::isCancelled(status, pHostApp); ++iter)
+    {
+        BlockDescriptor<algorithmFPType> responseBlock;
+        DAAL_CHECK_STATUS_VAR(const_cast<NumericTable *>(y)->getBlockOfRows(0, nRows, readOnly, responseBlock));
+
+        size_t nNodes   = 1; // num of potential nodes to split on current tree level
+        size_t nOOBRows = 0;
+
+        Collection<TreeLevel> DFTreeRecords;
+        Collection<UniversalBuffer> levelNodeLists;    // lists of nodes int props(rowsOffset, rows, ftrId, ftrVal ... )
+        Collection<UniversalBuffer> levelNodeImpLists; // list of nodes fptype props (impurity, mean)
+        UniversalBuffer oobRows;
+
+        levelNodeLists.push_back(context.allocate(TypeIds::id<int>(), nNodes * TreeLevel::_nNodeSplitProps, &status));
+        levelNodeImpLists.push_back(context.allocate(TypeIds::id<algorithmFPType>(), nNodes * (TreeLevel::_nNodeImpProps + _nClasses), &status));
+        DAAL_CHECK_STATUS_VAR(status);
+
+        {
+            auto rootNode = levelNodeLists[0].template get<int>().toHost(ReadWriteMode::writeOnly);
+            DAAL_CHECK_MALLOC(rootNode.get());
+            rootNode.get()[0] = 0;             // rows offset
+            rootNode.get()[1] = nSelectedRows; // num of rows
+        }
+
+        auto engineImpl = dynamic_cast<engines::internal::BatchBaseImpl *>(engines[iter].get());
+        if (!engineImpl) return Status(ErrorEngineNotSupported);
+
+        if (par.bootstrap)
+        {
+            // TODO migrate to gpu generators and gpu sort version
+            DAAL_ITTNOTIFY_SCOPED_TASK(compute.RNG);
+            daal::internal::RNGs<int, sse2> rng;
+            rng.uniform(nSelectedRows, selectedRowsHost.get(), engineImpl->getState(), 0, nRows);
+            daal::algorithms::internal::qSort<int, sse2>(nSelectedRows, selectedRowsHost.get());
+
+            context.copy(treeOrderLev, 0, (void *)selectedRowsHost.get(), 0, nSelectedRows, &status);
+            DAAL_CHECK_STATUS_VAR(status);
+        }
+
+        if (oobRequired)
+        {
+            _treeLevelBuildHelper.getOOBRows(treeOrderLev, nSelectedRows, nOOBRows, oobRows); // nOOBRows and oobRows are the output
+        }
+
+        for (size_t level = 0; nNodes > 0; level++)
+        {
+            auto nodeList = levelNodeLists[level];
+            auto impList  = levelNodeImpLists[level];
+
+            daal::services::internal::TArray<int, sse2> selectedFeaturesHost(
+                (nNodes + 1) * nSelectedFeatures); // first part is used features indices, +1 - part for generator
+            DAAL_CHECK_MALLOC(selectedFeaturesHost.get());
+
+            auto selectedFeaturesCom = context.allocate(TypeIds::id<int>(), nNodes * nSelectedFeatures, &status);
+            DAAL_CHECK_STATUS_VAR(status);
+
+            if (nSelectedFeatures != nFeatures)
+            {
+                daal::internal::RNGs<int, sse2> rng;
+                for (size_t node = 0; node < nNodes; node++)
+                {
+                    rng.uniformWithoutReplacement(nSelectedFeatures, selectedFeaturesHost.get() + node * nSelectedFeatures,
+                                                  selectedFeaturesHost.get() + (node + 1) * nSelectedFeatures, engineImpl->getState(), 0, nFeatures);
+                }
+            }
+            else
+            {
+                for (size_t node = 0; node < nNodes; node++)
+                {
+                    for (size_t i = 0; i < nSelectedFeatures; i++)
+                    {
+                        selectedFeaturesHost.get()[node * nSelectedFeatures + i] = i;
+                    }
+                }
+            }
+
+            context.copy(selectedFeaturesCom, 0, (void *)selectedFeaturesHost.get(), 0, nSelectedFeatures * nNodes, &status);
+            DAAL_CHECK_STATUS_VAR(status);
+
+            if (mdiRequired)
+            {
+                nodeImpDecreaseList = context.allocate(TypeIds::id<algorithmFPType>(), nNodes, &status);
+            }
+
+            DAAL_CHECK_STATUS_VAR(computeBestSplit(indexedFeatures.getFullData(), treeOrderLev, selectedFeaturesCom, nSelectedFeatures,
+                                                   responseBlock.getBuffer(), nodeList, indexedFeatures.binOffsets(), impList, nodeImpDecreaseList,
+                                                   mdiRequired, nFeatures, nNodes, par.minObservationsInLeafNode, par.impurityThreshold));
+
+            if (par.maxTreeDepth > 0 && par.maxTreeDepth == level)
+            {
+                DAAL_CHECK_STATUS_VAR(_treeLevelBuildHelper.convertSplitToLeaf(nodeList, nNodes));
+                TreeLevel levelRecord;
+                DAAL_CHECK_STATUS_VAR(levelRecord.init(nodeList, impList, nNodes, _nClasses));
+                DFTreeRecords.push_back(levelRecord);
+                break;
+            }
+
+            TreeLevel levelRecord;
+            DAAL_CHECK_STATUS_VAR(levelRecord.init(nodeList, impList, nNodes, _nClasses));
+            DFTreeRecords.push_back(levelRecord);
+
+            if (mdiRequired)
+            {
+                /*mdi is calculated only on split nodes and not calculated on last level*/
+                auto varImpBuffer = varImpBlock.getBuffer();
+                DAAL_CHECK_STATUS_VAR(_treeLevelBuildHelper.updateMDIVarImportance(nodeList, nodeImpDecreaseList, nNodes, varImpBuffer, nFeatures));
+            }
+
+            size_t nNodesNewLevel;
+            DAAL_CHECK_STATUS_VAR(_treeLevelBuildHelper.getNumOfSplitNodes(nodeList, nNodes, nNodesNewLevel));
+
+            if (nNodesNewLevel)
+            {
+                /*there are split nodes -> next level is required*/
+                nNodesNewLevel *= 2;
+
+                auto nodeListNewLevel = context.allocate(TypeIds::id<int>(), nNodesNewLevel * TreeLevel::_nNodeSplitProps, &status);
+                auto impListNewLevel =
+                    context.allocate(TypeIds::id<algorithmFPType>(), nNodesNewLevel * (TreeLevel::_nNodeImpProps + _nClasses), &status);
+                DAAL_CHECK_STATUS_VAR(status);
+
+                DAAL_CHECK_STATUS_VAR(_treeLevelBuildHelper.doNodesSplit(nodeList, nNodes, nodeListNewLevel));
+
+                levelNodeLists.push_back(nodeListNewLevel);
+                levelNodeImpLists.push_back(impListNewLevel);
+
+                DAAL_CHECK_STATUS_VAR(_treeLevelBuildHelper.doLevelPartition(indexedFeatures.getFullData(), nodeList, nNodes, treeOrderLev,
+                                                                             treeOrderLevBuf, nSelectedRows, nFeatures));
+            }
+
+            nNodes = nNodesNewLevel;
+        } // for level
+
+        services::Collection<SharedPtr<algorithmFPType> > binValuesHost(nFeatures);
+        DAAL_CHECK_MALLOC(binValuesHost.data());
+        services::Collection<algorithmFPType *> binValues(nFeatures);
+        DAAL_CHECK_MALLOC(binValues.data());
+
+        for (size_t i = 0; i < nFeatures; i++)
+        {
+            binValuesHost[i] = indexedFeatures.binBorders(i).template get<algorithmFPType>().toHost(ReadWriteMode::readOnly);
+            DAAL_CHECK_MALLOC(binValuesHost[i].get());
+            binValues[i] = binValuesHost[i].get();
+        }
+
+        typename DFTreeConverterType::TreeHelperType mTreeHelper;
+
+        DFTreeConverterType converter;
+        converter.convertToDFDecisionTree(DFTreeRecords, binValues.data(), mTreeHelper, _nClasses);
+
+        mdImpl.add(mTreeHelper._tree, _nClasses);
+
+        DAAL_CHECK_STATUS_VAR(computeResults(mTreeHelper._tree, dataBlock.getBlockPtr(), responseBlock.getBlockPtr(), nSelectedRows, nFeatures,
+                                             oobRows, nOOBRows, oobBufferPerObs, varImpBlock.getBlockPtr(), varImpVariance.get(), iter + 1,
+                                             engines[iter], par));
+
+        DAAL_CHECK_STATUS_VAR(const_cast<NumericTable *>(y)->releaseBlockOfRows(responseBlock));
+    }
+
+    /* Finalize results */
+    if (par.resultsToCompute & (decision_forest::training::computeOutOfBagError | decision_forest::training::computeOutOfBagErrorPerObservation))
+    {
+        BlockDescriptor<algorithmFPType> responseBlock;
+        DAAL_CHECK_STATUS_VAR(const_cast<NumericTable *>(y)->getBlockOfRows(0, nRows, readOnly, responseBlock));
+
+        NumericTablePtr oobErrPtr = res.get(outOfBagError);
+        BlockDescriptor<algorithmFPType> oobErrBlock;
+        if (par.resultsToCompute & decision_forest::training::computeOutOfBagError)
+            DAAL_CHECK_STATUS_VAR(oobErrPtr->getBlockOfRows(0, 1, writeOnly, oobErrBlock));
+
+        NumericTablePtr oobErrPerObsPtr = res.get(outOfBagErrorPerObservation);
+        BlockDescriptor<algorithmFPType> oobErrPerObsBlock;
+        if (par.resultsToCompute & decision_forest::training::computeOutOfBagErrorPerObservation)
+            DAAL_CHECK_STATUS_VAR(oobErrPerObsPtr->getBlockOfRows(0, nRows, writeOnly, oobErrPerObsBlock));
+
+        DAAL_CHECK_STATUS_VAR(
+            finalizeOOBError(responseBlock.getBlockPtr(), oobBufferPerObs, nRows, oobErrBlock.getBlockPtr(), oobErrPerObsBlock.getBlockPtr()));
+
+        if (oobErrPtr) DAAL_CHECK_STATUS_VAR(oobErrPtr->releaseBlockOfRows(oobErrBlock));
+
+        if (oobErrPerObsPtr) DAAL_CHECK_STATUS_VAR(oobErrPerObsPtr->releaseBlockOfRows(oobErrPerObsBlock));
+
+        DAAL_CHECK_STATUS_VAR(const_cast<NumericTable *>(y)->releaseBlockOfRows(responseBlock));
+    }
+
+    if (par.varImportance != decision_forest::training::none && par.varImportance != decision_forest::training::MDA_Raw)
+    {
+        finalizeVarImp(par, varImpBlock.getBlockPtr(), varImpVariance.get(), nFeatures);
+    }
+
+    if (mdiRequired || mdaRequired) DAAL_CHECK_STATUS_VAR(varImpResPtr->releaseBlockOfRows(varImpBlock));
+
+    DAAL_CHECK_STATUS_VAR(const_cast<NumericTable *>(x)->releaseBlockOfRows(dataBlock));
+
+    return status;
+}
+
+} /* namespace internal */
+} /* namespace training */
+} /* namespace classification */
+} /* namespace decision_forest */
+} /* namespace algorithms */
+} /* namespace daal */
+
+#endif

--- a/algorithms/kernel/dtrees/forest/classification/oneapi/df_classification_train_hist_oneapi_impl.i
+++ b/algorithms/kernel/dtrees/forest/classification/oneapi/df_classification_train_hist_oneapi_impl.i
@@ -277,7 +277,9 @@ services::Status ClassificationTrainBatchKernelOneAPI<algorithmFPType, hist>::co
             //_maxLocalHistograms/2 (128) showed better performance than _maxLocalHistograms need to investigate
             int reduceLocalSize = 16; // add logic for its adjustment
 
-            size_t partHistSize = nSelectedFeatures * _nMaxBinsAmongFtrs * _nClasses;
+            size_t nHistBins    = nSelectedFeatures * _nMaxBinsAmongFtrs;
+            nHistBins           = (nHistBins > _totalBins) ? _totalBins : nHistBins;
+            size_t partHistSize = nHistBins * _nHistProps;
 
             auto partialHistograms = context.allocate(TypeIds::id<algorithmFPType>(), nGroupNodes * nPartialHistograms * partHistSize, &status);
             auto nodesHistograms   = context.allocate(TypeIds::id<algorithmFPType>(), nGroupNodes * partHistSize, &status);
@@ -652,6 +654,7 @@ services::Status ClassificationTrainBatchKernelOneAPI<algorithmFPType, hist>::co
     DAAL_CHECK_MALLOC(featTypes.init(*x));
     DAAL_CHECK_STATUS(status, (indexedFeatures.init(*const_cast<NumericTable *>(x), &featTypes, &prm)));
 
+    _totalBins = indexedFeatures.totalBins();
     /* calculating the maximal number of bins for feature among all features */
     {
         auto binOffsetsHost = indexedFeatures.binOffsets().template get<int>().toHost(ReadWriteMode::readOnly);

--- a/algorithms/kernel/dtrees/forest/classification/oneapi/df_classification_train_hist_oneapi_impl.i
+++ b/algorithms/kernel/dtrees/forest/classification/oneapi/df_classification_train_hist_oneapi_impl.i
@@ -279,7 +279,7 @@ services::Status ClassificationTrainBatchKernelOneAPI<algorithmFPType, hist>::co
 
             size_t nHistBins    = nSelectedFeatures * _nMaxBinsAmongFtrs;
             nHistBins           = (nHistBins > _totalBins) ? _totalBins : nHistBins;
-            size_t partHistSize = nHistBins * _nHistProps;
+            size_t partHistSize = nHistBins * _nClasses;
 
             auto partialHistograms = context.allocate(TypeIds::id<algorithmFPType>(), nGroupNodes * nPartialHistograms * partHistSize, &status);
             auto nodesHistograms   = context.allocate(TypeIds::id<algorithmFPType>(), nGroupNodes * partHistSize, &status);

--- a/algorithms/kernel/dtrees/forest/classification/oneapi/df_classification_tree_helper_impl.i
+++ b/algorithms/kernel/dtrees/forest/classification/oneapi/df_classification_tree_helper_impl.i
@@ -1,0 +1,185 @@
+/* file: df_classification_tree_helper_impl.i */
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+/*
+//++
+//  Implementation of the class defining the decision forest classification tree
+//--
+*/
+
+#ifndef __DF_CLASSIFICATION_TREE_HELPER_IMPL__
+#define __DF_CLASSIFICATION_TREE_HELPER_IMPL__
+
+#include "data_management/data/aos_numeric_table.h"
+#include "service/kernel/service_arrays.h"
+#include "algorithms/kernel/dtrees/dtrees_predict_dense_default_impl.i"
+
+namespace daal
+{
+namespace algorithms
+{
+namespace decision_forest
+{
+namespace classification
+{
+namespace internal
+{
+using namespace daal::algorithms::dtrees::internal;
+using namespace daal::services::internal;
+
+template <typename algorithmFPType, CpuType cpu>
+class ClassificationTreeHelperOneAPI
+{
+public:
+    typedef dtrees::internal::TreeImpClassification<> TreeType;
+    typedef typename TreeType::NodeType NodeType;
+
+    typename NodeType::Leaf * makeLeaf(size_t n, size_t response, algorithmFPType impurity, algorithmFPType * hist, size_t nClasses)
+    {
+        typename NodeType::Leaf * pNode = _tree.allocator().allocLeaf(nClasses);
+        DAAL_ASSERT(n > 0);
+        pNode->response.value = response;
+        pNode->count          = n;
+        pNode->impurity       = impurity;
+
+        for (size_t i = 0; i < nClasses; i++)
+        {
+            pNode->hist[i] = hist[i];
+        }
+
+        return pNode;
+    }
+
+    typename NodeType::Split * makeSplit(size_t iFeature, algorithmFPType featureValue, bool bUnordered, algorithmFPType impurity,
+                                         typename NodeType::Base * left, typename NodeType::Base * right)
+    {
+        typename NodeType::Split * pNode = _tree.allocator().allocSplit();
+        pNode->set(iFeature, featureValue, bUnordered);
+        pNode->kid[0]   = left;
+        pNode->kid[1]   = right;
+        pNode->impurity = impurity;
+
+        return pNode;
+    }
+
+    size_t predict(const dtrees::internal::Tree & t, const algorithmFPType * x) const
+    {
+        const typename NodeType::Base * pNode = dtrees::prediction::internal::findNode<algorithmFPType, TreeType, cpu>(t, x);
+        DAAL_ASSERT(pNode);
+        return NodeType::castLeaf(pNode)->response.value;
+    }
+
+    TreeType _tree;
+};
+
+template <typename algorithmFPType>
+struct TreeLevelRecord
+{
+    TreeLevelRecord() : _nodeList(nullptr), _impInfo(nullptr), _nNodes(0), _nClasses(0) {}
+    services::Status init(oneapi::internal::UniversalBuffer & nodeList, oneapi::internal::UniversalBuffer & impInfo, size_t nNodes, size_t nClasses)
+    {
+        _nNodes   = nNodes;
+        _nClasses = nClasses;
+
+        auto nodeListHost = nodeList.template get<int>().toHost(ReadWriteMode::readOnly);
+        _nodeList         = nodeListHost.get();
+        DAAL_CHECK_MALLOC(_nodeList);
+
+        auto impInfoHost = impInfo.template get<algorithmFPType>().toHost(ReadWriteMode::readOnly);
+        _impInfo         = impInfoHost.get();
+        DAAL_CHECK_MALLOC(_impInfo);
+
+        return services::Status();
+    }
+
+    size_t getNodesNum() { return _nNodes; }
+    int getRowsNum(size_t nodeIdx) { return _nodeList[nodeIdx * _nNodeSplitProps + 1]; }
+    int getFtrIdx(size_t nodeIdx) { return _nodeList[nodeIdx * _nNodeSplitProps + 2]; }
+    int getFtrVal(size_t nodeIdx) { return _nodeList[nodeIdx * _nNodeSplitProps + 3]; }
+    algorithmFPType getImpurity(size_t nodeIdx) { return _impInfo[nodeIdx * (_nNodeImpProps + _nClasses) + 0]; }
+    size_t getResponse(size_t nodeIdx) { return static_cast<size_t>(_nodeList[nodeIdx * _nNodeSplitProps + 5]); }
+    algorithmFPType * getHist(size_t nodeIdx) { return &_impInfo[nodeIdx * (_nNodeImpProps + _nClasses) + _nNodeImpProps]; }
+    bool hasUnorderedFtr(size_t nodeIdx) { return false; /* unordered features are not supported yet */ }
+
+    constexpr static int _nNodeImpProps   = 1;
+    constexpr static int _nNodeSplitProps = 6;
+
+    int * _nodeList;
+    algorithmFPType * _impInfo;
+    size_t _nNodes;
+    size_t _nClasses;
+};
+
+template <typename algorithmFPType, CpuType cpu>
+struct DFTreeConverter
+{
+    typedef ClassificationTreeHelperOneAPI<algorithmFPType, cpu> TreeHelperType;
+
+    void convertToDFDecisionTree(Collection<TreeLevelRecord<algorithmFPType> > & treeLevelsList, algorithmFPType ** binValues,
+                                 TreeHelperType & treeBuilder, size_t nClasses)
+    {
+        typedef TArray<typename TreeHelperType::NodeType::Base *, cpu> DFTreeNodesArr;
+        typedef SharedPtr<DFTreeNodesArr> DFTreeNodesArrPtr;
+
+        DFTreeNodesArrPtr dfTreeLevelNodesPrev;
+        bool unorderedFeaturesUsed = false;
+        const int notFoundVal      = -1;
+
+        TreeLevelRecord<algorithmFPType> & r0 = treeLevelsList[0];
+
+        size_t level = treeLevelsList.size();
+        do
+        {
+            level--;
+            TreeLevelRecord<algorithmFPType> & record = treeLevelsList[level];
+            DFTreeNodesArrPtr dfTreeLevelNodes(new DFTreeNodesArr(record.getNodesNum()));
+
+            size_t nSplits = 0;
+            // nSplits is used to calculate index of child nodes on next level
+            for (size_t nodeIdx = 0; nodeIdx < record.getNodesNum(); nodeIdx++)
+            {
+                if (record.getFtrIdx(nodeIdx) == notFoundVal)
+                {
+                    // leaf node
+                    dfTreeLevelNodes->get()[nodeIdx] = treeBuilder.makeLeaf(record.getRowsNum(nodeIdx), record.getResponse(nodeIdx),
+                                                                            record.getImpurity(nodeIdx), record.getHist(nodeIdx), nClasses);
+                }
+                else
+                {
+                    //split node
+                    dfTreeLevelNodes->get()[nodeIdx] =
+                        treeBuilder.makeSplit(record.getFtrIdx(nodeIdx), binValues[record.getFtrIdx(nodeIdx)][record.getFtrVal(nodeIdx)],
+                                              static_cast<bool>(record.hasUnorderedFtr(nodeIdx)), record.getImpurity(nodeIdx),
+                                              dfTreeLevelNodesPrev->get()[nSplits * 2], dfTreeLevelNodesPrev->get()[nSplits * 2 + 1]);
+                    nSplits++;
+                }
+            }
+
+            dfTreeLevelNodesPrev = dfTreeLevelNodes;
+        } while (level > 0);
+
+        treeBuilder._tree.reset(dfTreeLevelNodesPrev->get()[0], unorderedFeaturesUsed);
+    }
+};
+
+} // namespace internal
+} // namespace classification
+} // namespace decision_forest
+} // namespace algorithms
+} // namespace daal
+
+#endif

--- a/algorithms/kernel/dtrees/forest/oneapi/cl_kernels/df_tree_level_build_helper_kernels.cl
+++ b/algorithms/kernel/dtrees/forest/oneapi/cl_kernels/df_tree_level_build_helper_kernels.cl
@@ -1,0 +1,383 @@
+/* file: df_tree_level_build_helper_kernels.cl */
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+/*
+//++
+//  Implementation of tree level build helper OpenCL kernels.
+//--
+*/
+
+#ifndef __DF_TREE_LEVEL_BUILD_HELPER_KERNELS_CL__
+#define __DF_TREE_LEVEL_BUILD_HELPER_KERNELS_CL__
+
+#include <string.h>
+
+#define DECLARE_SOURCE(name, src) static const char * name = #src;
+
+DECLARE_SOURCE(
+    df_tree_level_build_helper_kernels,
+
+    __kernel void initializeTreeOrder(__global int * treeOrder) {
+        const int id  = get_global_id(0);
+        treeOrder[id] = id;
+    }
+
+    __kernel void partitionCopy(const __global int * treeOrderBuf, __global int * treeOrder, int offset) {
+        const int id           = get_global_id(0);
+        treeOrder[offset + id] = treeOrderBuf[offset + id];
+    }
+
+    __kernel void doLevelPartition(const __global int * data, const __global int * nodeList, const __global int * treeOrder,
+                                   __global int * treeOrderBuf, int nFeatures) {
+        const int nNodeProp  = NODE_PROPS; // num of split attributes for node
+        const int leafMark   = -1;
+        const int local_id   = get_sub_group_local_id();
+        const int nodeId     = get_global_id(1);
+        const int local_size = get_sub_group_size();
+
+        __global const int * node = nodeList + nodeId * nNodeProp;
+        const int offset          = node[0];
+        const int nRows           = node[1];
+        const int featId          = node[2];
+        const int splitVal        = node[3];
+        const int nRowsLeft       = node[4]; // num of items in Left part
+
+        if (featId != leafMark) // split node
+        {
+            int sum = 0;
+
+            for (int i = local_id; i < nRows; i += local_size)
+            {
+                int id                        = treeOrder[offset + i];
+                int toRight                   = (int)(data[id * nFeatures + featId] > splitVal);
+                int boundary                  = sum + sub_group_scan_exclusive_add(toRight);
+                int posNew                    = (toRight ? nRowsLeft + boundary : i - boundary);
+                treeOrderBuf[offset + posNew] = id;
+                sum += sub_group_reduce_add(toRight);
+            }
+        }
+    }
+
+    __kernel void getNumOfSplitNodes(const __global int * nodeList, int nNodes, __global int * nSplitNodes) {
+        const int local_id   = get_sub_group_local_id();
+        const int local_size = get_sub_group_size();
+        const int nNodeProp  = NODE_PROPS; // num of node properties in node
+        const int badVal     = -1;
+
+        int sum = 0;
+        for (int i = local_id; i < nNodes; i += local_size)
+        {
+            sum += (int)(nodeList[i * nNodeProp + 2] != badVal);
+        }
+
+        sum = sub_group_reduce_add(sum);
+
+        if (local_id == 0)
+        {
+            nSplitNodes[0] = sum;
+        }
+    }
+
+    __kernel void convertSplitToLeaf(__global int * nodeList) {
+        const int nNodeProp = NODE_PROPS; // num of split attributes for node
+        const int leafMark  = -1;
+        const int id        = get_global_id(0);
+
+        nodeList[id * nNodeProp + 2] = leafMark;
+        nodeList[id * nNodeProp + 3] = leafMark;
+    }
+
+    __kernel void doNodesSplit(const __global int * nodeList, int nNodes, __global int * nodeListNew) {
+        const int nNodeProp  = NODE_PROPS; // num of split attributes for node
+        const int badVal     = -1;
+        const int local_id   = get_sub_group_local_id();
+        const int local_size = get_sub_group_size();
+
+        int nCreatedNodes = 0;
+        for (int i = local_id; i < nNodes; i += local_size)
+        {
+            int splitNode      = (int)(nodeList[i * nNodeProp + 2] != badVal); // featId != -1
+            int newLeftNodePos = nCreatedNodes + sub_group_scan_exclusive_add(splitNode) * 2;
+            if (splitNode)
+            {
+                // split parent node on left and right nodes
+                __global const int * nodeP = nodeList + i * nNodeProp;
+                __global int * nodeL       = nodeListNew + newLeftNodePos * nNodeProp;
+                __global int * nodeR       = nodeListNew + (newLeftNodePos + 1) * nNodeProp;
+
+                nodeL[0] = nodeP[0]; // rows offset
+                nodeL[1] = nodeP[4]; // nRows
+                nodeL[2] = badVal;   // featureId
+                nodeL[3] = badVal;   // featureVal
+                nodeL[4] = nodeP[4]; // num of items in Left part = nRows in new node
+
+                nodeR[0] = nodeL[0] + nodeL[1];
+                nodeR[1] = nodeP[1] - nodeL[1];
+                nodeR[2] = badVal;
+                nodeR[3] = badVal;
+                nodeR[4] = nodeR[1]; // num of items in Left part = nRows in new node
+            }
+            nCreatedNodes += sub_group_reduce_add(splitNode) * 2;
+        }
+    }
+
+    __kernel void splitNodeListOnGroupsBySize(const __global int * nodeList, int nNodes, __global int * bigNodesGroups, __global int * nodeIndices,
+                                              int minRowsBlock) {
+        /*for now only 3 groups are produced, may be more required*/
+        const int bigNodeLowBorderBlocksNum = BIG_NODE_LOW_BORDER_BLOCKS_NUM; // fine, need to experiment and find better one
+        const int blockSize                 = minRowsBlock;
+        const int nNodeProp                 = NODE_PROPS; // num of split attributes for node
+
+        const int local_id   = get_sub_group_local_id();
+        const int nodeId     = get_global_id(1);
+        const int local_size = get_sub_group_size();
+
+        int nBigNodes       = 0;
+        int maxBigBlocksNum = 1;
+        int nMidNodes       = 0;
+        int maxMidBlocksNum = 1;
+
+        /*calculate num of big and mid nodes*/
+        for (int i = local_id; i < nNodes; i += local_size)
+        {
+            int nRows   = nodeList[i * nNodeProp + 1];
+            int nBlocks = nRows / blockSize + !!(nRows % blockSize);
+
+            int bigNode = (int)(nBlocks > bigNodeLowBorderBlocksNum);
+            int midNode = (int)(nBlocks <= bigNodeLowBorderBlocksNum && nBlocks > 1);
+
+            nBigNodes += sub_group_reduce_add(bigNode);
+            nMidNodes += sub_group_reduce_add(midNode);
+            maxBigBlocksNum = max(maxBigBlocksNum, bigNode ? nBlocks : 0);
+            maxBigBlocksNum = sub_group_reduce_max(maxBigBlocksNum);
+            maxMidBlocksNum = max(maxMidBlocksNum, midNode ? nBlocks : 0);
+            maxMidBlocksNum = sub_group_reduce_max(maxMidBlocksNum);
+        }
+
+        nBigNodes = sub_group_broadcast(nBigNodes, 0);
+        nMidNodes = sub_group_broadcast(nMidNodes, 0);
+
+        if (0 == local_id)
+        {
+            bigNodesGroups[0] = nBigNodes;
+            bigNodesGroups[1] = maxBigBlocksNum;
+            bigNodesGroups[2] = nMidNodes;
+            bigNodesGroups[3] = maxMidBlocksNum;
+            bigNodesGroups[4] = nNodes - nBigNodes - nMidNodes;
+            bigNodesGroups[5] = 1;
+        }
+
+        int sumBig = 0;
+        int sumMid = 0;
+
+        /*split nodes on groups*/
+        for (int i = local_id; i < nNodes; i += local_size)
+        {
+            int nRows   = nodeList[i * nNodeProp + 1];
+            int nBlocks = nRows / blockSize + !!(nRows % blockSize);
+            int bigNode = (int)(nBlocks > bigNodeLowBorderBlocksNum);
+            int midNode = (int)(nBlocks <= bigNodeLowBorderBlocksNum && nBlocks > 1);
+
+            int boundaryBig = sumBig + sub_group_scan_exclusive_add(bigNode);
+            int boundaryMid = sumMid + sub_group_scan_exclusive_add(midNode);
+            int posNew      = (bigNode ? boundaryBig : (midNode ? nBigNodes + boundaryMid : nBigNodes + nMidNodes + i - boundaryBig - boundaryMid));
+            nodeIndices[posNew] = i;
+            sumBig += sub_group_reduce_add(bigNode);
+            sumMid += sub_group_reduce_add(midNode);
+        }
+    }
+
+    __kernel void updateMDIVarImportance(const __global int * nodeList, const __global algorithmFPType * nodeImpDecreaseList, int nNodes,
+                                         __global algorithmFPType * featureImportanceList) {
+        const int nNodeProp = NODE_PROPS; // num of node properties in nodeList
+
+        const int local_id           = get_local_id(0);
+        const int sub_group_local_id = get_sub_group_local_id();
+        const int sub_group_size     = get_sub_group_size();
+        const int local_size         = get_local_size(0);
+        const int n_sub_groups       = local_size / sub_group_size; // num of subgroups for current node processing
+        const int sub_group_id       = local_id / sub_group_size;
+        const int max_sub_groups_num = 16; //replace with define
+
+        const int bufIdx = get_global_id(1) % (max_sub_groups_num / n_sub_groups); // local buffer is shared between 16 sub groups
+        const int ftrId  = get_global_id(1);
+
+        const int leafMark             = -1;
+        const int nElementsForSubgroup = nNodes / n_sub_groups + !!(nNodes % n_sub_groups);
+
+        __local algorithmFPType bufI[max_sub_groups_num]; // storage for impurity decrease
+
+        int iStart = sub_group_id * nElementsForSubgroup;
+        int iEnd   = (sub_group_id + 1) * nElementsForSubgroup;
+
+        iEnd = (iEnd > nNodes) ? nNodes : iEnd;
+
+        algorithmFPType ftrImp = (algorithmFPType)0;
+
+        for (int nodeIdx = iStart + sub_group_local_id; nodeIdx < iEnd; nodeIdx += sub_group_size)
+        {
+            int splitFtrId = nodeList[nodeIdx * nNodeProp + 2];
+            ftrImp += sub_group_reduce_add((splitFtrId != leafMark && ftrId == splitFtrId) ? nodeImpDecreaseList[nodeIdx] : (algorithmFPType)0);
+        }
+
+        if (0 == sub_group_local_id)
+        {
+            if (1 == n_sub_groups)
+            {
+                featureImportanceList[ftrId] += ftrImp;
+            }
+            else
+            {
+                bufI[bufIdx + sub_group_id] = ftrImp;
+            }
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+        if (1 < n_sub_groups && 0 == sub_group_id)
+        {
+            // first sub group for current node reduces over local buffer if required
+            algorithmFPType ftrImp      = (sub_group_local_id < n_sub_groups) ? bufI[bufIdx + sub_group_local_id] : (algorithmFPType)0;
+            algorithmFPType totalFtrImp = sub_group_reduce_add(ftrImp);
+
+            if (0 == local_id)
+            {
+                featureImportanceList[ftrId] += totalFtrImp;
+            }
+        }
+    }
+
+    __kernel void markPresentRows(const __global int * rowsList, __global int * rowsBuffer, int nRows) {
+        const int n_groups             = get_num_groups(0);
+        const int n_sub_groups         = get_num_sub_groups();
+        const int n_total_sub_groups   = n_sub_groups * n_groups;
+        const int nElementsForSubgroup = nRows / n_total_sub_groups + !!(nRows % n_total_sub_groups);
+        const int local_size           = get_sub_group_size();
+
+        const int id           = get_local_id(0);
+        const int local_id     = get_sub_group_local_id();
+        const int sub_group_id = get_sub_group_id();
+        const int group_id     = get_group_id(0) * n_sub_groups + sub_group_id;
+
+        const int itemPresentMark = 1;
+
+        int iStart = group_id * nElementsForSubgroup;
+        int iEnd   = (group_id + 1) * nElementsForSubgroup;
+
+        iEnd = (iEnd > nRows) ? nRows : iEnd;
+
+        for (int i = iStart + local_id; i < iEnd; i += local_size)
+        {
+            rowsBuffer[rowsList[i]] = itemPresentMark;
+        }
+    }
+
+    __kernel void countAbsentRowsForBlocks(const __global int * rowsBuffer, __global int * partialSums, int nRows) {
+        const int n_groups             = get_num_groups(0);
+        const int n_sub_groups         = get_num_sub_groups();
+        const int n_total_sub_groups   = n_sub_groups * n_groups;
+        const int nElementsForSubgroup = nRows / n_total_sub_groups + !!(nRows % n_total_sub_groups);
+        const int local_size           = get_sub_group_size();
+
+        const int id           = get_local_id(0);
+        const int local_id     = get_sub_group_local_id();
+        const int sub_group_id = get_sub_group_id();
+        const int group_id     = get_group_id(0) * n_sub_groups + sub_group_id;
+
+        const int itemAbsentMark = -1;
+
+        int iStart = group_id * nElementsForSubgroup;
+        int iEnd   = (group_id + 1) * nElementsForSubgroup;
+
+        iEnd = (iEnd > nRows) ? nRows : iEnd;
+
+        int subSum = 0;
+
+        for (int i = iStart + local_id; i < iEnd; i += local_size)
+        {
+            subSum += (int)(itemAbsentMark == rowsBuffer[i]);
+        }
+
+        int sum = sub_group_reduce_add(subSum);
+
+        if (local_id == 0)
+        {
+            partialSums[group_id] = sum;
+        }
+    }
+
+    __kernel void countAbsentRowsTotal(const __global int * partialSums, __global int * partialPrefixSums, __global int * totalSum,
+                                       int nSubgroupSums) {
+        if (get_sub_group_id() > 0) return;
+
+        const int local_size = get_sub_group_size();
+        const int local_id   = get_sub_group_local_id();
+
+        int sum = 0;
+
+        for (int i = local_id; i < nSubgroupSums; i += local_size)
+        {
+            int value            = partialSums[i];
+            int boundary         = sub_group_scan_exclusive_add(value);
+            partialPrefixSums[i] = sum + boundary;
+            sum += sub_group_reduce_add(value);
+        }
+
+        if (local_id == 0)
+        {
+            totalSum[0] = sum;
+        }
+    }
+
+    __kernel void fillOOBRowsListByBlocks(const __global int * rowsBuffer, const __global int * partialPrefixSums, __global int * oobRowsList,
+                                          int nRows) {
+        const int n_groups           = get_num_groups(0);
+        const int n_sub_groups       = get_num_sub_groups();
+        const int n_total_sub_groups = n_sub_groups * n_groups;
+        const int local_size         = get_sub_group_size();
+
+        const int id           = get_local_id(0);
+        const int local_id     = get_sub_group_local_id();
+        const int sub_group_id = get_sub_group_id();
+        const int group_id     = get_group_id(0) * n_sub_groups + sub_group_id;
+
+        const int nElementsForSubgroup = nRows / n_total_sub_groups + !!(nRows % n_total_sub_groups);
+
+        const int itemAbsentMark = -1;
+
+        int iStart = group_id * nElementsForSubgroup;
+        int iEnd   = (group_id + 1) * nElementsForSubgroup;
+
+        iEnd = (iEnd > nRows) ? nRows : iEnd;
+
+        int groupOffset = partialPrefixSums[group_id];
+        int sum         = 0;
+
+        for (int i = iStart + local_id; i < iEnd; i += local_size)
+        {
+            int oobRow = (int)(itemAbsentMark == rowsBuffer[i]);
+            int pos    = groupOffset + sum + sub_group_scan_exclusive_add(oobRow);
+            if (oobRow)
+            {
+                oobRowsList[pos] = i;
+            }
+            sum += sub_group_reduce_add(oobRow);
+        }
+    }
+
+);
+
+#endif

--- a/algorithms/kernel/dtrees/forest/oneapi/df_tree_level_build_helper_oneapi.h
+++ b/algorithms/kernel/dtrees/forest/oneapi/df_tree_level_build_helper_oneapi.h
@@ -17,8 +17,8 @@
 
 /*
 //++
-//  Implementation of a service class that provides 
-//  common kernels required for building tree levels 
+//  Implementation of a service class that provides
+//  common kernels required for building tree levels
 //--
 */
 

--- a/algorithms/kernel/dtrees/forest/oneapi/df_tree_level_build_helper_oneapi.h
+++ b/algorithms/kernel/dtrees/forest/oneapi/df_tree_level_build_helper_oneapi.h
@@ -1,0 +1,125 @@
+/* file: df_tree_level_build_helper_oneapi.h */
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+/*
+//++
+//  Implementation of a service class that provides 
+//  common kernels required for building tree levels 
+//--
+*/
+
+#ifndef __DF_TREE_LEVEL_BUILD_HELPER_ONEAPI_H__
+#define __DF_TREE_LEVEL_BUILD_HELPER_ONEAPI_H__
+
+#include "algorithms/kernel/service_error_handling.h"
+#include "algorithms/kernel/dtrees/service_array.h"
+#include "service/kernel/service_arrays.h"
+#include "externals/service_memory.h"
+#include "service/kernel/service_data_utils.h"
+
+#include "oneapi/internal/execution_context.h"
+#include "oneapi/internal/types.h"
+
+namespace daal
+{
+namespace algorithms
+{
+namespace decision_forest
+{
+namespace internal
+{
+//////////////////////////////////////////////////////////////////////////////////////////
+// TreeLevelBuildHelperOneAPI - contains common kernels (for classification and regression)
+// required for building tree level
+//////////////////////////////////////////////////////////////////////////////////////////
+template <typename algorithmFPType>
+class TreeLevelBuildHelperOneAPI
+{
+public:
+    TreeLevelBuildHelperOneAPI() {}
+    ~TreeLevelBuildHelperOneAPI() {}
+
+    services::Status init(const char * buildOptions);
+
+    services::Status initializeTreeOrder(size_t nRows, oneapi::internal::UniversalBuffer & treeOrder);
+
+    services::Status convertSplitToLeaf(oneapi::internal::UniversalBuffer & nodeList, size_t nNodes);
+
+    services::Status markPresentRows(const oneapi::internal::UniversalBuffer & rowsList, oneapi::internal::UniversalBuffer & rowsBuffer, size_t nRows,
+                                     size_t localSize, size_t nSubgroupSums);
+    services::Status countAbsentRowsForBlocks(const oneapi::internal::UniversalBuffer & rowsBuffer, size_t nRows,
+                                              oneapi::internal::UniversalBuffer & partialSums, size_t localSize, size_t nSubgroupSums);
+    services::Status countAbsentRowsTotal(const oneapi::internal::UniversalBuffer & partialSums,
+                                          oneapi::internal::UniversalBuffer & partialPrefixSums, oneapi::internal::UniversalBuffer & totalSum,
+                                          size_t localSize, size_t nSubgroupSums);
+    services::Status fillOOBRowsListByBlocks(const oneapi::internal::UniversalBuffer & rowsBuffer, size_t nRows,
+                                             const oneapi::internal::UniversalBuffer & partialPrefixSums,
+                                             oneapi::internal::UniversalBuffer & oobRowsList, size_t localSize, size_t nSubgroupSums);
+
+    services::Status getOOBRows(const oneapi::internal::UniversalBuffer & rowsList, size_t nRows, size_t & nOOBRows,
+                                oneapi::internal::UniversalBuffer & oobRowsList);
+
+    services::Status getNumOfSplitNodes(const oneapi::internal::UniversalBuffer & nodeList, size_t nNodes, size_t & nSplitNodes);
+
+    services::Status doNodesSplit(const oneapi::internal::UniversalBuffer & nodeList, size_t nNodes, oneapi::internal::UniversalBuffer & nodeListNew);
+
+    services::Status splitNodeListOnGroupsBySize(const oneapi::internal::UniversalBuffer & nodeList, size_t nNodes,
+                                                 oneapi::internal::UniversalBuffer & bigNodesGroups, oneapi::internal::UniversalBuffer & nodeIndeces);
+
+    services::Status doLevelPartition(const oneapi::internal::UniversalBuffer & data, oneapi::internal::UniversalBuffer & nodeList, size_t nNodes,
+                                      oneapi::internal::UniversalBuffer & treeOrder, oneapi::internal::UniversalBuffer & treeOrderBuf, size_t nRows,
+                                      size_t nFeatures);
+
+    services::Status partitionCopy(oneapi::internal::UniversalBuffer & treeOrderBuf, oneapi::internal::UniversalBuffer & treeOrder, size_t iStart,
+                                   size_t nRows);
+
+    services::Status updateMDIVarImportance(const oneapi::internal::UniversalBuffer & nodeList,
+                                            const oneapi::internal::UniversalBuffer & nodeImpDecreaseList, size_t nNodes,
+                                            services::Buffer<algorithmFPType> & varImp, size_t nFeatures);
+
+private:
+    services::Status buildProgram(oneapi::internal::ClKernelFactoryIface & factory, const char * buildOptions = nullptr);
+
+    oneapi::internal::KernelPtr kernelInitializeTreeOrder;
+    oneapi::internal::KernelPtr kernelConvertSplitToLeaf;
+    oneapi::internal::KernelPtr kernelGetNumOfSplitNodes;
+    oneapi::internal::KernelPtr kernelDoNodesSplit;
+    oneapi::internal::KernelPtr kernelDoLevelPartition;
+    oneapi::internal::KernelPtr kernelSplitNodeListOnGroupsBySize;
+
+    oneapi::internal::KernelPtr kernelMarkPresentRows;
+    oneapi::internal::KernelPtr kernelCountAbsentRowsForBlocks;
+    oneapi::internal::KernelPtr kernelCountAbsentRowsTotal;
+    oneapi::internal::KernelPtr kernelFillOOBRowsListByBlocks;
+
+    oneapi::internal::KernelPtr kernelUpdateMDIVarImportance;
+    oneapi::internal::KernelPtr kernelPartitionCopy;
+
+    const uint32_t _maxLocalSums = 256;
+    const uint32_t _minRowsBlock = 256;
+
+    const uint32_t _preferableGroupSize  = 256;
+    const uint32_t _maxWorkItemsPerGroup = 256; // should be a power of two for interal needs
+    const uint32_t _preferableSubGroup   = 16;  // preferable maximal sub-group size
+};
+
+} /* namespace internal */
+} /* namespace decision_forest */
+} /* namespace algorithms */
+} /* namespace daal */
+
+#endif

--- a/algorithms/kernel/dtrees/forest/oneapi/df_tree_level_build_helper_oneapi.i
+++ b/algorithms/kernel/dtrees/forest/oneapi/df_tree_level_build_helper_oneapi.i
@@ -39,7 +39,6 @@ namespace decision_forest
 {
 namespace internal
 {
-
 template <typename algorithmFPType>
 services::Status TreeLevelBuildHelperOneAPI<algorithmFPType>::buildProgram(ClKernelFactoryIface & factory, const char * buildOptions)
 {

--- a/algorithms/kernel/dtrees/forest/oneapi/df_tree_level_build_helper_oneapi.i
+++ b/algorithms/kernel/dtrees/forest/oneapi/df_tree_level_build_helper_oneapi.i
@@ -1,0 +1,560 @@
+/* file: df_tree_level_build_helper_oneapi.i */
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+/*
+//++
+// Implementation of common functions for building tree level
+//--
+*/
+#include "algorithms/kernel/dtrees/forest/oneapi/df_tree_level_build_helper_oneapi.h"
+#include "algorithms/kernel/dtrees/forest/oneapi/cl_kernels/df_tree_level_build_helper_kernels.cl"
+
+#include "service/kernel/service_data_utils.h"
+#include "externals/service_ittnotify.h"
+
+//DAAL_ITTNOTIFY_DOMAIN(df.common.oneapi);
+
+using namespace daal::oneapi::internal;
+using namespace daal::services::internal;
+
+namespace daal
+{
+namespace algorithms
+{
+namespace decision_forest
+{
+namespace internal
+{
+
+template <typename algorithmFPType>
+services::Status TreeLevelBuildHelperOneAPI<algorithmFPType>::buildProgram(ClKernelFactoryIface & factory, const char * buildOptions)
+{
+    services::Status status;
+    DAAL_ITTNOTIFY_SCOPED_TASK(treeLevelHelperOneAPI.buildProgram);
+    {
+        auto fptype_name   = getKeyFPType<algorithmFPType>();
+        auto build_options = fptype_name;
+
+        build_options.add(" -cl-std=CL1.2 ");
+        if (buildOptions)
+        {
+            build_options.add(buildOptions);
+        }
+        build_options.add(" -D BIG_NODE_LOW_BORDER_BLOCKS_NUM=32 -D LOCAL_BUFFER_SIZE=256 -D MAX_WORK_ITEMS_PER_GROUP=256 ");
+
+        services::String cachekey("__daal_algorithms_df_tree_level_build_helper_");
+        cachekey.add(build_options);
+
+        factory.build(ExecutionTargetIds::device, cachekey.c_str(), df_tree_level_build_helper_kernels, build_options.c_str());
+    }
+
+    return status;
+}
+
+template <typename algorithmFPType>
+services::Status TreeLevelBuildHelperOneAPI<algorithmFPType>::initializeTreeOrder(size_t nRows, UniversalBuffer & treeOrder)
+{
+    DAAL_ITTNOTIFY_SCOPED_TASK(compute.initializeTreeOrder);
+
+    services::Status status;
+
+    auto & context = services::Environment::getInstance()->getDefaultExecutionContext();
+
+    auto & kernel = kernelInitializeTreeOrder;
+
+    {
+        KernelArguments args(1);
+        args.set(0, treeOrder, AccessModeIds::write);
+
+        KernelRange global_range(nRows);
+
+        context.run(global_range, kernel, args, &status);
+        DAAL_CHECK_STATUS_VAR(status);
+    }
+
+    return status;
+}
+
+template <typename algorithmFPType>
+services::Status TreeLevelBuildHelperOneAPI<algorithmFPType>::markPresentRows(const UniversalBuffer & rowsList, UniversalBuffer & rowsBuffer,
+                                                                              size_t nRows, size_t localSize, size_t nSubgroupSums)
+{
+    DAAL_ITTNOTIFY_SCOPED_TASK(compute.markPresentRows);
+    services::Status status;
+
+    auto & context = services::Environment::getInstance()->getDefaultExecutionContext();
+
+    {
+        auto & kernel = kernelMarkPresentRows;
+        KernelArguments args(3);
+        args.set(0, rowsList, AccessModeIds::read);
+        args.set(1, rowsBuffer, AccessModeIds::write);
+        args.set(2, (int32_t)nRows);
+
+        KernelRange local_range(localSize);
+        KernelRange global_range(localSize * nSubgroupSums);
+
+        KernelNDRange range(1);
+        range.local(local_range, &status);
+        DAAL_CHECK_STATUS_VAR(status);
+        range.global(global_range, &status);
+        DAAL_CHECK_STATUS_VAR(status);
+
+        context.run(range, kernel, args, &status);
+        DAAL_CHECK_STATUS_VAR(status);
+    }
+
+    return status;
+}
+
+template <typename algorithmFPType>
+services::Status TreeLevelBuildHelperOneAPI<algorithmFPType>::countAbsentRowsForBlocks(const UniversalBuffer & rowsBuffer, size_t nRows,
+                                                                                       UniversalBuffer & partialSums, size_t localSize,
+                                                                                       size_t nSubgroupSums)
+{
+    DAAL_ITTNOTIFY_SCOPED_TASK(compute.countAbsentRowsForBlocks);
+    services::Status status;
+
+    auto & context = services::Environment::getInstance()->getDefaultExecutionContext();
+
+    {
+        auto & kernel = kernelCountAbsentRowsForBlocks;
+        KernelArguments args(3);
+        args.set(0, rowsBuffer, AccessModeIds::read);
+        args.set(1, partialSums, AccessModeIds::write);
+        args.set(2, (int32_t)nRows);
+
+        KernelRange local_range(localSize);
+        KernelRange global_range(localSize * nSubgroupSums);
+
+        KernelNDRange range(1);
+        range.local(local_range, &status);
+        DAAL_CHECK_STATUS_VAR(status);
+        range.global(global_range, &status);
+        DAAL_CHECK_STATUS_VAR(status);
+
+        context.run(range, kernel, args, &status);
+        DAAL_CHECK_STATUS_VAR(status);
+    }
+
+    return status;
+}
+
+template <typename algorithmFPType>
+services::Status TreeLevelBuildHelperOneAPI<algorithmFPType>::countAbsentRowsTotal(const UniversalBuffer & partialSums,
+                                                                                   UniversalBuffer & partialPrefixSums, UniversalBuffer & totalSum,
+                                                                                   size_t localSize, size_t nSubgroupSums)
+{
+    DAAL_ITTNOTIFY_SCOPED_TASK(compute.countAbsentRowsTotal);
+    services::Status status;
+
+    auto & context = services::Environment::getInstance()->getDefaultExecutionContext();
+
+    {
+        auto & kernel = kernelCountAbsentRowsTotal;
+        KernelArguments args(4);
+        args.set(0, partialSums, AccessModeIds::read);
+        args.set(1, partialPrefixSums, AccessModeIds::write);
+        args.set(2, totalSum, AccessModeIds::write);
+        args.set(3, (int32_t)nSubgroupSums);
+
+        KernelRange local_range(localSize);
+        KernelRange global_range(localSize);
+
+        KernelNDRange range(1);
+        range.local(local_range, &status);
+        DAAL_CHECK_STATUS_VAR(status);
+        range.global(global_range, &status);
+        DAAL_CHECK_STATUS_VAR(status);
+
+        context.run(range, kernel, args, &status);
+        DAAL_CHECK_STATUS_VAR(status);
+    }
+
+    return status;
+}
+
+template <typename algorithmFPType>
+services::Status TreeLevelBuildHelperOneAPI<algorithmFPType>::fillOOBRowsListByBlocks(const UniversalBuffer & rowsBuffer, size_t nRows,
+                                                                                      const UniversalBuffer & partialPrefixSums,
+                                                                                      UniversalBuffer & oobRowsList, size_t localSize,
+                                                                                      size_t nSubgroupSums)
+{
+    DAAL_ITTNOTIFY_SCOPED_TASK(compute.fillOOBRowsListByBlocks);
+    services::Status status;
+
+    auto & context = services::Environment::getInstance()->getDefaultExecutionContext();
+
+    {
+        auto & kernel = kernelFillOOBRowsListByBlocks;
+        KernelArguments args(4);
+        args.set(0, rowsBuffer, AccessModeIds::read);
+        args.set(1, partialPrefixSums, AccessModeIds::read);
+        args.set(2, oobRowsList, AccessModeIds::write);
+        args.set(3, (int32_t)nRows);
+
+        KernelRange local_range(localSize);
+        KernelRange global_range(localSize * nSubgroupSums);
+
+        KernelNDRange range(1);
+        range.local(local_range, &status);
+        DAAL_CHECK_STATUS_VAR(status);
+        range.global(global_range, &status);
+        DAAL_CHECK_STATUS_VAR(status);
+
+        context.run(range, kernel, args, &status);
+        DAAL_CHECK_STATUS_VAR(status);
+    }
+
+    return status;
+}
+template <typename algorithmFPType>
+services::Status TreeLevelBuildHelperOneAPI<algorithmFPType>::getOOBRows(const UniversalBuffer & rowsList, size_t nRows, size_t & nOOBRows,
+                                                                         UniversalBuffer & oobRowsList)
+{
+    services::Status status;
+
+    auto & context = services::Environment::getInstance()->getDefaultExecutionContext();
+
+    const int absentMark    = -1;
+    const int localSize     = _preferableSubGroup;
+    const int nSubgroupSums = _maxLocalSums * localSize < nRows ? _maxLocalSums : (nRows / localSize + !(nRows / localSize));
+
+    auto rowsBuffer        = context.allocate(TypeIds::id<int>(), nRows, &status); // it is filled with marks Present/Absent for each rows
+    auto partialSums       = context.allocate(TypeIds::id<int>(), nSubgroupSums, &status);
+    auto partialPrefixSums = context.allocate(TypeIds::id<int>(), nSubgroupSums, &status);
+    auto totalSum          = context.allocate(TypeIds::id<int>(), 1, &status);
+    DAAL_CHECK_STATUS_VAR(status);
+
+    context.fill(rowsBuffer, absentMark, &status);
+    DAAL_CHECK_STATUS_VAR(status);
+
+    DAAL_CHECK_STATUS_VAR(markPresentRows(rowsList, rowsBuffer, nRows, localSize, nSubgroupSums));
+    DAAL_CHECK_STATUS_VAR(countAbsentRowsForBlocks(rowsBuffer, nRows, partialSums, localSize, nSubgroupSums));
+    DAAL_CHECK_STATUS_VAR(countAbsentRowsTotal(partialSums, partialPrefixSums, totalSum, localSize, nSubgroupSums));
+
+    auto nOOBRowsHost = totalSum.template get<int>().toHost(ReadWriteMode::readOnly);
+    DAAL_CHECK_MALLOC(nOOBRowsHost.get());
+
+    nOOBRows = (size_t)nOOBRowsHost.get()[0];
+
+    if (nOOBRows > 0)
+    {
+        // assign buffer of required size to the input oobRowsList buffer
+        oobRowsList = context.allocate(TypeIds::id<int>(), nOOBRows, &status);
+        DAAL_CHECK_STATUS_VAR(status);
+
+        DAAL_CHECK_STATUS_VAR(fillOOBRowsListByBlocks(rowsBuffer, nRows, partialPrefixSums, oobRowsList, localSize, nSubgroupSums));
+    }
+
+    return status;
+}
+
+template <typename algorithmFPType>
+services::Status TreeLevelBuildHelperOneAPI<algorithmFPType>::getNumOfSplitNodes(const UniversalBuffer & nodeList, size_t nNodes,
+                                                                                 size_t & nSplitNodes)
+{
+    DAAL_ITTNOTIFY_SCOPED_TASK(compute.getNumOfSplitNodes);
+
+    services::Status status;
+
+    auto & context = services::Environment::getInstance()->getDefaultExecutionContext();
+
+    auto & kernel = kernelGetNumOfSplitNodes;
+
+    auto bufNSplitNodes = context.allocate(TypeIds::id<int>(), 1, &status);
+    DAAL_CHECK_STATUS_VAR(status);
+
+    {
+        KernelArguments args(3);
+        args.set(0, nodeList, AccessModeIds::read);
+        args.set(1, (int32_t)nNodes);
+        args.set(2, bufNSplitNodes, AccessModeIds::write);
+
+        size_t localSize = _preferableSubGroup;
+
+        // will add more range for it
+        KernelRange local_range(localSize);
+        KernelRange global_range(localSize);
+
+        KernelNDRange range(1);
+        range.local(local_range, &status);
+        DAAL_CHECK_STATUS_VAR(status);
+        range.global(global_range, &status);
+        DAAL_CHECK_STATUS_VAR(status);
+
+        context.run(range, kernel, args, &status);
+        DAAL_CHECK_STATUS_VAR(status);
+    }
+
+    auto bufNsplitNodesHost = bufNSplitNodes.template get<int>().toHost(ReadWriteMode::readOnly);
+    DAAL_CHECK_MALLOC(bufNsplitNodesHost.get());
+    nSplitNodes = bufNsplitNodesHost.get()[0];
+
+    return status;
+}
+
+template <typename algorithmFPType>
+services::Status TreeLevelBuildHelperOneAPI<algorithmFPType>::convertSplitToLeaf(UniversalBuffer & nodeList, size_t nNodes)
+{
+    DAAL_ITTNOTIFY_SCOPED_TASK(compute.convertSplitToLeaf);
+
+    services::Status status;
+
+    auto & context = services::Environment::getInstance()->getDefaultExecutionContext();
+
+    auto & kernel = kernelConvertSplitToLeaf;
+
+    {
+        KernelArguments args(1);
+        args.set(0, nodeList, AccessModeIds::readwrite);
+
+        KernelRange global_range(nNodes);
+
+        context.run(global_range, kernel, args, &status);
+        DAAL_CHECK_STATUS_VAR(status);
+    }
+
+    return status;
+}
+
+template <typename algorithmFPType>
+services::Status TreeLevelBuildHelperOneAPI<algorithmFPType>::doNodesSplit(const UniversalBuffer & nodeList, size_t nNodes,
+                                                                           UniversalBuffer & nodeListNew)
+{
+    DAAL_ITTNOTIFY_SCOPED_TASK(compute.doNodesSplit);
+
+    /*split rows for each nodes in accordance with best split info*/
+
+    services::Status status;
+
+    auto & context = services::Environment::getInstance()->getDefaultExecutionContext();
+
+    auto & kernel = kernelDoNodesSplit;
+
+    {
+        KernelArguments args(3);
+        args.set(0, nodeList, AccessModeIds::read);
+        args.set(1, (int32_t)nNodes);
+        args.set(2, nodeListNew, AccessModeIds::write);
+
+        size_t localSize = _preferableSubGroup;
+
+        // will add more range for it
+        KernelRange local_range(localSize);
+        KernelRange global_range(localSize);
+
+        KernelNDRange range(1);
+        range.local(local_range, &status);
+        DAAL_CHECK_STATUS_VAR(status);
+        range.global(global_range, &status);
+        DAAL_CHECK_STATUS_VAR(status);
+
+        context.run(range, kernel, args, &status);
+        DAAL_CHECK_STATUS_VAR(status);
+    }
+
+    return status;
+}
+
+template <typename algorithmFPType>
+services::Status TreeLevelBuildHelperOneAPI<algorithmFPType>::splitNodeListOnGroupsBySize(const UniversalBuffer & nodeList, size_t nNodes,
+                                                                                          UniversalBuffer & nodesGroups,
+                                                                                          UniversalBuffer & nodeIndices)
+{
+    DAAL_ITTNOTIFY_SCOPED_TASK(compute.splitNodeListOnGroupsBySize);
+
+    services::Status status;
+
+    auto & context = services::Environment::getInstance()->getDefaultExecutionContext();
+
+    auto & kernel = kernelSplitNodeListOnGroupsBySize;
+
+    {
+        KernelArguments args(5);
+        args.set(0, nodeList, AccessModeIds::read);
+        args.set(1, (int32_t)nNodes);
+        args.set(2, nodesGroups, AccessModeIds::write);
+        args.set(3, nodeIndices, AccessModeIds::write);
+        args.set(4, _minRowsBlock);
+
+        size_t localSize = _preferableSubGroup;
+
+        KernelRange local_range(localSize);
+        KernelRange global_range(localSize);
+
+        KernelNDRange range(1);
+        range.local(local_range, &status);
+        DAAL_CHECK_STATUS_VAR(status);
+        range.global(global_range, &status);
+        DAAL_CHECK_STATUS_VAR(status);
+
+        context.run(range, kernel, args, &status);
+        DAAL_CHECK_STATUS_VAR(status);
+    }
+
+    return status;
+}
+
+template <typename algorithmFPType>
+services::Status TreeLevelBuildHelperOneAPI<algorithmFPType>::doLevelPartition(const UniversalBuffer & data, UniversalBuffer & nodeList,
+                                                                               size_t nNodes, UniversalBuffer & treeOrder,
+                                                                               UniversalBuffer & treeOrderBuf, size_t nRows, size_t nFeatures)
+{
+    DAAL_ITTNOTIFY_SCOPED_TASK(compute.doLevelPartition);
+
+    services::Status status;
+
+    auto & context = services::Environment::getInstance()->getDefaultExecutionContext();
+
+    auto & kernel = kernelDoLevelPartition;
+
+    {
+        KernelArguments args(5);
+        args.set(0, data, AccessModeIds::read);
+        args.set(1, nodeList, AccessModeIds::read);
+        args.set(2, treeOrder, AccessModeIds::read);
+        args.set(3, treeOrderBuf, AccessModeIds::write);
+        args.set(4, (int32_t)nFeatures);
+
+        size_t localSize = _preferableSubGroup;
+
+        KernelRange local_range(localSize, 1);
+        KernelRange global_range(localSize, nNodes);
+
+        KernelNDRange range(2);
+        range.global(global_range, &status);
+        DAAL_CHECK_STATUS_VAR(status);
+        range.local(local_range, &status);
+        DAAL_CHECK_STATUS_VAR(status);
+
+        context.run(range, kernel, args, &status);
+        DAAL_CHECK_STATUS_VAR(status);
+    }
+
+    DAAL_CHECK_STATUS_VAR(partitionCopy(treeOrderBuf, treeOrder, 0, nRows));
+
+    return status;
+}
+
+template <typename algorithmFPType>
+services::Status TreeLevelBuildHelperOneAPI<algorithmFPType>::partitionCopy(UniversalBuffer & treeOrderBuf, UniversalBuffer & treeOrder,
+                                                                            size_t iStart, size_t nRows)
+{
+    DAAL_ITTNOTIFY_SCOPED_TASK(compute.partitionCopy);
+
+    services::Status status;
+
+    auto & context = services::Environment::getInstance()->getDefaultExecutionContext();
+
+    auto & kernel = kernelPartitionCopy;
+
+    {
+        KernelArguments args(3);
+        args.set(0, treeOrderBuf, AccessModeIds::read);
+        args.set(1, treeOrder, AccessModeIds::write);
+        args.set(2, (int32_t)iStart);
+
+        KernelRange global_range(nRows);
+
+        context.run(global_range, kernel, args, &status);
+        DAAL_CHECK_STATUS_VAR(status);
+    }
+
+    return status;
+}
+
+template <typename algorithmFPType>
+services::Status TreeLevelBuildHelperOneAPI<algorithmFPType>::updateMDIVarImportance(const UniversalBuffer & nodeList,
+                                                                                     const UniversalBuffer & nodeImpDecreaseList, size_t nNodes,
+                                                                                     services::Buffer<algorithmFPType> & varImp, size_t nFeatures)
+{
+    DAAL_ITTNOTIFY_SCOPED_TASK(compute.updateMDIVarImportance);
+
+    services::Status status;
+
+    auto & context = services::Environment::getInstance()->getDefaultExecutionContext();
+
+    auto & kernel = kernelUpdateMDIVarImportance;
+
+    {
+        KernelArguments args(4);
+        args.set(0, nodeList, AccessModeIds::read);
+        args.set(1, nodeImpDecreaseList, AccessModeIds::read);
+        args.set(2, (int32_t)nNodes);
+        args.set(3, varImp, AccessModeIds::write);
+
+        int localSize = _preferableGroupSize;
+        //calculating local size in way to have all subgroups for node in one group to use local buffer
+        while (localSize > nNodes && localSize > _preferableSubGroup)
+        {
+            localSize >>= 1;
+        }
+
+        KernelRange local_range(localSize, 1);
+        KernelRange global_range(localSize, nFeatures);
+
+        KernelNDRange range(2);
+        range.local(local_range, &status);
+        DAAL_CHECK_STATUS_VAR(status);
+        range.global(global_range, &status);
+        DAAL_CHECK_STATUS_VAR(status);
+
+        context.run(range, kernel, args, &status);
+        DAAL_CHECK_STATUS_VAR(status);
+    }
+
+    return status;
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////
+/* init method for TreeLevelBuildHelperOneAPI */
+///////////////////////////////////////////////////////////////////////////////////////////
+template <typename algorithmFPType>
+services::Status TreeLevelBuildHelperOneAPI<algorithmFPType>::init(const char * buildOptions)
+{
+    services::Status status;
+
+    auto & context        = Environment::getInstance()->getDefaultExecutionContext();
+    auto & kernel_factory = context.getClKernelFactory();
+
+    DAAL_CHECK_STATUS_VAR(buildProgram(kernel_factory, buildOptions));
+
+    kernelInitializeTreeOrder = kernel_factory.getKernel("initializeTreeOrder", &status);
+    kernelPartitionCopy       = kernel_factory.getKernel("partitionCopy", &status);
+
+    kernelConvertSplitToLeaf          = kernel_factory.getKernel("convertSplitToLeaf", &status);
+    kernelGetNumOfSplitNodes          = kernel_factory.getKernel("getNumOfSplitNodes", &status);
+    kernelDoNodesSplit                = kernel_factory.getKernel("doNodesSplit", &status);
+    kernelDoLevelPartition            = kernel_factory.getKernel("doLevelPartition", &status);
+    kernelSplitNodeListOnGroupsBySize = kernel_factory.getKernel("splitNodeListOnGroupsBySize", &status);
+
+    kernelMarkPresentRows          = kernel_factory.getKernel("markPresentRows", &status);
+    kernelCountAbsentRowsForBlocks = kernel_factory.getKernel("countAbsentRowsForBlocks", &status);
+    kernelCountAbsentRowsTotal     = kernel_factory.getKernel("countAbsentRowsTotal", &status);
+    kernelFillOOBRowsListByBlocks  = kernel_factory.getKernel("fillOOBRowsListByBlocks", &status);
+    kernelUpdateMDIVarImportance   = kernel_factory.getKernel("updateMDIVarImportance", &status);
+
+    DAAL_CHECK_STATUS_VAR(status);
+
+    return status;
+}
+
+} /* namespace internal */
+} /* namespace decision_forest */
+} /* namespace algorithms */
+} /* namespace daal */

--- a/algorithms/kernel/dtrees/forest/regression/oneapi/df_regression_train_hist_kernel_oneapi.h
+++ b/algorithms/kernel/dtrees/forest/regression/oneapi/df_regression_train_hist_kernel_oneapi.h
@@ -71,7 +71,8 @@ public:
                              Result & res, const Parameter & par);
 
 private:
-    services::Status buildProgram(oneapi::internal::ClKernelFactoryIface & factory, const char * buildOptions = nullptr);
+    services::Status buildProgram(oneapi::internal::ClKernelFactoryIface & factory, const char * programName, const char * programSrc,
+                                  const char * buildOptions);
 
     services::Status computeBestSplit(const oneapi::internal::UniversalBuffer & data, oneapi::internal::UniversalBuffer & treeOrder,
                                       oneapi::internal::UniversalBuffer & selectedFeatures, size_t nSelectedFeatures,

--- a/algorithms/kernel/dtrees/forest/regression/oneapi/df_regression_train_hist_kernel_oneapi.h
+++ b/algorithms/kernel/dtrees/forest/regression/oneapi/df_regression_train_hist_kernel_oneapi.h
@@ -33,6 +33,7 @@
 #include "algorithms/decision_forest/decision_forest_regression_training_types.h"
 #include "algorithms/decision_forest/decision_forest_regression_model.h"
 #include "algorithms/kernel/dtrees/forest/oneapi/df_feature_type_helper_oneapi.h"
+#include "algorithms/kernel/dtrees/forest/oneapi/df_tree_level_build_helper_oneapi.h"
 
 using namespace daal::data_management;
 using namespace daal::services;
@@ -70,34 +71,7 @@ public:
                              Result & res, const Parameter & par);
 
 private:
-    services::Status initializeTreeOrder(size_t nRows, oneapi::internal::UniversalBuffer & treeOrder);
-
-    services::Status convertSplitToLeaf(oneapi::internal::UniversalBuffer & nodeList, size_t nNodes);
-
-    services::Status markPresentRows(const oneapi::internal::UniversalBuffer & rowsList, oneapi::internal::UniversalBuffer & rowsBuffer, size_t nRows,
-                                     size_t localSize, size_t nSubgroupSums);
-    services::Status countAbsentRowsForBlocks(const oneapi::internal::UniversalBuffer & rowsBuffer, size_t nRows,
-                                              oneapi::internal::UniversalBuffer & partialSums, size_t localSize, size_t nSubgroupSums);
-    services::Status countAbsentRowsTotal(const oneapi::internal::UniversalBuffer & partialSums,
-                                          oneapi::internal::UniversalBuffer & partialPrefixSums, oneapi::internal::UniversalBuffer & totalSum,
-                                          size_t localSize, size_t nSubgroupSums);
-    services::Status fillOOBRowsListByBlocks(const oneapi::internal::UniversalBuffer & rowsBuffer, size_t nRows,
-                                             const oneapi::internal::UniversalBuffer & partialPrefixSums,
-                                             oneapi::internal::UniversalBuffer & oobRowsList, size_t localSize, size_t nSubgroupSums);
-
-    services::Status getOOBRows(const oneapi::internal::UniversalBuffer & rowsList, size_t nRows, size_t & nOOBRows,
-                                oneapi::internal::UniversalBuffer & oobRowsList);
-
-    services::Status getNumOfSplitNodes(const oneapi::internal::UniversalBuffer & nodeList, size_t nNodes, size_t & nSplitNodes);
-
-    services::Status doNodesSplit(const oneapi::internal::UniversalBuffer & nodeList, size_t nNodes, oneapi::internal::UniversalBuffer & nodeListNew);
-
-    services::Status splitNodeListOnGroupsBySize(const oneapi::internal::UniversalBuffer & nodeList, size_t nNodes,
-                                                 oneapi::internal::UniversalBuffer & bigNodesGroups, oneapi::internal::UniversalBuffer & nodeIndeces);
-
-    services::Status doLevelPartition(const oneapi::internal::UniversalBuffer & data, oneapi::internal::UniversalBuffer & nodeList, size_t nNodes,
-                                      oneapi::internal::UniversalBuffer & treeOrder, oneapi::internal::UniversalBuffer & treeOrderBuf, size_t nRows,
-                                      size_t nFeatures);
+    services::Status buildProgram(oneapi::internal::ClKernelFactoryIface & factory, const char * buildOptions = nullptr);
 
     services::Status computeBestSplit(const oneapi::internal::UniversalBuffer & data, oneapi::internal::UniversalBuffer & treeOrder,
                                       oneapi::internal::UniversalBuffer & selectedFeatures, size_t nSelectedFeatures,
@@ -134,13 +108,6 @@ private:
                                              size_t nPartialHistograms, size_t nNodes, size_t nSelectedFeatures, size_t nMaxBinsAmongFtrs,
                                              size_t reduceLocalSize);
 
-    services::Status partitionCopy(oneapi::internal::UniversalBuffer & treeOrderBuf, oneapi::internal::UniversalBuffer & treeOrder, size_t iStart,
-                                   size_t nRows);
-
-    services::Status updateMDIVarImportance(const oneapi::internal::UniversalBuffer & nodeList,
-                                            const oneapi::internal::UniversalBuffer & nodeImpDecreaseList, size_t nNodes,
-                                            services::Buffer<algorithmFPType> & varImp, size_t nFeatures);
-
     services::Status computeResults(const dtrees::internal::Tree & t, const algorithmFPType * x, const algorithmFPType * y, const size_t nRows,
                                     const size_t nFeatures, const oneapi::internal::UniversalBuffer & oobIndices, size_t nOOB,
                                     oneapi::internal::UniversalBuffer & oobBuf, algorithmFPType * varImp, algorithmFPType * varImpVariance,
@@ -159,27 +126,12 @@ private:
 
     services::Status finalizeVarImp(const Parameter & par, algorithmFPType * varImp, algorithmFPType * varImpVariance, size_t nFeatures);
 
-    oneapi::internal::KernelPtr kernelBumper;
-
-    oneapi::internal::KernelPtr kernelInitializeTreeOrder;
     oneapi::internal::KernelPtr kernelComputePartialHistograms;
     oneapi::internal::KernelPtr kernelReducePartialHistograms;
     oneapi::internal::KernelPtr kernelComputeBestSplitByHistogram;
     oneapi::internal::KernelPtr kernelComputeBestSplitSinglePass;
-    oneapi::internal::KernelPtr kernelPartitionCopy;
 
-    oneapi::internal::KernelPtr kernelConvertSplitToLeaf;
-    oneapi::internal::KernelPtr kernelGetNumOfSplitNodes;
-    oneapi::internal::KernelPtr kernelDoNodesSplit;
-    oneapi::internal::KernelPtr kernelDoLevelPartition;
-    oneapi::internal::KernelPtr kernelSplitNodeListOnGroupsBySize;
-
-    oneapi::internal::KernelPtr kernelMarkPresentRows;
-    oneapi::internal::KernelPtr kernelCountAbsentRowsForBlocks;
-    oneapi::internal::KernelPtr kernelCountAbsentRowsTotal;
-    oneapi::internal::KernelPtr kernelFillOOBRowsListByBlocks;
-
-    oneapi::internal::KernelPtr kernelUpdateMDIVarImportance;
+    decision_forest::internal::TreeLevelBuildHelperOneAPI<algorithmFPType> _treeLevelBuildHelper;
 
     const uint32_t _maxWorkItemsPerGroup = 256;   // should be a power of two for interal needs
     const uint32_t _maxLocalBuffer       = 30000; // should be less than a half of local memory (two buffers)
@@ -194,6 +146,9 @@ private:
     const uint32_t _nHistProps     = 3; // number of properties in bins histogram (i.e. n, mean and var)
     const uint32_t _nNodesGroups   = 3; // all nodes are split on groups (big, medium, small)
     const uint32_t _nodeGroupProps = 2; // each nodes Group contains props: numOfNodes, maxNumOfBlocks
+
+    size_t _nMaxBinsAmongFtrs;
+    size_t _totalBins;
 };
 
 } // namespace internal

--- a/algorithms/kernel/dtrees/forest/regression/oneapi/df_regression_train_hist_oneapi_impl.i
+++ b/algorithms/kernel/dtrees/forest/regression/oneapi/df_regression_train_hist_oneapi_impl.i
@@ -252,7 +252,6 @@ services::Status RegressionTrainBatchKernelOneAPI<algorithmFPType, hist>::comput
             int reduceLocalSize = 16; // add logic for its adjustment
 
             size_t nHistBins    = nSelectedFeatures * _nMaxBinsAmongFtrs;
-            nHistBins           = (nHistBins > _totalBins) ? _totalBins : nHistBins;
             size_t partHistSize = nHistBins * _nHistProps;
 
             auto partialHistograms = context.allocate(TypeIds::id<algorithmFPType>(), nGroupNodes * nPartialHistograms * partHistSize, &status);

--- a/algorithms/kernel/dtrees/forest/regression/oneapi/df_regression_tree_helper_impl.i
+++ b/algorithms/kernel/dtrees/forest/regression/oneapi/df_regression_tree_helper_impl.i
@@ -24,7 +24,7 @@
 #ifndef __DF_REGRESSION_TREE_HELPER_IMPL__
 #define __DF_REGRESSION_TREE_HELPER_IMPL__
 
-#include "data_management/data/aos_numeric_table.h"
+//#include "data_management/data/aos_numeric_table.h"
 #include "service/kernel/service_arrays.h"
 #include "algorithms/kernel/dtrees/dtrees_predict_dense_default_impl.i"
 
@@ -85,10 +85,19 @@ template <typename algorithmFPType>
 struct TreeLevelRecord
 {
     TreeLevelRecord() : _nodeList(nullptr), _impInfo(nullptr), _nNodes(0) {}
-    TreeLevelRecord(oneapi::internal::UniversalBuffer & nodeList, oneapi::internal::UniversalBuffer & impInfo, size_t nNodes) : _nNodes(nNodes)
+    services::Status init(oneapi::internal::UniversalBuffer & nodeList, oneapi::internal::UniversalBuffer & impInfo, size_t nNodes)
     {
-        _nodeList = nodeList.template get<int>().toHost(ReadWriteMode::readOnly).get();
-        _impInfo  = impInfo.template get<algorithmFPType>().toHost(ReadWriteMode::readOnly).get();
+        _nNodes = nNodes;
+
+        auto nodeListHost = nodeList.template get<int>().toHost(ReadWriteMode::readOnly);
+        _nodeList         = nodeListHost.get();
+        DAAL_CHECK_MALLOC(_nodeList);
+
+        auto impInfoHost = impInfo.template get<algorithmFPType>().toHost(ReadWriteMode::readOnly);
+        _impInfo         = impInfoHost.get();
+        DAAL_CHECK_MALLOC(_impInfo);
+
+        return services::Status();
     }
 
     size_t getNodesNum() { return _nNodes; }

--- a/examples/cpp_sycl/DAALExamples_sycl.sln
+++ b/examples/cpp_sycl/DAALExamples_sycl.sln
@@ -49,6 +49,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "kernel_func_lin_dense_batch
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "df_reg_dense_batch", "vcproj\df_reg_dense_batch\df_reg_dense_batch.vcxproj", "{0AB49A34-5876-4C9F-A869-BF316D545232}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "df_cls_dense_batch", "vcproj\df_cls_dense_batch\df_cls_dense_batch.vcxproj", "{F14CFA96-1962-41BC-81BC-E1957F0C334E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug.dynamic.sequential|x64 = Debug.dynamic.sequential|x64
@@ -429,6 +431,22 @@ Global
 		{0AB49A34-5876-4C9F-A869-BF316D545232}.Release.static.sequential|x64.Build.0 = Release.static.sequential|x64
 		{0AB49A34-5876-4C9F-A869-BF316D545232}.Release.static.threaded|x64.ActiveCfg = Release.static.threaded|x64
 		{0AB49A34-5876-4C9F-A869-BF316D545232}.Release.static.threaded|x64.Build.0 = Release.static.threaded|x64
+		{F14CFA96-1962-41BC-81BC-E1957F0C334E}.Debug.dynamic.sequential|x64.ActiveCfg = Debug.dynamic.sequential|x64
+		{F14CFA96-1962-41BC-81BC-E1957F0C334E}.Debug.dynamic.sequential|x64.Build.0 = Debug.dynamic.sequential|x64
+		{F14CFA96-1962-41BC-81BC-E1957F0C334E}.Debug.dynamic.threaded|x64.ActiveCfg = Debug.dynamic.threaded|x64
+		{F14CFA96-1962-41BC-81BC-E1957F0C334E}.Debug.dynamic.threaded|x64.Build.0 = Debug.dynamic.threaded|x64
+		{F14CFA96-1962-41BC-81BC-E1957F0C334E}.Debug.static.sequential|x64.ActiveCfg = Debug.static.sequential|x64
+		{F14CFA96-1962-41BC-81BC-E1957F0C334E}.Debug.static.sequential|x64.Build.0 = Debug.static.sequential|x64
+		{F14CFA96-1962-41BC-81BC-E1957F0C334E}.Debug.static.threaded|x64.ActiveCfg = Debug.static.threaded|x64
+		{F14CFA96-1962-41BC-81BC-E1957F0C334E}.Debug.static.threaded|x64.Build.0 = Debug.static.threaded|x64
+		{F14CFA96-1962-41BC-81BC-E1957F0C334E}.Release.dynamic.sequential|x64.ActiveCfg = Release.dynamic.sequential|x64
+		{F14CFA96-1962-41BC-81BC-E1957F0C334E}.Release.dynamic.sequential|x64.Build.0 = Release.dynamic.sequential|x64
+		{F14CFA96-1962-41BC-81BC-E1957F0C334E}.Release.dynamic.threaded|x64.ActiveCfg = Release.dynamic.threaded|x64
+		{F14CFA96-1962-41BC-81BC-E1957F0C334E}.Release.dynamic.threaded|x64.Build.0 = Release.dynamic.threaded|x64
+		{F14CFA96-1962-41BC-81BC-E1957F0C334E}.Release.static.sequential|x64.ActiveCfg = Release.static.sequential|x64
+		{F14CFA96-1962-41BC-81BC-E1957F0C334E}.Release.static.sequential|x64.Build.0 = Release.static.sequential|x64
+		{F14CFA96-1962-41BC-81BC-E1957F0C334E}.Release.static.threaded|x64.ActiveCfg = Release.static.threaded|x64
+		{F14CFA96-1962-41BC-81BC-E1957F0C334E}.Release.static.threaded|x64.Build.0 = Release.static.threaded|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/examples/cpp_sycl/daal_lnx.lst
+++ b/examples/cpp_sycl/daal_lnx.lst
@@ -40,4 +40,5 @@ DAAL  = datastructures_soa                    \
         gbt_reg_dense_batch                   \
         bf_knn_dense_batch                    \
         svm_two_class_dense_batch             \
-        df_reg_dense_batch
+        df_reg_dense_batch                    \
+        df_cls_dense_batch

--- a/examples/cpp_sycl/source/decision_forest/df_cls_dense_batch.cpp
+++ b/examples/cpp_sycl/source/decision_forest/df_cls_dense_batch.cpp
@@ -1,0 +1,153 @@
+/* file: df_cls_dense_batch.cpp */
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+/*
+!  Content:
+!    C++ example of decision forest classification in the batch processing mode.
+!
+!    The program trains the decision forest classification model on a training
+!    datasetFileName and computes classification for the test data.
+!******************************************************************************/
+
+/**
+ * <a name="DAAL-EXAMPLE-CPP-DF_CLS_DENSE_BATCH"></a>
+ * \example df_cls_dense_batch.cpp
+ */
+
+#include "daal_sycl.h"
+#include "service.h"
+#include "service_sycl.h"
+
+using namespace std;
+using namespace daal;
+using namespace daal::algorithms;
+using namespace daal::data_management;
+using namespace daal::algorithms::decision_forest::classification;
+
+/* Input data set parameters */
+const string trainDatasetFileName = "../data/batch/df_classification_train.csv";
+const string testDatasetFileName  = "../data/batch/df_classification_test.csv";
+//const size_t categoricalFeaturesIndices[] = { 2 };
+const size_t categoricalFeaturesIndices[] = {};
+const size_t nFeatures                    = 3; /* Number of features in training and testing data sets */
+
+/* Decision forest parameters */
+const size_t nTrees                    = 10;
+const size_t minObservationsInLeafNode = 8;
+
+const size_t nClasses = 5; /* Number of classes */
+
+template <typename algorithmType>
+training::ResultPtr trainModel(algorithmType && algorithm);
+void testModel(const training::ResultPtr & res);
+void loadData(const std::string & fileName, NumericTablePtr & pData, NumericTablePtr & pDependentVar);
+
+int main(int argc, char * argv[])
+{
+    checkArguments(argc, argv, 2, &trainDatasetFileName, &testDatasetFileName);
+
+    for (const auto & deviceSelector : getListOfDevices())
+    {
+        const auto & nameDevice = deviceSelector.first;
+        const auto & device     = deviceSelector.second;
+        cl::sycl::queue queue(device);
+        std::cout << "Running on " << nameDevice << "\n\n";
+
+        daal::services::SyclExecutionContext ctx(queue);
+        services::Environment::getInstance()->setDefaultExecutionContext(ctx);
+
+        /* Create an algorithm object to train the decision forest classification model */
+        training::ResultPtr trainingResult =
+            device.is_gpu() ? trainModel(training::Batch<float, training::hist>(nClasses)) : trainModel(training::Batch<>(nClasses));
+
+        testModel(trainingResult);
+    }
+    return 0;
+}
+
+template <typename algorithmType>
+training::ResultPtr trainModel(algorithmType && algorithm)
+{
+    /* Create Numeric Tables for training data and dependent variables */
+    NumericTablePtr trainData;
+    NumericTablePtr trainDependentVariable;
+
+    loadData(trainDatasetFileName, trainData, trainDependentVariable);
+
+    /* Pass a training data set and dependent values to the algorithm */
+    algorithm.input.set(classifier::training::data, trainData);
+    algorithm.input.set(classifier::training::labels, trainDependentVariable);
+
+    algorithm.parameter.nTrees                    = nTrees;
+    algorithm.parameter.featuresPerNode           = nFeatures;
+    algorithm.parameter.minObservationsInLeafNode = minObservationsInLeafNode;
+    algorithm.parameter.varImportance             = algorithms::decision_forest::training::MDI;
+    algorithm.parameter.resultsToCompute          = algorithms::decision_forest::training::computeOutOfBagError;
+
+    /* Build the decision forest classification model */
+    algorithm.compute();
+
+    /* Retrieve the algorithm results */
+    training::ResultPtr trainingResult = algorithm.getResult();
+    printNumericTable(trainingResult->get(training::variableImportance), "Variable importance results: ");
+    printNumericTable(trainingResult->get(training::outOfBagError), "OOB error: ");
+    return trainingResult;
+}
+
+void testModel(const training::ResultPtr & trainingResult)
+{
+    /* Create Numeric Tables for testing data and ground truth values */
+    NumericTablePtr testData;
+    NumericTablePtr testGroundTruth;
+
+    loadData(testDatasetFileName, testData, testGroundTruth);
+
+    /* Create an algorithm object to predict values of decision forest classification */
+    prediction::Batch<> algorithm(nClasses);
+
+    /* Pass a testing data set and the trained model to the algorithm */
+    algorithm.input.set(classifier::prediction::data, testData);
+    algorithm.input.set(classifier::prediction::model, trainingResult->get(classifier::training::model));
+    algorithm.parameter().votingMethod = prediction::weighted;
+    algorithm.parameter().resultsToEvaluate |= static_cast<DAAL_UINT64>(classifier::computeClassProbabilities);
+    /* Predict values of decision forest classification */
+    algorithm.compute();
+
+    /* Retrieve the algorithm results */
+    classifier::prediction::ResultPtr predictionResult = algorithm.getResult();
+    printNumericTable(predictionResult->get(classifier::prediction::prediction), "Decision forest prediction results (first 10 rows):", 10);
+    printNumericTable(predictionResult->get(classifier::prediction::probabilities), "Decision forest probabilities results (first 10 rows):", 10);
+    printNumericTable(testGroundTruth, "Ground truth (first 10 rows):", 10);
+}
+
+void loadData(const std::string & fileName, NumericTablePtr & pData, NumericTablePtr & pDependentVar)
+{
+    /* Initialize FileDataSource<CSVFeatureManager> to retrieve the input data from a .csv file */
+    FileDataSource<CSVFeatureManager> trainDataSource(fileName, DataSource::notAllocateNumericTable, DataSource::doDictionaryFromContext);
+
+    /* Create Numeric Tables for training data and dependent variables */
+    pData         = SyclHomogenNumericTable<>::create(nFeatures, 0, NumericTable::notAllocate);
+    pDependentVar = SyclHomogenNumericTable<>::create(1, 0, NumericTable::notAllocate);
+    NumericTablePtr mergedData(new MergedNumericTable(pData, pDependentVar));
+
+    /* Retrieve the data from input file */
+    trainDataSource.loadDataBlock(mergedData.get());
+
+    NumericTableDictionaryPtr pDictionary = pData->getDictionarySharedPtr();
+    for (size_t i = 0, n = sizeof(categoricalFeaturesIndices) / sizeof(categoricalFeaturesIndices[0]); i < n; ++i)
+        (*pDictionary)[categoricalFeaturesIndices[i]].featureType = data_feature_utils::DAAL_CATEGORICAL;
+}

--- a/examples/cpp_sycl/source/decision_forest/df_cls_dense_batch.cpp
+++ b/examples/cpp_sycl/source/decision_forest/df_cls_dense_batch.cpp
@@ -41,7 +41,6 @@ using namespace daal::algorithms::decision_forest::classification;
 /* Input data set parameters */
 const string trainDatasetFileName = "../data/batch/df_classification_train.csv";
 const string testDatasetFileName  = "../data/batch/df_classification_test.csv";
-//const size_t categoricalFeaturesIndices[] = { 2 };
 const size_t categoricalFeaturesIndices[] = {};
 const size_t nFeatures                    = 3; /* Number of features in training and testing data sets */
 

--- a/examples/cpp_sycl/source/decision_forest/df_cls_dense_batch.cpp
+++ b/examples/cpp_sycl/source/decision_forest/df_cls_dense_batch.cpp
@@ -39,8 +39,8 @@ using namespace daal::data_management;
 using namespace daal::algorithms::decision_forest::classification;
 
 /* Input data set parameters */
-const string trainDatasetFileName = "../data/batch/df_classification_train.csv";
-const string testDatasetFileName  = "../data/batch/df_classification_test.csv";
+const string trainDatasetFileName         = "../data/batch/df_classification_train.csv";
+const string testDatasetFileName          = "../data/batch/df_classification_test.csv";
 const size_t categoricalFeaturesIndices[] = {};
 const size_t nFeatures                    = 3; /* Number of features in training and testing data sets */
 

--- a/examples/cpp_sycl/vcproj/df_cls_dense_batch/df_cls_dense_batch.filters
+++ b/examples/cpp_sycl/vcproj/df_cls_dense_batch/df_cls_dense_batch.filters
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="$(ProjectDir)..\..\source\decision_forest\df_cls_dense_batch.cpp" />
+  </ItemGroup>
+</Project>

--- a/examples/cpp_sycl/vcproj/df_cls_dense_batch/df_cls_dense_batch.user
+++ b/examples/cpp_sycl/vcproj/df_cls_dense_batch/df_cls_dense_batch.user
@@ -1,0 +1,59 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug.static.threaded|x64'">
+    <LocalDebuggerEnvironment>PATH=$(SolutionDir)..\..\redist\intel64;$(SolutionDir)..\..\..\..\tbb\latest\redist\intel64\vc_mt;$(SolutionDir)..\..\..\..\compiler\latest\windows\bin;$(SolutionDir)..\..\..\..\compiler\latest\windows\redist\intel64_win\compiler;$(PATH)</LocalDebuggerEnvironment>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+    <LocalDebuggerCommandArguments>
+    </LocalDebuggerCommandArguments>
+    <LocalDebuggerWorkingDirectory>$(ProjectDir)..\..</LocalDebuggerWorkingDirectory>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug.dynamic.threaded|x64'">
+    <LocalDebuggerEnvironment>PATH=$(SolutionDir)..\..\redist\intel64;$(SolutionDir)..\..\..\..\tbb\latest\redist\intel64\vc_mt;$(SolutionDir)..\..\..\..\compiler\latest\windows\bin;$(SolutionDir)..\..\..\..\compiler\latest\windows\redist\intel64_win\compiler;$(PATH)</LocalDebuggerEnvironment>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+    <LocalDebuggerCommandArguments>
+    </LocalDebuggerCommandArguments>
+    <LocalDebuggerWorkingDirectory>$(ProjectDir)..\..</LocalDebuggerWorkingDirectory>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release.static.threaded|x64'">
+    <LocalDebuggerEnvironment>PATH=$(SolutionDir)..\..\redist\intel64;$(SolutionDir)..\..\..\..\tbb\latest\redist\intel64\vc_mt;$(SolutionDir)..\..\..\..\compiler\latest\windows\bin;$(SolutionDir)..\..\..\..\compiler\latest\windows\redist\intel64_win\compiler;$(PATH)</LocalDebuggerEnvironment>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+    <LocalDebuggerCommandArguments>
+    </LocalDebuggerCommandArguments>
+    <LocalDebuggerWorkingDirectory>$(ProjectDir)..\..</LocalDebuggerWorkingDirectory>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release.dynamic.threaded|x64'">
+    <LocalDebuggerEnvironment>PATH=$(SolutionDir)..\..\redist\intel64;$(SolutionDir)..\..\..\..\tbb\latest\redist\intel64\vc_mt;$(SolutionDir)..\..\..\..\compiler\latest\windows\bin;$(SolutionDir)..\..\..\..\compiler\latest\windows\redist\intel64_win\compiler;$(PATH)</LocalDebuggerEnvironment>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+    <LocalDebuggerCommandArguments>
+    </LocalDebuggerCommandArguments>
+    <LocalDebuggerWorkingDirectory>$(ProjectDir)..\..</LocalDebuggerWorkingDirectory>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug.static.sequential|x64'">
+    <LocalDebuggerEnvironment>PATH=$(SolutionDir)..\..\redist\intel64;$(SolutionDir)..\..\..\..\tbb\latest\redist\intel64\vc_mt;$(SolutionDir)..\..\..\..\compiler\latest\windows\bin;$(SolutionDir)..\..\..\..\compiler\latest\windows\redist\intel64_win\compiler;$(PATH)</LocalDebuggerEnvironment>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+    <LocalDebuggerCommandArguments>
+    </LocalDebuggerCommandArguments>
+    <LocalDebuggerWorkingDirectory>$(ProjectDir)..\..</LocalDebuggerWorkingDirectory>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug.dynamic.sequential|x64'">
+    <LocalDebuggerEnvironment>PATH=$(SolutionDir)..\..\redist\intel64;$(SolutionDir)..\..\..\..\tbb\latest\redist\intel64\vc_mt;$(SolutionDir)..\..\..\..\compiler\latest\windows\bin;$(SolutionDir)..\..\..\..\compiler\latest\windows\redist\intel64_win\compiler;$(PATH)</LocalDebuggerEnvironment>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+    <LocalDebuggerCommandArguments>
+    </LocalDebuggerCommandArguments>
+    <LocalDebuggerWorkingDirectory>$(ProjectDir)..\..</LocalDebuggerWorkingDirectory>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release.static.sequential|x64'">
+    <LocalDebuggerEnvironment>PATH=$(SolutionDir)..\..\redist\intel64;$(SolutionDir)..\..\..\..\tbb\latest\redist\intel64\vc_mt;$(SolutionDir)..\..\..\..\compiler\latest\windows\bin;$(SolutionDir)..\..\..\..\compiler\latest\windows\redist\intel64_win\compiler;$(PATH)</LocalDebuggerEnvironment>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+    <LocalDebuggerCommandArguments>
+    </LocalDebuggerCommandArguments>
+    <LocalDebuggerWorkingDirectory>$(ProjectDir)..\..</LocalDebuggerWorkingDirectory>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release.dynamic.sequential|x64'">
+    <LocalDebuggerEnvironment>PATH=$(SolutionDir)..\..\redist\intel64;$(SolutionDir)..\..\..\..\tbb\latest\redist\intel64\vc_mt;$(SolutionDir)..\..\..\..\compiler\latest\windows\bin;$(SolutionDir)..\..\..\..\compiler\latest\windows\redist\intel64_win\compiler;$(PATH)</LocalDebuggerEnvironment>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+    <LocalDebuggerCommandArguments>
+    </LocalDebuggerCommandArguments>
+    <LocalDebuggerWorkingDirectory>$(ProjectDir)..\..</LocalDebuggerWorkingDirectory>
+  </PropertyGroup>
+</Project>

--- a/examples/cpp_sycl/vcproj/df_cls_dense_batch/df_cls_dense_batch.vcxproj
+++ b/examples/cpp_sycl/vcproj/df_cls_dense_batch/df_cls_dense_batch.vcxproj
@@ -35,9 +35,9 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <ProjectGuid>{0AB49A34-5876-4C9F-A869-BF316D545232}</ProjectGuid>
-    <RootNamespace>df_reg_dense_batch</RootNamespace>
-    <ProjectName>df_reg_dense_batch</ProjectName>
+    <ProjectGuid>{F14CFA96-1962-41BC-81BC-E1957F0C334E}</ProjectGuid>
+    <RootNamespace>df_cls_dense_batch</RootNamespace>
+    <ProjectName>df_cls_dense_batch</ProjectName>
     <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
@@ -306,7 +306,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="$(ProjectDir)..\..\source\decision_forest\df_reg_dense_batch.cpp" />
+    <ClCompile Include="$(ProjectDir)..\..\source\decision_forest\df_cls_dense_batch.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/include/algorithms/decision_forest/decision_forest_classification_training_types.h
+++ b/include/algorithms/decision_forest/decision_forest_classification_training_types.h
@@ -54,7 +54,8 @@ namespace training
  */
 enum Method
 {
-    defaultDense = 0 /*!< Bagging, random choice of features, Gini impurity */
+    defaultDense = 0, /*!< Bagging, random choice of features, Gini impurity */
+    hist         = 1  /*!< Subset of splits(bins), bagging, random choice of features, variance-based impurity */
 };
 
 /**


### PR DESCRIPTION
Added RF classifier for GPU.
Most part of the kernels are very like to regressor's. The main difference in best split calculation and classes statistic processing.
Common kernels for manipulation with nodes were moved into shared helper between classifier and regressor.
Corresponding changes in regressor (for migration into shared part) will be added a little bit later