### PR TITLE
[master] Removing conversions for SOA tables in Finite Check

### DIFF
--- a/cpp/daal/src/data_management/finiteness_checker.cpp
+++ b/cpp/daal/src/data_management/finiteness_checker.cpp
@@ -311,18 +311,16 @@ services::Status allValuesAreFiniteImpl(NumericTable & table, bool allowNaN, boo
     const size_t nElements = nRows * nColumns;
     const NTLayout layout  = table.getDataLayout();
 
-    size_t nDataPtrs, nElementsPerPtr;
+    size_t nDataPtrs;
     if (layout == NTLayout::soa)
     {
         // SOA layout: pointer for each column
-        nDataPtrs       = nColumns;
-        nElementsPerPtr = nRows;
+        nDataPtrs = nColumns;
     }
     else
     {
         // AOS layout: one pointer for all data
-        nDataPtrs       = 1;
-        nElementsPerPtr = nRows * nColumns;
+        nDataPtrs = 1;
     }
 
     NumericTableDictionaryPtr tableFeaturesDict = table.getDictionarySharedPtr();
@@ -360,7 +358,7 @@ services::Status allValuesAreFiniteImpl(NumericTable & table, bool allowNaN, boo
             DAAL_CHECK_BLOCK_STATUS(dataBlock);
             const DataType * dataPtr = dataBlock.get();
 
-            sum += computeSum<DataType, cpu>(1, nElementsPerPtr, &dataPtr);
+            sum += computeSum<DataType, cpu>(1, nElements, &dataPtr);
         }
         sumIsFinite &= !valuesAreNotFinite(&sum, 1, false);
     }
@@ -371,7 +369,7 @@ services::Status allValuesAreFiniteImpl(NumericTable & table, bool allowNaN, boo
         return s;
     }
 
-    // second stage: chech finiteness of all values
+    // second stage: check finiteness of all values
     bool valuesAreFinite = true;
     for (size_t i = 0; (i < nDataPtrs) && valuesAreFinite; ++i)
     {
@@ -403,7 +401,7 @@ services::Status allValuesAreFiniteImpl(NumericTable & table, bool allowNaN, boo
             DAAL_CHECK_BLOCK_STATUS(dataBlock);
             const DataType * dataPtr = dataBlock.get();
 
-            valuesAreFinite &= checkFiniteness<DataType, cpu>(nRows, 1, nRows, &dataPtr, allowNaN);
+            valuesAreFinite &= checkFiniteness<DataType, cpu>(nElements, 1, nElements, &dataPtr, allowNaN);
         }
     }
 

--- a/cpp/daal/src/data_management/finiteness_checker.cpp
+++ b/cpp/daal/src/data_management/finiteness_checker.cpp
@@ -22,8 +22,7 @@
 #include "src/externals/service_dispatch.h"
 #include "src/threading/threading.h"
 #include "service_numeric_table.h"
