### PR TITLE
enable public CI for rls branches

### DIFF
--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -4,7 +4,16 @@
 # https://docs.microsoft.com/azure/devops/pipelines/apps/c-cpp/gcc
 
 trigger:
-- master
+  branches:
+    include:
+    - master
+    - rls/*
+
+pr:
+  branches:
+    include:
+    - master
+    - rls/*
 
 jobs:
 - job: 'ClangFormat'


### PR DESCRIPTION
# Description
In this change we are enabling public CI for non master branches