### PR TITLE
DBSCAN optimizations for CPU

### DIFF
--- a/cpp/daal/src/algorithms/dbscan/dbscan_kernel.h
+++ b/cpp/daal/src/algorithms/dbscan/dbscan_kernel.h
@@ -55,6 +55,10 @@ private:
     services::Status processNeighborhood(size_t clusterId, int * assignments, const Neighborhood<algorithmFPType, cpu> & neigh,
                                          Queue<size_t, cpu> & qu);
 
+    services::Status processNeighborhoodParallel(size_t clusterId, int * const assignments, const Neighborhood<algorithmFPType, cpu> & neigh,
+                                                 daal::tls<Queue<size_t, cpu> *> & tls, TArray<Neighborhood<algorithmFPType, cpu>, cpu> & neighs,
+                                                 algorithmFPType minObservations, int * const isCore, size_t nestedLevel);
+
     services::Status processResultsToCompute(DAAL_UINT64 resultsToCompute, int * const isCore, const NumericTable * ntData,
                                              NumericTable * ntCoreIndices, NumericTable * ntCoreObservations);
 };

--- a/cpp/daal/src/algorithms/k_nearest_neighbors/kdtree_knn_impl.i
+++ b/cpp/daal/src/algorithms/k_nearest_neighbors/kdtree_knn_impl.i
@@ -28,20 +28,6 @@
     #include <immintrin.h>
 #endif
 
-#if defined(_MSC_VER)
-    #define DAAL_FORCEINLINE   __forceinline
-    #define DAAL_FORCENOINLINE __declspec(noinline)
-#else
-    #define DAAL_FORCEINLINE   inline __attribute__((always_inline))
-    #define DAAL_FORCENOINLINE __attribute__((noinline))
-#endif
-
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
-    #define DAAL_ALIGNAS(n) __declspec(align(n))
-#else
-    #define DAAL_ALIGNAS(n) alignas(n)
-#endif
-
 namespace daal
 {
 namespace algorithms

--- a/cpp/daal/src/algorithms/service_kernel_math.h
+++ b/cpp/daal/src/algorithms/service_kernel_math.h
@@ -24,7 +24,18 @@
 #ifndef __SERVICE_KERNEL_MATH_H__
 #define __SERVICE_KERNEL_MATH_H__
 
+#include "services/daal_defines.h"
+#include "services/error_handling.h"
+#include "src/data_management/service_numeric_table.h"
+#include "src/services/service_data_utils.h"
+#include "src/services/service_arrays.h"
+#include "src/externals/service_blas.h"
+#include "src/externals/service_memory.h"
 #include "src/externals/service_math.h"
+
+using namespace daal::internal;
+using namespace daal::services;
+using namespace daal::services::internal;
 
 namespace daal
 {
@@ -70,6 +81,174 @@ FPType distance(const FPType * a, const FPType * b, size_t dim, FPType p)
 
     return daal::internal::Math<FPType, cpu>::sPowx(sum, (FPType)1.0 / p);
 }
+
+template <typename FPType, CpuType cpu>
+class PairwiseDistances
+{
+public:
+    virtual ~PairwiseDistances() {};
+
+    virtual services::Status init() = 0;
+
+    virtual services::Status computeBatch(const FPType * const a, const FPType * const b, size_t aOffset, size_t aSize, size_t bOffset, size_t bSize,
+                                          FPType * const res)                                                             = 0;
+    virtual services::Status computeBatch(size_t aOffset, size_t aSize, size_t bOffset, size_t bSize, FPType * const res) = 0;
+    virtual services::Status computeFull(FPType * const res)                                                              = 0;
+};
+
+// compute: sum(A^2, 2) + sum(B^2, 2) -2*A*B'
+template <typename FPType, CpuType cpu>
+class EuclideanDistances : public PairwiseDistances<FPType, cpu>
+{
+public:
+    EuclideanDistances(const NumericTable & a, const NumericTable & b) : _a(a), _b(b) {}
+
+    virtual ~EuclideanDistances() {}
+
+    virtual services::Status init()
+    {
+        services::Status s;
+
+        normBufferA.reset(_a.getNumberOfRows());
+        DAAL_CHECK_MALLOC(normBufferA.get());
+        s |= computeNorm(_a, normBufferA.get());
+
+        if (&_a != &_b)
+        {
+            normBufferB.reset(_b.getNumberOfRows());
+            DAAL_CHECK_MALLOC(normBufferB.get());
+            s |= computeNorm(_b, normBufferB.get());
+        }
+
+        return s;
+    }
+
+    // output:  Row-major matrix of size { aSize x bSize }
+    virtual services::Status computeBatch(const FPType * const a, const FPType * const b, size_t aOffset, size_t aSize, size_t bOffset, size_t bSize,
+                                          FPType * const res)
+    {
+        const size_t nRowsA = aSize;
+        const size_t nColsA = _a.getNumberOfColumns();
+        const size_t nRowsB = bSize;
+
+        const size_t nRowsC = nRowsA;
+        const size_t nColsC = nRowsB;
+
+        computeABt(a, b, nRowsA, nColsA, nRowsB, res);
+
+        const FPType * const aa = normBufferA.get() + aOffset;
+        const FPType * const bb = (&_a == &_b) ? normBufferA.get() + bOffset : normBufferB.get() + bOffset;
+
+        PRAGMA_IVDEP
+        PRAGMA_VECTOR_ALWAYS
+        for (size_t i = 0; i < nRowsC; i++)
+        {
+            for (size_t j = 0; j < nColsC; j++)
+            {
+                res[i * nColsC + j] = aa[i] + bb[j] - 2 * res[i * nColsC + j];
+            }
+        }
+
+        return services::Status();
+    }
+
+    // output:  Row-major matrix of size { aSize x bSize }
+    virtual services::Status computeBatch(size_t aOffset, size_t aSize, size_t bOffset, size_t bSize, FPType * const res)
+    {
+        ReadRows<FPType, cpu> aDataRows(const_cast<NumericTable *>(&_a), aOffset, aSize);
+        DAAL_CHECK_BLOCK_STATUS(aDataRows);
+        const FPType * const aData = aDataRows.get();
+
+        ReadRows<FPType, cpu> bDataRows(const_cast<NumericTable *>(&_b), bOffset, bSize);
+        DAAL_CHECK_BLOCK_STATUS(bDataRows);
+        const FPType * const bData = bDataRows.get();
+
+        return computeBatch(aData, bData, aOffset, aSize, bOffset, bSize, res);
+    }
+
+    // output:  Row-major matrix of size { nrows(A) x nrows(B) }
+    virtual services::Status computeFull(FPType * const res)
+    {
+        SafeStatus safeStat;
+
+        const size_t nRowsA    = _a.getNumberOfRows();
+        const size_t blockSize = 256;
+        const size_t nBlocks   = nRowsA / blockSize + (nRowsA % blockSize > 0);
+
+        daal::threader_for(nBlocks, nBlocks, [&](size_t iBlock) {
+            const size_t i1    = iBlock * blockSize;
+            const size_t i2    = (iBlock + 1 == nBlocks ? nRowsA : i1 + blockSize);
+            const size_t iSize = i2 - i1;
+
+            const size_t nRowsB = _b.getNumberOfRows();
+
+            DAAL_CHECK_STATUS_THR(computeBatch(i1, iSize, 0, nRowsB, res + i1 * nRowsB));
+        });
+
+        return safeStat.detach();
+    }
+
+protected:
+    // compute (sum(A^2, 2))
+    services::Status computeNorm(const NumericTable & ntData, FPType * const res)
+    {
+        const size_t nRows = ntData.getNumberOfRows();
+        const size_t nCols = ntData.getNumberOfColumns();
+
+        const size_t blockSize = 512;
+        const size_t nBlocks   = nRows / blockSize + !!(nRows % blockSize);
+
+        SafeStatus safeStat;
+
+        daal::threader_for(nBlocks, nBlocks, [&](size_t iBlock) {
+            size_t begin = iBlock * blockSize;
+            size_t end   = services::internal::min<cpu, size_t>(begin + blockSize, nRows);
+
+            ReadRows<FPType, cpu> dataRows(const_cast<NumericTable &>(ntData), begin, end - begin);
+            DAAL_CHECK_BLOCK_STATUS_THR(dataRows);
+            const FPType * const data = dataRows.get();
+
+            FPType * r = res + begin;
+
+            for (size_t i = 0; i < end - begin; i++)
+            {
+                FPType sum = FPType(0);
+                PRAGMA_IVDEP
+                PRAGMA_ICC_NO16(omp simd reduction(+ : sum))
+                for (size_t j = 0; j < nCols; j++)
+                {
+                    sum += data[i * nCols + j] * data[i * nCols + j];
+                }
+                r[i] = sum;
+            }
+        });
+
+        return safeStat.detach();
+    }
+
+    // compute (A x B')
+    void computeABt(const FPType * const a, const FPType * const b, const size_t nRowsA, const size_t nColsA, const size_t nRowsB, FPType * const out)
+    {
+        const char transa    = 't';
+        const char transb    = 'n';
+        const DAAL_INT _m    = nRowsB;
+        const DAAL_INT _n    = nRowsA;
+        const DAAL_INT _k    = nColsA;
+        const FPType alpha   = 1.0;
+        const DAAL_INT lda   = nColsA;
+        const DAAL_INT ldy   = nColsA;
+        const FPType beta    = 0.0;
+        const DAAL_INT ldaty = nRowsB;
+
+        Blas<FPType, cpu>::xxgemm(&transa, &transb, &_m, &_n, &_k, &alpha, b, &lda, a, &ldy, &beta, out, &ldaty);
+    }
+
+    const NumericTable & _a;
+    const NumericTable & _b;
+
+    TArray<FPType, cpu> normBufferA;
+    TArray<FPType, cpu> normBufferB;
+};
 
 } // namespace internal
 } // namespace algorithms

