### PR TITLE
Modifying the input check for normEqDense for linear regression 

### DIFF
--- a/cpp/daal/src/algorithms/linear_regression/linear_regression_training_input.cpp
+++ b/cpp/daal/src/algorithms/linear_regression/linear_regression_training_input.cpp
@@ -90,7 +90,7 @@ services::Status Input::check(const daal::algorithms::Parameter * par, int metho
     size_t nColumnsInData     = dataTable->getNumberOfColumns();
     if (method == normEqDense)
     {
-        DAAL_CHECK(nRowsInData >= nColumnsInData + (int)(parameter->interceptFlag == true), ErrorIncorrectNumberOfRows);
+        DAAL_CHECK(nRowsInData >= nColumnsInData, ErrorIncorrectNumberOfRows);
     }
     else
     {


### PR DESCRIPTION
condition for normEqDense has changed,  so no need to add interceptFlag.