### PR TITLE
Fix illegal instructions on Windows

### DIFF
--- a/cpp/daal/src/algorithms/decision_tree/decision_tree_train_impl.i
+++ b/cpp/daal/src/algorithms/decision_tree/decision_tree_train_impl.i
@@ -650,11 +650,14 @@ public:
         TreeNodeIndex nodeIndex = pushBack(statusPushBack);
         DAAL_CHECK_STATUS_VAR(statusPushBack)
 
-        BlockDescriptor<IndependentVariableType> * xBD = new BlockDescriptor<IndependentVariableType>[xColumnCount];
-        const IndependentVariableType ** dx            = new const IndependentVariableType *[xColumnCount];
+        daal::internal::BlockDescriptorArray<IndependentVariableType> xBD(xColumnCount);
+        DAAL_CHECK_MALLOC(xBD.get());
+
+        const IndependentVariableType ** dx = new const IndependentVariableType *[xColumnCount];
+        DAAL_CHECK_MALLOC(dx);
+
         BlockDescriptor<DependentVariableType> yBD;
         const_cast<NumericTable *>(&y)->getBlockOfColumnValues(0, 0, xRowCount, readOnly, yBD);
-
         BlockDescriptor<IndependentVariableType> wBD;
         if (w)
         {
@@ -859,10 +862,8 @@ public:
             const_cast<NumericTable *>(&x)->releaseBlockOfColumnValues(xBD[i]);
         }
         delete[] dx;
-        delete[] xBD;
         daal_free(indexes);
         dx      = nullptr;
-        xBD     = nullptr;
         indexes = nullptr;
         return services::Status();
     }
@@ -891,9 +892,11 @@ public:
 
         clear();
 
-        BlockDescriptor<IndependentVariableType> * xBD = new BlockDescriptor<IndependentVariableType>[xColumnCount];
-        const IndependentVariableType ** dx            = new const IndependentVariableType *[xColumnCount];
-        DAAL_CHECK_MALLOC(xBD && dx)
+        daal::internal::BlockDescriptorArray<IndependentVariableType> xBD(xColumnCount);
+        DAAL_CHECK_MALLOC(xBD.get());
+
+        const IndependentVariableType ** dx = new const IndependentVariableType *[xColumnCount];
+        DAAL_CHECK_MALLOC(dx)
         if (x.getDataLayout() == data_management::NumericTableIface::soa)
         {
             for (size_t i = 0; i < xColumnCount; ++i)
@@ -942,11 +945,9 @@ public:
         }
 
         delete[] dx;
-        delete[] xBD;
         daal_free(indexes);
         indexes = nullptr;
         dx      = nullptr;
-        xBD     = nullptr;
 
         return services::Status();
     }

--- a/cpp/daal/src/algorithms/decision_tree/decision_tree_train_impl.i
+++ b/cpp/daal/src/algorithms/decision_tree/decision_tree_train_impl.i
@@ -739,7 +739,7 @@ public:
         typedef daal::services::internal::EpsilonVal<typename SplitCriterion::ValueType> SplitCriterionEpsilon;
         const typename SplitCriterion::ValueType epsilon = SplitCriterionEpsilon::get();
 
