### PR TITLE
Kernel implementation and support as parameters for SVM in new interfaces

### DIFF
--- a/cpp/daal/src/algorithms/kernel_function/kernel_function_linear_dense_default_batch_fpt_cpu.cpp
+++ b/cpp/daal/src/algorithms/kernel_function/kernel_function_linear_dense_default_batch_fpt_cpu.cpp
@@ -40,14 +40,9 @@ template class BatchContainer<DAAL_FPTYPE, defaultDense, DAAL_CPU>;
 }
 namespace internal
 {
-template class KernelImplLinear<defaultDense, DAAL_FPTYPE, DAAL_CPU>;
-
+template class DAAL_EXPORT KernelImplLinear<defaultDense, DAAL_FPTYPE, DAAL_CPU>;
 } // namespace internal
-
 } // namespace linear
-
 } // namespace kernel_function
-
 } // namespace algorithms
-
 } // namespace daal

--- a/cpp/daal/src/algorithms/kernel_function/kernel_function_rbf_dense_default_batch_fpt_cpu.cpp
+++ b/cpp/daal/src/algorithms/kernel_function/kernel_function_rbf_dense_default_batch_fpt_cpu.cpp
@@ -40,7 +40,7 @@ template class BatchContainer<DAAL_FPTYPE, defaultDense, DAAL_CPU>;
 }
 namespace internal
 {
-template class KernelImplRBF<defaultDense, DAAL_FPTYPE, DAAL_CPU>;
+template class DAAL_EXPORT KernelImplRBF<defaultDense, DAAL_FPTYPE, DAAL_CPU>;
 
 } // namespace internal
 

--- a/cpp/daal/src/algorithms/svm/svm_train_boser_batch_fpt_cpu.cpp
+++ b/cpp/daal/src/algorithms/svm/svm_train_boser_batch_fpt_cpu.cpp
@@ -39,7 +39,7 @@ template class BatchContainer<DAAL_FPTYPE, boser, DAAL_CPU>;
 }
 namespace internal
 {
-template struct SVMTrainImpl<boser, DAAL_FPTYPE, svm::interface2::Parameter, DAAL_CPU>;
+template struct DAAL_EXPORT SVMTrainImpl<boser, DAAL_FPTYPE, svm::interface2::Parameter, DAAL_CPU>;
 
 } // namespace internal
 } // namespace training

--- a/cpp/oneapi/dal/algo/linear_kernel.hpp
+++ b/cpp/oneapi/dal/algo/linear_kernel.hpp
@@ -1,0 +1,19 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#pragma once
+
+#include "oneapi/dal/algo/linear_kernel/compute.hpp"

--- a/cpp/oneapi/dal/algo/linear_kernel/backend/cpu/compute_kernel.hpp
+++ b/cpp/oneapi/dal/algo/linear_kernel/backend/cpu/compute_kernel.hpp
@@ -1,0 +1,31 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#pragma once
+
+#include "oneapi/dal/algo/linear_kernel/compute_types.hpp"
+#include "oneapi/dal/backend/dispatcher.hpp"
+
+namespace oneapi::dal::linear_kernel::backend {
+
+template <typename Float, typename Method>
+struct compute_kernel_cpu {
+    compute_result operator()(const dal::backend::context_cpu& ctx,
+                              const descriptor_base& params,
+                              const compute_input& input) const;
+};
+
+} // namespace oneapi::dal::linear_kernel::backend

--- a/cpp/oneapi/dal/algo/linear_kernel/backend/cpu/compute_kernel_csr.cpp
+++ b/cpp/oneapi/dal/algo/linear_kernel/backend/cpu/compute_kernel_csr.cpp
@@ -1,0 +1,33 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "oneapi/dal/algo/linear_kernel/backend/cpu/compute_kernel.hpp"
+
+namespace oneapi::dal::linear_kernel::backend {
+
+template <typename Float>
+struct compute_kernel_cpu<Float, method::csr> {
+    compute_result operator()(const dal::backend::context_cpu& ctx,
+                              const descriptor_base& desc,
+                              const compute_input& input) const {
+        return compute_result();
+    }
+};
+
+template struct compute_kernel_cpu<float, method::csr>;
+template struct compute_kernel_cpu<double, method::csr>;
+
+} // namespace oneapi::dal::linear_kernel::backend

--- a/cpp/oneapi/dal/algo/linear_kernel/backend/cpu/compute_kernel_dense.cpp
+++ b/cpp/oneapi/dal/algo/linear_kernel/backend/cpu/compute_kernel_dense.cpp
@@ -1,0 +1,83 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include <daal/src/algorithms/kernel_function/kernel_function_linear_dense_default_kernel.h>
+
+#include "oneapi/dal/algo/linear_kernel/backend/cpu/compute_kernel.hpp"
+#include "oneapi/dal/backend/interop/common.hpp"
+#include "oneapi/dal/backend/interop/table_conversion.hpp"
+
+namespace oneapi::dal::linear_kernel::backend {
+
+using dal::backend::context_cpu;
+
+namespace daal_linear_kernel = daal::algorithms::kernel_function::linear;
+namespace interop            = dal::backend::interop;
+
+template <typename Float, daal::CpuType Cpu>
+using daal_linear_kernel_t =
+    daal_linear_kernel::internal::KernelImplLinear<daal_linear_kernel::defaultDense, Float, Cpu>;
+
+template <typename Float>
+static compute_result call_daal_kernel(const context_cpu& ctx,
+                                       const descriptor_base& desc,
+                                       const table& x,
+                                       const table& y) {
+    const int64_t row_count_x  = x.get_row_count();
+    const int64_t row_count_y  = y.get_row_count();
+    const int64_t column_count = x.get_column_count();
+
+    auto arr_x = row_accessor<const Float>{ x }.pull();
+    auto arr_y = row_accessor<const Float>{ y }.pull();
+
+    array<Float> arr_values{ row_count_x * row_count_y };
+
+    const auto daal_x = interop::convert_to_daal_homogen_table(arr_x, row_count_x, column_count);
+    const auto daal_y = interop::convert_to_daal_homogen_table(arr_y, row_count_y, column_count);
+    const auto daal_values =
+        interop::convert_to_daal_homogen_table(arr_values, row_count_x, row_count_y);
+
+    daal_linear_kernel::Parameter daal_parameter(desc.get_k(), desc.get_b());
+
+    interop::call_daal_kernel<Float, daal_linear_kernel_t>(ctx,
+                                                           daal_x.get(),
+                                                           daal_y.get(),
+                                                           daal_values.get(),
+                                                           &daal_parameter);
+
+    return compute_result().set_values(homogen_table_builder{ row_count_y, arr_values }.build());
+}
+
+template <typename Float>
+static compute_result compute(const context_cpu& ctx,
+                              const descriptor_base& desc,
+                              const compute_input& input) {
+    return call_daal_kernel<Float>(ctx, desc, input.get_x(), input.get_y());
+}
+
+template <typename Float>
+struct compute_kernel_cpu<Float, method::dense> {
+    compute_result operator()(const context_cpu& ctx,
+                              const descriptor_base& desc,
+                              const compute_input& input) const {
+        return compute<Float>(ctx, desc, input);
+    }
+};
+
+template struct compute_kernel_cpu<float, method::dense>;
+template struct compute_kernel_cpu<double, method::dense>;
+
+} // namespace oneapi::dal::linear_kernel::backend

