### PR TITLE
Fix count subvectors for multiclass SVM for CSR data

### DIFF
--- a/cpp/daal/src/algorithms/multiclassclassifier/multiclassclassifier_predict_votebased_impl.i
+++ b/cpp/daal/src/algorithms/multiclassclassifier/multiclassclassifier_predict_votebased_impl.i
@@ -273,10 +273,9 @@ protected:
 
 private:
     SubTaskVoteBasedCSR(size_t nClasses, size_t nRows, const SharedPtr<ClsType> & simplePrediction, bool & valid)
-        : super(nClasses, nRows, simplePrediction, valid), _rowOffsets(nRows + 1)
+        : super(nClasses, nRows, simplePrediction, valid)
     {}
 
-    TArrayScalable<size_t, cpu> _rowOffsets;
     ReadRowsCSR<algorithmFPType, cpu> _xRows;
 };
 

--- a/cpp/daal/src/algorithms/multiclassclassifier/multiclassclassifier_predict_votebased_impl.i
+++ b/cpp/daal/src/algorithms/multiclassclassifier/multiclassclassifier_predict_votebased_impl.i
@@ -76,7 +76,7 @@ public:
 
         PRAGMA_IVDEP
         PRAGMA_VECTOR_ALWAYS
-        for (size_t i = 0; i < _nClasses * nRows; i++)
+        for (size_t i = 0; i < _nClasses * nRows; ++i)
         {
             votes[i] = 0;
         }
@@ -89,9 +89,9 @@ public:
             if (nRows != _yTable->getNumberOfRows()) _yTable->resize(nRows);
 
             /* TODO: Try threading here */
