### PR TITLE
enable initial mergify config for labels

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,17 @@
+pull_request_rules:
+  - name: backport patches to 2021 branch
+    conditions:
+      - base=master
+      - label=backport-2021
+    actions:
+      backport:
+        branches:
+          - rls/2021-gold-mnt
+  - name: backport patches to 2020 branch
+    conditions:
+      - base=master
+      - label=backport-2020
+    actions:
+      backport:
+        branches:
+          - rls/daal-2020-mnt


### PR DESCRIPTION
# Description
In this change we enable mergify configuration to use 'backport-2020' and 'backport-2021' to be used for automatic backport PRs creation
https://doc.mergify.io/examples.html#using-labels-to-backport-pull-requests