--- a/cpp/oneapi/dal/algo/linear_kernel/backend/cpu/compute_kernel_test.cpp
+++ b/cpp/oneapi/dal/algo/linear_kernel/backend/cpu/compute_kernel_test.cpp
@@ -1,0 +1,211 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "gtest/gtest.h"
+#include "oneapi/dal/algo/linear_kernel.hpp"
+#include "oneapi/dal/data/accessor.hpp"
+#include "oneapi/dal/data/table.hpp"
+
+using namespace oneapi::dal;
+using std::int32_t;
+
+TEST(linear_kernel_dense_test, can_compute_unit_matrix) {
+    constexpr std::int64_t row_count    = 2;
+    constexpr std::int64_t column_count = 2;
+    const float x_data[]                = {
+        1.f,
+        1.f,
+        1.f,
+        1.f,
+    };
+    const float y_data[] = {
+        1.f,
+        1.f,
+        1.f,
+        1.f,
+    };
+
+    const auto x_table = homogen_table{ row_count, column_count, x_data };
+    const auto y_table = homogen_table{ row_count, column_count, y_data };
+
+    const auto kernel_desc  = linear_kernel::descriptor{};
+    const auto values_table = compute(kernel_desc, x_table, y_table).get_values();
+    ASSERT_EQ(values_table.get_row_count(), row_count);
+    ASSERT_EQ(values_table.get_column_count(), row_count);
+
+    const auto values = row_accessor<const float>(values_table).pull();
+    for (size_t i = 0; i < values.get_count(); i++) {
+        ASSERT_FLOAT_EQ(values[i], static_cast<float>(column_count));
+    }
+}
+
+TEST(linear_kernel_dense_test, can_compute_same_unit_matrix) {
+    constexpr std::int64_t row_count    = 2;
+    constexpr std::int64_t column_count = 2;
+    const float x_data[]                = {
+        1.f,
+        1.f,
+        1.f,
+        1.f,
+    };
+
+    const auto x_table = homogen_table{ row_count, column_count, x_data };
+
+    const auto kernel_desc  = linear_kernel::descriptor{};
+    const auto values_table = compute(kernel_desc, x_table, x_table).get_values();
+    ASSERT_EQ(values_table.get_row_count(), row_count);
+    ASSERT_EQ(values_table.get_column_count(), row_count);
+
+    const auto values = row_accessor<const float>(values_table).pull();
+    for (size_t i = 0; i < values.get_count(); i++) {
+        ASSERT_FLOAT_EQ(values[i], static_cast<float>(column_count));
+    }
+}
+
+TEST(linear_kernel_dense_test, can_compute_one_element) {
+    constexpr std::int64_t row_count    = 1;
+    constexpr std::int64_t column_count = 1;
+    const float x_data[]                = {
+        0.5f,
+    };
+    const float y_data[] = {
+        10.f,
+    };
+
+    const auto x_table = homogen_table{ row_count, column_count, x_data };
+    const auto y_table = homogen_table{ row_count, column_count, y_data };
+
+    const auto kernel_desc  = linear_kernel::descriptor{};
+    const auto values_table = compute(kernel_desc, x_table, y_table).get_values();
+    ASSERT_EQ(values_table.get_row_count(), row_count);
+    ASSERT_EQ(values_table.get_column_count(), row_count);
+
+    const auto values = row_accessor<const float>(values_table).pull();
+    ASSERT_FLOAT_EQ(values[0], 5.f);
+}
+
+TEST(linear_kernel_dense_test, can_compute_simple_matrix) {
+    constexpr std::int64_t row_count    = 2;
+    constexpr std::int64_t column_count = 2;
+    const float x_data[]                = {
+        1.f,
+        2.f,
+        1.f,
+        1.f,
+    };
+    const float y_data[] = {
+        1.f,
+        1.f,
+        3.f,
+        1.f,
+    };
+
+    const auto x_table = homogen_table{ row_count, column_count, x_data };
+    const auto y_table = homogen_table{ row_count, column_count, y_data };
+
+    const auto kernel_desc  = linear_kernel::descriptor{};
+    const auto values_table = compute(kernel_desc, x_table, y_table).get_values();
+    ASSERT_EQ(values_table.get_row_count(), row_count);
+    ASSERT_EQ(values_table.get_column_count(), row_count);
+
+    const auto values = row_accessor<const float>(values_table).pull();
+    ASSERT_FLOAT_EQ(values[0], 3.f);
+    ASSERT_FLOAT_EQ(values[1], 5.f);
+    ASSERT_FLOAT_EQ(values[2], 2.f);
+    ASSERT_FLOAT_EQ(values[3], 4.f);
+}
+
+TEST(linear_kernel_dense_test, can_compute_same_simple_matrix) {
+    constexpr std::int64_t row_count    = 2;
+    constexpr std::int64_t column_count = 2;
+    const float x_data[]                = {
+        1.f,
+        2.f,
+        1.f,
+        3.f,
+    };
+
+    const auto x_table = homogen_table{ row_count, column_count, x_data };
+
+    const auto kernel_desc  = linear_kernel::descriptor{};
+    const auto values_table = compute(kernel_desc, x_table, x_table).get_values();
+    ASSERT_EQ(values_table.get_row_count(), row_count);
+    ASSERT_EQ(values_table.get_column_count(), row_count);
+
+    const auto values = row_accessor<const float>(values_table).pull();
+    ASSERT_FLOAT_EQ(values[0], 5.f);
+    ASSERT_FLOAT_EQ(values[1], 7.f);
+    ASSERT_FLOAT_EQ(values[2], 7.f);
+    ASSERT_FLOAT_EQ(values[3], 10.f);
+}
+
+TEST(linear_kernel_dense_test, can_compute_diff_matrix) {
+    constexpr std::int64_t row_count_x  = 2;
+    constexpr std::int64_t row_count_y  = 3;
+    constexpr std::int64_t column_count = 1;
+    const float x_data[]                = {
+        1.f,
+        2.f,
+    };
+    const float y_data[] = {
+        1.f,
+        1.f,
+        3.f,
+    };
+
+    const auto x_table = homogen_table{ row_count_x, column_count, x_data };
+    const auto y_table = homogen_table{ row_count_y, column_count, y_data };
+
+    const auto kernel_desc  = linear_kernel::descriptor{};
+    const auto values_table = compute(kernel_desc, x_table, y_table).get_values();
+    ASSERT_EQ(values_table.get_row_count(), row_count_x);
+    ASSERT_EQ(values_table.get_column_count(), row_count_y);
+
+    const auto values = row_accessor<const float>(values_table).pull();
+    ASSERT_FLOAT_EQ(values[0], 1.f);
+    ASSERT_FLOAT_EQ(values[1], 1.f);
+    ASSERT_FLOAT_EQ(values[2], 3.f);
+    ASSERT_FLOAT_EQ(values[3], 2.f);
+}
+
+TEST(linear_kernel_dense_test, can_compute_diff_matrix_not_default_params) {
+    constexpr std::int64_t row_count_x  = 2;
+    constexpr std::int64_t row_count_y  = 3;
+    constexpr std::int64_t column_count = 1;
+    const float x_data[]                = {
+        1.f,
+        2.f,
+    };
+    const float y_data[] = {
+        1.f,
+        1.f,
+        3.f,
+    };
+
+    const auto x_table = homogen_table{ row_count_x, column_count, x_data };
+    const auto y_table = homogen_table{ row_count_y, column_count, y_data };
+
+    const auto kernel_desc  = linear_kernel::descriptor{}.set_k(2.0).set_b(1.0);
+    const auto values_table = compute(kernel_desc, x_table, y_table).get_values();
+    ASSERT_EQ(values_table.get_row_count(), row_count_x);
+    ASSERT_EQ(values_table.get_column_count(), row_count_y);
+
+    const auto values = row_accessor<const float>(values_table).pull();
+    ASSERT_FLOAT_EQ(values[0], 3.f);
+    ASSERT_FLOAT_EQ(values[1], 3.f);
+    ASSERT_FLOAT_EQ(values[2], 7.f);
+    ASSERT_FLOAT_EQ(values[3], 5.f);
+}

--- a/cpp/oneapi/dal/algo/linear_kernel/backend/gpu/compute_kernel.hpp
+++ b/cpp/oneapi/dal/algo/linear_kernel/backend/gpu/compute_kernel.hpp
@@ -1,0 +1,31 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#pragma once
+
+#include "oneapi/dal/algo/linear_kernel/compute_types.hpp"
+#include "oneapi/dal/backend/dispatcher_dpc.hpp"
+
+namespace oneapi::dal::linear_kernel::backend {
+
+template <typename Float, typename Method>
+struct compute_kernel_gpu {
+    compute_result operator()(const dal::backend::context_gpu& ctx,
+                              const descriptor_base& params,
+                              const compute_input& input) const;
+};
+
+} // namespace oneapi::dal::linear_kernel::backend

--- a/cpp/oneapi/dal/algo/linear_kernel/backend/gpu/compute_kernel_csr_dpc.cpp
+++ b/cpp/oneapi/dal/algo/linear_kernel/backend/gpu/compute_kernel_csr_dpc.cpp
@@ -1,0 +1,33 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "oneapi/dal/algo/linear_kernel/backend/gpu/compute_kernel.hpp"
+
+namespace oneapi::dal::linear_kernel::backend {
+
+template <typename Float>
+struct compute_kernel_gpu<Float, method::csr> {
+    compute_result operator()(const dal::backend::context_gpu& ctx,
+                              const descriptor_base& params,
+                              const compute_input& input) const {
+        return compute_result();
+    }
+};
+
+template struct compute_kernel_gpu<float, method::csr>;
+template struct compute_kernel_gpu<double, method::csr>;
+
+} // namespace oneapi::dal::linear_kernel::backend

--- a/cpp/oneapi/dal/algo/linear_kernel/backend/gpu/compute_kernel_dense_dpc.cpp
+++ b/cpp/oneapi/dal/algo/linear_kernel/backend/gpu/compute_kernel_dense_dpc.cpp
@@ -1,0 +1,33 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "oneapi/dal/algo/linear_kernel/backend/gpu/compute_kernel.hpp"
+
+namespace oneapi::dal::linear_kernel::backend {
+
+template <typename Float>
+struct compute_kernel_gpu<Float, method::dense> {
+    compute_result operator()(const dal::backend::context_gpu& ctx,
+                              const descriptor_base& params,
+                              const compute_input& input) const {
+        return compute_result();
+    }
+};
+
+template struct compute_kernel_gpu<float, method::dense>;
+template struct compute_kernel_gpu<double, method::dense>;
+
+} // namespace oneapi::dal::linear_kernel::backend

--- a/cpp/oneapi/dal/algo/linear_kernel/common.cpp
+++ b/cpp/oneapi/dal/algo/linear_kernel/common.cpp
@@ -1,0 +1,47 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "oneapi/dal/algo/linear_kernel/common.hpp"
+
+namespace oneapi::dal::linear_kernel {
+
+class detail::descriptor_impl : public base {
+public:
+    double k = 1.0;
+    double b = 0.0;
+};
+
+using detail::descriptor_impl;
+
+descriptor_base::descriptor_base() : impl_(new descriptor_impl{}) {}
+
+double descriptor_base::get_k() const {
+    return impl_->k;
+}
+
+double descriptor_base::get_b() const {
+    return impl_->b;
+}
+
+void descriptor_base::set_k_impl(const double value) {
+    impl_->k = value;
+}
+
+void descriptor_base::set_b_impl(const double value) {
+    impl_->b = value;
+}
+
+} // namespace oneapi::dal::linear_kernel

--- a/cpp/oneapi/dal/algo/linear_kernel/common.hpp
+++ b/cpp/oneapi/dal/algo/linear_kernel/common.hpp
@@ -1,0 +1,71 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#pragma once
+
+#include "oneapi/dal/data/table.hpp"
+#include "oneapi/dal/detail/common.hpp"
+
+namespace oneapi::dal::linear_kernel {
+
+namespace detail {
+struct tag {};
+class descriptor_impl;
+class model_impl;
+} // namespace detail
+
+namespace method {
+struct dense {};
+struct csr {};
+using by_default = dense;
+} // namespace method
+
+class ONEAPI_DAL_EXPORT descriptor_base : public base {
+public:
+    using tag_t    = detail::tag;
+    using float_t  = float;
+    using method_t = method::by_default;
+
+    descriptor_base();
+
+    double get_k() const;
+    double get_b() const;
+
+protected:
+    void set_k_impl(const double value);
+    void set_b_impl(const double value);
+
+    dal::detail::pimpl<detail::descriptor_impl> impl_;
+};
+
+template <typename Float = descriptor_base::float_t, typename Method = descriptor_base::method_t>
+class descriptor : public descriptor_base {
+public:
+    using float_t  = Float;
+    using method_t = Method;
+
+    auto& set_k(const double value) {
+        set_k_impl(value);
+        return *this;
+    }
+
+    auto& set_b(const double value) {
+        set_b_impl(value);
+        return *this;
+    }
+};
+
+} // namespace oneapi::dal::linear_kernel

--- a/cpp/oneapi/dal/algo/linear_kernel/compute.hpp
+++ b/cpp/oneapi/dal/algo/linear_kernel/compute.hpp
@@ -1,0 +1,29 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#pragma once
+
+#include "oneapi/dal/algo/linear_kernel/compute_types.hpp"
+#include "oneapi/dal/algo/linear_kernel/detail/compute_ops.hpp"
+#include "oneapi/dal/compute.hpp"
+
+namespace oneapi::dal::detail {
+
+template <typename Descriptor>
+struct compute_ops<Descriptor, dal::linear_kernel::detail::tag>
+        : dal::linear_kernel::detail::compute_ops<Descriptor> {};
+
+} // namespace oneapi::dal::detail

--- a/cpp/oneapi/dal/algo/linear_kernel/compute_types.cpp
+++ b/cpp/oneapi/dal/algo/linear_kernel/compute_types.cpp
@@ -1,0 +1,66 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "oneapi/dal/algo/linear_kernel/compute_types.hpp"
+#include "oneapi/dal/detail/common.hpp"
+
+namespace oneapi::dal::linear_kernel {
+
+class detail::compute_input_impl : public base {
+public:
+    compute_input_impl(const table& x, const table& y) : x(x), y(y) {}
+    table x;
+    table y;
+};
+
+class detail::compute_result_impl : public base {
+public:
+    table values;
+};
+
+using detail::compute_input_impl;
+using detail::compute_result_impl;
+
+compute_input::compute_input(const table& x, const table& y)
+        : impl_(new compute_input_impl(x, y)) {}
+
+table compute_input::get_x() const {
+    return impl_->x;
+}
+
+table compute_input::get_y() const {
+    return impl_->y;
+}
+
+void compute_input::set_x_impl(const table& value) {
+    impl_->x = value;
+}
+
+void compute_input::set_y_impl(const table& value) {
+    impl_->y = value;
+}
+
+compute_result::compute_result() : impl_(new compute_result_impl{}) {}
+
+table compute_result::get_values() const {
+    return impl_->values;
+}
+
+void compute_result::set_values_impl(const table& value) {
+    impl_->values = value;
+}
+
+} // namespace oneapi::dal::linear_kernel

