### PR TITLE
MPI samples launcher fix for VS2017 [beta 08 rls]

### DIFF
--- a/samples/daal/cpp/mpi/launcher.bat
+++ b/samples/daal/cpp/mpi/launcher.bat
@@ -73,10 +73,8 @@ setlocal enabledelayedexpansion enableextensions
 for %%T in (%MPI_SAMPLE_LIST%) do (
 
     if not "%RMODE%"=="run" (
-        echo call mpiicc -c %CFLAGS% %MPI_CPP_PATH%\%%T.cpp %LIB_DAAL% -Fo%RESULT_DIR%\%%T.obj 2>&1 >> %MPI_LOGFILE%
-        call mpiicc -c %CFLAGS% %MPI_CPP_PATH%\%%T.cpp %LIB_DAAL% -Fo%RESULT_DIR%\%%T.obj 2>&1 >> %MPI_LOGFILE%
-        echo call mpiicc %LFLAGS% %RESULT_DIR%\%%T.obj %LFLAGS_DAAL% -Fe%RESULT_DIR%\%%T.exe 2>&1 >> %MPI_LOGFILE%
-        call mpiicc %LFLAGS% %RESULT_DIR%\%%T.obj %LFLAGS_DAAL% -Fe%RESULT_DIR%\%%T.exe 2>&1 >> %MPI_LOGFILE%
+        echo call mpiicc %CFLAGS% %MPI_CPP_PATH%\%%T.cpp -Fo%RESULT_DIR%\%%T.obj %LFLAGS_DAAL% -Fe%RESULT_DIR%\%%T.exe 2>&1 >> %MPI_LOGFILE%
+        call mpiicc %CFLAGS% %MPI_CPP_PATH%\%%T.cpp -Fo%RESULT_DIR%\%%T.obj %LFLAGS_DAAL% -Fe%RESULT_DIR%\%%T.exe 2>&1 >> %MPI_LOGFILE%
         echo call mpiicc %LFLAGS% %RESULT_DIR%\%%T.obj %LFLAGS_DAAL_DLL% -Fe%RESULT_DIR%\%%T_dll.exe 2>&1 >> %MPI_LOGFILE%
         call mpiicc %LFLAGS% %RESULT_DIR%\%%T.obj %LFLAGS_DAAL_DLL% -Fe%RESULT_DIR%\%%T_dll.exe 2>&1 >> %MPI_LOGFILE%
         del /F /Q %RESULT_DIR%\%%T.obj


### PR DESCRIPTION
# Description
Fix for infinite compilation of MPI samples with oneDAL built by VS2017.

Old line `call mpiicc %LFLAGS% %RESULT_DIR%\%%T.obj %LFLAGS_DAAL% -Fe%RESULT_DIR%\%%T.exe 2>&1 >> %MPI_LOGFILE%` leads to infinite compilation and error 10014 (code -42) on cancelling.

Example of failed job:
http://intel-ci.intel.com/eac15e34-a163-f19a-92ed-8cdcd4b723a1

Successful PCm with changes:
http://intel-ci.intel.com/eac4f9c0-00cd-f13e-8adb-8cdcd4b723a1

Duplicate of https://github.com/oneapi-src/oneDAL/pull/734