### PR TITLE
Update reference for example in docs & fix minor mistakes

### DIFF
--- a/docs/source/dev_guide/algorithms/kernel_function/kernel-functions.rst
+++ b/docs/source/dev_guide/algorithms/kernel_function/kernel-functions.rst
@@ -88,7 +88,7 @@ The linear kernel function has the following parameters:
        + defaultDense - default performance-oriented method
        + fastCSR - performance-oriented method for CSR numeric tables
 
-   * - ComputationMode
+   * - computationMode
      - matrixMatrix
      - Computation mode for the kernel function. Can be:
 
@@ -114,10 +114,10 @@ The linear kernel function has the following parameters:
      - :math:`0`
      - Row index in the values numeric table to locate the result of the computation for the vectorVector computation mode.
    * - :math:`k`
-     - :math:`1`
+     - :math:`1.0`
      - The coefficient :math:`k` of the linear kernel.
    * - :math:`b`
-     - :math:`0`
+     - :math:`0.0`
      - The coefficient :math:`b` of the linear kernel.
 
 Algorithm Output
@@ -146,6 +146,10 @@ Examples
 ++++++++
 
 .. tabs::
+
+  .. tab:: DPC++
+    
+    -  :ref:`kernel_func_lin_dense_batch.cpp`
 
   .. tab:: C++
 
@@ -223,7 +227,7 @@ The RBF kernel has the following parameters:
        + defaultDense - default performance-oriented method
        + fastCSR - performance-oriented method for CSR numeric tables
 
-   * - ComputationMode
+   * - computationMode
      - matrixMatrix
      - Computation mode for the kernel function. Can be:
 
@@ -249,7 +253,7 @@ The RBF kernel has the following parameters:
      - :math:`0`
      - Row index in the values numeric table to locate the result of the computation for the vectorVector computation mode.
    * - sigma
-     - :math:`0`
+     - :math:`1.0`
      - The coefficient :math:`\sigma` of the RBF kernel.
 
 Algorithm Output
@@ -277,6 +281,10 @@ Examples
 ********
 
 .. tabs::
+
+  .. tab:: DPC++
+    
+    -  :ref:`kernel_func_rbf_dense_batch.cpp`
 
   .. tab:: C++
 

--- a/docs/source/dev_guide/algorithms/svm/support-vector-machine-classifier.rst
+++ b/docs/source/dev_guide/algorithms/svm/support-vector-machine-classifier.rst
@@ -254,12 +254,12 @@ Examples
     -  :java_example:`SVMTwoClassThunderDenseBatch.java <svm/SVMTwoClassThunderDenseBatch.java>`
     -  :java_example:`SVMTwoClassThunderCSRBatch.java <svm/SVMTwoClassThunderCSRBatch.java>`
 
-  .. tab:: Python*:
+  .. tab:: Python*
 
     Batch Processing:
 
     -  :daal4py_example:`svm_batch.py`
-    -  :daal4py_example:`<sycl/svm_batch.py>`
+    -  :daal4py_example:`sycl/svm_batch.py`
 
 Performance Considerations
 **************************

--- a/docs/source/dev_guide/algorithms/svm/support-vector-machine-classifier.rst
+++ b/docs/source/dev_guide/algorithms/svm/support-vector-machine-classifier.rst
@@ -254,12 +254,12 @@ Examples
     -  :java_example:`SVMTwoClassThunderDenseBatch.java <svm/SVMTwoClassThunderDenseBatch.java>`
     -  :java_example:`SVMTwoClassThunderCSRBatch.java <svm/SVMTwoClassThunderCSRBatch.java>`
 
-.. Python*:
+  .. tab:: Python*:
 
-.. -  sycl/svm_batch.py
-.. -  svm_two_class_dense_batch.py
-.. -  svm_two_class_csr_batch.py
-.. -  svm_two_class_metrics_dense_batch.py
+    Batch Processing:
+
+    -  :daal4py_example:`svm_batch.py`
+    -  :daal4py_example:`<sycl/svm_batch.py>`
 
 Performance Considerations
 **************************

--- a/docs/source/dev_guide/algorithms/svm/support-vector-machine-classifier.rst
+++ b/docs/source/dev_guide/algorithms/svm/support-vector-machine-classifier.rst
@@ -161,6 +161,7 @@ At the training stage, SVM classifier has the following parameters:
        For CPU:
 
         - ``defaultDense`` – Boser method [Boser92]_
+        - ``thunder`` - Thunder method [Wen2018]_
 
        For GPU:
 
@@ -170,7 +171,7 @@ At the training stage, SVM classifier has the following parameters:
      - :math:`2`
      - The number of classes.
    * - ``C``
-     - :math:`1`
+     - :math:`1.0`
      - The upper bound in conditions of the quadratic optimization problem.
    * - ``accuracyThreshold``
      - :math:`0.001`
@@ -248,13 +249,14 @@ Examples
   
     Batch Processing:
 