--- a/cpp/oneapi/dal/algo/linear_kernel/compute_types.hpp
+++ b/cpp/oneapi/dal/algo/linear_kernel/compute_types.hpp
@@ -1,0 +1,69 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#pragma once
+
+#include "oneapi/dal/algo/linear_kernel/common.hpp"
+
+namespace oneapi::dal::linear_kernel {
+
+namespace detail {
+class compute_input_impl;
+class compute_result_impl;
+} // namespace detail
+
+class ONEAPI_DAL_EXPORT compute_input : public base {
+public:
+    compute_input(const table& x, const table& y);
+
+    table get_x() const;
+    table get_y() const;
+
+    auto& set_x(const table& data) {
+        set_x_impl(data);
+        return *this;
+    }
+
+    auto& set_y(const table& data) {
+        set_y_impl(data);
+        return *this;
+    }
+
+private:
+    void set_x_impl(const table& data);
+    void set_y_impl(const table& data);
+
+    dal::detail::pimpl<detail::compute_input_impl> impl_;
+};
+
+class ONEAPI_DAL_EXPORT compute_result : public base {
+public:
+    compute_result();
+
+    table get_values() const;
+
+    auto& set_values(const table& value) {
+        set_values_impl(value);
+        return *this;
+    }
+
+private:
+    void set_values_impl(const table&);
+
+    dal::detail::pimpl<detail::compute_result_impl> impl_;
+};
+
+} // namespace oneapi::dal::linear_kernel

--- a/cpp/oneapi/dal/algo/linear_kernel/detail/compute_ops.cpp
+++ b/cpp/oneapi/dal/algo/linear_kernel/detail/compute_ops.cpp
@@ -1,0 +1,42 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "oneapi/dal/algo/linear_kernel/detail/compute_ops.hpp"
+#include "oneapi/dal/algo/linear_kernel/backend/cpu/compute_kernel.hpp"
+#include "oneapi/dal/backend/dispatcher.hpp"
+
+namespace oneapi::dal::linear_kernel::detail {
+
+template <typename Float, typename Method>
+struct ONEAPI_DAL_EXPORT compute_ops_dispatcher<host_policy, Float, Method> {
+    compute_result operator()(const host_policy& ctx,
+                              const descriptor_base& desc,
+                              const compute_input& input) const {
+        using kernel_dispatcher_t =
+            dal::backend::kernel_dispatcher<backend::compute_kernel_cpu<Float, Method>>;
+        return kernel_dispatcher_t()(ctx, desc, input);
+    }
+};
+
+#define INSTANTIATE(F, M) \
+    template struct ONEAPI_DAL_EXPORT compute_ops_dispatcher<host_policy, F, M>;
+
+INSTANTIATE(float, method::dense)
+INSTANTIATE(float, method::csr)
+INSTANTIATE(double, method::dense)
+INSTANTIATE(double, method::csr)
+
+} // namespace oneapi::dal::linear_kernel::detail

--- a/cpp/oneapi/dal/algo/linear_kernel/detail/compute_ops.hpp
+++ b/cpp/oneapi/dal/algo/linear_kernel/detail/compute_ops.hpp
@@ -16,32 +16,30 @@
 
 #pragma once
 
-#include "oneapi/dal/algo/svm/train_types.hpp"
+#include "oneapi/dal/algo/linear_kernel/compute_types.hpp"
 
