### PR TITLE
fix of misprint in variable name

### DIFF
--- a/cpp/oneapi/dal/util/type_traits.hpp
+++ b/cpp/oneapi/dal/util/type_traits.hpp
@@ -59,12 +59,12 @@ inline constexpr bool check_mask_flag(T mask, T flag) {
 template <typename T>
 inline constexpr T bitwise_and(T lhs_mask, T rhs_mask) {
     using U = std::underlying_type_t<T>;
-    return static_cast<T>(static_cast<U>(lhs_mask) & static_cast<U>(lhs_mask));
+    return static_cast<T>(static_cast<U>(lhs_mask) & static_cast<U>(rhs_mask));
 }
 
 template <typename T>
 inline constexpr T bitwise_or(T lhs_mask, T rhs_mask) {
     using U = std::underlying_type_t<T>;
-    return static_cast<T>(static_cast<U>(lhs_mask) | static_cast<U>(lhs_mask));
+    return static_cast<T>(static_cast<U>(lhs_mask) | static_cast<U>(rhs_mask));
 }
 } // namespace oneapi::dal


### PR DESCRIPTION
fix of misprint in variable name (it causes issue that oob_error_per_observation table isn't generated)