### PR TITLE
moved results_to_compute to [train|infer]_input classes

### DIFF
--- a/cpp/oneapi/dal/algo/decision_forest/backend/cpu/infer_kernel_regression_dense.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/cpu/infer_kernel_regression_dense.cpp
@@ -41,10 +41,11 @@ using rgr_model_p = rgr::ModelPtr;
 template <typename Float, typename Task>
 static infer_result<Task> call_daal_kernel(const context_cpu& ctx,
                                            const descriptor_base<Task>& desc,
-                                           const model<Task>& trained_model,
-                                           const table& data) {
-    const int64_t row_count    = data.get_row_count();
-    const int64_t column_count = data.get_column_count();
+                                           const infer_input<Task>& input) {
+    const model<Task>& trained_model = input.get_model();
+    const table& data                = input.get_data();
+    const int64_t row_count          = data.get_row_count();
+    const int64_t column_count       = data.get_column_count();
 
     auto arr_data = row_accessor<const Float>{ data }.pull();
 
@@ -87,7 +88,7 @@ template <typename Float, typename Task>
 static infer_result<Task> infer(const context_cpu& ctx,
                                 const descriptor_base<Task>& desc,
                                 const infer_input<Task>& input) {
-    return call_daal_kernel<Float, Task>(ctx, desc, input.get_model(), input.get_data());
+    return call_daal_kernel<Float, Task>(ctx, desc, input);
 }
 
 template <typename Float, typename Task>

--- a/cpp/oneapi/dal/algo/decision_forest/backend/cpu/train_kernel_classification_dense.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/cpu/train_kernel_classification_dense.cpp
@@ -51,8 +51,9 @@ using cls_model_p = cls::ModelPtr;
 template <typename Float, typename Task>
 static train_result<Task> call_daal_kernel(const context_cpu& ctx,
                                            const descriptor_base<Task>& desc,
-                                           const table& data,
-                                           const table& labels) {
+                                           const train_input<Task>& input) {
+    const table& data          = input.get_data();
+    const table& labels        = input.get_labels();
     const int64_t row_count    = data.get_row_count();
     const int64_t column_count = data.get_column_count();
 
@@ -84,7 +85,7 @@ static train_result<Task> call_daal_kernel(const context_cpu& ctx,
     daal_parameter.minImpurityDecreaseInSplitNode = desc.get_min_impurity_decrease_in_split_node();
     daal_parameter.maxLeafNodes                   = desc.get_max_leaf_nodes();
 
-    daal_parameter.resultsToCompute = desc.get_train_results_to_compute();
+    daal_parameter.resultsToCompute = input.get_results_to_compute();
 
     auto vimp = desc.get_variable_importance_mode();
 
@@ -95,7 +96,7 @@ static train_result<Task> call_daal_kernel(const context_cpu& ctx,
     auto daal_result = cls::training::Result();
 
     /* init daal result's objects */
-    if (desc.get_train_results_to_compute() &
+    if (input.get_results_to_compute() &
         static_cast<std::uint64_t>(train_result_to_compute::compute_out_of_bag_error)) {
         auto arr_oob_err = array<Float>::empty(1 * 1);
         res.set_oob_err(homogen_table_builder{}.reset(arr_oob_err, 1, 1).build());
@@ -104,7 +105,7 @@ static train_result<Task> call_daal_kernel(const context_cpu& ctx,
         daal_result.set(cls::training::outOfBagError, res_oob_err);
     }
 
-    if (desc.get_train_results_to_compute() &
+    if (input.get_results_to_compute() &
         static_cast<std::uint64_t>(
             train_result_to_compute::compute_out_of_bag_error_per_observation)) {
         auto arr_oob_per_obs_err = array<Float>::empty(row_count * 1);
@@ -136,14 +137,14 @@ static train_result<Task> call_daal_kernel(const context_cpu& ctx,
         daal_parameter));
 
     /* extract results from daal objects */
-    if (desc.get_train_results_to_compute() &
+    if (input.get_results_to_compute() &
         static_cast<std::uint64_t>(train_result_to_compute::compute_out_of_bag_error)) {
         auto table_oob_err = interop::convert_from_daal_homogen_table<Float>(
             daal_result.get(cls::training::outOfBagError));
         res.set_oob_err(table_oob_err);
     }
 
-    if (desc.get_train_results_to_compute() &
+    if (input.get_results_to_compute() &
         static_cast<std::uint64_t>(
             train_result_to_compute::compute_out_of_bag_error_per_observation)) {
         auto table_oob_per_obs_err = interop::convert_from_daal_homogen_table<Float>(
@@ -165,7 +166,7 @@ template <typename Float, typename Task>
 static train_result<Task> train(const context_cpu& ctx,
                                 const descriptor_base<Task>& desc,
                                 const train_input<Task>& input) {
-    return call_daal_kernel<Float>(ctx, desc, input.get_data(), input.get_labels());
+    return call_daal_kernel<Float>(ctx, desc, input);
 }
 
 template <typename Float, typename Task>

--- a/cpp/oneapi/dal/algo/decision_forest/backend/gpu/train_kernel_classification_hist_dpc.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/gpu/train_kernel_classification_hist_dpc.cpp
@@ -52,9 +52,10 @@ using cls_model_p = cls::ModelPtr;
 template <typename Float, typename Task>
 static train_result<Task> call_daal_kernel(const context_gpu& ctx,
                                            const descriptor_base<Task>& desc,
-                                           const table& data,
-                                           const table& labels) {
-    auto& queue = ctx.get_queue();
+                                           const train_input<Task>& input) {
+    const table& data   = input.get_data();
+    const table& labels = input.get_labels();
+    auto& queue         = ctx.get_queue();
     interop::execution_context_guard guard(queue);
 
     const int64_t row_count    = data.get_row_count();
@@ -89,7 +90,7 @@ static train_result<Task> call_daal_kernel(const context_gpu& ctx,
     daal_parameter.minImpurityDecreaseInSplitNode = desc.get_min_impurity_decrease_in_split_node();
     daal_parameter.maxLeafNodes                   = desc.get_max_leaf_nodes();
 
-    daal_parameter.resultsToCompute = desc.get_train_results_to_compute();
+    daal_parameter.resultsToCompute = input.get_results_to_compute();
 
     auto vimp = desc.get_variable_importance_mode();
 
@@ -101,7 +102,7 @@ static train_result<Task> call_daal_kernel(const context_gpu& ctx,
 
     /* init daal result's objects */
     array<Float> arr_oob_err;
-    if (desc.get_train_results_to_compute() &
+    if (input.get_results_to_compute() &
         static_cast<std::uint64_t>(train_result_to_compute::compute_out_of_bag_error)) {
         arr_oob_err = array<Float>::empty(1 * 1);
 
@@ -111,7 +112,7 @@ static train_result<Task> call_daal_kernel(const context_gpu& ctx,
     }
 
     array<Float> arr_oob_per_obs_err;
-    if (desc.get_train_results_to_compute() &
+    if (input.get_results_to_compute() &
         static_cast<std::uint64_t>(
             train_result_to_compute::compute_out_of_bag_error_per_observation)) {
         arr_oob_per_obs_err = array<Float>::empty(queue, row_count * 1);
@@ -142,11 +143,11 @@ static train_result<Task> call_daal_kernel(const context_gpu& ctx,
 
     /* extract results from daal objects */
 
-    if (desc.get_train_results_to_compute() &
+    if (input.get_results_to_compute() &
         static_cast<std::uint64_t>(train_result_to_compute::compute_out_of_bag_error)) {
         res.set_oob_err(homogen_table_builder{}.reset(arr_oob_err, 1, 1).build());
     }
-    if (desc.get_train_results_to_compute() &
+    if (input.get_results_to_compute() &
         static_cast<std::uint64_t>(
             train_result_to_compute::compute_out_of_bag_error_per_observation)) {
         res.set_oob_per_observation_err(
@@ -164,7 +165,7 @@ template <typename Float, typename Task>
 static train_result<Task> train(const context_gpu& ctx,
                                 const descriptor_base<Task>& desc,
                                 const train_input<Task>& input) {
-    return call_daal_kernel<Float>(ctx, desc, input.get_data(), input.get_labels());
+    return call_daal_kernel<Float>(ctx, desc, input);
 }
 
 template <typename Float, typename Task>

--- a/cpp/oneapi/dal/algo/decision_forest/common.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/common.cpp
@@ -35,10 +35,6 @@ public:
     std::int64_t min_observations_in_split_node = 2;
     std::int64_t max_leaf_nodes                 = 0;
 
-    std::uint64_t train_results_to_compute = 0;
-    std::uint64_t infer_results_to_compute =
-        static_cast<std::uint64_t>(infer_result_to_compute::compute_class_labels);
-
     bool memory_saving_mode = false;
     bool bootstrap          = true;
 
@@ -61,10 +57,6 @@ public:
     std::int64_t min_observations_in_leaf_node  = 5;
     std::int64_t min_observations_in_split_node = 2;
     std::int64_t max_leaf_nodes                 = 0;
-
-    std::uint64_t train_results_to_compute = 0;
-    std::uint64_t infer_results_to_compute =
-        static_cast<std::uint64_t>(infer_result_to_compute::compute_class_labels);
 
     bool memory_saving_mode = false;
     bool bootstrap          = true;
@@ -125,16 +117,6 @@ template <typename Task>
 std::int64_t descriptor_base<Task>::get_max_leaf_nodes() const {
     return impl_->max_leaf_nodes;
 }
-
-template <typename Task>
-std::uint64_t descriptor_base<Task>::get_train_results_to_compute() const {
-    return impl_->train_results_to_compute;
-}
-template <typename Task>
-std::uint64_t descriptor_base<Task>::get_infer_results_to_compute() const {
-    return impl_->infer_results_to_compute;
-}
-
 template <typename Task>
 bool descriptor_base<Task>::get_memory_saving_mode() const {
     return impl_->memory_saving_mode;
@@ -200,16 +182,6 @@ template <typename Task>
 void descriptor_base<Task>::set_max_leaf_nodes_impl(std::int64_t value) {
     impl_->max_leaf_nodes = value;
 }
-
-template <typename Task>
-void descriptor_base<Task>::set_train_results_to_compute_impl(std::uint64_t value) {
-    impl_->train_results_to_compute = value;
-}
-template <typename Task>
-void descriptor_base<Task>::set_infer_results_to_compute_impl(std::uint64_t value) {
-    impl_->infer_results_to_compute = value;
-}
-
 template <typename Task>
 void descriptor_base<Task>::set_memory_saving_mode_impl(bool value) {
     impl_->memory_saving_mode = value;

--- a/cpp/oneapi/dal/algo/decision_forest/common.hpp
+++ b/cpp/oneapi/dal/algo/decision_forest/common.hpp
@@ -102,9 +102,6 @@ public:
     bool get_memory_saving_mode() const;
     bool get_bootstrap() const;
 
-    std::uint64_t get_train_results_to_compute() const;
-    std::uint64_t get_infer_results_to_compute() const;
-
     variable_importance_mode get_variable_importance_mode() const;
 
     /* classification specific methods */
@@ -130,11 +127,6 @@ protected:
     void set_min_observations_in_leaf_node_impl(std::int64_t value);
     void set_min_observations_in_split_node_impl(std::int64_t value);
     void set_max_leaf_nodes_impl(std::int64_t value);
-
-    void set_train_results_to_compute_impl(std::uint64_t value);
-    void set_train_results_to_compute_impl(train_result_to_compute value);
-    void set_infer_results_to_compute_impl(std::uint64_t value);
-    void set_infer_results_to_compute_impl(infer_result_to_compute value);
 
     void set_memory_saving_mode_impl(bool value);
     void set_bootstrap_impl(bool value);
@@ -205,23 +197,6 @@ public:
     }
     auto& set_max_leaf_nodes(std::int64_t value) {
         parent::set_max_leaf_nodes_impl(value);
-        return *this;
-    }
-
-    auto& set_train_results_to_compute(std::uint64_t value) {
-        parent::set_train_results_to_compute_impl(value);
-        return *this;
-    }
-    auto& set_train_results_to_compute(train_result_to_compute value) {
-        parent::set_train_results_to_compute_impl(static_cast<std::uint64_t>(value));
-        return *this;
-    }
-    auto& set_infer_results_to_compute(infer_result_to_compute value) {
-        parent::set_infer_results_to_compute_impl(static_cast<std::uint64_t>(value));
-        return *this;
-    }
-    auto& set_infer_results_to_compute(std::uint64_t value) {
-        parent::set_infer_results_to_compute_impl(value);
         return *this;
     }
 

--- a/cpp/oneapi/dal/algo/decision_forest/infer_types.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/infer_types.cpp
@@ -22,11 +22,23 @@ namespace oneapi::dal::decision_forest {
 template <typename Task>
 class detail::infer_input_impl : public base {
 public:
-    infer_input_impl(const model<Task>& trained_model, const table& data)
+    infer_input_impl(const model<Task>& trained_model,
+                     const table& data,
+                     std::uint64_t results_to_compute)
             : trained_model(trained_model),
-              data(data) {}
+              data(data),
+              results_to_compute(results_to_compute) {}
+    infer_input_impl(
+        const model<Task>& trained_model,
+        const table& data,
+        infer_result_to_compute results_to_compute = infer_result_to_compute::compute_class_labels)
+            : trained_model(trained_model),
+              data(data),
+              results_to_compute(static_cast<std::uint64_t>(results_to_compute)) {}
     model<Task> trained_model;
     table data;
+    std::uint64_t results_to_compute =
+        static_cast<std::uint64_t>(infer_result_to_compute::compute_class_labels);
 };
 
 template <typename Task>
@@ -40,8 +52,16 @@ using detail::infer_input_impl;
 using detail::infer_result_impl;
 
 template <typename Task>
-infer_input<Task>::infer_input(const model<Task>& trained_model, const table& data)
-        : impl_(new infer_input_impl<Task>(trained_model, data)) {}
+infer_input<Task>::infer_input(const model<Task>& trained_model,
+                               const table& data,
+                               std::uint64_t results_to_compute)
+        : impl_(new infer_input_impl<Task>(trained_model, data, results_to_compute)) {}
+
+template <typename Task>
+infer_input<Task>::infer_input(const model<Task>& trained_model,
+                               const table& data,
+                               infer_result_to_compute results_to_compute)
+        : impl_(new infer_input_impl<Task>(trained_model, data, results_to_compute)) {}
 
 template <typename Task>
 model<Task> infer_input<Task>::get_model() const {
@@ -54,6 +74,11 @@ table infer_input<Task>::get_data() const {
 }
 
 template <typename Task>
+std::uint64_t infer_input<Task>::get_results_to_compute() const {
+    return impl_->results_to_compute;
+}
+
+template <typename Task>
 void infer_input<Task>::set_model_impl(const model<Task>& value) {
     impl_->trained_model = value;
 }
@@ -61,6 +86,11 @@ void infer_input<Task>::set_model_impl(const model<Task>& value) {
 template <typename Task>
 void infer_input<Task>::set_data_impl(const table& value) {
     impl_->data = value;
+}
+
+template <typename Task>
+void infer_input<Task>::set_results_to_compute_impl(std::uint64_t value) {
+    impl_->results_to_compute = value;
 }
 
 template class ONEAPI_DAL_EXPORT infer_input<task::classification>;

--- a/cpp/oneapi/dal/algo/decision_forest/infer_types.hpp
+++ b/cpp/oneapi/dal/algo/decision_forest/infer_types.hpp
@@ -32,25 +32,40 @@ template <typename Task = task::by_default>
 class infer_input : public base {
 public:
     using pimpl = dal::detail::pimpl<detail::infer_input_impl<Task>>;
-    infer_input(const model<Task>& trained_model, const table& data);
+    infer_input(const model<Task>& trained_model,
+                const table& data,
+                std::uint64_t results_to_compute);
+    infer_input(
+        const model<Task>& trained_model,
+        const table& data,
+        infer_result_to_compute results_to_compute = infer_result_to_compute::compute_class_labels);
 
     model<Task> get_model() const;
+    table get_data() const;
+    std::uint64_t get_results_to_compute() const;
 
     auto& set_model(const model<Task>& value) {
         set_model_impl(value);
         return *this;
     }
-
-    table get_data() const;
-
     auto& set_data(const table& value) {
         set_data_impl(value);
+        return *this;
+    }
+
+    auto& set_results_to_compute(infer_result_to_compute value) {
+        set_results_to_compute_impl(static_cast<std::uint64_t>(value));
+        return *this;
+    }
+    auto& set_results_to_compute(std::uint64_t value) {
+        set_results_to_compute_impl(value);
         return *this;
     }
 
 private:
     void set_model_impl(const model<Task>& value);
     void set_data_impl(const table& value);
+    void set_results_to_compute_impl(std::uint64_t value);
 
     pimpl impl_;
 };

--- a/cpp/oneapi/dal/algo/decision_forest/train_types.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/train_types.cpp
@@ -22,10 +22,20 @@ namespace oneapi::dal::decision_forest {
 template <typename Task>
 class detail::train_input_impl : public base {
 public:
-    train_input_impl(const table& data, const table& labels) : data(data), labels(labels) {}
+    train_input_impl(const table& data, const table& labels, std::uint64_t results_to_compute = 0)
+            : data(data),
+              labels(labels),
+              results_to_compute(results_to_compute) {}
+    train_input_impl(const table& data,
+                     const table& labels,
+                     train_result_to_compute results_to_compute)
+            : data(data),
+              labels(labels),
+              results_to_compute(static_cast<std::uint64_t>(results_to_compute)) {}
 
     table data;
     table labels;
+    std::uint64_t results_to_compute = 0;
 };
 
 template <typename Task>
@@ -42,8 +52,16 @@ using detail::train_input_impl;
 using detail::train_result_impl;
 
 template <typename Task>
-train_input<Task>::train_input(const table& data, const table& labels)
-        : impl_(new train_input_impl<Task>(data, labels)) {}
+train_input<Task>::train_input(const table& data,
+                               const table& labels,
+                               std::uint64_t results_to_compute)
+        : impl_(new train_input_impl<Task>(data, labels, results_to_compute)) {}
+
+template <typename Task>
+train_input<Task>::train_input(const table& data,
+                               const table& labels,
+                               train_result_to_compute results_to_compute)
+        : impl_(new train_input_impl<Task>(data, labels, results_to_compute)) {}
 
 template <typename Task>
 table train_input<Task>::get_data() const {
@@ -56,6 +74,11 @@ table train_input<Task>::get_labels() const {
 }
 
 template <typename Task>
+std::uint64_t train_input<Task>::get_results_to_compute() const {
+    return impl_->results_to_compute;
+}
+
+template <typename Task>
 void train_input<Task>::set_data_impl(const table& value) {
     impl_->data = value;
 }
@@ -63,6 +86,11 @@ void train_input<Task>::set_data_impl(const table& value) {
 template <typename Task>
 void train_input<Task>::set_labels_impl(const table& value) {
     impl_->labels = value;
+}
+
+template <typename Task>
+void train_input<Task>::set_results_to_compute_impl(std::uint64_t value) {
+    impl_->results_to_compute = value;
 }
 
 template class ONEAPI_DAL_EXPORT train_input<task::classification>;

--- a/cpp/oneapi/dal/algo/decision_forest/train_types.hpp
+++ b/cpp/oneapi/dal/algo/decision_forest/train_types.hpp
@@ -32,25 +32,35 @@ template <typename Task = task::by_default>
 class train_input : public base {
 public:
     using pimpl = dal::detail::pimpl<detail::train_input_impl<Task>>;
-    train_input(const table& data, const table& labels);
+    train_input(const table& data, const table& labels, std::uint64_t results_to_compute = 0);
+    train_input(const table& data, const table& labels, train_result_to_compute results_to_compute);
 
     table get_data() const;
+    table get_labels() const;
+    std::uint64_t get_results_to_compute() const;
 
     auto& set_data(const table& value) {
         set_data_impl(value);
         return *this;
     }
-
-    table get_labels() const;
-
     auto& set_labels(const table& value) {
         set_labels_impl(value);
+        return *this;
+    }
+
+    auto& set_results_to_compute(train_result_to_compute value) {
+        set_results_to_compute_impl(static_cast<std::uint64_t>(value));
+        return *this;
+    }
+    auto& set_results_to_compute(std::uint64_t value) {
+        set_results_to_compute_impl(value);
         return *this;
     }
 
 private:
     void set_data_impl(const table& value);
     void set_labels_impl(const table& value);
+    void set_results_to_compute_impl(std::uint64_t value);
 
     pimpl impl_;
 };

--- a/examples/oneapi/cpp/source/decision_forest/df_cls_dense_batch.cpp
+++ b/examples/oneapi/cpp/source/decision_forest/df_cls_dense_batch.cpp
@@ -56,14 +56,9 @@ int main(int argc, char const *argv[]) {
           .set_features_per_node(1)
           .set_min_observations_in_leaf_node(1)
           .set_variable_importance_mode(df::variable_importance_mode::mdi)
-          .set_train_results_to_compute(
-              df::train_result_to_compute::compute_out_of_bag_error)
-          .set_infer_results_to_compute(
-              df::infer_result_to_compute::compute_class_labels |
-              df::infer_result_to_compute::compute_class_probabilities)
           .set_voting_method(df::voting_method::weighted);
 
-  const auto result_train = dal::train(df_desc, x_train_table, y_train_table);
+  const auto result_train = dal::train(df_desc, x_train_table, y_train_table, df::train_result_to_compute::compute_out_of_bag_error);
 
   std::cout << "Variable importance results:" << std::endl
             << result_train.get_var_importance() << std::endl;
@@ -71,7 +66,8 @@ int main(int argc, char const *argv[]) {
   std::cout << "OOB error: " << result_train.get_oob_err() << std::endl;
 
   const auto result_infer =
-      dal::infer(df_desc, result_train.get_model(), x_test_table);
+      dal::infer(df_desc, result_train.get_model(), x_test_table, df::infer_result_to_compute::compute_class_labels |
+              df::infer_result_to_compute::compute_class_probabilities);
 
   std::cout << "Prediction results:" << std::endl
             << result_infer.get_labels() << std::endl;

--- a/examples/oneapi/cpp/source/decision_forest/df_reg_dense_batch.cpp
+++ b/examples/oneapi/cpp/source/decision_forest/df_reg_dense_batch.cpp
@@ -55,15 +55,12 @@ int main(int argc, char const *argv[]) {
           .set_tree_count(10)
           .set_features_per_node(1)
           .set_min_observations_in_leaf_node(1)
-          .set_variable_importance_mode(df::variable_importance_mode::mdi)
-          .set_train_results_to_compute(
+          .set_variable_importance_mode(df::variable_importance_mode::mdi);
+
+  const auto result_train = dal::train(df_desc, x_train_table, y_train_table,
               df::train_result_to_compute::compute_out_of_bag_error |
               df::train_result_to_compute::
-                  compute_out_of_bag_error_per_observation)
-          .set_infer_results_to_compute(
-              df::infer_result_to_compute::compute_class_labels);
-
-  const auto result_train = dal::train(df_desc, x_train_table, y_train_table);
+                  compute_out_of_bag_error_per_observation);
 
   std::cout << "Variable importance results:" << std::endl
             << result_train.get_var_importance() << std::endl;
@@ -73,7 +70,7 @@ int main(int argc, char const *argv[]) {
             << result_train.get_oob_per_observation_err() << std::endl;
 
   const auto result_infer =
-      dal::infer(df_desc, result_train.get_model(), x_test_table);
+      dal::infer(df_desc, result_train.get_model(), x_test_table, df::infer_result_to_compute::compute_class_labels);
 
   std::cout << "Prediction results:" << std::endl
             << result_infer.get_labels() << std::endl;

--- a/examples/oneapi/dpc/source/decision_forest/df_reg_dense_batch.cpp
+++ b/examples/oneapi/dpc/source/decision_forest/df_reg_dense_batch.cpp
@@ -69,18 +69,17 @@ void run(sycl::queue &queue) {
           .set_tree_count(10)
           .set_features_per_node(2)
           .set_min_observations_in_leaf_node(1)
-          .set_variable_importance_mode(df::variable_importance_mode::mdi)
-          .set_train_results_to_compute(
-              df::train_result_to_compute::compute_out_of_bag_error |
-              df::train_result_to_compute::
-                  compute_out_of_bag_error_per_observation);
+          .set_variable_importance_mode(df::variable_importance_mode::mdi);
 
   const auto df_infer_desc =
       df::descriptor<float, df::task::regression, df::method::dense>();
 
   try {
     const auto result_train =
-        dal::train(queue, df_train_desc, x_train_table, y_train_table);
+        dal::train(queue, df_train_desc, x_train_table, y_train_table,
+              df::train_result_to_compute::compute_out_of_bag_error |
+              df::train_result_to_compute::
+                  compute_out_of_bag_error_per_observation);
 
     std::cout << "Variable importance results:" << std::endl
               << result_train.get_var_importance() << std::endl;


### PR DESCRIPTION
moved functionality for assignment of results_to_compute to train|infer input classes