-namespace oneapi::dal::svm::detail {
+namespace oneapi::dal::linear_kernel::detail {
 
 template <typename Context, typename... Options>
-struct ONEAPI_DAL_EXPORT train_ops_dispatcher {
-    train_result operator()(const Context&, const descriptor_base&, const train_input&) const;
+struct compute_ops_dispatcher {
+    compute_result operator()(const Context&, const descriptor_base&, const compute_input&) const;
 };
 
 template <typename Descriptor>
-struct train_ops {
+struct compute_ops {
     using float_t           = typename Descriptor::float_t;
-    using task_t            = typename Descriptor::task_t;
     using method_t          = typename Descriptor::method_t;
-    using kernel_t          = typename Descriptor::kernel_t;
-    using input_t           = train_input;
-    using result_t          = train_result;
+    using input_t           = compute_input;
+    using result_t          = compute_result;
     using descriptor_base_t = descriptor_base;
 
-    void validate(const Descriptor& params, const train_input& input) const {}
+    void validate(const Descriptor& params, const compute_input& input) const {}
 
     template <typename Context>
-    auto operator()(const Context& ctx, const Descriptor& desc, const train_input& input) const {
+    auto operator()(const Context& ctx, const Descriptor& desc, const compute_input& input) const {
         validate(desc, input);
-        return train_ops_dispatcher<Context, float_t, task_t, method_t>()(ctx, desc, input);
+        return compute_ops_dispatcher<Context, float_t, method_t>()(ctx, desc, input);
     }
 };
 
-} // namespace oneapi::dal::svm::detail
+} // namespace oneapi::dal::linear_kernel::detail

--- a/cpp/oneapi/dal/algo/linear_kernel/detail/compute_ops_dpc.cpp
+++ b/cpp/oneapi/dal/algo/linear_kernel/detail/compute_ops_dpc.cpp
@@ -1,0 +1,44 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "oneapi/dal/algo/linear_kernel/backend/cpu/compute_kernel.hpp"
+#include "oneapi/dal/algo/linear_kernel/backend/gpu/compute_kernel.hpp"
+#include "oneapi/dal/algo/linear_kernel/detail/compute_ops.hpp"
+#include "oneapi/dal/backend/dispatcher_dpc.hpp"
+
+namespace oneapi::dal::linear_kernel::detail {
+
+template <typename Float, typename Method>
+struct ONEAPI_DAL_EXPORT compute_ops_dispatcher<data_parallel_policy, Float, Method> {
+    compute_result operator()(const data_parallel_policy& ctx,
+                              const descriptor_base& params,
+                              const compute_input& input) const {
+        using kernel_dispatcher_t =
+            dal::backend::kernel_dispatcher<backend::compute_kernel_cpu<Float, Method>,
+                                            backend::compute_kernel_gpu<Float, Method>>;
+        return kernel_dispatcher_t{}(ctx, params, input);
+    }
+};
+
+#define INSTANTIATE(F, M) \
+    template struct ONEAPI_DAL_EXPORT compute_ops_dispatcher<data_parallel_policy, F, M>;
+
+INSTANTIATE(float, method::dense)
+INSTANTIATE(float, method::csr)
+INSTANTIATE(double, method::dense)
+INSTANTIATE(double, method::csr)
+
+} // namespace oneapi::dal::linear_kernel::detail

--- a/cpp/oneapi/dal/algo/rbf_kernel.hpp
+++ b/cpp/oneapi/dal/algo/rbf_kernel.hpp
@@ -1,0 +1,19 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#pragma once
+
+#include "oneapi/dal/algo/rbf_kernel/compute.hpp"

--- a/cpp/oneapi/dal/algo/rbf_kernel/backend/cpu/compute_kernel.hpp
+++ b/cpp/oneapi/dal/algo/rbf_kernel/backend/cpu/compute_kernel.hpp
@@ -1,0 +1,31 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#pragma once
+
+#include "oneapi/dal/algo/rbf_kernel/compute_types.hpp"
+#include "oneapi/dal/backend/dispatcher.hpp"
+
+namespace oneapi::dal::rbf_kernel::backend {
+
+template <typename Float, typename Method>
+struct compute_kernel_cpu {
+    compute_result operator()(const dal::backend::context_cpu& ctx,
+                              const descriptor_base& params,
+                              const compute_input& input) const;
+};
+
+} // namespace oneapi::dal::rbf_kernel::backend

--- a/cpp/oneapi/dal/algo/rbf_kernel/backend/cpu/compute_kernel_csr.cpp
+++ b/cpp/oneapi/dal/algo/rbf_kernel/backend/cpu/compute_kernel_csr.cpp
@@ -1,0 +1,33 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "oneapi/dal/algo/rbf_kernel/backend/cpu/compute_kernel.hpp"
+
+namespace oneapi::dal::rbf_kernel::backend {
+
+template <typename Float>
+struct compute_kernel_cpu<Float, method::csr> {
+    compute_result operator()(const dal::backend::context_cpu& ctx,
+                              const descriptor_base& desc,
+                              const compute_input& input) const {
+        return compute_result();
+    }
+};
+
+template struct compute_kernel_cpu<float, method::csr>;
+template struct compute_kernel_cpu<double, method::csr>;
+
+} // namespace oneapi::dal::rbf_kernel::backend

--- a/cpp/oneapi/dal/algo/rbf_kernel/backend/cpu/compute_kernel_dense.cpp
+++ b/cpp/oneapi/dal/algo/rbf_kernel/backend/cpu/compute_kernel_dense.cpp
@@ -1,0 +1,83 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include <daal/src/algorithms/kernel_function/kernel_function_rbf_dense_default_kernel.h>
+
+#include "oneapi/dal/algo/rbf_kernel/backend/cpu/compute_kernel.hpp"
+#include "oneapi/dal/backend/interop/common.hpp"
+#include "oneapi/dal/backend/interop/table_conversion.hpp"
+
+namespace oneapi::dal::rbf_kernel::backend {
+
+using dal::backend::context_cpu;
+
+namespace daal_rbf_kernel = daal::algorithms::kernel_function::rbf;
+namespace interop         = dal::backend::interop;
+
+template <typename Float, daal::CpuType Cpu>
+using daal_rbf_kernel_t =
+    daal_rbf_kernel::internal::KernelImplRBF<daal_rbf_kernel::defaultDense, Float, Cpu>;
+
+template <typename Float>
+static compute_result call_daal_kernel(const context_cpu& ctx,
+                                       const descriptor_base& desc,
+                                       const table& x,
+                                       const table& y) {
+    const int64_t row_count_x  = x.get_row_count();
+    const int64_t row_count_y  = y.get_row_count();
+    const int64_t column_count = x.get_column_count();
+
+    auto arr_x = row_accessor<const Float>{ x }.pull();
+    auto arr_y = row_accessor<const Float>{ y }.pull();
+
+    array<Float> arr_values{ row_count_x * row_count_y };
+
+    const auto daal_x = interop::convert_to_daal_homogen_table(arr_x, row_count_x, column_count);
+    const auto daal_y = interop::convert_to_daal_homogen_table(arr_y, row_count_y, column_count);
+    const auto daal_values =
+        interop::convert_to_daal_homogen_table(arr_values, row_count_x, row_count_y);
+
+    daal_rbf_kernel::Parameter daal_parameter(desc.get_sigma());
+
+    interop::call_daal_kernel<Float, daal_rbf_kernel_t>(ctx,
+                                                        daal_x.get(),
+                                                        daal_y.get(),
+                                                        daal_values.get(),
+                                                        &daal_parameter);
+
+    return compute_result().set_values(homogen_table_builder{ row_count_y, arr_values }.build());
+}
+
+template <typename Float>
+static compute_result compute(const context_cpu& ctx,
+                              const descriptor_base& desc,
+                              const compute_input& input) {
+    return call_daal_kernel<Float>(ctx, desc, input.get_x(), input.get_y());
+}
+
+template <typename Float>
+struct compute_kernel_cpu<Float, method::dense> {
+    compute_result operator()(const context_cpu& ctx,
+                              const descriptor_base& desc,
+                              const compute_input& input) const {
+        return compute<Float>(ctx, desc, input);
+    }
+};
+
+template struct compute_kernel_cpu<float, method::dense>;
+template struct compute_kernel_cpu<double, method::dense>;
+
+} // namespace oneapi::dal::rbf_kernel::backend

--- a/cpp/oneapi/dal/algo/rbf_kernel/backend/cpu/compute_kernel_test.cpp
+++ b/cpp/oneapi/dal/algo/rbf_kernel/backend/cpu/compute_kernel_test.cpp
@@ -1,0 +1,168 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "gtest/gtest.h"
+#include "oneapi/dal/algo/rbf_kernel.hpp"
+#include "oneapi/dal/data/accessor.hpp"
+#include "oneapi/dal/data/table.hpp"
+
+#include <cmath>
+
+using namespace oneapi::dal;
+using std::int32_t;
+
+TEST(rbf_kernel_dense_test, can_compute_unit_matrix) {
+    constexpr std::int64_t row_count    = 2;
+    constexpr std::int64_t column_count = 2;
+    const float x_data[]                = {
+        1.f,
+        1.f,
+        1.f,
+        1.f,
+    };
+    const float y_data[] = {
+        1.f,
+        1.f,
+        1.f,
+        1.f,
+    };
+
+    const auto x_table = homogen_table{ row_count, column_count, x_data };
+    const auto y_table = homogen_table{ row_count, column_count, y_data };
+
+    const auto kernel_desc  = rbf_kernel::descriptor{};
+    const auto values_table = compute(kernel_desc, x_table, y_table).get_values();
+    ASSERT_EQ(values_table.get_row_count(), row_count);
+    ASSERT_EQ(values_table.get_column_count(), row_count);
+
+    const auto values = row_accessor<const float>(values_table).pull();
+    for (size_t i = 0; i < values.get_count(); i++) {
+        ASSERT_FLOAT_EQ(values[i], 1.f);
+    }
+}
+
+TEST(rbf_kernel_dense_test, can_compute_same_unit_matrix) {
+    constexpr std::int64_t row_count    = 2;
+    constexpr std::int64_t column_count = 2;
+    const float x_data[]                = {
+        1.f,
+        1.f,
+        1.f,
+        1.f,
+    };
+
+    const auto x_table = homogen_table{ row_count, column_count, x_data };
+
+    const auto kernel_desc  = rbf_kernel::descriptor{};
+    const auto values_table = compute(kernel_desc, x_table, x_table).get_values();
+    ASSERT_EQ(values_table.get_row_count(), row_count);
+    ASSERT_EQ(values_table.get_column_count(), row_count);
+
+    const auto values = row_accessor<const float>(values_table).pull();
+    for (size_t i = 0; i < values.get_count(); i++) {
+        ASSERT_FLOAT_EQ(values[i], 1.f);
+    }
+}
+
+TEST(rbf_kernel_dense_test, can_compute_one_element) {
+    constexpr std::int64_t row_count    = 1;
+    constexpr std::int64_t column_count = 1;
+    const float x_data[]                = {
+        1.f,
+    };
+    const float y_data[] = {
+        0.1f,
+    };
+
+    const auto x_table = homogen_table{ row_count, column_count, x_data };
+    const auto y_table = homogen_table{ row_count, column_count, y_data };
+
+    const auto kernel_desc  = rbf_kernel::descriptor{};
+    const auto values_table = compute(kernel_desc, x_table, y_table).get_values();
+    ASSERT_EQ(values_table.get_row_count(), row_count);
+    ASSERT_EQ(values_table.get_column_count(), row_count);
+
+    const auto values      = row_accessor<const float>(values_table).pull();
+    const double ref_value = std::exp(-0.5 * (x_data[0] - y_data[0]) * (x_data[0] - y_data[0]));
+    ASSERT_FLOAT_EQ(values[0], ref_value);
+}
+
+TEST(rbf_kernel_dense_test, can_compute_diff_matrix) {
+    constexpr std::int64_t row_count_x  = 2;
+    constexpr std::int64_t row_count_y  = 3;
+    constexpr std::int64_t column_count = 1;
+    const float x_data[]                = {
+        1.f,
+        2.f,
+    };
+    const float y_data[] = {
+        1.f,
+        1.f,
+        3.f,
+    };
+
+    const auto x_table = homogen_table{ row_count_x, column_count, x_data };
+    const auto y_table = homogen_table{ row_count_y, column_count, y_data };
+
+    const auto kernel_desc  = rbf_kernel::descriptor{};
+    const auto values_table = compute(kernel_desc, x_table, y_table).get_values();
+    ASSERT_EQ(values_table.get_row_count(), row_count_x);
+    ASSERT_EQ(values_table.get_column_count(), row_count_y);
+
+    const auto values = row_accessor<const float>(values_table).pull();
+    for (std::int64_t i = 0; i < row_count_x; i++) {
+        for (std::int64_t j = 0; j < row_count_y; j++) {
+            const double ref_value =
+                std::exp(-0.5 * (x_data[i] - y_data[j]) * (x_data[i] - y_data[j]));
+
+            ASSERT_FLOAT_EQ(values[i * row_count_y + j], ref_value);
+        }
+    }
+}
+
+TEST(rbf_kernel_dense_test, can_compute_diff_matrix_not_default_params) {
+    constexpr std::int64_t row_count_x  = 2;
+    constexpr std::int64_t row_count_y  = 3;
+    constexpr std::int64_t column_count = 1;
+    const float x_data[]                = {
+        1.f,
+        2.f,
+    };
+    const float y_data[] = {
+        1.f,
+        1.f,
+        3.f,
+    };
+
+    const auto x_table      = homogen_table{ row_count_x, column_count, x_data };
+    const auto y_table      = homogen_table{ row_count_y, column_count, y_data };
+    constexpr double sigma  = 0.9;
+    const auto kernel_desc  = rbf_kernel::descriptor{}.set_sigma(sigma);
+    const auto values_table = compute(kernel_desc, x_table, y_table).get_values();
+    ASSERT_EQ(values_table.get_row_count(), row_count_x);
+    ASSERT_EQ(values_table.get_column_count(), row_count_y);
+
+    const auto values = row_accessor<const float>(values_table).pull();
+    for (std::int64_t i = 0; i < row_count_x; i++) {
+        for (std::int64_t j = 0; j < row_count_y; j++) {
+            const double inv_sigma = 1.0 / (sigma * sigma);
+            const double ref_value =
+                std::exp(-0.5 * inv_sigma * (x_data[i] - y_data[j]) * (x_data[i] - y_data[j]));
+
+            ASSERT_FLOAT_EQ(values[i * row_count_y + j], ref_value);
+        }
+    }
+}

--- a/cpp/oneapi/dal/algo/rbf_kernel/backend/gpu/compute_kernel.hpp
+++ b/cpp/oneapi/dal/algo/rbf_kernel/backend/gpu/compute_kernel.hpp
@@ -1,0 +1,31 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#pragma once
+
+#include "oneapi/dal/algo/rbf_kernel/compute_types.hpp"
+#include "oneapi/dal/backend/dispatcher_dpc.hpp"
+
+namespace oneapi::dal::rbf_kernel::backend {
+
+template <typename Float, typename Method>
+struct compute_kernel_gpu {
+    compute_result operator()(const dal::backend::context_gpu& ctx,
+                              const descriptor_base& params,
+                              const compute_input& input) const;
+};
+
+} // namespace oneapi::dal::rbf_kernel::backend

--- a/cpp/oneapi/dal/algo/rbf_kernel/backend/gpu/compute_kernel_csr_dpc.cpp
+++ b/cpp/oneapi/dal/algo/rbf_kernel/backend/gpu/compute_kernel_csr_dpc.cpp
@@ -1,0 +1,33 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "oneapi/dal/algo/rbf_kernel/backend/gpu/compute_kernel.hpp"
+
+namespace oneapi::dal::rbf_kernel::backend {
+
+template <typename Float>
+struct compute_kernel_gpu<Float, method::csr> {
+    compute_result operator()(const dal::backend::context_gpu& ctx,
+                              const descriptor_base& params,
+                              const compute_input& input) const {
+        return compute_result();
+    }
+};
+
+template struct compute_kernel_gpu<float, method::csr>;
+template struct compute_kernel_gpu<double, method::csr>;
+
+} // namespace oneapi::dal::rbf_kernel::backend

--- a/cpp/oneapi/dal/algo/rbf_kernel/backend/gpu/compute_kernel_dense_dpc.cpp
+++ b/cpp/oneapi/dal/algo/rbf_kernel/backend/gpu/compute_kernel_dense_dpc.cpp
@@ -1,0 +1,33 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "oneapi/dal/algo/rbf_kernel/backend/gpu/compute_kernel.hpp"
+
+namespace oneapi::dal::rbf_kernel::backend {
+
+template <typename Float>
+struct compute_kernel_gpu<Float, method::dense> {
+    compute_result operator()(const dal::backend::context_gpu& ctx,
+                              const descriptor_base& params,
+                              const compute_input& input) const {
+        return compute_result();
+    }
+};
+
+template struct compute_kernel_gpu<float, method::dense>;
+template struct compute_kernel_gpu<double, method::dense>;
+
+} // namespace oneapi::dal::rbf_kernel::backend

--- a/cpp/oneapi/dal/algo/rbf_kernel/common.cpp
+++ b/cpp/oneapi/dal/algo/rbf_kernel/common.cpp
@@ -1,0 +1,38 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "oneapi/dal/algo/rbf_kernel/common.hpp"
+
+namespace oneapi::dal::rbf_kernel {
+
+class detail::descriptor_impl : public base {
+public:
+    double sigma = 1.0;
+};
+
+using detail::descriptor_impl;
+
+descriptor_base::descriptor_base() : impl_(new descriptor_impl{}) {}
+
+double descriptor_base::get_sigma() const {
+    return impl_->sigma;
+}
+
+void descriptor_base::set_sigma_impl(const double value) {
+    impl_->sigma = value;
+}
+
+} // namespace oneapi::dal::rbf_kernel

--- a/cpp/oneapi/dal/algo/rbf_kernel/common.hpp
+++ b/cpp/oneapi/dal/algo/rbf_kernel/common.hpp
@@ -1,0 +1,64 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#pragma once
+
+#include "oneapi/dal/data/table.hpp"
+#include "oneapi/dal/detail/common.hpp"
+
+namespace oneapi::dal::rbf_kernel {
+
+namespace detail {
+struct tag {};
+class descriptor_impl;
+class model_impl;
+} // namespace detail
+
+namespace method {
+struct dense {};
+struct csr {};
+using by_default = dense;
+} // namespace method
+
+class ONEAPI_DAL_EXPORT descriptor_base : public base {
+public:
+    using tag_t    = detail::tag;
+    using float_t  = float;
+    using method_t = method::by_default;
+
+    descriptor_base();
+
+    double get_sigma() const;
+
+protected:
+    void set_sigma_impl(const double value);
+
+    dal::detail::pimpl<detail::descriptor_impl> impl_;
+};
+
+template <typename Float = descriptor_base::float_t, typename Method = descriptor_base::method_t>
+class descriptor : public descriptor_base {
+public:
+    using float_t  = Float;
+    using method_t = Method;
+
+    auto& set_sigma(const double value) {
+        set_sigma_impl(value);
+        return *this;
+    }
+};
+
+} // namespace oneapi::dal::rbf_kernel

--- a/cpp/oneapi/dal/algo/rbf_kernel/compute.hpp
+++ b/cpp/oneapi/dal/algo/rbf_kernel/compute.hpp
@@ -1,0 +1,29 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#pragma once
+
+#include "oneapi/dal/algo/rbf_kernel/compute_types.hpp"
+#include "oneapi/dal/algo/rbf_kernel/detail/compute_ops.hpp"
+#include "oneapi/dal/compute.hpp"
+
+namespace oneapi::dal::detail {
+
+template <typename Descriptor>
+struct compute_ops<Descriptor, dal::rbf_kernel::detail::tag>
+        : dal::rbf_kernel::detail::compute_ops<Descriptor> {};
+
+} // namespace oneapi::dal::detail

--- a/cpp/oneapi/dal/algo/rbf_kernel/compute_types.cpp
+++ b/cpp/oneapi/dal/algo/rbf_kernel/compute_types.cpp
@@ -1,0 +1,66 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "oneapi/dal/algo/rbf_kernel/compute_types.hpp"
+#include "oneapi/dal/detail/common.hpp"
+
+namespace oneapi::dal::rbf_kernel {
+
+class detail::compute_input_impl : public base {
+public:
+    compute_input_impl(const table& x, const table& y) : x(x), y(y) {}
+    table x;
+    table y;
+};
+
+class detail::compute_result_impl : public base {
+public:
+    table values;
+};
+
+using detail::compute_input_impl;
+using detail::compute_result_impl;
+
+compute_input::compute_input(const table& x, const table& y)
+        : impl_(new compute_input_impl(x, y)) {}
+
+table compute_input::get_x() const {
+    return impl_->x;
+}
+
+table compute_input::get_y() const {
+    return impl_->y;
+}
+
+void compute_input::set_x_impl(const table& value) {
+    impl_->x = value;
+}
+
+void compute_input::set_y_impl(const table& value) {
+    impl_->y = value;
+}
+
+compute_result::compute_result() : impl_(new compute_result_impl{}) {}
+
+table compute_result::get_values() const {
+    return impl_->values;
+}
+
+void compute_result::set_values_impl(const table& value) {
+    impl_->values = value;
+}
+
+} // namespace oneapi::dal::rbf_kernel

--- a/cpp/oneapi/dal/algo/rbf_kernel/compute_types.hpp
+++ b/cpp/oneapi/dal/algo/rbf_kernel/compute_types.hpp
@@ -1,0 +1,69 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#pragma once
+
+#include "oneapi/dal/algo/rbf_kernel/common.hpp"
+
+namespace oneapi::dal::rbf_kernel {
+
+namespace detail {
+class compute_input_impl;
+class compute_result_impl;
+} // namespace detail
+
+class ONEAPI_DAL_EXPORT compute_input : public base {
+public:
+    compute_input(const table& x, const table& y);
+
+    table get_x() const;
+    table get_y() const;
+
+    auto& set_x(const table& data) {
+        set_x_impl(data);
+        return *this;
+    }
+
+    auto& set_y(const table& data) {
+        set_y_impl(data);
+        return *this;
+    }
+
+private:
+    void set_x_impl(const table& data);
+    void set_y_impl(const table& data);
+
+    dal::detail::pimpl<detail::compute_input_impl> impl_;
+};
+
+class ONEAPI_DAL_EXPORT compute_result : public base {
+public:
+    compute_result();
+
+    table get_values() const;
+
+    auto& set_values(const table& value) {
+        set_values_impl(value);
+        return *this;
+    }
+
+private:
+    void set_values_impl(const table&);
+
+    dal::detail::pimpl<detail::compute_result_impl> impl_;
+};
+
+} // namespace oneapi::dal::rbf_kernel

--- a/cpp/oneapi/dal/algo/rbf_kernel/detail/compute_ops.cpp
+++ b/cpp/oneapi/dal/algo/rbf_kernel/detail/compute_ops.cpp
@@ -1,0 +1,42 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "oneapi/dal/algo/rbf_kernel/detail/compute_ops.hpp"
+#include "oneapi/dal/algo/rbf_kernel/backend/cpu/compute_kernel.hpp"
+#include "oneapi/dal/backend/dispatcher.hpp"
+
+namespace oneapi::dal::rbf_kernel::detail {
+
+template <typename Float, typename Method>
+struct ONEAPI_DAL_EXPORT compute_ops_dispatcher<host_policy, Float, Method> {
+    compute_result operator()(const host_policy& ctx,
+                              const descriptor_base& desc,
+                              const compute_input& input) const {
+        using kernel_dispatcher_t =
+            dal::backend::kernel_dispatcher<backend::compute_kernel_cpu<Float, Method>>;
+        return kernel_dispatcher_t()(ctx, desc, input);
+    }
+};
+
+#define INSTANTIATE(F, M) \
+    template struct ONEAPI_DAL_EXPORT compute_ops_dispatcher<host_policy, F, M>;
+
+INSTANTIATE(float, method::dense)
+INSTANTIATE(float, method::csr)
+INSTANTIATE(double, method::dense)
+INSTANTIATE(double, method::csr)
+
+} // namespace oneapi::dal::rbf_kernel::detail

--- a/cpp/oneapi/dal/algo/rbf_kernel/detail/compute_ops.hpp
+++ b/cpp/oneapi/dal/algo/rbf_kernel/detail/compute_ops.hpp
@@ -16,32 +16,30 @@
 
 #pragma once
 
-#include "oneapi/dal/algo/svm/train_types.hpp"
+#include "oneapi/dal/algo/rbf_kernel/compute_types.hpp"
 
-namespace oneapi::dal::svm::detail {
+namespace oneapi::dal::rbf_kernel::detail {
 
 template <typename Context, typename... Options>
-struct ONEAPI_DAL_EXPORT train_ops_dispatcher {
-    train_result operator()(const Context&, const descriptor_base&, const train_input&) const;
+struct compute_ops_dispatcher {
+    compute_result operator()(const Context&, const descriptor_base&, const compute_input&) const;
 };
 
 template <typename Descriptor>
-struct train_ops {
+struct compute_ops {
     using float_t           = typename Descriptor::float_t;
-    using task_t            = typename Descriptor::task_t;
     using method_t          = typename Descriptor::method_t;
-    using kernel_t          = typename Descriptor::kernel_t;
-    using input_t           = train_input;
-    using result_t          = train_result;
+    using input_t           = compute_input;
+    using result_t          = compute_result;
     using descriptor_base_t = descriptor_base;
 
-    void validate(const Descriptor& params, const train_input& input) const {}
+    void validate(const Descriptor& params, const compute_input& input) const {}
 
     template <typename Context>
-    auto operator()(const Context& ctx, const Descriptor& desc, const train_input& input) const {
+    auto operator()(const Context& ctx, const Descriptor& desc, const compute_input& input) const {
         validate(desc, input);
-        return train_ops_dispatcher<Context, float_t, task_t, method_t>()(ctx, desc, input);
+        return compute_ops_dispatcher<Context, float_t, method_t>()(ctx, desc, input);
     }
 };
 
-} // namespace oneapi::dal::svm::detail
+} // namespace oneapi::dal::rbf_kernel::detail

--- a/cpp/oneapi/dal/algo/rbf_kernel/detail/compute_ops_dpc.cpp
+++ b/cpp/oneapi/dal/algo/rbf_kernel/detail/compute_ops_dpc.cpp
@@ -1,0 +1,44 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "oneapi/dal/algo/rbf_kernel/backend/cpu/compute_kernel.hpp"
+#include "oneapi/dal/algo/rbf_kernel/backend/gpu/compute_kernel.hpp"
+#include "oneapi/dal/algo/rbf_kernel/detail/compute_ops.hpp"
+#include "oneapi/dal/backend/dispatcher_dpc.hpp"
+
+namespace oneapi::dal::rbf_kernel::detail {
+
+template <typename Float, typename Method>
+struct ONEAPI_DAL_EXPORT compute_ops_dispatcher<data_parallel_policy, Float, Method> {
+    compute_result operator()(const data_parallel_policy& ctx,
+                              const descriptor_base& params,
+                              const compute_input& input) const {
+        using kernel_dispatcher_t =
+            dal::backend::kernel_dispatcher<backend::compute_kernel_cpu<Float, Method>,
+                                            backend::compute_kernel_gpu<Float, Method>>;
+        return kernel_dispatcher_t{}(ctx, params, input);
+    }
+};
+
+#define INSTANTIATE(F, M) \
+    template struct ONEAPI_DAL_EXPORT compute_ops_dispatcher<data_parallel_policy, F, M>;
+
+INSTANTIATE(float, method::dense)
+INSTANTIATE(float, method::csr)
+INSTANTIATE(double, method::dense)
+INSTANTIATE(double, method::csr)
+
+} // namespace oneapi::dal::rbf_kernel::detail

--- a/cpp/oneapi/dal/algo/svm/backend/cpu/infer_kernel.cpp
+++ b/cpp/oneapi/dal/algo/svm/backend/cpu/infer_kernel.cpp
@@ -18,6 +18,7 @@
 
 #include "oneapi/dal/algo/svm/backend/cpu/infer_kernel.hpp"
 #include "oneapi/dal/algo/svm/backend/interop_model.hpp"
+#include "oneapi/dal/algo/svm/backend/kernel_function_impl.hpp"
 #include "oneapi/dal/backend/interop/common.hpp"
 #include "oneapi/dal/backend/interop/table_conversion.hpp"
 
@@ -62,10 +63,8 @@ static infer_result call_daal_kernel(const context_cpu& ctx,
                           .set_coefficients(daal_coefficients)
                           .set_bias(trained_model.get_bias());
 
-    // TODO: move as parameter onedal SVM
-    auto kernel =
-        daal_kernel_function::KernelIfacePtr(new daal_kernel_function::linear::Batch<Float>());
-    daal_svm::Parameter daal_parameter(kernel);
+    const auto daal_kernel = desc.get_kernel_impl()->get_impl()->get_daal_kernel_function();
+    daal_svm::Parameter daal_parameter(daal_kernel);
 
     array<Float> arr_decision_function{ row_count * 1 };
     const auto daal_decision_function =

--- a/cpp/oneapi/dal/algo/svm/backend/cpu/train_kernel_test.cpp
+++ b/cpp/oneapi/dal/algo/svm/backend/cpu/train_kernel_test.cpp
@@ -1,0 +1,299 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "gtest/gtest.h"
+#include "oneapi/dal/algo/svm.hpp"
+#include "oneapi/dal/data/accessor.hpp"
+#include "oneapi/dal/data/table.hpp"
+
+using namespace oneapi::dal;
+using std::int32_t;
+
+TEST(svm_thunder_dense_test, can_classify_linear_separable_surface) {
+    constexpr std::int64_t row_count_train = 6;
+    constexpr std::int64_t column_count    = 2;
+    const float x_train[]                  = {
+        -2.f, -1.f, -1.f, -1.f, -1.f, -2.f, +1.f, +1.f, +1.f, +2.f, +2.f, +1.f,
+    };
+    const float y_train[] = {
+        -1.f, -1.f, -1.f, +1.f, +1.f, +1.f,
+    };
+    constexpr std::int64_t support_index_negative = 1;
+    constexpr std::int64_t support_index_positive = 3;
+    const auto x_train_table = homogen_table{ row_count_train, column_count, x_train };
+    const auto y_train_table = homogen_table{ row_count_train, 1, y_train };
+
+    const auto svm_desc     = svm::descriptor{}.set_c(1.0);
+    const auto result_train = train(svm_desc, x_train_table, y_train_table);
+    ASSERT_EQ(result_train.get_support_vector_count(), 2);
+
+    auto support_indices_table = result_train.get_support_indices();
+    const auto support_indices = row_accessor<const float>(support_indices_table).pull();
+    ASSERT_EQ(support_indices[0], support_index_negative);
+    ASSERT_EQ(support_indices[1], support_index_positive);
+
+    const auto result_infer      = infer(svm_desc, result_train.get_model(), x_train_table);
+    auto decision_function_table = result_infer.get_decision_function();
+    const auto decision_function = row_accessor<const float>(decision_function_table).pull();
+
+    ASSERT_FLOAT_EQ(decision_function[support_index_negative], -1.f);
+    ASSERT_FLOAT_EQ(decision_function[support_index_positive], +1.f);
+}
+
+TEST(svm_thunder_dense_test, can_classify_linear_separable_surface_with_not_default_linear_kernel) {
+    constexpr std::int64_t row_count_train = 6;
+    constexpr std::int64_t column_count    = 2;
+    const float x_train[]                  = {
+        -2.f, -1.f, -1.f, -1.f, -1.f, -2.f, +1.f, +1.f, +1.f, +2.f, +2.f, +1.f,
+    };
+    const float y_train[] = {
+        -1.f, -1.f, -1.f, +1.f, +1.f, +1.f,
+    };
+    constexpr std::int64_t support_index_negative = 1;
+    constexpr std::int64_t support_index_positive = 3;
+    const auto x_train_table = homogen_table{ row_count_train, column_count, x_train };
+    const auto y_train_table = homogen_table{ row_count_train, 1, y_train };
+
+    const auto kernel_desc  = linear_kernel::descriptor{}.set_k(0.1).set_b(0.0);
+    const auto svm_desc     = svm::descriptor{ kernel_desc }.set_c(10.0);
+    const auto result_train = train(svm_desc, x_train_table, y_train_table);
+    ASSERT_EQ(result_train.get_support_vector_count(), 2);
+
+    auto support_indices_table = result_train.get_support_indices();
+    const auto support_indices = row_accessor<const float>(support_indices_table).pull();
+    ASSERT_EQ(support_indices[0], support_index_negative);
+    ASSERT_EQ(support_indices[1], support_index_positive);
+
+    const auto result_infer      = infer(svm_desc, result_train.get_model(), x_train_table);
+    auto decision_function_table = result_infer.get_decision_function();
+    const auto decision_function = row_accessor<const float>(decision_function_table).pull();
+    ASSERT_FLOAT_EQ(decision_function[support_index_negative], -1.f);
+    ASSERT_FLOAT_EQ(decision_function[support_index_positive], +1.f);
+}
+
+TEST(svm_thunder_dense_test, can_classify_linear_separable_surface_with_big_margin) {
+    constexpr std::int64_t row_count_train = 6;
+    constexpr std::int64_t column_count    = 2;
+    const float x_train[]                  = {
+        -2.f, -1.f, -1.f, -1.f, -1.f, -2.f, +1.f, +1.f, +1.f, +2.f, +2.f, +1.f,
+    };
+    const float y_train[] = {
+        -1.f, -1.f, -1.f, +1.f, +1.f, +1.f,
+    };
+    const auto x_train_table = homogen_table{ row_count_train, column_count, x_train };
+    const auto y_train_table = homogen_table{ row_count_train, 1, y_train };
+    const auto svm_desc      = svm::descriptor{}.set_c(1e-1);
+
+    const auto result_train = train(svm_desc, x_train_table, y_train_table);
+    ASSERT_EQ(result_train.get_support_vector_count(), row_count_train);
+
+    auto support_indices_table = result_train.get_support_indices();
+    const auto support_indices = row_accessor<const float>(support_indices_table).pull();
+    for (size_t i = 0; i < support_indices.get_count(); i++)
+        ASSERT_EQ(support_indices[i], i);
+
+    const auto result_infer = infer(svm_desc, result_train.get_model(), x_train_table);
+
+    auto labels_table = result_infer.get_labels();
+    const auto labels = row_accessor<const float>(labels_table).pull();
+    for (size_t i = 0; i < row_count_train / 2; i++) {
+        ASSERT_FLOAT_EQ(labels[i], -1.f);
+    }
+    for (size_t i = row_count_train / 2; i < row_count_train; i++) {
+        ASSERT_FLOAT_EQ(labels[i], +1.f);
+    }
+}
+
+TEST(svm_thunder_dense_test, can_classify_linear_not_separable_surface) {
+    constexpr std::int64_t row_count_train = 8;
+    constexpr std::int64_t column_count    = 2;
+    const float x_train[]                  = { -2.f, -1.f, -1.f, -1.f, -1.f, -2.f, +1.f, +1.f,
+                              +1.f, +2.f, +2.f, +1.f, -3.f, -3.f, +3.f, +3.f };
+    const float y_train[]                  = { -1.f, -1.f, -1.f, +1.f, +1.f, +1.f, +1.f, -1.f };
+    constexpr std::int64_t support_index_negative = 1;
+    constexpr std::int64_t support_index_positive = 3;
+    const auto x_train_table = homogen_table{ row_count_train, column_count, x_train };
+    const auto y_train_table = homogen_table{ row_count_train, 1, y_train };
+
+    const auto svm_desc     = svm::descriptor{}.set_c(1.0);
+    const auto result_train = train(svm_desc, x_train_table, y_train_table);
+
+    const auto result_infer = infer(svm_desc, result_train.get_model(), x_train_table);
+    auto labels_table       = result_infer.get_labels();
+    const auto labels       = row_accessor<const float>(labels_table).pull();
+    for (size_t i = 0; i < 3; i++) {
+        ASSERT_FLOAT_EQ(labels[i], -1.f);
+    }
+    for (size_t i = 3; i < 6; i++) {
+        ASSERT_FLOAT_EQ(labels[i], +1.f);
+    }
+}
+
+TEST(svm_thunder_dense_test, can_classify_quadric_separable_surface_with_rbf_kernel) {
+    constexpr std::int64_t row_count_train = 12;
+    constexpr std::int64_t column_count    = 2;
+    const float x_train[]                  = {
+        -2.f, 0.f, -2.f, -1.f,  -2.f, +1.f,  +2.f, 0.f,  +2.f, -1.f,  +2.f, +1.f,
+        -1.f, 0.f, -1.f, -0.5f, -1.f, +0.5f, +1.f, 0.5f, +1.f, -0.5f, +1.f, +0.5f,
+    };
+    const float y_train[] = {
+        -1.f, -1.f, -1.f, -1.f, -1.f, -1.f, +1.f, +1.f, +1.f, +1.f, +1.f, +1.f,
+    };
+    constexpr std::int64_t support_index_negative = 1;
+    constexpr std::int64_t support_index_positive = 3;
+    const auto x_train_table = homogen_table{ row_count_train, column_count, x_train };
+    const auto y_train_table = homogen_table{ row_count_train, 1, y_train };
+
+    const auto kernel_desc  = rbf_kernel::descriptor{}.set_sigma(1.0);
+    const auto svm_desc     = svm::descriptor{ kernel_desc }.set_c(1.0);
+    const auto result_train = train(svm_desc, x_train_table, y_train_table);
+    ASSERT_EQ(result_train.get_support_vector_count(), row_count_train);
+
+    const auto result_infer = infer(svm_desc, result_train.get_model(), x_train_table);
+
+    auto labels_table = result_infer.get_labels();
+    const auto labels = row_accessor<const float>(labels_table).pull();
+    for (size_t i = 0; i < row_count_train / 2; i++) {
+        ASSERT_FLOAT_EQ(labels[i], -1.f);
+    }
+    for (size_t i = row_count_train / 2; i < row_count_train; i++) {
+        ASSERT_FLOAT_EQ(labels[i], +1.f);
+    }
+}
+
+TEST(svm_thunder_dense_test, can_classify_linear_separable_surface_with_equal_weights) {
+    constexpr std::int64_t row_count_train = 6;
+    constexpr std::int64_t column_count    = 2;
+    const float x_train[]                  = {
+        -2.f, 0.f, -1.f, -1.f, 0.f, -2.f, 0.f, +2.f, +1.f, +1.f, +2.f, +0.f,
+    };
+    const float y_train[] = {
+        -1.f, -1.f, -1.f, +1.f, +1.f, +1.f,
+    };
+    const float weights[] = {
+        +1.f, +1.f, +1.f, +1.f, +1.f, +1.f,
+    };
+    const auto x_train_table = homogen_table{ row_count_train, column_count, x_train };
+    const auto y_train_table = homogen_table{ row_count_train, 1, y_train };
+    const auto weights_table = homogen_table{ row_count_train, 1, weights };
+
+    const auto svm_desc     = svm::descriptor{}.set_c(0.1);
+    const auto result_train = train(svm_desc, x_train_table, y_train_table, weights_table);
+
+    const float x_test[] = {
+        -1.f,
+        1.f,
+    };
+    const auto x_test_table      = homogen_table{ 1, column_count, x_test };
+    const auto result_infer      = infer(svm_desc, result_train.get_model(), x_test_table);
+    auto decision_function_table = result_infer.get_decision_function();
+    const auto decision_function = row_accessor<const float>(decision_function_table).pull();
+    ASSERT_NEAR(decision_function[0], 0.f, 1e-6);
+}
+
+TEST(svm_thunder_dense_test, can_classify_linear_separable_surface_with_boundary_weights) {
+    constexpr std::int64_t row_count_train = 6;
+    constexpr std::int64_t column_count    = 2;
+    const float x_train[]                  = {
+        -2.f, 0.f, -1.f, -1.f, 0.f, -2.f, 0.f, +2.f, +1.f, +1.f, +2.f, +0.f,
+    };
+    const float y_train[] = {
+        -1.f, -1.f, -1.f, +1.f, +1.f, +1.f,
+    };
+    const float weights[] = {
+        +10.f, +0.1f, +0.1f, +0.1f, +.1f, 10.f,
+    };
+    const auto x_train_table = homogen_table{ row_count_train, column_count, x_train };
+    const auto y_train_table = homogen_table{ row_count_train, 1, y_train };
+    const auto weights_table = homogen_table{ row_count_train, 1, weights };
+
+    const auto svm_desc     = svm::descriptor{}.set_c(0.1);
+    const auto result_train = train(svm_desc, x_train_table, y_train_table, weights_table);
+
+    const float x_test[] = {
+        -1.f,
+        1.f,
+    };
+    const auto x_test_table      = homogen_table{ 1, column_count, x_test };
+    const auto result_infer      = infer(svm_desc, result_train.get_model(), x_test_table);
+    auto decision_function_table = result_infer.get_decision_function();
+    const auto decision_function = row_accessor<const float>(decision_function_table).pull();
+    ASSERT_LT(decision_function[0], 0.f);
+}
+
+TEST(svm_thunder_dense_test, can_classify_linear_separable_surface_with_center_weights) {
+    constexpr std::int64_t row_count_train = 6;
+    constexpr std::int64_t column_count    = 2;
+    const float x_train[]                  = {
+        -2.f, 0.f, -1.f, -1.f, 0.f, -2.f, 0.f, +2.f, +1.f, +1.f, +2.f, +0.f,
+    };
+    const float y_train[] = {
+        -1.f, -1.f, -1.f, +1.f, +1.f, +1.f,
+    };
+    const float weights[] = {
+        +0.1f, +0.1f, +10.f, +10.f, +0.1f, +0.1f,
+    };
+    const auto x_train_table = homogen_table{ row_count_train, column_count, x_train };
+    const auto y_train_table = homogen_table{ row_count_train, 1, y_train };
+    const auto weights_table = homogen_table{ row_count_train, 1, weights };
+
+    const auto svm_desc     = svm::descriptor{}.set_c(0.1);
+    const auto result_train = train(svm_desc, x_train_table, y_train_table, weights_table);
+
+    const float x_test[] = {
+        -1.f,
+        1.f,
+    };
+    const auto x_test_table      = homogen_table{ 1, column_count, x_test };
+    const auto result_infer      = infer(svm_desc, result_train.get_model(), x_test_table);
+    auto decision_function_table = result_infer.get_decision_function();
+    const auto decision_function = row_accessor<const float>(decision_function_table).pull();
+    ASSERT_GT(decision_function[0], 0.f);
+}
+
+TEST(svm_thunder_dense_test, can_classify_linear_separable_surface_with_different_type_desc) {
+    constexpr std::int64_t row_count_train = 6;
+    constexpr std::int64_t column_count    = 2;
+    const float x_train[]                  = {
+        -2.f, -1.f, -1.f, -1.f, -1.f, -2.f, +1.f, +1.f, +1.f, +2.f, +2.f, +1.f,
+    };
+    const float y_train[] = {
+        -1.f, -1.f, -1.f, +1.f, +1.f, +1.f,
+    };
+    const auto x_train_table  = homogen_table{ row_count_train, column_count, x_train };
+    const auto y_train_table  = homogen_table{ row_count_train, 1, y_train };
+    const auto svm_desc_train = svm::descriptor<float>{}.set_c(1e-1);
+
+    const auto result_train = train(svm_desc_train, x_train_table, y_train_table);
+    ASSERT_EQ(result_train.get_support_vector_count(), row_count_train);
+
+    auto support_indices_table = result_train.get_support_indices();
+    const auto support_indices = row_accessor<const float>(support_indices_table).pull();
+    for (size_t i = 0; i < support_indices.get_count(); i++)
+        ASSERT_EQ(support_indices[i], i);
+
+    const auto svm_desc_infer = svm::descriptor<double>{}.set_c(1e-1);
+    const auto result_infer   = infer(svm_desc_infer, result_train.get_model(), x_train_table);
+
+    auto labels_table = result_infer.get_labels();
+    const auto labels = row_accessor<const float>(labels_table).pull();
+    for (size_t i = 0; i < row_count_train / 2; i++) {
+        ASSERT_FLOAT_EQ(labels[i], -1.f);
+    }
+    for (size_t i = row_count_train / 2; i < row_count_train; i++) {
+        ASSERT_FLOAT_EQ(labels[i], +1.f);
+    }
+}

--- a/cpp/oneapi/dal/algo/svm/backend/kernel_function_impl.hpp
+++ b/cpp/oneapi/dal/algo/svm/backend/kernel_function_impl.hpp
@@ -14,20 +14,20 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include "oneapi/dal/algo/svm/backend/cpu/train_kernel.hpp"
+#pragma once
 
-namespace oneapi::dal::svm::backend {
+#include "oneapi/dal/algo/svm/common.hpp"
 
-template <typename Float>
-struct train_kernel_cpu<Float, task::classification, method::smo> {
-    train_result operator()(const dal::backend::context_cpu& ctx,
-                            const descriptor_base& params,
-                            const train_input& input) const {
-        return train_result();
-    }
+#include <daal/include/algorithms/kernel_function/kernel_function_linear.h>
+#include <daal/include/algorithms/kernel_function/kernel_function_rbf.h>
+
+namespace oneapi::dal::svm::detail {
+
+class kernel_function_impl : public base {
+public:
+    virtual ~kernel_function_impl() = default;
+
+    virtual daal::algorithms::kernel_function::KernelIfacePtr get_daal_kernel_function() = 0;
 };
 
-template struct train_kernel_cpu<float, task::classification, method::smo>;
-template struct train_kernel_cpu<double, task::classification, method::smo>;
-
-} // namespace oneapi::dal::svm::backend
+} // namespace oneapi::dal::svm::detail

--- a/cpp/oneapi/dal/algo/svm/common.cpp
+++ b/cpp/oneapi/dal/algo/svm/common.cpp
@@ -15,11 +15,117 @@
 *******************************************************************************/
 
 #include "oneapi/dal/algo/svm/common.hpp"
+#include "oneapi/dal/algo/svm/backend/kernel_function_impl.hpp"
 
 namespace oneapi::dal::svm {
 
+namespace detail {
+
+using daal_kf                = daal::algorithms::kernel_function::KernelIfacePtr;
+namespace daal_linear_kernel = daal::algorithms::kernel_function::linear;
+namespace daal_rbf_kernel    = daal::algorithms::kernel_function::rbf;
+
+template <typename Float, typename Method>
+class daal_interop_linear_kernel_impl : public kernel_function_impl {
+public:
+    daal_interop_linear_kernel_impl(double k, double b) : k_(k), b_(b) {}
+
+    daal_kf get_daal_kernel_function() override {
+        constexpr daal_linear_kernel::Method daal_method = get_daal_method();
+        auto alg         = new daal_linear_kernel::Batch<Float, daal_method>;
+        alg->parameter.k = k_;
+        alg->parameter.b = b_;
+        return daal_kf(alg);
+    }
+
+private:
+    static constexpr daal_linear_kernel::Method get_daal_method() {
+        if constexpr (std::is_same_v<Method, linear_kernel::method::dense>)
+            return daal_linear_kernel::Method::defaultDense;
+        else if constexpr (std::is_same_v<Method, linear_kernel::method::csr>)
+            return daal_linear_kernel::Method::fastCSR;
+        return daal_linear_kernel::Method::defaultDense;
+    }
+
+    double k_;
+    double b_;
+};
+
+template <typename F, typename M>
+using linear_kernel_t = linear_kernel::descriptor<F, M>;
+
+template <typename F, typename M>
+kernel_function<linear_kernel_t<F, M>>::kernel_function(const linear_kernel_t<F, M> &kernel)
+        : kernel_(kernel),
+          impl_(new daal_interop_linear_kernel_impl<F, M>{ kernel.get_k(), kernel.get_b() }) {}
+
+template <typename F, typename M>
+kernel_function_impl *kernel_function<linear_kernel_t<F, M>>::get_impl() const {
+    return impl_.get();
+}
+
+#define INSTANTIATE_LINEAR(F, M) template class kernel_function<linear_kernel_t<F, M>>;
+
+INSTANTIATE_LINEAR(float, linear_kernel::method::dense)
+INSTANTIATE_LINEAR(float, linear_kernel::method::csr)
+INSTANTIATE_LINEAR(double, linear_kernel::method::dense)
+INSTANTIATE_LINEAR(double, linear_kernel::method::csr)
+
+#undef INSTANTIATE_LINEAR
+
+template <typename F, typename M>
+using rbf_kernel_t = rbf_kernel::descriptor<F, M>;
+
+template <typename Float, typename Method>
+class daal_interop_rbf_kernel_impl : public kernel_function_impl {
+public:
+    daal_interop_rbf_kernel_impl(double sigma) : sigma_(sigma) {}
+
+    daal_kf get_daal_kernel_function() override {
+        constexpr daal_rbf_kernel::Method daal_method = get_daal_method();
+        auto alg             = new daal_rbf_kernel::Batch<Float, daal_method>;
+        alg->parameter.sigma = sigma_;
+        return daal_kf(alg);
+    }
+
+private:
+    static constexpr daal_rbf_kernel::Method get_daal_method() {
+        if constexpr (std::is_same_v<Method, linear_kernel::method::dense>)
+            return daal_rbf_kernel::Method::defaultDense;
+        else if constexpr (std::is_same_v<Method, linear_kernel::method::csr>)
+            return daal_rbf_kernel::Method::fastCSR;
+        return daal_rbf_kernel::Method::defaultDense;
+    }
+
+    double sigma_;
+};
+
+template <typename F, typename M>
+kernel_function<rbf_kernel_t<F, M>>::kernel_function(const rbf_kernel_t<F, M> &kernel)
+        : kernel_(kernel),
+          impl_(new daal_interop_rbf_kernel_impl<F, M>{ kernel.get_sigma() }) {}
+
+template <typename F, typename M>
+kernel_function_impl *kernel_function<rbf_kernel_t<F, M>>::get_impl() const {
+    return impl_.get();
+}
+
+#define INSTANTIATE_RBF(F, M) template class kernel_function<rbf_kernel_t<F, M>>;
+
+INSTANTIATE_RBF(float, rbf_kernel::method::dense)
+INSTANTIATE_RBF(float, rbf_kernel::method::csr)
+INSTANTIATE_RBF(double, rbf_kernel::method::dense)
+INSTANTIATE_RBF(double, rbf_kernel::method::csr)
+
+#undef INSTANTIATE_RBF
+
+} // namespace detail
+
 class detail::descriptor_impl : public base {
 public:
+    explicit descriptor_impl(const detail::kf_iface_ptr &kernel) : kernel(kernel) {}
+
+    detail::kf_iface_ptr kernel;
     double c                         = 1.0;
     double accuracy_threshold        = 0.001;
     std::int64_t max_iteration_count = 100000;
@@ -39,7 +145,8 @@ public:
 using detail::descriptor_impl;
 using detail::model_impl;
 
-descriptor_base::descriptor_base() : impl_(new descriptor_impl{}) {}
+descriptor_base::descriptor_base(const detail::kf_iface_ptr &kernel)
+        : impl_(new descriptor_impl{ kernel }) {}
 
 double descriptor_base::get_c() const {
     return impl_->c;
@@ -87,6 +194,14 @@ void descriptor_base::set_tau_impl(const double value) {
 
 void descriptor_base::set_shrinking_impl(const bool value) {
     impl_->shrinking = value;
+}
+
+void descriptor_base::set_kernel_impl(const detail::kf_iface_ptr &kernel) {
+    impl_->kernel = kernel;
+}
+
+const detail::kf_iface_ptr &descriptor_base::get_kernel_impl() const {
+    return impl_->kernel;
 }
 
 model::model() : impl_(new model_impl{}) {}

--- a/cpp/oneapi/dal/algo/svm/detail/infer_ops_dpc.cpp
+++ b/cpp/oneapi/dal/algo/svm/detail/infer_ops_dpc.cpp
@@ -20,7 +20,6 @@
 #include "oneapi/dal/backend/dispatcher_dpc.hpp"
 
 namespace oneapi::dal::svm::detail {
-
 template <typename Float, typename Task, typename Method>
 struct ONEAPI_DAL_EXPORT infer_ops_dispatcher<data_parallel_policy, Float, Task, Method> {
     infer_result operator()(const data_parallel_policy& ctx,

--- a/cpp/oneapi/dal/algo/svm/infer_types.hpp
+++ b/cpp/oneapi/dal/algo/svm/infer_types.hpp
@@ -50,7 +50,7 @@ private:
     dal::detail::pimpl<detail::infer_input_impl> impl_;
 };
 
-class ONEAPI_DAL_EXPORT infer_result {
+class ONEAPI_DAL_EXPORT infer_result : public base {
 public:
     infer_result();
 

--- a/cpp/oneapi/dal/algo/svm/train_types.hpp
+++ b/cpp/oneapi/dal/algo/svm/train_types.hpp
@@ -58,7 +58,7 @@ private:
     dal::detail::pimpl<detail::train_input_impl> impl_;
 };
 
-class ONEAPI_DAL_EXPORT train_result {
+class ONEAPI_DAL_EXPORT train_result : public base {
 public:
     train_result();
 

--- a/cpp/oneapi/dal/compute.hpp
+++ b/cpp/oneapi/dal/compute.hpp
@@ -1,0 +1,35 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#pragma once
+
+#include "oneapi/dal/detail/compute_ops.hpp"
+
+namespace oneapi::dal {
+
+template <typename... Args>
+auto compute(Args&&... args) {
+    return detail::compute_dispatch(std::forward<Args>(args)...);
+}
+
+#ifdef ONEAPI_DAL_DATA_PARALLEL
+template <typename... Args>
+auto compute(sycl::queue& queue, Args&&... args) {
+    return detail::compute_dispatch(data_parallel_policy{ queue }, std::forward<Args>(args)...);
+}
+#endif
+
+} // namespace oneapi::dal

--- a/cpp/oneapi/dal/detail/compute_ops.hpp
+++ b/cpp/oneapi/dal/detail/compute_ops.hpp
@@ -1,0 +1,35 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#pragma once
+
+#include "oneapi/dal/detail/ops_dispatcher.hpp"
+
+namespace oneapi::dal::detail {
+
+template <typename Descriptor, typename Tag>
+struct compute_ops;
+
+template <typename Descriptor>
+using tagged_compute_ops = compute_ops<Descriptor, typename Descriptor::tag_t>;
+
+template <typename Head, typename... Tail>
+auto compute_dispatch(Head&& head, Tail&&... tail) {
+    using dispatcher_t = ops_policy_dispatcher<std::decay_t<Head>, tagged_compute_ops>;
+    return dispatcher_t{}(std::forward<Head>(head), std::forward<Tail>(tail)...);
+}
+
+} // namespace oneapi::dal::detail

--- a/examples/oneapi/cpp/daal_lnx.lst
+++ b/examples/oneapi/cpp/daal_lnx.lst
@@ -18,5 +18,9 @@
 ##     Intel(R) Data Analytics Acceleration Library examples list
 ##******************************************************************************
 
-DAAL = pca_cor_dense_batch               \
+DAAL = linear_kernel_dense_batch         \
+       pca_cor_dense_batch               \
+       rbf_kernel_dense_batch            \
        svm_two_class_thunder_dense_batch \
+       svm_two_class_smo_dense_batch
+

--- a/examples/oneapi/cpp/makefile_lnx
+++ b/examples/oneapi/cpp/makefile_lnx
@@ -155,7 +155,7 @@ sointel64:
 _make_ex: $(RES)
 
 vpath
-vpath %.cpp $(addprefix ./source/,pca svm)
+vpath %.cpp $(addprefix ./source/,linear_kernel pca rbf_kernel svm)
 
 .SECONDARY:
 $(RES_DIR)/%.exe: %.cpp | $(RES_DIR)/.

--- a/examples/oneapi/cpp/source/linear_kernel/linear_kernel_dense_batch.cpp
+++ b/examples/oneapi/cpp/source/linear_kernel/linear_kernel_dense_batch.cpp
@@ -1,0 +1,48 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "oneapi/dal/algo/linear_kernel.hpp"
+
+#include "example_util/utils.hpp"
+
+using namespace oneapi;
+
+int main(int argc, char const *argv[]) {
+    constexpr std::int64_t row_count_x = 2;
+    constexpr std::int64_t row_count_y = 3;
+    constexpr std::int64_t column_count = 3;
+
+    const float x[] = {
+        1.f, 2.f, 3.f,
+        1.f, -1.f, 0.f,
+    };
+
+    const float y[] = {
+        1.f, 2.f, 3.f,
+        1.f, -1.f, 0.f,
+        4.f, 5.f, 6.f,
+    };
+
+    const auto x_table = dal::homogen_table{ row_count_x, column_count, x };
+    const auto y_table = dal::homogen_table{ row_count_y, column_count, y };
+    const auto kernel_desc = dal::linear_kernel::descriptor{}.set_k(2.0).set_b(1.0);
+
+    const auto result = dal::compute(kernel_desc, x_table, y_table);
+
+    std::cout << "Values:" << std::endl << result.get_values() << std::endl;
+
+    return 0;
+}

--- a/examples/oneapi/cpp/source/rbf_kernel/rbf_kernel_dense_batch.cpp
+++ b/examples/oneapi/cpp/source/rbf_kernel/rbf_kernel_dense_batch.cpp
@@ -1,0 +1,48 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "oneapi/dal/algo/rbf_kernel.hpp"
+
+#include "example_util/utils.hpp"
+
+using namespace oneapi;
+
+int main(int argc, char const *argv[]) {
+    constexpr std::int64_t row_count_x = 2;
+    constexpr std::int64_t row_count_y = 3;
+    constexpr std::int64_t column_count = 3;
+
+    const float x[] = {
+        1.f, 2.f, 3.f,
+        1.f, -1.f, 0.f,
+    };
+
+    const float y[] = {
+        1.f, 2.f, 3.f,
+        1.f, -1.f, 0.f,
+        4.f, 5.f, 6.f,
+    };
+
+    const auto x_table = dal::homogen_table{ row_count_x, column_count, x };
+    const auto y_table = dal::homogen_table{ row_count_y, column_count, y };
+    const auto kernel_desc = dal::rbf_kernel::descriptor{}.set_sigma(10.0);
+
+    const auto result = dal::compute(kernel_desc, x_table, y_table);
+
+    std::cout << "Values:" << std::endl << result.get_values() << std::endl;
+
+    return 0;
+}

--- a/examples/oneapi/cpp/source/svm/svm_two_class_smo_dense_batch.cpp
+++ b/examples/oneapi/cpp/source/svm/svm_two_class_smo_dense_batch.cpp
@@ -40,22 +40,31 @@ int main(int argc, char const *argv[]) {
         +1.f,
     };
 
-    const auto x_train_table = dal::homogen_table{ row_count_train, column_count, x_train };
-    const auto y_train_table = dal::homogen_table{ row_count_train, 1, y_train };
+    const auto x_train_table =
+        dal::homogen_table{ row_count_train, column_count, x_train };
+    const auto y_train_table =
+        dal::homogen_table{ row_count_train, 1, y_train };
 
-    const auto kernel_desc = dal::linear_kernel::descriptor{}.set_k(1.0).set_b(0.0);
+    const auto kernel_desc =
+        dal::linear_kernel::descriptor{}.set_k(1.0).set_b(0.0);
 
-    const auto svm_desc = dal::svm::descriptor{ kernel_desc }
-                              .set_c(1.0)
-                              .set_accuracy_threshold(0.01)
-                              .set_max_iteration_count(100)
-                              .set_cache_size(200.0)
-                              .set_tau(1e-6);
+    const auto svm_desc =
+        dal::svm::descriptor<float,
+                             dal::svm::task::classification,
+                             dal::svm::method::smo>{ kernel_desc }
+            .set_c(1.0)
+            .set_accuracy_threshold(0.01)
+            .set_max_iteration_count(100)
+            .set_cache_size(200.0)
+            .set_shrinking(false)
+            .set_tau(1e-6);
 
-    const auto result_train = dal::train(svm_desc, x_train_table, y_train_table);
+    const auto result_train =
+        dal::train(svm_desc, x_train_table, y_train_table);
 
     std::cout << "Bias:" << std::endl << result_train.get_bias() << std::endl;
-    std::cout << "Support indices:" << std::endl << result_train.get_support_indices() << std::endl;
+    std::cout << "Support indices:" << std::endl
+              << result_train.get_support_indices() << std::endl;
 
     constexpr std::int64_t row_count_test = 3;
     const float x_test[] = {
@@ -69,14 +78,17 @@ int main(int argc, char const *argv[]) {
         +1.f,
     };
 
-    const auto x_test_table = dal::homogen_table{ row_count_test, column_count, x_test };
+    const auto x_test_table =
+        dal::homogen_table{ row_count_test, column_count, x_test };
     const auto y_true_table = dal::homogen_table{ row_count_test, 1, y_true };
 
-    const auto result_test = dal::infer(svm_desc, result_train.get_model(), x_test_table);
+    const auto result_test =
+        dal::infer(svm_desc, result_train.get_model(), x_test_table);
 
     std::cout << "Decision function result:" << std::endl
               << result_test.get_decision_function() << std::endl;
-    std::cout << "Labels result:" << std::endl << result_test.get_labels() << std::endl;
+    std::cout << "Labels result:" << std::endl
+              << result_test.get_labels() << std::endl;
     std::cout << "Labels true:" << std::endl << y_true_table << std::endl;
 
     return 0;

--- a/makefile.lst
+++ b/makefile.lst
@@ -224,12 +224,16 @@ CORE.SERVICES       := compression            \
                        data_management
 
 # Dependencies between oneAPI and core (CPU-only) algorithms
-ONEAPI.ALGOS.pca := CORE.pca
-ONEAPI.ALGOS.svm := CORE.svm
+ONEAPI.ALGOS.linear_kernel := CORE.kernel_function
+ONEAPI.ALGOS.pca           := CORE.pca
+ONEAPI.ALGOS.rbf_kernel    := CORE.kernel_function
+ONEAPI.ALGOS.svm           := CORE.svm
 
 # List of algorithms in oneAPI part
-ONEAPI.ALGOS := \
-    pca         \
+ONEAPI.ALGOS :=     \
+    linear_kernel   \
+    pca             \
+    rbf_kernel      \
     svm
 
 JJ.ALGORITHMS       := adaboost                                                  \


### PR DESCRIPTION
1. Added common interfaces of compute for all algorithms
2. Added Interface for compute for Linear & RBF Kernels
3. Created example for Linear & RBF Kernels
4. Added support Linear & RBF Kernels for SVM algorithm
5. Updated example of SVM for parameter kernel
6. Implemented SMO method
7. Added example for SMO method
8. Implemented tests for SVM, RBF, Linear Kernels