-        daal::threader_for(xColumnCount, xColumnCount, [=, &context, &localTLS, &totalDataStatistics, &safeStat](size_t featureIndex) {
+        daal::threader_for(xColumnCount, xColumnCount, [=, &context, &localTLS, &totalDataStatistics, &safeStat, &xBD](size_t featureIndex) {
             const_cast<NumericTable *>(&context.x)->getBlockOfColumnValues(featureIndex, 0, xRowCount, readOnly, xBD[featureIndex]);
             dx[featureIndex] = xBD[featureIndex].getBlockPtr();
 

--- a/cpp/daal/src/data_management/service_numeric_table.cpp
+++ b/cpp/daal/src/data_management/service_numeric_table.cpp
@@ -29,6 +29,7 @@ BlockDescriptorArray<algorithmFPType>::BlockDescriptorArray(size_t nBlocks)
 template <typename algorithmFPType>
 BlockDescriptorArray<algorithmFPType>::~BlockDescriptorArray() {
     delete[] _blocks;
+    _blocks = nullptr;
 }
 
 template class BlockDescriptorArray<float>;

--- a/cpp/daal/src/data_management/service_numeric_table.cpp
+++ b/cpp/daal/src/data_management/service_numeric_table.cpp
@@ -21,13 +21,13 @@ namespace daal
 {
 namespace internal
 {
+template <typename algorithmFPType>
+BlockDescriptorArray<algorithmFPType>::BlockDescriptorArray(size_t nBlocks) : _blocks(new BlockDescriptor<algorithmFPType>[nBlocks])
+{}
 
 template <typename algorithmFPType>
-BlockDescriptorArray<algorithmFPType>::BlockDescriptorArray(size_t nBlocks)
-    : _blocks(new BlockDescriptor<algorithmFPType>[nBlocks]) {}
-
-template <typename algorithmFPType>
-BlockDescriptorArray<algorithmFPType>::~BlockDescriptorArray() {
+BlockDescriptorArray<algorithmFPType>::~BlockDescriptorArray()
+{
     delete[] _blocks;
     _blocks = nullptr;
 }

--- a/cpp/daal/src/data_management/service_numeric_table.cpp
+++ b/cpp/daal/src/data_management/service_numeric_table.cpp
@@ -1,0 +1,39 @@
+/* file: service_numeric_table.cpp */
+/*******************************************************************************
+* Copyright 2014-2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "src/data_management/service_numeric_table.h"
+
+namespace daal
+{
+namespace internal
+{
+
+template <typename algorithmFPType>
+BlockDescriptorArray<algorithmFPType>::BlockDescriptorArray(size_t nBlocks)
+    : _blocks(new BlockDescriptor<algorithmFPType>[nBlocks]) {}
+
+template <typename algorithmFPType>
+BlockDescriptorArray<algorithmFPType>::~BlockDescriptorArray() {
+    delete[] _blocks;
+}
+
+template class BlockDescriptorArray<float>;
+template class BlockDescriptorArray<double>;
+template class BlockDescriptorArray<int>;
+
+} // namespace internal
+} // namespace daal

--- a/cpp/daal/src/data_management/service_numeric_table.h
+++ b/cpp/daal/src/data_management/service_numeric_table.h
@@ -785,6 +785,27 @@ using daal::services::internal::TNArray;
 template <typename algorithmFPType>
 services::Status createSparseTable(const NumericTablePtr & inputTable, CSRNumericTablePtr & resTable);
 
+template <typename algorithmFPType>
+class BlockDescriptorArray {
+public:
+    explicit BlockDescriptorArray(size_t nBlocks);
+    ~BlockDescriptorArray();
+
+    BlockDescriptorArray(const BlockDescriptorArray &) = delete;
+    BlockDescriptorArray & operator=(const BlockDescriptorArray &) = delete;
+
+    DAAL_FORCEINLINE BlockDescriptor<algorithmFPType> & operator[](size_t index) {
+        return _blocks[index];
+    }
+
+    DAAL_FORCEINLINE const BlockDescriptor<algorithmFPType> & operator[](size_t index) const {
+        return _blocks[index];
+    }
+
+private:
+    BlockDescriptor<algorithmFPType> _blocks;
+};
+
 } // namespace internal
 } // namespace daal
 

--- a/cpp/daal/src/data_management/service_numeric_table.h
+++ b/cpp/daal/src/data_management/service_numeric_table.h
@@ -786,7 +786,8 @@ template <typename algorithmFPType>
 services::Status createSparseTable(const NumericTablePtr & inputTable, CSRNumericTablePtr & resTable);
 
 template <typename algorithmFPType>
-class BlockDescriptorArray {
+class BlockDescriptorArray
+{
 public:
     explicit BlockDescriptorArray(size_t nBlocks);
     ~BlockDescriptorArray();
@@ -794,17 +795,11 @@ public:
     BlockDescriptorArray(const BlockDescriptorArray &) = delete;
     BlockDescriptorArray & operator=(const BlockDescriptorArray &) = delete;
 
-    DAAL_FORCEINLINE BlockDescriptor<algorithmFPType> * get() const {
-        return _blocks;
-    }
+    DAAL_FORCEINLINE BlockDescriptor<algorithmFPType> * get() const { return _blocks; }
 
-    DAAL_FORCEINLINE BlockDescriptor<algorithmFPType> & operator[](size_t index) {
-        return _blocks[index];
-    }
+    DAAL_FORCEINLINE BlockDescriptor<algorithmFPType> & operator[](size_t index) { return _blocks[index]; }
 
-    DAAL_FORCEINLINE const BlockDescriptor<algorithmFPType> & operator[](size_t index) const {
-        return _blocks[index];
-    }
+    DAAL_FORCEINLINE const BlockDescriptor<algorithmFPType> & operator[](size_t index) const { return _blocks[index]; }
 
 private:
     BlockDescriptor<algorithmFPType> * _blocks;

--- a/cpp/daal/src/data_management/service_numeric_table.h
+++ b/cpp/daal/src/data_management/service_numeric_table.h
@@ -794,6 +794,10 @@ public:
     BlockDescriptorArray(const BlockDescriptorArray &) = delete;
     BlockDescriptorArray & operator=(const BlockDescriptorArray &) = delete;
 
+    DAAL_FORCEINLINE BlockDescriptor<algorithmFPType> * get() const {
+        return _blocks;
+    }
+
     DAAL_FORCEINLINE BlockDescriptor<algorithmFPType> & operator[](size_t index) {
         return _blocks[index];
     }
@@ -803,7 +807,7 @@ public:
     }
 
 private:
-    BlockDescriptor<algorithmFPType> _blocks;
+    BlockDescriptor<algorithmFPType> * _blocks;
 };
 
 } // namespace internal


### PR DESCRIPTION
The problem is that on Windows Intel compiler replaces the `new BlockDescritptor<T>[n]` expression with the custom compiler-generated function that allocates and initializes all `BlockDesriptor` elements in the array. The function is compiled multiple times with different compiler options and behaves as C++ `inline` that leads to ODR violation. Some versions of that function being compiled for multiple CPUs contain AVX2 instructions. When user's application (in fact, example or test system) is linked statically against DAL, the linker selects 'wrong' version of the function (the one which contains AVX2) that leads to 'illegal' instruction on old architectures.

The fix consists in moving `new BlockDescritptor<T>[n]` to separate object file that will be compiled once to satisfy ODR. Additionally, it introduces `BlockDescriptorArray` that simplifies resource management and fixes possible memory leaks in the existing decision tree code.   