-            for (size_t iClass = 1, imodel = 0; iClass < _nClasses; iClass++)
+            for (size_t iClass = 1, imodel = 0; iClass < _nClasses; ++iClass)
             {
-                for (size_t jClass = 0; jClass < iClass; jClass++, imodel++)
+                for (size_t jClass = 0; jClass < iClass; ++jClass, ++imodel)
                 {
                     /* Compute two-class predictions for the pair of classes (iClass, jClass)
                        for the block of input observations */
@@ -106,7 +106,7 @@ public:
                     /* Compute votes for the block of input observations */
                     PRAGMA_IVDEP
                     PRAGMA_VECTOR_ALWAYS
-                    for (size_t i = 0; i < nRows; i++)
+                    for (size_t i = 0; i < nRows; ++i)
                     {
                         if (y[i] >= 0)
                             votes[i * _nClasses + iClass]++;
@@ -266,9 +266,12 @@ protected:
         size_t * const cols            = const_cast<size_t *>(_xRows.cols());
         Status s;
         const size_t * const rows = _xRows.rows();
-        if (!values || !cols || !rows) s |= services::Status(services::ErrorMemoryAllocationFailed);
+        if (!values || !cols || !rows)
+        {
+            s |= services::Status(services::ErrorMemoryAllocationFailed);
+        }
         _rowOffsets[0] = 1;
-        for (size_t i = 0; i < nRows; i++)
+        for (size_t i = 0; i < nRows; ++i)
         {
             const size_t nNonZeroValuesInRow = rows[i + 1] - rows[i];
             _rowOffsets[i + 1]               = _rowOffsets[i] + nNonZeroValuesInRow;

--- a/cpp/daal/src/algorithms/multiclassclassifier/multiclassclassifier_predict_votebased_impl.i
+++ b/cpp/daal/src/algorithms/multiclassclassifier/multiclassclassifier_predict_votebased_impl.i
@@ -259,25 +259,15 @@ public:
 protected:
     Status getDataBlock(size_t startRow, size_t nRows, const NumericTable * a, NumericTablePtr & xTable) DAAL_C11_OVERRIDE
     {
-        _xRows.set(dynamic_cast<CSRNumericTableIface *>(const_cast<NumericTable *>(a)), startRow, nRows);
+        const bool toOneBaseRowIndices = true;
+        _xRows.set(dynamic_cast<CSRNumericTableIface *>(const_cast<NumericTable *>(a)), startRow, nRows, toOneBaseRowIndices);
         DAAL_CHECK_BLOCK_STATUS(_xRows);
 
         algorithmFPType * const values = const_cast<algorithmFPType *>(_xRows.values());
         size_t * const cols            = const_cast<size_t *>(_xRows.cols());
+        size_t * const rows            = const_cast<size_t *>(_xRows.rows());
         Status s;
-        const size_t * const rows = _xRows.rows();
-        if (!values || !cols || !rows)
-        {
-            s |= services::Status(services::ErrorMemoryAllocationFailed);
-        }
-        _rowOffsets[0] = 1;
-        for (size_t i = 0; i < nRows; ++i)
-        {
-            const size_t nNonZeroValuesInRow = rows[i + 1] - rows[i];
-            _rowOffsets[i + 1]               = _rowOffsets[i] + nNonZeroValuesInRow;
-        }
-
-        xTable = CSRNumericTable::create(values, cols, _rowOffsets.get(), a->getNumberOfColumns(), nRows, CSRNumericTableIface::oneBased, &s);
+        xTable = CSRNumericTable::create(values, cols, rows, a->getNumberOfColumns(), nRows, CSRNumericTableIface::oneBased, &s);
         return s;
     }
 

--- a/cpp/daal/src/algorithms/multiclassclassifier/multiclassclassifier_train_oneagainstone_impl.i
+++ b/cpp/daal/src/algorithms/multiclassclassifier/multiclassclassifier_train_oneagainstone_impl.i
@@ -56,9 +56,9 @@ services::Status MultiClassClassifierTrainKernel<oneAgainstOne, algorithmFPType,
     const MccParType * mccPar = static_cast<const MccParType *>(par);
 
     const size_t nVectors = xTable->getNumberOfRows();
-    ReadColumns<int, cpu> mtY(*const_cast<NumericTable *>(yTable), 0, 0, nVectors);
+    ReadColumns<algorithmFPType, cpu> mtY(*const_cast<NumericTable *>(yTable), 0, 0, nVectors);
     DAAL_CHECK_BLOCK_STATUS(mtY);
-    const int * y = mtY.get();
+    const algorithmFPType * y = mtY.get();
 
     ReadColumns<algorithmFPType, cpu> mtW(const_cast<NumericTable *>(wTable), 0, 0, nVectors);
     DAAL_CHECK_BLOCK_STATUS(mtW);
@@ -133,18 +133,18 @@ services::Status MultiClassClassifierTrainKernel<oneAgainstOne, algorithmFPType,
 
 template <typename algorithmFPType, typename ClsType, typename MccParType, CpuType cpu>
 Status MultiClassClassifierTrainKernel<oneAgainstOne, algorithmFPType, ClsType, MccParType, cpu>::computeDataSize(
-    size_t nVectors, size_t nFeatures, size_t nClasses, const NumericTable * xTable, const int * y, size_t & nSubsetVectors, size_t & dataSize)
+    size_t nVectors, size_t nFeatures, size_t nClasses, const NumericTable * xTable, const algorithmFPType * y, size_t & nSubsetVectors, size_t & dataSize)
 {
     TArray<size_t, cpu> buffer(4 * nClasses);
     DAAL_CHECK_MALLOC(buffer.get());
-    daal::services::internal::service_memset<size_t, cpu>(buffer.get(), 0, buffer.size());
+    daal::services::internal::service_memset_seq<size_t, cpu>(buffer.get(), 0, buffer.size());
     size_t * classLabelsCount        = buffer.get();
     size_t * classNonZeroValuesCount = buffer.get() + nClasses;
     size_t * classDataSize           = buffer.get() + 2 * nClasses;
     size_t * classIndex              = buffer.get() + 3 * nClasses;
     for (size_t i = 0; i < nVectors; i++)
     {
-        classLabelsCount[y[i]]++;
+        classLabelsCount[size_t(y[i])]++;
     }
     if (xTable->getDataLayout() == NumericTableIface::csrArray)
     {
@@ -153,7 +153,7 @@ Status MultiClassClassifierTrainKernel<oneAgainstOne, algorithmFPType, ClsType, 
         DAAL_CHECK_BLOCK_STATUS(_mtX);
         const size_t * rowOffsets = _mtX.rows();
         /* Compute data size needed to store the largest subset of input tables */
-        for (size_t i = 0; i < nVectors; i++) classNonZeroValuesCount[y[i]] += (rowOffsets[i + 1] - rowOffsets[i]);
+        for (size_t i = 0; i < nVectors; i++) classNonZeroValuesCount[size_t(y[i])] += (rowOffsets[i + 1] - rowOffsets[i]);
 
         for (size_t i = 0; i < nClasses; i++)
         {
@@ -163,25 +163,25 @@ Status MultiClassClassifierTrainKernel<oneAgainstOne, algorithmFPType, ClsType, 
 
         daal::algorithms::internal::qSort<size_t, size_t, cpu>(nClasses, classDataSize, classIndex);
         const auto idx1 = classIndex[nClasses - 1], idx2 = classIndex[nClasses - 2];
-        nSubsetVectors = classLabelsCount[idx1] + classLabelsCount[idx2];
         dataSize       = classNonZeroValuesCount[idx1] + classNonZeroValuesCount[idx2];
     }
     else
     {
-        daal::algorithms::internal::qSort<size_t, cpu>(nClasses, classLabelsCount);
-        nSubsetVectors = classLabelsCount[nClasses - 1] + classLabelsCount[nClasses - 2];
         dataSize       = nFeatures * nSubsetVectors;
     }
+    daal::algorithms::internal::qSort<size_t, cpu>(nClasses, classLabelsCount);
+    nSubsetVectors = classLabelsCount[nClasses - 1] + classLabelsCount[nClasses - 2];
+
     return Status();
 }
 
 template <typename algorithmFPType, typename ClsType, CpuType cpu>
 Status SubTaskDense<algorithmFPType, ClsType, cpu>::copyDataIntoSubtable(size_t nFeatures, size_t nVectors, int classIdx, algorithmFPType label,
-                                                                         const int * y, size_t & nRows)
+                                                                         const algorithmFPType * y, size_t & nRows)
 {
     for (size_t ix = 0; ix < nVectors; ix++)
     {
-        if (y[ix] != classIdx) continue;
+        if (size_t(y[ix]) != classIdx) continue;
         _mtX.next(ix, 1);
         DAAL_CHECK_BLOCK_STATUS(_mtX);
         PRAGMA_IVDEP
@@ -199,13 +199,13 @@ Status SubTaskDense<algorithmFPType, ClsType, cpu>::copyDataIntoSubtable(size_t 
 
 template <typename algorithmFPType, typename ClsType, CpuType cpu>
 Status SubTaskCSR<algorithmFPType, ClsType, cpu>::copyDataIntoSubtable(size_t nFeatures, size_t nVectors, int classIdx, algorithmFPType label,
-                                                                       const int * y, size_t & nRows)
+                                                                       const algorithmFPType * y, size_t & nRows)
 {
     _rowOffsetsX[0]  = 1;
     size_t dataIndex = (nRows ? _rowOffsetsX[nRows] - _rowOffsetsX[0] : 0);
     for (size_t ix = 0; ix < nVectors; ix++)
     {
-        if (y[ix] != classIdx) continue;
+        if (size_t(y[ix]) != classIdx) continue;
         _mtX.next(ix, 1);
         DAAL_CHECK_BLOCK_STATUS(_mtX);
         const size_t nNonZeroValuesInRow = _mtX.rows()[1] - _mtX.rows()[0];

--- a/cpp/daal/src/algorithms/multiclassclassifier/multiclassclassifier_train_oneagainstone_impl.i
+++ b/cpp/daal/src/algorithms/multiclassclassifier/multiclassclassifier_train_oneagainstone_impl.i
@@ -165,13 +165,15 @@ Status MultiClassClassifierTrainKernel<oneAgainstOne, algorithmFPType, ClsType, 
         daal::algorithms::internal::qSort<size_t, size_t, cpu>(nClasses, classDataSize, classIndex);
         const auto idx1 = classIndex[nClasses - 1], idx2 = classIndex[nClasses - 2];
         dataSize = classNonZeroValuesCount[idx1] + classNonZeroValuesCount[idx2];
+        daal::algorithms::internal::qSort<size_t, cpu>(nClasses, classLabelsCount);
+        nSubsetVectors = classLabelsCount[nClasses - 1] + classLabelsCount[nClasses - 2];
     }
     else
     {
-        dataSize = nFeatures * nSubsetVectors;
+        daal::algorithms::internal::qSort<size_t, cpu>(nClasses, classLabelsCount);
+        nSubsetVectors = classLabelsCount[nClasses - 1] + classLabelsCount[nClasses - 2];
+        dataSize       = nFeatures * nSubsetVectors;
     }
-    daal::algorithms::internal::qSort<size_t, cpu>(nClasses, classLabelsCount);
-    nSubsetVectors = classLabelsCount[nClasses - 1] + classLabelsCount[nClasses - 2];
 
     return Status();
 }

--- a/cpp/daal/src/algorithms/multiclassclassifier/multiclassclassifier_train_oneagainstone_impl.i
+++ b/cpp/daal/src/algorithms/multiclassclassifier/multiclassclassifier_train_oneagainstone_impl.i
@@ -133,7 +133,8 @@ services::Status MultiClassClassifierTrainKernel<oneAgainstOne, algorithmFPType,
 
 template <typename algorithmFPType, typename ClsType, typename MccParType, CpuType cpu>
 Status MultiClassClassifierTrainKernel<oneAgainstOne, algorithmFPType, ClsType, MccParType, cpu>::computeDataSize(
-    size_t nVectors, size_t nFeatures, size_t nClasses, const NumericTable * xTable, const algorithmFPType * y, size_t & nSubsetVectors, size_t & dataSize)
+    size_t nVectors, size_t nFeatures, size_t nClasses, const NumericTable * xTable, const algorithmFPType * y, size_t & nSubsetVectors,
+    size_t & dataSize)
 {
     TArray<size_t, cpu> buffer(4 * nClasses);
     DAAL_CHECK_MALLOC(buffer.get());
@@ -163,11 +164,11 @@ Status MultiClassClassifierTrainKernel<oneAgainstOne, algorithmFPType, ClsType, 
 
         daal::algorithms::internal::qSort<size_t, size_t, cpu>(nClasses, classDataSize, classIndex);
         const auto idx1 = classIndex[nClasses - 1], idx2 = classIndex[nClasses - 2];
-        dataSize       = classNonZeroValuesCount[idx1] + classNonZeroValuesCount[idx2];
+        dataSize = classNonZeroValuesCount[idx1] + classNonZeroValuesCount[idx2];
     }
     else
     {
-        dataSize       = nFeatures * nSubsetVectors;
+        dataSize = nFeatures * nSubsetVectors;
     }
     daal::algorithms::internal::qSort<size_t, cpu>(nClasses, classLabelsCount);
     nSubsetVectors = classLabelsCount[nClasses - 1] + classLabelsCount[nClasses - 2];

--- a/cpp/daal/src/algorithms/multiclassclassifier/multiclassclassifier_train_oneagainstone_impl.i
+++ b/cpp/daal/src/algorithms/multiclassclassifier/multiclassclassifier_train_oneagainstone_impl.i
@@ -143,9 +143,9 @@ Status MultiClassClassifierTrainKernel<oneAgainstOne, algorithmFPType, ClsType, 
     size_t * classNonZeroValuesCount = buffer.get() + nClasses;
     size_t * classDataSize           = buffer.get() + 2 * nClasses;
     size_t * classIndex              = buffer.get() + 3 * nClasses;
-    for (size_t i = 0; i < nVectors; i++)
+    for (size_t i = 0; i < nVectors; ++i)
     {
-        classLabelsCount[size_t(y[i])]++;
+        ++classLabelsCount[size_t(y[i])];
     }
     if (xTable->getDataLayout() == NumericTableIface::csrArray)
     {
@@ -154,9 +154,12 @@ Status MultiClassClassifierTrainKernel<oneAgainstOne, algorithmFPType, ClsType, 
         DAAL_CHECK_BLOCK_STATUS(_mtX);
         const size_t * rowOffsets = _mtX.rows();
         /* Compute data size needed to store the largest subset of input tables */
-        for (size_t i = 0; i < nVectors; i++) classNonZeroValuesCount[size_t(y[i])] += (rowOffsets[i + 1] - rowOffsets[i]);
+        for (size_t i = 0; i < nVectors; ++i)
+        {
+            classNonZeroValuesCount[size_t(y[i])] += (rowOffsets[i + 1] - rowOffsets[i]);
+        }
 
-        for (size_t i = 0; i < nClasses; i++)
+        for (size_t i = 0; i < nClasses; ++i)
         {
             classDataSize[i] = classLabelsCount[i] + classNonZeroValuesCount[i];
             classIndex[i]    = i;

--- a/cpp/daal/src/algorithms/multiclassclassifier/multiclassclassifier_train_oneagainstone_kernel.h
+++ b/cpp/daal/src/algorithms/multiclassclassifier/multiclassclassifier_train_oneagainstone_kernel.h
@@ -52,7 +52,7 @@ public:
     DAAL_NEW_DELETE();
     virtual ~SubTask() {}
 
-    services::Status getDataSubset(size_t nFeatures, size_t nVectors, int classIdxPositive, int classIdxNegative, const int * y, size_t & nRows)
+    services::Status getDataSubset(size_t nFeatures, size_t nVectors, int classIdxPositive, int classIdxNegative, const algorithmFPType * y, size_t & nRows)
     {
         nRows = 0;
         /* Prepare "positive" observations of the training subset */
@@ -96,7 +96,7 @@ protected:
         if (_weights)
         {
             _subsetW.reset(nSubsetVectors);
-            _subsetWTable = HomogenNT::create(_subsetW.get(), 1, nSubsetVectors, &status);
+            // _subsetWTable = HomogenNT::create(_subsetW.get(), 1, nSubsetVectors, &status);
         }
 
         if (!status) return;
@@ -105,7 +105,7 @@ protected:
 
     bool isValid() const { return _subsetX.get() && _subsetYTable.get() && _simpleTraining.get(); }
 
-    virtual services::Status copyDataIntoSubtable(size_t nFeatures, size_t nVectors, int classIdx, algorithmFPType label, const int * y,
+    virtual services::Status copyDataIntoSubtable(size_t nFeatures, size_t nVectors, int classIdx, algorithmFPType label, const algorithmFPType * y,
                                                   size_t & nRows) = 0;
 
 protected:
@@ -123,6 +123,8 @@ template <typename algorithmFPType, typename ClsType, CpuType cpu>
 class SubTaskCSR : public SubTask<algorithmFPType, ClsType, cpu>
 {
 public:
+    virtual ~SubTaskCSR() DAAL_C11_OVERRIDE {}
+
     typedef SubTask<algorithmFPType, ClsType, cpu> super;
     static SubTaskCSR * create(size_t nFeatures, size_t nSubsetVectors, size_t dataSize, const NumericTable * xTable, const algorithmFPType * weights,
                                const services::SharedPtr<ClsType> & st)
@@ -152,7 +154,7 @@ private:
         }
     }
 
-    virtual services::Status copyDataIntoSubtable(size_t nFeatures, size_t nVectors, int classIdx, algorithmFPType label, const int * y,
+    virtual services::Status copyDataIntoSubtable(size_t nFeatures, size_t nVectors, int classIdx, algorithmFPType label, const algorithmFPType * y,
                                                   size_t & nRows) DAAL_C11_OVERRIDE;
 
 private:
@@ -165,6 +167,8 @@ template <typename algorithmFPType, typename ClsType, CpuType cpu>
 class SubTaskDense : public SubTask<algorithmFPType, ClsType, cpu>
 {
 public:
+    virtual ~SubTaskDense() DAAL_C11_OVERRIDE {}
+
     typedef SubTask<algorithmFPType, ClsType, cpu> super;
     static SubTaskDense * create(size_t nFeatures, size_t nSubsetVectors, size_t dataSize, const NumericTable * xTable,
                                  const algorithmFPType * weights, const services::SharedPtr<ClsType> & st)
@@ -189,7 +193,7 @@ private:
         if (!status) return;
     }
 
-    virtual services::Status copyDataIntoSubtable(size_t nFeatures, size_t nVectors, int classIdx, algorithmFPType label, const int * y,
+    virtual services::Status copyDataIntoSubtable(size_t nFeatures, size_t nVectors, int classIdx, algorithmFPType label, const algorithmFPType * y,
                                                   size_t & nRows) DAAL_C11_OVERRIDE;
 
 private:
@@ -204,7 +208,7 @@ public:
                              const daal::algorithms::Parameter * par);
 
 protected:
-    services::Status computeDataSize(size_t nVectors, size_t nFeatures, size_t nClasses, const NumericTable * xTable, const int * y,
+    services::Status computeDataSize(size_t nVectors, size_t nFeatures, size_t nClasses, const NumericTable * xTable, const algorithmFPType * y,
                                      size_t & nSubsetVectors, size_t & dataSize);
 };
 

--- a/cpp/daal/src/algorithms/multiclassclassifier/multiclassclassifier_train_oneagainstone_kernel.h
+++ b/cpp/daal/src/algorithms/multiclassclassifier/multiclassclassifier_train_oneagainstone_kernel.h
@@ -52,7 +52,8 @@ public:
     DAAL_NEW_DELETE();
     virtual ~SubTask() {}
 
-    services::Status getDataSubset(size_t nFeatures, size_t nVectors, int classIdxPositive, int classIdxNegative, const algorithmFPType * y, size_t & nRows)
+    services::Status getDataSubset(size_t nFeatures, size_t nVectors, int classIdxPositive, int classIdxNegative, const algorithmFPType * y,
+                                   size_t & nRows)
     {
         nRows = 0;
         /* Prepare "positive" observations of the training subset */

--- a/cpp/daal/src/algorithms/multiclassclassifier/multiclassclassifier_train_oneagainstone_kernel.h
+++ b/cpp/daal/src/algorithms/multiclassclassifier/multiclassclassifier_train_oneagainstone_kernel.h
@@ -97,7 +97,7 @@ protected:
         if (_weights)
         {
             _subsetW.reset(nSubsetVectors);
-            // _subsetWTable = HomogenNT::create(_subsetW.get(), 1, nSubsetVectors, &status);
+            _subsetWTable = HomogenNT::create(_subsetW.get(), 1, nSubsetVectors, &status);
         }
 
         if (!status) return;

--- a/cpp/daal/src/data_management/service_numeric_table.h
+++ b/cpp/daal/src/data_management/service_numeric_table.h
@@ -506,6 +506,13 @@ private:
     bool _toReleaseFlag;
 };
 
+using daal::services::internal::TArray;
+using daal::services::internal::TArrayCalloc;
+using daal::services::internal::TArrayScalable;
+using daal::services::internal::TArrayScalableCalloc;
+
+using daal::services::internal::TNArray;
+
 template <typename algorithmFPType, CpuType cpu, typename NumericTableType = NumericTable>
 using ReadRows = GetRows<algorithmFPType, const algorithmFPType, cpu, readOnly, NumericTableType>;
 
@@ -519,26 +526,32 @@ template <typename algorithmFPType, typename algorithmFPAccessType, CpuType cpu,
 class GetRowsCSR
 {
 public:
-    GetRowsCSR(CSRNumericTableIface & data, size_t iStartFrom, size_t nRows) : _data(&data) { getBlock(iStartFrom, nRows); }
-    GetRowsCSR(CSRNumericTableIface * data, size_t iStartFrom, size_t nRows) : _data(data), _toReleaseFlag(false)
+    GetRowsCSR(CSRNumericTableIface & data, size_t iStartFrom, size_t nRows, bool toOneBaseRowIndices = false)
+        : _data(&data), _toReleaseFlag(false), _toOneBaseRowIndices(toOneBaseRowIndices)
+    {
+        getBlock(iStartFrom, nRows);
+    }
+    GetRowsCSR(CSRNumericTableIface * data, size_t iStartFrom, size_t nRows, bool toOneBaseRowIndices = false)
+        : _data(data), _toReleaseFlag(false), _toOneBaseRowIndices(toOneBaseRowIndices)
     {
         if (_data)
         {
             getBlock(iStartFrom, nRows);
         }
     }
-    GetRowsCSR(CSRNumericTableIface * data = nullptr) : _data(data), _toReleaseFlag(false) {}
+    GetRowsCSR(CSRNumericTableIface * data = nullptr) : _data(data), _toReleaseFlag(false), _toOneBaseRowIndices(false) {}
     ~GetRowsCSR() { release(); }
 
     const algorithmFPAccessType * values() const { return _data ? _block.getBlockValuesPtr() : nullptr; }
     const size_t * cols() const { return _data ? _block.getBlockColumnIndicesPtr() : nullptr; }
-    const size_t * rows() const { return _data ? _block.getBlockRowIndicesPtr() : nullptr; }
+    const size_t * rows() const { return _data ? _toOneBaseRowIndices ? _rowOffsets.get() : _block.getBlockRowIndicesPtr() : nullptr; }
     algorithmFPAccessType * values() { return _data ? _block.getBlockValuesPtr() : nullptr; }
     size_t * cols() { return _data ? _block.getBlockColumnIndicesPtr() : nullptr; }
-    size_t * rows() { return _data ? _block.getBlockRowIndicesPtr() : nullptr; }
+    size_t * rows() { return _data ? _toOneBaseRowIndices ? _rowOffsets.get() : _block.getBlockRowIndicesPtr() : nullptr; }
 
-    void next(size_t iStartFrom, size_t nRows)
+    void next(size_t iStartFrom, size_t nRows, const bool toOneBaseRowIndices = false)
     {
+        _toOneBaseRowIndices = toOneBaseRowIndices;
         if (_data)
         {
             if (_toReleaseFlag)
@@ -548,8 +561,9 @@ public:
             getBlock(iStartFrom, nRows);
         }
     }
-    void set(CSRNumericTableIface * data, size_t iStartFrom, size_t nRows)
+    void set(CSRNumericTableIface * data, size_t iStartFrom, size_t nRows, const bool toOneBaseRowIndices = false)
     {
+        _toOneBaseRowIndices = toOneBaseRowIndices;
         release();
         if (data)
         {
@@ -557,6 +571,7 @@ public:
             getBlock(iStartFrom, nRows);
         }
     }
+
     void release()
     {
         if (_toReleaseFlag)
@@ -576,12 +591,29 @@ private:
     {
         _status        = _data->getSparseBlock(iStartFrom, nRows, mode, _block);
         _toReleaseFlag = _status.ok();
+
+        if (_toOneBaseRowIndices)
+        {
+            if (_rowOffsets.size() < nRows + 1)
+            {
+                _rowOffsets.reset(nRows + 1);
+            }
+            const size_t * const rows = _block.getBlockRowIndicesPtr();
+            _rowOffsets[0]            = 1;
+            for (size_t i = 0; i < nRows; ++i)
+            {
+                const size_t nNonZeroValuesInRow = rows[i + 1] - rows[i];
+                _rowOffsets[i + 1]               = _rowOffsets[i] + nNonZeroValuesInRow;
+            }
+        }
     }
 
 private:
     CSRNumericTableIface * _data;
     CSRBlockDescriptor<algorithmFPType> _block;
+    TArray<size_t, cpu> _rowOffsets;
     services::Status _status;
+    bool _toOneBaseRowIndices;
     bool _toReleaseFlag;
 };
 
@@ -722,13 +754,6 @@ using WritePacked = GetPacked<algorithmFPType, algorithmFPType, cpu, readWrite, 
 
 template <typename algorithmFPType, CpuType cpu, typename NumericTableType = NumericTable>
 using WriteOnlyPacked = GetPacked<algorithmFPType, algorithmFPType, cpu, writeOnly, NumericTableType>;
-
-using daal::services::internal::TArray;
-using daal::services::internal::TArrayCalloc;
-using daal::services::internal::TArrayScalable;
-using daal::services::internal::TArrayScalableCalloc;
-
-using daal::services::internal::TNArray;
 
 template <typename algorithmFPType>
 services::Status createSparseTable(const NumericTablePtr & inputTable, CSRNumericTablePtr & resTable);


### PR DESCRIPTION
1. Fix allocation for training CSR multiclass: `nSubsetVectors =classLabelsCount[nClasses - 1] + classLabelsCount[nClasses - 2];`
2. Fix vote predict for CSR multiclass - need to set offset indices between rows correctly