### PR TITLE
Fix clang format in master

### DIFF
--- a/cpp/oneapi/dal/algo/pca/backend/cpu/train_kernel_cov.cpp
+++ b/cpp/oneapi/dal/algo/pca/backend/cpu/train_kernel_cov.cpp
@@ -41,10 +41,10 @@ static train_result call_daal_kernel(const context_cpu& ctx,
     const int64_t component_count = desc.get_component_count();
 
     auto arr_data = row_accessor<const Float>{ data }.pull();
-    array<Float> arr_eigvec { column_count * component_count };
-    array<Float> arr_eigval { 1 * component_count };
-    array<Float> arr_means { 1 * component_count };
-    array<Float> arr_vars { 1 * component_count };
+    array<Float> arr_eigvec{ column_count * component_count };
+    array<Float> arr_eigval{ 1 * component_count };
+    array<Float> arr_means{ 1 * component_count };
+    array<Float> arr_vars{ 1 * component_count };
 
     // TODO: read-only access performed with deep copy of data since daal numeric tables are mutable.
     // Need to create special immutable homogen table on daal interop side

--- a/cpp/oneapi/dal/data/array_dpc_test.cpp
+++ b/cpp/oneapi/dal/data/array_dpc_test.cpp
@@ -23,7 +23,7 @@ using namespace oneapi::dal;
 using std::int32_t;
 
 TEST(array_dpc_test, can_construct_array_of_zeros) {
-    sycl::queue q { sycl::gpu_selector() };
+    sycl::queue q{ sycl::gpu_selector() };
 
     auto arr = array<float>::zeros(q, 5);
 
@@ -38,7 +38,7 @@ TEST(array_dpc_test, can_construct_array_of_zeros) {
 }
 
 TEST(array_dpc_test, can_construct_array_of_ones) {
-    sycl::queue q { sycl::gpu_selector() };
+    sycl::queue q{ sycl::gpu_selector() };
 
     auto arr = array<float>::full(5, 1.0f);
 
@@ -53,32 +53,31 @@ TEST(array_dpc_test, can_construct_array_of_ones) {
 }
 
 TEST(array_dpc_test, can_construct_device_array_without_initialization) {
-    sycl::queue q { sycl::gpu_selector() };
+    sycl::queue q{ sycl::gpu_selector() };
 
-    array<float> arr { q, 10, sycl::usm::alloc::device };
+    array<float> arr{ q, 10, sycl::usm::alloc::device };
 
     ASSERT_EQ(arr.get_count(), 10);
     ASSERT_EQ(arr.get_capacity(), 10);
     ASSERT_TRUE(arr.is_data_owner());
     ASSERT_TRUE(arr.has_mutable_data());
 
-    ASSERT_EQ(sycl::get_pointer_type(arr.get_data(), q.get_context()),
-              sycl::usm::alloc::device);
+    ASSERT_EQ(sycl::get_pointer_type(arr.get_data(), q.get_context()), sycl::usm::alloc::device);
 }
 
 TEST(array_dpc_test, can_construct_array_with_events) {
-    sycl::queue q { sycl::gpu_selector() };
+    sycl::queue q{ sycl::gpu_selector() };
 
     constexpr std::int64_t count = 10;
 
     auto* data = sycl::malloc_shared<float>(count, q);
-    auto event = q.submit([&](sycl::handler& cgh){
+    auto event = q.submit([&](sycl::handler& cgh) {
         cgh.parallel_for(sycl::range<1>(count), [=](sycl::id<1> idx) {
             data[idx[0]] = idx;
         });
     });
 
-    array<float> arr { q, data, 10, { event } };
+    array<float> arr{ q, data, 10, { event } };
 
     ASSERT_EQ(arr.get_count(), 10);
     ASSERT_EQ(arr.get_capacity(), 10);
@@ -91,7 +90,7 @@ TEST(array_dpc_test, can_construct_array_with_events) {
 }
 
 TEST(array_dpc_test, can_make_owning_array_from_non_owning) {
-    sycl::queue q { sycl::gpu_selector() };
+    sycl::queue q{ sycl::gpu_selector() };
 
     array<float> arr;
 
@@ -120,7 +119,7 @@ TEST(array_dpc_test, can_make_owning_array_from_non_owning) {
 }
 
 TEST(array_dpc_test, can_reset_array_with_bigger_size) {
-    sycl::queue q { sycl::gpu_selector() };
+    sycl::queue q{ sycl::gpu_selector() };
 
     auto arr = array<float>::zeros(q, 5);
     arr.reset(q, 10);
@@ -132,7 +131,7 @@ TEST(array_dpc_test, can_reset_array_with_bigger_size) {
 }
 
 TEST(array_dpc_test, can_reset_array_with_smaller_size) {
-    sycl::queue q { sycl::gpu_selector() };
+    sycl::queue q{ sycl::gpu_selector() };
 
     auto arr = array<float>::zeros(q, 5);
     arr.reset(q, 4);
@@ -144,19 +143,19 @@ TEST(array_dpc_test, can_reset_array_with_smaller_size) {
 }
 
 TEST(array_dpc_test, can_reset_array_with_raw_pointer) {
-    sycl::queue q { sycl::gpu_selector() };
+    sycl::queue q{ sycl::gpu_selector() };
 
     auto arr = array<float>::zeros(q, 5);
 
     constexpr int64_t count = 10;
-    auto* data = sycl::malloc_shared<float>(count, q);
-    auto event = q.submit([&](sycl::handler& cgh){
+    auto* data              = sycl::malloc_shared<float>(count, q);
+    auto event              = q.submit([&](sycl::handler& cgh) {
         cgh.parallel_for(sycl::range<1>(count), [=](sycl::id<1> idx) {
             data[idx[0]] = idx;
         });
     });
 
-    arr.reset(q, data, count, {event});
+    arr.reset(q, data, count, { event });
 
     ASSERT_EQ(arr.get_size(), count * sizeof(float));
     ASSERT_EQ(arr.get_count(), count);

--- a/cpp/oneapi/dal/data/array_test.cpp
+++ b/cpp/oneapi/dal/data/array_test.cpp
@@ -77,7 +77,7 @@ TEST(array_test, can_construct_array_from_raw_pointer) {
 }
 
 TEST(array_test, can_construct_array_reference) {
-    auto arr = array<float>::zeros(5);
+    auto arr          = array<float>::zeros(5);
     array<float> arr2 = arr;
 
     ASSERT_EQ(arr.get_count(), arr2.get_count());
@@ -232,7 +232,7 @@ TEST(array_test, can_make_owning_array_from_non_owning_readonly) {
 
 TEST(array_test, can_construct_non_owning_read_write_array) {
     float data[] = { 1.0f, 2.0f, 3.0f };
-    array<float> arr { data, 3 };
+    array<float> arr{ data, 3 };
 
     ASSERT_EQ(arr.get_count(), 3);
     ASSERT_EQ(arr.get_data(), data);
@@ -242,7 +242,7 @@ TEST(array_test, can_construct_non_owning_read_write_array) {
 
 TEST(array_test, can_construct_non_owning_read_only_array) {
     float data[] = { 1.0f, 2.0f, 3.0f };
-    array<float> arr { static_cast<const float*>(data), 3 };
+    array<float> arr{ static_cast<const float*>(data), 3 };
 
     ASSERT_EQ(arr.get_count(), 3);
     ASSERT_EQ(arr.get_data(), data);

--- a/cpp/oneapi/dal/data/backend/homogen_table_impl.cpp
+++ b/cpp/oneapi/dal/data/backend/homogen_table_impl.cpp
@@ -46,7 +46,8 @@ void homogen_table_impl::pull_rows(array<T>& block, const range& rows) const {
     else {
         if (!block.is_data_owner() || block.get_capacity() < block_size) {
             block.reset(block_size);
-        } else if (block.get_count() < block_size) {
+        }
+        else if (block.get_count() < block_size) {
             block.resize(block_size);
         }
 
@@ -123,7 +124,8 @@ void homogen_table_impl::pull_column(array<T>& block, int64_t idx, const range& 
     else {
         if (!block.is_data_owner() || block.get_capacity() < block_size) {
             block.reset(block_size);
-        } else if (block.get_count() < block_size) {
+        }
+        else if (block.get_count() < block_size) {
             block.resize(block_size);
         }
 

--- a/cpp/oneapi/dal/data/backend/homogen_table_impl.hpp
+++ b/cpp/oneapi/dal/data/backend/homogen_table_impl.hpp
@@ -42,8 +42,8 @@ public:
 
     template <typename DataType>
     homogen_table_impl(std::int64_t p, const array<DataType>& data, homogen_data_layout layout)
-        : meta_(homogen_table_metadata{ make_data_type<DataType>(), layout,  p }),
-          row_count_(data.get_count() / p) {
+            : meta_(homogen_table_metadata{ make_data_type<DataType>(), layout, p }),
+              row_count_(data.get_count() / p) {
         const std::int64_t N = row_count_;
 
         if (N * p != data.get_count()) {

--- a/cpp/oneapi/dal/data/table_builder_test.cpp
+++ b/cpp/oneapi/dal/data/table_builder_test.cpp
@@ -44,7 +44,7 @@ TEST(table_builder_test, can_modify_table) {
     row_accessor<const float> acc{ t };
     auto arr = acc.pull();
 
-    for(std::int64_t i = 0; i < arr.get_count(); i++) {
+    for (std::int64_t i = 0; i < arr.get_count(); i++) {
         ASSERT_FLOAT_EQ(arr.get_data()[i], data2[i]);
     }
 }

--- a/cpp/oneapi/dal/data/table_metadata.cpp
+++ b/cpp/oneapi/dal/data/table_metadata.cpp
@@ -128,7 +128,8 @@ table_feature& table_feature::set_type(feature_type ft) {
 table_metadata::table_metadata() : impl_(new detail::empty_metadata_impl()) {}
 
 table_metadata::table_metadata(const table_feature& feature, int64_t feature_count)
-    : impl_(new detail::simple_metadata_impl { array<table_feature>::full(feature_count, feature) }) {}
+        : impl_(new detail::simple_metadata_impl{
+              array<table_feature>::full(feature_count, feature) }) {}
 
 table_metadata::table_metadata(array<table_feature> features)
         : impl_(new detail::simple_metadata_impl{ features }) {}

--- a/cpp/oneapi/dal/detail/common.hpp
+++ b/cpp/oneapi/dal/detail/common.hpp
@@ -65,6 +65,6 @@ Object make_from_pointer(typename Object::pimpl::element_type* pointer) {
     return pimpl_accessor().template make_from_pointer<Object>(pointer);
 }
 
-struct host_seq_policy{};
+struct host_seq_policy {};
 
-}  // namespace oneapi::dal::detail
+} // namespace oneapi::dal::detail

--- a/cpp/oneapi/dal/detail/common_dpc.hpp
+++ b/cpp/oneapi/dal/detail/common_dpc.hpp
@@ -17,5 +17,5 @@
 #pragma once
 
 #ifdef ONEAPI_DAL_DATA_PARALLEL
-#include <CL/sycl.hpp>
+    #include <CL/sycl.hpp>
 #endif // ONEAPI_DAL_DATA_PARALLEL

--- a/cpp/oneapi/dal/detail/memory.hpp
+++ b/cpp/oneapi/dal/detail/memory.hpp
@@ -18,16 +18,15 @@
 
 #include <cstring>
 
-#include "oneapi/dal/detail/memory_impl_host.hpp"
 #include "oneapi/dal/detail/memory_impl_dpc.hpp"
+#include "oneapi/dal/detail/memory_impl_host.hpp"
 
 namespace oneapi::dal::detail {
 
 template <typename T, typename Policy>
 class default_delete {
 public:
-    explicit default_delete(const Policy& policy)
-        : policy_(policy) {}
+    explicit default_delete(const Policy& policy) : policy_(policy) {}
 
     void operator()(T* data) {
         detail::free(policy_, data);

--- a/cpp/oneapi/dal/detail/memory_impl_dpc.hpp
+++ b/cpp/oneapi/dal/detail/memory_impl_dpc.hpp
@@ -25,7 +25,7 @@ namespace oneapi::dal::detail {
 #ifdef ONEAPI_DAL_DATA_PARALLEL
 template <typename T>
 inline T* malloc(sycl::queue& queue, std::int64_t count, sycl::usm::alloc kind) {
-    auto device = queue.get_device();
+    auto device  = queue.get_device();
     auto context = queue.get_context();
     // TODO: is not safe since sycl::memset accepts count as size_t
     return sycl::malloc<T>(count, device, context, kind);
@@ -52,8 +52,7 @@ template <typename T>
 inline void fill(sycl::queue& queue, T* dest, std::int64_t count, const T& value) {
     // TODO: can be optimized in future
     auto event = queue.submit([&](sycl::handler& cgh) {
-        cgh.parallel_for<class oneapi_dal_memory_fill>(sycl::range<1>(count),
-        [=](sycl::id<1> idx) {
+        cgh.parallel_for<class oneapi_dal_memory_fill>(sycl::range<1>(count), [=](sycl::id<1> idx) {
             dest[idx[0]] = value;
         });
     });

--- a/cpp/oneapi/dal/detail/memory_impl_host.hpp
+++ b/cpp/oneapi/dal/detail/memory_impl_host.hpp
@@ -22,7 +22,7 @@
 
 namespace oneapi::dal::detail {
 
-struct host_only_alloc{};
+struct host_only_alloc {};
 
 template <typename T>
 inline T* malloc(const host_seq_policy&, std::int64_t count, host_only_alloc) {


### PR DESCRIPTION
Surprisingly, @michael-smirnov's array merge was not checked by clang-format (it was added later). Here is the fix.