### PR TITLE
[mnt] fix observationsPerTreeFraction in GBT regression

### DIFF
--- a/algorithms/kernel/dtrees/gbt/gbt_train_dense_default_impl.i
+++ b/algorithms/kernel/dtrees/gbt/gbt_train_dense_default_impl.i
@@ -307,6 +307,7 @@ services::Status TrainBatchTaskBase<algorithmFPType, BinIndexType, cpu>::run(gbt
 template <typename algorithmFPType, typename BinIndexType, CpuType cpu>
 void TrainBatchTaskBase<algorithmFPType, BinIndexType, cpu>::updateOOB(size_t iTree, TreeType & t)
 {
+    const double res      = _initialF;
     const auto aSampleToF = _aSampleToF.get();
     auto pf               = f();
     const size_t n        = _aSampleToF.size();
@@ -317,7 +318,8 @@ void TrainBatchTaskBase<algorithmFPType, BinIndexType, cpu>::updateOOB(size_t iT
         auto pNode = dtrees::prediction::internal::findNode<algorithmFPType, TreeType, cpu>(t, x.get());
         DAAL_ASSERT(pNode);
         algorithmFPType inc = TreeType::NodeType::castLeaf(pNode)->response;
-        pf[iRow * _nTrees + iTree] += inc;
+        // pf buffer was already initialized by _initialF before first iteration
+        pf[iRow * _nTrees + iTree] += inc - res;
     });
 }
 


### PR DESCRIPTION
We found that using observationsPerTreeFraction <1.0 leads to some very wrong predictions.
After some research, it became clear that the reason for this is incorrectly built trees.
At the first iteration, the initial estimation of y is initialized by single value: sum (column) / nRows.
The final step is updating the values ​​of this estimation for OOB objects. At the first iteration, this value is obtained sum (column) / nRows + inc. This leads to a very large value of OOB objects, which leads to the incorrect construction of subsequent trees.
I believe that the best way to fix this is to initialize the current estimation of y for OOB objects with zeros in the first iteration.