--- a/cpp/daal/src/services/service_defines.h
+++ b/cpp/daal/src/services/service_defines.h
@@ -293,6 +293,20 @@ typedef union
 #endif
 
 #if defined(_MSC_VER)
+    #define DAAL_FORCEINLINE   __forceinline
+    #define DAAL_FORCENOINLINE __declspec(noinline)
+#else
+    #define DAAL_FORCEINLINE   inline __attribute__((always_inline))
+    #define DAAL_FORCENOINLINE __attribute__((noinline))
+#endif
+
+#if defined(_MSC_VER) && (_MSC_VER < 1900)
+    #define DAAL_ALIGNAS(n) __declspec(align(n))
+#else
+    #define DAAL_ALIGNAS(n) alignas(n)
+#endif
+
+#if defined(_MSC_VER)
     #define DAAL_PACKED_STRUCT(...) __pragma(pack(push, 1)) __VA_ARGS__ __pragma(pack(pop))
 #else
     #define DAAL_PACKED_STRUCT(...) __VA_ARGS__ __attribute__((packed))


### PR DESCRIPTION

Speedup relies on dimensions highly, but here are some numbers just for reference:

100k rows x nFeatures | master, ms | this PR, ms | Speedup
-- | -- | -- | --
10 | 4100 | 846 | 4.84
50 | 6160 | 1485 | 4.15

Out of scope of this PR:
- noMemSafe mode optimizations
- Distributed mode optimizations

it's quite easy to do, but need to allocate additional time for this.