-    -  :java_example:`SVMTwoClassBoserDenseBatch.java <svm/SVMTwoClasBosersDenseBatch.java>`
+    -  :java_example:`SVMTwoClassBoserDenseBatch.java <svm/SVMTwoClassBoserDenseBatch.java>`
     -  :java_example:`SVMTwoClassBoserCSRBatch.java <svm/SVMTwoClassBoserCSRBatch.java>`
     -  :java_example:`SVMTwoClassThunderDenseBatch.java <svm/SVMTwoClassThunderDenseBatch.java>`
     -  :java_example:`SVMTwoClassThunderCSRBatch.java <svm/SVMTwoClassThunderCSRBatch.java>`
 
 .. Python*:
 
+.. -  sycl/svm_batch.py
 .. -  svm_two_class_dense_batch.py
 .. -  svm_two_class_csr_batch.py
 .. -  svm_two_class_metrics_dense_batch.py
@@ -275,5 +277,3 @@ required to store :math:`n^2` data elements because the algorithm
 does not fully utilize the cache in this case.
 
 .. include:: ../../../opt-notice.rst
-
-

--- a/docs/source/dev_guide/algorithms/svm_multi_class/multi-class-classifier.rst
+++ b/docs/source/dev_guide/algorithms/svm_multi_class/multi-class-classifier.rst
@@ -212,8 +212,8 @@ Examples
     -  :java_example:`SVMMultiClassThunderCSRBatch.java <svm/SVMMultiClassThunderCSRBatch.java>`
     -  :java_example:`SVMMultiClassThunderDenseBatch.java <svm/SVMMultiClassThunderDenseBatch.java>`
 
-.. Python*:
+  .. tab:: Python*:
 
-.. -  svm_multi_class_dense_batch.py
-.. -  svm_multi_class_csr_batch.py
-.. -  svm_multi_class_metrics_dense_batch.py
+    Batch Processing:
+
+    -  :daal4py_example:`svm_multiclass_batch.py`

--- a/docs/source/dev_guide/algorithms/svm_multi_class/multi-class-classifier.rst
+++ b/docs/source/dev_guide/algorithms/svm_multi_class/multi-class-classifier.rst
@@ -212,7 +212,7 @@ Examples
     -  :java_example:`SVMMultiClassThunderCSRBatch.java <svm/SVMMultiClassThunderCSRBatch.java>`
     -  :java_example:`SVMMultiClassThunderDenseBatch.java <svm/SVMMultiClassThunderDenseBatch.java>`
 
-  .. tab:: Python*:
+  .. tab:: Python*
 
     Batch Processing:
 

--- a/docs/source/dev_guide/algorithms/svm_multi_class/multi-class-classifier.rst
+++ b/docs/source/dev_guide/algorithms/svm_multi_class/multi-class-classifier.rst
@@ -198,19 +198,22 @@ Examples
 
     Batch Processing:
 
-    -  :cpp_example:`svm_multi_class_dense_batch.cpp <svm/svm_multi_class_dense_batch.cpp>`
-    -  :cpp_example:`svm_multi_class_csr_batch.cpp <svm/svm_multi_class_csr_batch.cpp>`
+    -  :cpp_example:`svm_multi_class_boser_csr_batch.cpp <svm/svm_multi_class_boser_csr_batch.cpp>`
+    -  :cpp_example:`svm_multi_class_boser_dense_batch.cpp <svm/svm_multi_class_boser_dense_batch.cpp>`
+    -  :cpp_example:`svm_multi_class_thunder_csr_batch.cpp <svm/svm_multi_class_thunder_csr_batch.cpp>`
+    -  :cpp_example:`svm_multi_class_thunder_dense_batch.cpp <svm/svm_multi_class_thunder_dense_batch.cpp>`
 
   .. tab:: Java*
-
+  
     Batch Processing:
-    
-    -  :java_example:`SVMMultiClassDenseBatch.java <svm/SVMMultiClassDenseBatch.java>`
-    -  :java_example:`SVMMultiClassCSRBatch.java <svm/SVMMultiClassCSRBatch.java>`
+
+    -  :java_example:`SVMMultiClassBoserCSRBatch.java <svm/SVMMultiClassBoserCSRBatch.java>`
+    -  :java_example:`SVMMultiClassBoserDenseBatch.java <svm/SVMMultiClassBoserDenseBatch.java>`
+    -  :java_example:`SVMMultiClassThunderCSRBatch.java <svm/SVMMultiClassThunderCSRBatch.java>`
+    -  :java_example:`SVMMultiClassThunderDenseBatch.java <svm/SVMMultiClassThunderDenseBatch.java>`
 
 .. Python*:
 
 .. -  svm_multi_class_dense_batch.py
 .. -  svm_multi_class_csr_batch.py
 .. -  svm_multi_class_metrics_dense_batch.py
-


### PR DESCRIPTION
1. Update reference for multiclass & svm for example
2. Add reference dpc++ examples for Kernel Functions
3. Add info for thunder method for CPU
4. Fix name typo `ComputationMode`->`computationMode` for Kernel Functions and default parameter `sigma=0`->`sigma=1.0` (mathematically `sigma` cannot be 0) for RBF. Need apply same here: [DevGuide](https://software.intel.com/content/www/us/en/develop/documentation/daal-programming-guide/top/algorithms/analysis/kernel-functions/radial-basis-function-kernel/batch-processing-19.html)
5. Add daal4py examples for SVM