### PR TITLE
[2020-mnt] Optimization for train_test_split indices shuffling

### DIFF
--- a/externals/service_rng.h
+++ b/externals/service_rng.h
@@ -83,6 +83,11 @@ public:
         return _generators.uniform(n, r, state, a, b, method);
     }
 
+    int uniformBits32(const SizeType n, Type * r, void * state, const int method = __DAAL_RNG_METHOD_UNIFORMBITS32_STD)
+    {
+        return _generators.uniformBits32(n, r, state, method);
+    }
+
     int bernoulli(const SizeType n, Type * r, BaseRNGs<cpu, BaseType> & brng, const double p, const int method = __DAAL_RNG_METHOD_BERNOULLI_ICDF)
     {
         return _generators.bernoulli(n, r, brng.getBrng(), p, method);

--- a/externals/service_rng_mkl.h
+++ b/externals/service_rng_mkl.h
@@ -33,6 +33,7 @@
 #define __DAAL_BRNG_MT19937                   VSL_BRNG_MT19937
 #define __DAAL_BRNG_MCG59                     VSL_BRNG_MCG59
 #define __DAAL_RNG_METHOD_UNIFORM_STD         VSL_RNG_METHOD_UNIFORM_STD
+#define __DAAL_RNG_METHOD_UNIFORMBITS32_STD   0
 #define __DAAL_RNG_METHOD_BERNOULLI_ICDF      VSL_RNG_METHOD_BERNOULLI_ICDF
 #define __DAAL_RNG_METHOD_GAUSSIAN_BOXMULLER  VSL_RNG_METHOD_GAUSSIAN_BOXMULLER
 #define __DAAL_RNG_METHOD_GAUSSIAN_BOXMULLER2 VSL_RNG_METHOD_GAUSSIAN_BOXMULLER2
@@ -189,6 +190,16 @@ int uniformRNG(const size_t n, double * r, void * stream, const double a, const 
     int nn      = (int)n;
     double * rr = r;
     __DAAL_VSLFN_CALL_NR_WHILE(fpk_vsl_kernel, dRngUniform, (method, stream, nn, rr, a, b), errcode);
+    return errcode;
+}
+
+template <CpuType cpu>
+int uniformBits32RNG(const size_t n, unsigned int * r, void * stream, const int method)
+{
+    int errcode       = 0;
+    int nn            = (int)n;
+    unsigned int * rr = r;
+    __DAAL_VSLFN_CALL_NR_WHILE(fpk_vsl_kernel, iRngUniformBits32, (method, stream, nn, rr), errcode);
     return errcode;
 }
 
@@ -360,6 +371,8 @@ public:
     {
         return uniformRNG<cpu>(n, r, state, a, b, method);
     }
+
+    int uniformBits32(const SizeType n, Type * r, void * state, const int method) { return uniformBits32RNG<cpu>(n, r, state, method); }
 
     int bernoulli(const SizeType n, Type * r, BaseType & brng, const double p, const int method)
     {

--- a/include/data_management/data/internal/train_test_split.h
+++ b/include/data_management/data/internal/train_test_split.h
@@ -28,6 +28,9 @@ namespace data_management
 namespace internal
 {
 template <typename IdxType>
+DAAL_EXPORT void generateShuffledIndices(const NumericTablePtr & idxTable, const NumericTablePtr & rngStateTable);
+
+template <typename IdxType>
 DAAL_EXPORT void trainTestSplit(const NumericTablePtr & inputTable, const NumericTablePtr & trainTable, const NumericTablePtr & testTable,
                                 const NumericTablePtr & trainIdxTable, const NumericTablePtr & testIdxTable);
 

--- a/service/kernel/data_management/train_test_split.cpp
+++ b/service/kernel/data_management/train_test_split.cpp
@@ -41,8 +41,11 @@ typedef daal::data_management::NumericTable::StorageLayout NTLayout;
 const size_t BLOCK_CONST      = 2048;
 const size_t THREADING_BORDER = 8388608;
 
-const size_t MT19937_NUMBERS        = 624;
-const size_t MT19937_SIZE           = 631;
+// quantity of internal numbers used for generation
+const size_t MT19937_NUMBERS = 624;
+// size of MT19937 RNG stream
+const size_t MT19937_SIZE = 631;
+// start position of internal numbers in stream
 const size_t MT19937_NUMBERS_OFFSET = 5;
 
 size_t genSwapIdx(size_t i, unsigned int * randomNumbers, size_t & rnIdx)
@@ -84,6 +87,8 @@ services::Status generateRandomNumbers(const int * rngState, unsigned int * rand
 
     if (nSkip != 0) baseRng.skipAhead(nSkip);
 
+    // last 16 random numbers are different than from reference algorithm
+    // workaround: generate additional 16 ending elements and drop them later
     daal::services::internal::TArray<unsigned int, cpu> tmpArr(n + 16);
     unsigned int * tmp = tmpArr.get();
     DAAL_CHECK_MALLOC(tmp);

--- a/service/kernel/data_management/train_test_split.cpp
+++ b/service/kernel/data_management/train_test_split.cpp
@@ -27,6 +27,8 @@
 #include "service/kernel/data_management/service_numeric_table.h"
 #include "data_management/features/defines.h"
 #include "algorithms/kernel/service_error_handling.h"
+#include "externals/service_rng.h"
+#include "externals/service_rng_mkl.h"
 
 namespace daal
 {
@@ -38,6 +40,134 @@ typedef daal::data_management::NumericTable::StorageLayout NTLayout;
 
 const size_t BLOCK_CONST      = 2048;
 const size_t THREADING_BORDER = 8388608;
+
+const size_t MT19937_NUMBERS        = 624;
+const size_t MT19937_SIZE           = 631;
+const size_t MT19937_NUMBERS_OFFSET = 5;
+
+size_t genSwapIdx(size_t i, unsigned int * randomNumbers, size_t & rnIdx)
+{
+    uint32_t bitMask = i;
+    bitMask |= bitMask >> 1;
+    bitMask |= bitMask >> 2;
+    bitMask |= bitMask >> 4;
+    bitMask |= bitMask >> 8;
+    bitMask |= bitMask >> 16;
+
+    size_t j = randomNumbers[rnIdx] & bitMask;
+    while (j > i)
+    {
+        ++rnIdx;
+        j = randomNumbers[rnIdx] & bitMask;
+    }
+    ++rnIdx;
+    return j;
+}
+
+template <daal::CpuType cpu>
+services::Status generateRandomNumbers(const int * rngState, unsigned int * randomNumbers, const size_t nSkip, const size_t n)
+{
+    // initialize baseRNG
+    daal::internal::mkl::BaseRNG<cpu> baseRng(0, VSL_BRNG_MT19937);
+    // check that it has correct size
+    DAAL_CHECK(baseRng.getStateSize() / 4 == MT19937_SIZE, daal::services::ErrorEngineNotSupported);
+    daal::services::internal::TArray<unsigned int, cpu> baseRngStateArr(baseRng.getStateSize() / 4);
+    unsigned int * baseRngState = baseRngStateArr.get();
+    DAAL_CHECK_MALLOC(baseRngState);
+    baseRng.saveState(baseRngState);
+    // copy input state numbers to baseRNG
+    services::internal::daal_memcpy_s(baseRngState + MT19937_NUMBERS_OFFSET, MT19937_NUMBERS * sizeof(unsigned int), rngState,
+                                      MT19937_NUMBERS * sizeof(unsigned int));
+
+    baseRng.loadState(baseRngState);
+    daal::internal::RNGs<unsigned int, cpu> rng;
+
+    if (nSkip != 0) baseRng.skipAhead(nSkip);
+
+    daal::services::internal::TArray<unsigned int, cpu> tmpArr(n + 16);
+    unsigned int * tmp = tmpArr.get();
+    DAAL_CHECK_MALLOC(tmp);
+
+    rng.uniformBits32(n + 16, tmp, baseRng.getState());
+
+    for (size_t i = 0; i < n; ++i) randomNumbers[nSkip + i] = tmp[i];
+
+    return services::Status();
+}
+
+template <typename IdxType, daal::CpuType cpu>
+services::Status generateShuffledIndicesImpl(const NumericTablePtr & idxTable, const NumericTablePtr & rngStateTable)
+{
+    daal::SafeStatus s;
+    const size_t nThreads  = threader_get_threads_number();
+    const size_t n         = idxTable->getNumberOfRows();
+    const size_t stateSize = rngStateTable->getNumberOfRows();
+    // number of generated uints: 1.5x of n for reserve
+    const size_t nRandomUInts = n * 3 / 2;
+
+    daal::internal::WriteColumns<IdxType, cpu> idxBlock(*idxTable, 0, 0, n);
+    IdxType * idx = idxBlock.get();
+    DAAL_CHECK_MALLOC(idx);
+
+    // check that input RNG state has needed quantity of state numbers
+    DAAL_CHECK(stateSize == MT19937_NUMBERS, daal::services::ErrorIncorrectSizeOfInputNumericTable);
+
+    daal::internal::ReadColumns<int, cpu> rngStateBlock(*rngStateTable, 0, 0, stateSize);
+    const int * rngState = rngStateBlock.get();
+    DAAL_CHECK_MALLOC(rngState);
+
+    daal::services::internal::TArray<unsigned int, cpu> randomUIntsArr(nRandomUInts);
+    unsigned int * randomUInts = randomUIntsArr.get();
+    DAAL_CHECK_MALLOC(randomUInts);
+
+    const size_t rngBlockSize = 16 * BLOCK_CONST;
+    const size_t nRngBlocks   = nRandomUInts / rngBlockSize + !!(nRandomUInts % rngBlockSize);
+
+    if (nThreads > 1 && nRandomUInts > THREADING_BORDER / 16)
+    {
+        daal::threader_for(nRngBlocks, nRngBlocks, [&](size_t iBlock) {
+            const size_t start = iBlock * rngBlockSize;
+            const size_t end   = daal::services::internal::min<cpu, size_t>(start + rngBlockSize, nRandomUInts);
+
+            s |= generateRandomNumbers<cpu>(rngState, randomUInts, start, end - start);
+        });
+    }
+    else
+    {
+        s |= generateRandomNumbers<cpu>(rngState, randomUInts, 0, nRandomUInts);
+    }
+
+    for (size_t i = 0; i < n; ++i)
+    {
+        idx[i] = i;
+    }
+
+    size_t iIdx = 0;
+    for (size_t i = n - 1; i > 0; --i)
+    {
+        size_t j = genSwapIdx(i, randomUInts, iIdx);
+        daal::services::internal::swap<cpu, IdxType>(idx[i], idx[j]);
+    }
+
+    return s.detach();
+}
+
+template <typename IdxType>
+void generateShuffledIndicesDispImpl(const NumericTablePtr & idxTable, const NumericTablePtr & rngStateTable)
+{
+#define DAAL_GENERATE_INDICES(cpuId, ...) generateShuffledIndicesImpl<IdxType, cpuId>(__VA_ARGS__);
+    DAAL_DISPATCH_FUNCTION_BY_CPU(DAAL_GENERATE_INDICES, idxTable, rngStateTable);
+#undef DAAL_GENERATE_INDICES
+}
+
+template <typename IdxType>
+DAAL_EXPORT void generateShuffledIndices(const NumericTablePtr & idxTable, const NumericTablePtr & rngStateTable)
+{
+    DAAL_SAFE_CPU_CALL((generateShuffledIndicesDispImpl<IdxType>(idxTable, rngStateTable)),
+                       (generateShuffledIndicesImpl<IdxType, daal::CpuType::sse2>(idxTable, rngStateTable)));
+}
+
+template DAAL_EXPORT void generateShuffledIndices<int>(const NumericTablePtr & idxTable, const NumericTablePtr & rngStateTable);
 
 template <typename DataType, typename IdxType, daal::CpuType cpu>
 services::Status assignColumnValues(const DataType * origDataPtr, const NumericTablePtr & dataTable, const IdxType * idxPtr, const size_t startRow,


### PR DESCRIPTION
# Description
Optimization of indices shuffling for scikit-learn train_test_split function.

Duplication of https://github.com/oneapi-src/oneDAL/pull/677