-#include "algorithms/kernel/service_error_handling.h"
-#include "service/kernel/data_management/service_numeric_table.h"
+#include "src/algorithms/service_error_handling.h"
 
 namespace daal
 {

--- a/cpp/daal/src/data_management/finiteness_checker.cpp
+++ b/cpp/daal/src/data_management/finiteness_checker.cpp
@@ -83,6 +83,41 @@ DataType computeSum(size_t nDataPtrs, size_t nElementsPerPtr, const DataType ** 
     return sum;
 }
 
+template <daal::CpuType cpu>
+double computeSumSOA(NumericTable & table, bool & sumIsFinite)
+{
+    double sum                                  = 0;
+    const size_t nRows                          = table.getNumberOfRows();
+    const size_t nCols                          = table.getNumberOfColumns();
+    NumericTableDictionaryPtr tableFeaturesDict = table.getDictionarySharedPtr();
+
+    for (size_t i = 0; (i < nCols) && sumIsFinite; ++i)
+    {
+        switch ((*tableFeaturesDict)[i].getIndexType())
+        {
+        case daal::data_management::features::IndexNumType::DAAL_FLOAT32:
+        {
+            ReadColumns<float, cpu> colBlock(table, i, 0, nRows);
+            DAAL_CHECK_BLOCK_STATUS(colBlock);
+            const float * colPtr = colBlock.get();
+            sum += computeSum<float, cpu>(1, nRows, &colPtr);
+            break;
+        }
+        case daal::data_management::features::IndexNumType::DAAL_FLOAT64:
+        {
+            ReadColumns<double, cpu> colBlock(table, i, 0, nRows);
+            DAAL_CHECK_BLOCK_STATUS(colBlock);
+            const double * colPtr = colBlock.get();
+            sum += static_cast<double>(computeSum<double, cpu>(1, nRows, &colPtr));
+            break;
+        }
+        }
+        sumIsFinite &= !valuesAreNotFinite(&sum, 1, false);
+    }
+
+    return sum;
+}
+
 template <typename DataType, daal::CpuType cpu>
 bool checkFiniteness(const size_t nElements, size_t nDataPtrs, size_t nElementsPerPtr, const DataType ** dataPtrs, bool allowNaN)
 {
@@ -90,6 +125,40 @@ bool checkFiniteness(const size_t nElements, size_t nDataPtrs, size_t nElementsP
     for (size_t ptrIdx = 0; ptrIdx < nDataPtrs; ++ptrIdx) notFinite = notFinite || valuesAreNotFinite(dataPtrs[ptrIdx], nElementsPerPtr, allowNaN);
 
     return !notFinite;
+}
+
+template <daal::CpuType cpu>
+bool checkFinitenessSOA(NumericTable & table, bool allowNaN)
+{
+    bool valuesAreFinite                        = true;
+    const size_t nRows                          = table.getNumberOfRows();
+    const size_t nCols                          = table.getNumberOfColumns();
+    NumericTableDictionaryPtr tableFeaturesDict = table.getDictionarySharedPtr();
+
+    for (size_t i = 0; (i < nCols) && valuesAreFinite; ++i)
+    {
+        switch ((*tableFeaturesDict)[i].getIndexType())
+        {
+        case daal::data_management::features::IndexNumType::DAAL_FLOAT32:
+        {
+            ReadColumns<float, cpu> colBlock(table, i, 0, nRows);
+            DAAL_CHECK_BLOCK_STATUS(colBlock);
+            const float * colPtr = colBlock.get();
+            valuesAreFinite &= checkFiniteness<float, cpu>(nRows, 1, nRows, &colPtr, allowNaN);
+            break;
+        }
+        case daal::data_management::features::IndexNumType::DAAL_FLOAT64:
+        {
+            ReadColumns<double, cpu> colBlock(table, i, 0, nRows);
+            DAAL_CHECK_BLOCK_STATUS(colBlock);
+            const double * colPtr = colBlock.get();
+            valuesAreFinite &= checkFiniteness<double, cpu>(nRows, 1, nRows, &colPtr, allowNaN);
+            break;
+        }
+        }
+    }
+
+    return valuesAreFinite;
 }
 
 #if defined(__INTEL_COMPILER)
@@ -159,6 +228,68 @@ template <>
 double computeSum<double, avx512>(size_t nDataPtrs, size_t nElementsPerPtr, const double ** dataPtrs)
 {
     return computeSumAVX512Impl<double>(nDataPtrs, nElementsPerPtr, dataPtrs);
+}
+
+double computeSumSOAAVX512Impl(NumericTable & table, bool & sumIsFinite)
+{
+    SafeStatus safeStat;
+    double sum                                  = 0;
+    bool breakFlag                              = false;
+    const size_t nRows                          = table.getNumberOfRows();
+    const size_t nCols                          = table.getNumberOfColumns();
+    NumericTableDictionaryPtr tableFeaturesDict = table.getDictionarySharedPtr();
+
+    daal::TlsMem<double, avx512, services::internal::ScalableCalloc<double, avx512> > tlsSum(1);
+    daal::TlsMem<bool, avx512, services::internal::ScalableCalloc<bool, avx512> > tlsFinite(1);
+    daal::threader_for(nCols, nCols, [&](size_t i) {
+        double * localSum  = tlsSum.local();
+        bool * localFinite = tlsFinite.local();
+
+        switch ((*tableFeaturesDict)[i].getIndexType())
+        {
+        case daal::data_management::features::IndexNumType::DAAL_FLOAT32:
+        {
+            ReadColumns<float, avx512> colBlock(table, i, 0, nRows);
+            DAAL_CHECK_BLOCK_STATUS_THR(colBlock);
+            const float * colPtr = colBlock.get();
+            *localSum += computeSum<float, avx512>(1, nRows, &colPtr);
+            break;
+        }
+        case daal::data_management::features::IndexNumType::DAAL_FLOAT64:
+        {
+            ReadColumns<double, avx512> colBlock(table, i, 0, nRows);
+            DAAL_CHECK_BLOCK_STATUS_THR(colBlock);
+            const double * colPtr = colBlock.get();
+            *localSum += static_cast<double>(computeSum<double, avx512>(1, nRows, &colPtr));
+            break;
+        }
+        }
+
+        *localFinite |= valuesAreNotFinite(localSum, 1, false);
+        if (*localFinite)
+        {
+            breakFlag = true;
+            daal::break_threader_for();
+        }
+    });
+    tlsSum.reduce([&](double * localSum) { sum += *localSum; });
+
+    if (breakFlag)
+    {
+        sumIsFinite = false;
+    }
+    else
+    {
+        tlsFinite.reduce([&](bool * localFinite) { sumIsFinite &= !*localFinite; });
+    }
+
+    return sum;
+}
+
+template <>
+double computeSumSOA<avx512>(NumericTable & table, bool & sumIsFinite)
+{
+    return computeSumSOAAVX512Impl(table, sumIsFinite);
 }
 
 services::Status checkFinitenessInBlocks(const float ** dataPtrs, bool inParallel, size_t nTotalBlocks, size_t nBlocksPerPtr, size_t nPerBlock,
@@ -298,6 +429,64 @@ bool checkFiniteness<double, avx512>(const size_t nElements, size_t nDataPtrs, s
     return checkFinitenessAVX512Impl<double>(nElements, nDataPtrs, nElementsPerPtr, dataPtrs, allowNaN);
 }
 
+bool checkFinitenessSOAAVX512Impl(NumericTable & table, bool allowNaN)
+{
+    SafeStatus safeStat;
+    bool valuesAreFinite                        = true;
+    bool breakFlag                              = false;
+    const size_t nRows                          = table.getNumberOfRows();
+    const size_t nCols                          = table.getNumberOfColumns();
+    NumericTableDictionaryPtr tableFeaturesDict = table.getDictionarySharedPtr();
+
+    daal::TlsMem<bool, avx512, services::internal::ScalableCalloc<bool, avx512> > tlsFinite(1);
+    daal::threader_for(nCols, nCols, [&](size_t i) {
+        bool * localFinite = tlsFinite.local();
+
+        switch ((*tableFeaturesDict)[i].getIndexType())
+        {
+        case daal::data_management::features::IndexNumType::DAAL_FLOAT32:
+        {
+            ReadColumns<float, avx512> colBlock(table, i, 0, nRows);
+            DAAL_CHECK_BLOCK_STATUS_THR(colBlock);
+            const float * colPtr = colBlock.get();
+            *localFinite |= !checkFiniteness<float, avx512>(nRows, 1, nRows, &colPtr, allowNaN);
+            break;
+        }
+        case daal::data_management::features::IndexNumType::DAAL_FLOAT64:
+        {
+            ReadColumns<double, avx512> colBlock(table, i, 0, nRows);
+            DAAL_CHECK_BLOCK_STATUS_THR(colBlock);
+            const double * colPtr = colBlock.get();
+            *localFinite |= !checkFiniteness<double, avx512>(nRows, 1, nRows, &colPtr, allowNaN);
+            break;
+        }
+        }
+
+        if (*localFinite)
+        {
+            breakFlag = true;
+            daal::break_threader_for();
+        }
+    });
+
+    if (breakFlag)
+    {
+        valuesAreFinite = false;
+    }
+    else
+    {
+        tlsFinite.reduce([&](bool * localFinite) { valuesAreFinite &= !*localFinite; });
+    }
+
+    return valuesAreFinite;
+}
+
+template <>
+bool checkFinitenessSOA<avx512>(NumericTable & table, bool allowNaN)
+{
+    return checkFinitenessSOAAVX512Impl(table, allowNaN);
+}
+
 #endif
 
 template <typename DataType, daal::CpuType cpu>
@@ -327,40 +516,21 @@ services::Status allValuesAreFiniteImpl(NumericTable & table, bool allowNaN, boo
     // first stage: compute sum of all values and check its finiteness
     double sum       = 0;
     bool sumIsFinite = true;
-    for (size_t i = 0; (i < nDataPtrs) && sumIsFinite; ++i)
-    {
-        if (layout == NTLayout::soa)
-        {
-            switch ((*tableFeaturesDict)[i].getIndexType())
-            {
-            case daal::data_management::features::IndexNumType::DAAL_FLOAT32:
-            {
-                ReadColumns<float, cpu> colBlock(table, i, 0, nRows);
-                DAAL_CHECK_BLOCK_STATUS(colBlock);
-                const float * colPtr = colBlock.get();
-                sum += computeSum<float, cpu>(1, nRows, &colPtr);
-                break;
-            }
-            case daal::data_management::features::IndexNumType::DAAL_FLOAT64:
-            {
-                ReadColumns<double, cpu> colBlock(table, i, 0, nRows);
-                DAAL_CHECK_BLOCK_STATUS(colBlock);
-                const double * colPtr = colBlock.get();
-                sum += static_cast<double>(computeSum<double, cpu>(1, nRows, &colPtr));
-                break;
-            }
-            }
-        }
-        else
-        {
-            ReadRows<DataType, cpu> dataBlock(table, 0, nRows);
-            DAAL_CHECK_BLOCK_STATUS(dataBlock);
-            const DataType * dataPtr = dataBlock.get();
 
-            sum += computeSum<DataType, cpu>(1, nElements, &dataPtr);
-        }
-        sumIsFinite &= !valuesAreNotFinite(&sum, 1, false);
+    if (layout == NTLayout::soa)
+    {
+        sum = computeSumSOA<cpu>(table, sumIsFinite);
     }
+    else
+    {
+        ReadRows<DataType, cpu> dataBlock(table, 0, nRows);
+        DAAL_CHECK_BLOCK_STATUS(dataBlock);
+        const DataType * dataPtr = dataBlock.get();
+
+        sum = computeSum<DataType, cpu>(1, nElements, &dataPtr);
+    }
+
+    sumIsFinite &= !valuesAreNotFinite(&sum, 1, false);
 
     if (sumIsFinite)
     {
@@ -370,38 +540,17 @@ services::Status allValuesAreFiniteImpl(NumericTable & table, bool allowNaN, boo
 
     // second stage: check finiteness of all values
     bool valuesAreFinite = true;
-    for (size_t i = 0; (i < nDataPtrs) && valuesAreFinite; ++i)
+    if (layout == NTLayout::soa)
     {
-        if (layout == NTLayout::soa)
-        {
-            switch ((*tableFeaturesDict)[i].getIndexType())
-            {
-            case daal::data_management::features::IndexNumType::DAAL_FLOAT32:
-            {
-                ReadColumns<float, cpu> colBlock(table, i, 0, nRows);
-                DAAL_CHECK_BLOCK_STATUS(colBlock);
-                const float * colPtr = colBlock.get();
-                valuesAreFinite &= checkFiniteness<float, cpu>(nRows, 1, nRows, &colPtr, allowNaN);
-                break;
-            }
-            case daal::data_management::features::IndexNumType::DAAL_FLOAT64:
-            {
-                ReadColumns<double, cpu> colBlock(table, i, 0, nRows);
-                DAAL_CHECK_BLOCK_STATUS(colBlock);
-                const double * colPtr = colBlock.get();
-                valuesAreFinite &= checkFiniteness<double, cpu>(nRows, 1, nRows, &colPtr, allowNaN);
-                break;
-            }
-            }
-        }
-        else
-        {
-            ReadRows<DataType, cpu> dataBlock(table, 0, nRows);
-            DAAL_CHECK_BLOCK_STATUS(dataBlock);
-            const DataType * dataPtr = dataBlock.get();
+        valuesAreFinite = checkFinitenessSOA<cpu>(table, allowNaN);
+    }
+    else
+    {
+        ReadRows<DataType, cpu> dataBlock(table, 0, nRows);
+        DAAL_CHECK_BLOCK_STATUS(dataBlock);
+        const DataType * dataPtr = dataBlock.get();
 
-            valuesAreFinite &= checkFiniteness<DataType, cpu>(nElements, 1, nElements, &dataPtr, allowNaN);
-        }
+        valuesAreFinite = checkFiniteness<DataType, cpu>(nElements, 1, nElements, &dataPtr, allowNaN);
     }
 
     *finiteness = valuesAreFinite;

--- a/cpp/daal/src/externals/core_threading_win_dll.cpp
+++ b/cpp/daal/src/externals/core_threading_win_dll.cpp
@@ -244,6 +244,7 @@ typedef void (*_threaded_free_t)(void *);
 typedef void (*_daal_threader_for_t)(int, int, const void *, daal::functype);
 typedef void (*_daal_threader_for_blocked_t)(int, int, const void *, daal::functype2);
 typedef int (*_daal_threader_get_max_threads_t)(void);
+typedef void (*_daal_threader_for_break_t)(int, int, const void *, daal::functype_break);
 
 typedef void * (*_daal_get_tls_ptr_t)(void *, daal::tls_functype);
 typedef void (*_daal_del_tls_ptr_t)(void *);
@@ -291,6 +292,7 @@ static _daal_threader_for_t _daal_threader_for_ptr                         = NUL
 static _daal_threader_for_blocked_t _daal_threader_for_blocked_ptr         = NULL;
 static _daal_threader_for_t _daal_threader_for_optional_ptr                = NULL;
 static _daal_threader_get_max_threads_t _daal_threader_get_max_threads_ptr = NULL;
+static _daal_threader_for_break_t _daal_threader_for_break_ptr             = NULL;
 
 static _daal_get_tls_ptr_t _daal_get_tls_ptr_ptr                 = NULL;
 static _daal_del_tls_ptr_t _daal_del_tls_ptr_ptr                 = NULL;
@@ -379,6 +381,16 @@ DAAL_EXPORT void _daal_threader_for_optional(int n, int threads_request, const v
         _daal_threader_for_optional_ptr = (_daal_threader_for_t)load_daal_thr_func("_daal_threader_for_optional");
     }
     _daal_threader_for_optional_ptr(n, threads_request, a, func);
+}
+
+DAAL_EXPORT void _daal_threader_for_break(int n, int threads_request, const void * a, daal::functype_break func)
+{
+    load_daal_thr_dll();
+    if (_daal_threader_for_break_ptr == NULL)
+    {
+        _daal_threader_for_break_ptr = (_daal_threader_for_break_t)load_daal_thr_func("_daal_threader_for_break");
+    }
+    _daal_threader_for_break_ptr(n, threads_request, a, func);
 }
 
 DAAL_EXPORT int _daal_threader_get_max_threads()

--- a/cpp/daal/src/threading/threading.cpp
+++ b/cpp/daal/src/threading/threading.cpp
@@ -139,6 +139,16 @@ DAAL_EXPORT void _daal_threader_for_optional(int n, int threads_request, const v
 #endif
 }
 
+DAAL_EXPORT void _daal_break_threader_for()
+{
+#if defined(__DO_TBB_LAYER__)
+    tbb::task::self().cancel_group_execution();
+    return;
+#elif defined(__DO_SEQ_LAYER__)
+    return;
+#endif
+}
+
 DAAL_EXPORT int _daal_threader_get_max_threads()
 {
 #if defined(__DO_TBB_LAYER__)

--- a/cpp/daal/src/threading/threading.cpp
+++ b/cpp/daal/src/threading/threading.cpp
@@ -142,15 +142,19 @@ DAAL_EXPORT void _daal_threader_for_optional(int n, int threads_request, const v
 DAAL_EXPORT void _daal_threader_for_break(int n, int threads_request, const void * a, daal::functype_break func)
 {
 #if defined(__DO_TBB_LAYER__)
-    tbb::parallel_for(tbb::blocked_range<int>(0, n, 1), [&](tbb::blocked_range<int> r) {
-        int i;
-        for (i = r.begin(); i < r.end(); ++i)
-        {
-            bool needBreak = false;
-            func(i, needBreak, a);
-            if (needBreak) tbb::task::self().cancel_group_execution();
-        }
-    });
+    tbb::task_group_context context;
+    tbb::parallel_for(
+        tbb::blocked_range<int>(0, n, 1),
+        [&](tbb::blocked_range<int> r) {
+            int i;
+            for (i = r.begin(); i < r.end(); ++i)
+            {
+                bool needBreak = false;
+                func(i, needBreak, a);
+                if (needBreak) context.cancel_group_execution();
+            }
+        },
+        context);
 #elif defined(__DO_SEQ_LAYER__)
     int i;
     for (i = 0; i < n; ++i)

--- a/cpp/daal/src/threading/threading.h
+++ b/cpp/daal/src/threading/threading.h
@@ -41,6 +41,7 @@ extern "C"
     DAAL_EXPORT void _daal_threader_for(int n, int threads_request, const void * a, daal::functype func);
     DAAL_EXPORT void _daal_threader_for_blocked(int n, int threads_request, const void * a, daal::functype2 func);
     DAAL_EXPORT void _daal_threader_for_optional(int n, int threads_request, const void * a, daal::functype func);
+    DAAL_EXPORT void _daal_break_threader_for();
 
     DAAL_EXPORT void * _daal_get_tls_ptr(void * a, daal::tls_functype func);
     DAAL_EXPORT void * _daal_get_tls_local(void * tlsPtr);
@@ -153,6 +154,11 @@ inline void threader_for_optional(int n, int threads_request, const F & lambda)
     const void * a = static_cast<const void *>(&lambda);
 
     _daal_threader_for_optional(n, threads_request, a, threader_func<F>);
+}
+
+inline void break_threader_for()
+{
+    _daal_break_threader_for();
 }
 
 template <typename lambdaType>


### PR DESCRIPTION
New versions of ```computeSum()``` and ```checkFiniteness()``` have been created for SOA tables