### PR TITLE
[beta08] Remove sse3 on mac (#740)

### DIFF
--- a/cpp/daal/src/externals/service_blas_mkl.h
+++ b/cpp/daal/src/externals/service_blas_mkl.h
@@ -38,8 +38,8 @@
 #endif
 
 #if defined(__APPLE__)
-    #define __DAAL_MKL_SSE2  ssse3_
-    #define __DAAL_MKL_SSSE3 ssse3_
+    #define __DAAL_MKL_SSE2  sse42_
+    #define __DAAL_MKL_SSSE3 sse42_
 #else
     #define __DAAL_MKL_SSE2  sse2_
     #define __DAAL_MKL_SSSE3 ssse3_

--- a/cpp/daal/src/externals/service_lapack_mkl.h
+++ b/cpp/daal/src/externals/service_lapack_mkl.h
@@ -38,8 +38,8 @@
 #endif
 
 #if defined(__APPLE__)
-    #define __DAAL_MKL_SSE2  ssse3_
-    #define __DAAL_MKL_SSSE3 ssse3_
+    #define __DAAL_MKL_SSE2  sse42_
+    #define __DAAL_MKL_SSSE3 sse42_
 #else
     #define __DAAL_MKL_SSE2  sse2_
     #define __DAAL_MKL_SSSE3 ssse3_

--- a/cpp/daal/src/externals/service_spblas_mkl.h
+++ b/cpp/daal/src/externals/service_spblas_mkl.h
@@ -38,8 +38,8 @@
 #endif
 
 #if defined(__APPLE__)
-    #define __DAAL_MKL_SSE2  ssse3_
-    #define __DAAL_MKL_SSSE3 ssse3_
+    #define __DAAL_MKL_SSE2  sse42_
+    #define __DAAL_MKL_SSSE3 sse42_
 #else
     #define __DAAL_MKL_SSE2  sse2_
     #define __DAAL_MKL_SSSE3 ssse3_

--- a/cpp/daal/src/externals/service_stat_rng_mkl.h
+++ b/cpp/daal/src/externals/service_stat_rng_mkl.h
@@ -50,9 +50,11 @@
 #if defined(_WIN64) || defined(__x86_64__)
 
     #if defined(__APPLE__)
-        #define __DAAL_MKLVSL_SSE2 u8
+        #define __DAAL_MKLVSL_SSE2  h8
+        #define __DAAL_MKLVSL_SSSE3 h8
     #else
-        #define __DAAL_MKLVSL_SSE2 ex
+        #define __DAAL_MKLVSL_SSE2  ex
+        #define __DAAL_MKLVSL_SSSE3 u8
     #endif
 
     #if (defined(__x86_64__) && !defined(__APPLE__))
@@ -84,7 +86,7 @@
         }                                                                            \
         if (ssse3 == cpu)                                                            \
         {                                                                            \
-            errcode = __DAAL_VSLFN(u8, f_pref, f_name) f_args;                       \
+            errcode = __DAAL_VSLFN(__DAAL_MKLVSL_SSSE3, f_pref, f_name) f_args;      \
         }                                                                            \
         if (sse2 == cpu)                                                             \
         {                                                                            \

--- a/dev/make/cmplr.icc.mk
+++ b/dev/make/cmplr.icc.mk
@@ -44,8 +44,10 @@ link.dynamic.mac.icc = icc
 daaldep.lnx32e.rt.icc = -static-intel
 daaldep.lnx32.rt.icc  = -static-intel
 
-p4_OPT.icc   = $(-Q)$(if $(OS_is_mac),xSSSE3,xSSE2)
-mc_OPT.icc   = $(-Q)xSSSE3
+# p4_OPT.icc   = $(-Q)$(if $(OS_is_mac),xSSSE3,xSSE2)
+p4_OPT.icc   = $(-Q)$(if $(OS_is_mac),xSSE4.2,xSSE2)
+# mc_OPT.icc   = $(-Q)xSSSE3
+mc_OPT.icc   = $(-Q)$(if $(OS_is_mac),xSSE4.2,xSSE3)
 mc3_OPT.icc  = $(-Q)xSSE4.2
 avx_OPT.icc  = $(-Q)xAVX
 avx2_OPT.icc = $(-Q)xCORE-AVX2


### PR DESCRIPTION
* fix of spark and hadoop launcher scripts

* remove tbb deprecated header

* remove ssse3 for mac

* lapack defines for mac fix

* fix other mkl macroses

Co-authored-by: konstantin.nektyagaev @teabagk7 