### PR TITLE
conformance between spec and API: kmeans_init

### DIFF
--- a/cpp/oneapi/dal/algo/kmeans_init/backend/cpu/compute_kernel.hpp
+++ b/cpp/oneapi/dal/algo/kmeans_init/backend/cpu/compute_kernel.hpp
@@ -21,11 +21,11 @@
 
 namespace oneapi::dal::kmeans_init::backend {
 
-template <typename Float, typename Method>
+template <typename Float, typename Method, typename Task>
 struct compute_kernel_cpu {
-    compute_result operator()(const dal::backend::context_cpu& ctx,
-                              const descriptor_base& params,
-                              const compute_input& input) const;
+    compute_result<Task> operator()(const dal::backend::context_cpu& ctx,
+                                    const descriptor_base<Task>& params,
+                                    const compute_input<Task>& input) const;
 };
 
 } // namespace oneapi::dal::kmeans_init::backend

--- a/cpp/oneapi/dal/algo/kmeans_init/backend/cpu/compute_kernel_dense.cpp
+++ b/cpp/oneapi/dal/algo/kmeans_init/backend/cpu/compute_kernel_dense.cpp
@@ -35,10 +35,10 @@ template <typename Float, daal::CpuType Cpu, typename Method>
 using daal_kmeans_init_kernel_t =
     daal_kmeans_init::internal::KMeansInitKernel<to_daal_method<Method>::value, Float, Cpu>;
 
-template <typename Float, typename Method>
-static compute_result call_daal_kernel(const context_cpu& ctx,
-                                       const descriptor_base& desc,
-                                       const table& data) {
+template <typename Float, typename Method, typename Task>
+static compute_result<Task> call_daal_kernel(const context_cpu& ctx,
+                                             const descriptor_base<Task>& desc,
+                                             const table& data) {
     const int64_t column_count = data.get_column_count();
     const int64_t cluster_count = desc.get_cluster_count();
 
@@ -65,32 +65,34 @@ static compute_result call_daal_kernel(const context_cpu& ctx,
             .compute(len_input, input, len_output, output, &par, *(par.engine));
     }));
 
-    return compute_result().set_centroids(dal::detail::homogen_table_builder{}
-                                              .reset(arr_centroids, cluster_count, column_count)
-                                              .build());
+    return compute_result<Task>().set_centroids(
+        dal::detail::homogen_table_builder{}
+            .reset(arr_centroids, cluster_count, column_count)
+            .build());
 }
 
-template <typename Float, typename Method>
-static compute_result compute(const context_cpu& ctx,
-                              const descriptor_base& desc,
-                              const compute_input& input) {
-    return call_daal_kernel<Float, Method>(ctx, desc, input.get_data());
+template <typename Float, typename Method, typename Task>
+static compute_result<Task> compute(const context_cpu& ctx,
+                                    const descriptor_base<Task>& desc,
+                                    const compute_input<Task>& input) {
+    return call_daal_kernel<Float, Method, Task>(ctx, desc, input.get_data());
 }
 
-template <typename Float, typename Method>
-compute_result compute_kernel_cpu<Float, Method>::operator()(const context_cpu& ctx,
-                                                             const descriptor_base& desc,
-                                                             const compute_input& input) const {
-    return compute<Float, Method>(ctx, desc, input);
+template <typename Float, typename Method, typename Task>
+compute_result<Task> compute_kernel_cpu<Float, Method, Task>::operator()(
+    const context_cpu& ctx,
+    const descriptor_base<Task>& desc,
+    const compute_input<Task>& input) const {
+    return compute<Float, Method, Task>(ctx, desc, input);
 }
 
-template struct compute_kernel_cpu<float, method::dense>;
-template struct compute_kernel_cpu<double, method::dense>;
-template struct compute_kernel_cpu<float, method::random_dense>;
-template struct compute_kernel_cpu<double, method::random_dense>;
-template struct compute_kernel_cpu<float, method::plus_plus_dense>;
-template struct compute_kernel_cpu<double, method::plus_plus_dense>;
-template struct compute_kernel_cpu<float, method::parallel_plus_dense>;
-template struct compute_kernel_cpu<double, method::parallel_plus_dense>;
+template struct compute_kernel_cpu<float, method::dense, task::init>;
+template struct compute_kernel_cpu<double, method::dense, task::init>;
+template struct compute_kernel_cpu<float, method::random_dense, task::init>;
+template struct compute_kernel_cpu<double, method::random_dense, task::init>;
+template struct compute_kernel_cpu<float, method::plus_plus_dense, task::init>;
+template struct compute_kernel_cpu<double, method::plus_plus_dense, task::init>;
+template struct compute_kernel_cpu<float, method::parallel_plus_dense, task::init>;
+template struct compute_kernel_cpu<double, method::parallel_plus_dense, task::init>;
 
 } // namespace oneapi::dal::kmeans_init::backend

--- a/cpp/oneapi/dal/algo/kmeans_init/backend/gpu/compute_kernel.hpp
+++ b/cpp/oneapi/dal/algo/kmeans_init/backend/gpu/compute_kernel.hpp
@@ -21,11 +21,11 @@
 
 namespace oneapi::dal::kmeans_init::backend {
 
-template <typename Float, typename Method>
+template <typename Float, typename Method, typename Task>
 struct compute_kernel_gpu {
-    compute_result operator()(const dal::backend::context_gpu& ctx,
-                              const descriptor_base& params,
-                              const compute_input& input) const;
+    compute_result<Task> operator()(const dal::backend::context_gpu& ctx,
+                                    const descriptor_base<Task>& params,
+                                    const compute_input<Task>& input) const;
 };
 
 } // namespace oneapi::dal::kmeans_init::backend

--- a/cpp/oneapi/dal/algo/kmeans_init/backend/gpu/compute_kernel_dense_dpc.cpp
+++ b/cpp/oneapi/dal/algo/kmeans_init/backend/gpu/compute_kernel_dense_dpc.cpp
@@ -42,10 +42,10 @@ using daal_kmeans_init_kernel_t =
     daal_kmeans_init::internal::KMeansInitDenseBatchKernelUCAPI<to_daal_method<Method>::value,
                                                                 Float>;
 
-template <typename Float, typename Method>
-static compute_result call_daal_kernel(const context_gpu& ctx,
-                                       const descriptor_base& params,
-                                       const table& data) {
+template <typename Float, typename Method, typename Task>
+static compute_result<Task> call_daal_kernel(const context_gpu& ctx,
+                                             const descriptor_base<Task>& params,
+                                             const table& data) {
     if constexpr (std::is_same_v<Method, method::plus_plus_dense>)
         throw unimplemented_error("plus_plus_dense method is not implemented for GPU");
     if constexpr (std::is_same_v<Method, method::parallel_plus_dense>)
@@ -83,32 +83,34 @@ static compute_result call_daal_kernel(const context_gpu& ctx,
                                                                                     &par,
                                                                                     *(par.engine)));
 
-    return compute_result().set_centroids(dal::detail::homogen_table_builder{}
-                                              .reset(arr_centroids, cluster_count, column_count)
-                                              .build());
+    return compute_result<Task>().set_centroids(
+        dal::detail::homogen_table_builder{}
+            .reset(arr_centroids, cluster_count, column_count)
+            .build());
 }
 
-template <typename Float, typename Method>
-static compute_result compute(const context_gpu& ctx,
-                              const descriptor_base& desc,
-                              const compute_input& input) {
-    return call_daal_kernel<Float, Method>(ctx, desc, input.get_data());
+template <typename Float, typename Method, typename Task>
+static compute_result<Task> compute(const context_gpu& ctx,
+                                    const descriptor_base<Task>& desc,
+                                    const compute_input<Task>& input) {
+    return call_daal_kernel<Float, Method, Task>(ctx, desc, input.get_data());
 }
 
-template <typename Float, typename Method>
-compute_result compute_kernel_gpu<Float, Method>::operator()(const context_gpu& ctx,
-                                                             const descriptor_base& desc,
-                                                             const compute_input& input) const {
-    return compute<Float, Method>(ctx, desc, input);
+template <typename Float, typename Method, typename Task>
+compute_result<Task> compute_kernel_gpu<Float, Method, Task>::operator()(
+    const context_gpu& ctx,
+    const descriptor_base<Task>& desc,
+    const compute_input<Task>& input) const {
+    return compute<Float, Method, Task>(ctx, desc, input);
 }
 
-template struct compute_kernel_gpu<float, method::dense>;
-template struct compute_kernel_gpu<double, method::dense>;
-template struct compute_kernel_gpu<float, method::random_dense>;
-template struct compute_kernel_gpu<double, method::random_dense>;
-template struct compute_kernel_gpu<float, method::plus_plus_dense>;
-template struct compute_kernel_gpu<double, method::plus_plus_dense>;
-template struct compute_kernel_gpu<float, method::parallel_plus_dense>;
-template struct compute_kernel_gpu<double, method::parallel_plus_dense>;
+template struct compute_kernel_gpu<float, method::dense, task::init>;
+template struct compute_kernel_gpu<double, method::dense, task::init>;
+template struct compute_kernel_gpu<float, method::random_dense, task::init>;
+template struct compute_kernel_gpu<double, method::random_dense, task::init>;
+template struct compute_kernel_gpu<float, method::plus_plus_dense, task::init>;
+template struct compute_kernel_gpu<double, method::plus_plus_dense, task::init>;
+template struct compute_kernel_gpu<float, method::parallel_plus_dense, task::init>;
+template struct compute_kernel_gpu<double, method::parallel_plus_dense, task::init>;
 
 } // namespace oneapi::dal::kmeans_init::backend

--- a/cpp/oneapi/dal/algo/kmeans_init/common.cpp
+++ b/cpp/oneapi/dal/algo/kmeans_init/common.cpp
@@ -19,24 +19,30 @@
 
 namespace oneapi::dal::kmeans_init {
 
-class detail::descriptor_impl : public base {
+template <>
+class detail::descriptor_impl<task::init> : public base {
 public:
     std::int64_t cluster_count = 2;
 };
 
 using detail::descriptor_impl;
 
-descriptor_base::descriptor_base() : impl_(new descriptor_impl{}) {}
+template <typename Task>
+descriptor_base<Task>::descriptor_base() : impl_(new descriptor_impl{}) {}
 
-std::int64_t descriptor_base::get_cluster_count() const {
+template <typename Task>
+std::int64_t descriptor_base<Task>::get_cluster_count() const {
     return impl_->cluster_count;
 }
 
-void descriptor_base::set_cluster_count_impl(std::int64_t value) {
+template <typename Task>
+void descriptor_base<Task>::set_cluster_count_impl(std::int64_t value) {
     if (value <= 0) {
         throw domain_error("cluster_count should be > 0");
     }
     impl_->cluster_count = value;
 }
+
+template class ONEAPI_DAL_EXPORT descriptor_base<task::init>;
 
 } // namespace oneapi::dal::kmeans_init

--- a/cpp/oneapi/dal/algo/kmeans_init/common.hpp
+++ b/cpp/oneapi/dal/algo/kmeans_init/common.hpp
@@ -21,8 +21,15 @@
 
 namespace oneapi::dal::kmeans_init {
 
+namespace task {
+struct init {};
+using by_default = init;
+} // namespace task
+
 namespace detail {
 struct tag {};
+
+template <typename Task = task::by_default>
 class descriptor_impl;
 } // namespace detail
 
@@ -31,12 +38,14 @@ struct dense {};
 struct random_dense {};
 struct plus_plus_dense {};
 struct parallel_plus_dense {};
-using by_default = random_dense;
+using by_default = dense;
 } // namespace method
 
+template <typename Task = task::by_default>
 class ONEAPI_DAL_EXPORT descriptor_base : public base {
 public:
     using tag_t = detail::tag;
+    using task_t = task::by_default;
     using float_t = float;
     using method_t = method::by_default;
 
@@ -47,17 +56,19 @@ public:
 protected:
     void set_cluster_count_impl(std::int64_t);
 
-    dal::detail::pimpl<detail::descriptor_impl> impl_;
+    dal::detail::pimpl<detail::descriptor_impl<task_t>> impl_;
 };
 
-template <typename Float = descriptor_base::float_t, typename Method = descriptor_base::method_t>
-class descriptor : public descriptor_base {
+template <typename Float = descriptor_base<task::by_default>::float_t,
+          typename Method = descriptor_base<task::by_default>::method_t,
+          typename Task = task::by_default>
+class descriptor : public descriptor_base<Task> {
 public:
     using float_t = Float;
     using method_t = Method;
 
     auto& set_cluster_count(int64_t value) {
-        set_cluster_count_impl(value);
+        descriptor_base<Task>::set_cluster_count_impl(value);
         return *this;
     }
 };

--- a/cpp/oneapi/dal/algo/kmeans_init/compute_types.cpp
+++ b/cpp/oneapi/dal/algo/kmeans_init/compute_types.cpp
@@ -19,6 +19,7 @@
 
 namespace oneapi::dal::kmeans_init {
 
+template <typename Task>
 class detail::compute_input_impl : public base {
 public:
     compute_input_impl(const table& data) : data(data) {}
@@ -26,6 +27,7 @@ public:
     table data;
 };
 
+template <typename Task>
 class detail::compute_result_impl : public base {
 public:
     table centroids;
@@ -34,24 +36,34 @@ public:
 using detail::compute_input_impl;
 using detail::compute_result_impl;
 
-compute_input::compute_input(const table& data) : impl_(new compute_input_impl(data)) {}
+template <typename Task>
+compute_input<Task>::compute_input(const table& data) : impl_(new compute_input_impl(data)) {}
 
-table compute_input::get_data() const {
+template <typename Task>
+table compute_input<Task>::get_data() const {
     return impl_->data;
 }
 
-void compute_input::set_data_impl(const table& value) {
+template <typename Task>
+void compute_input<Task>::set_data_impl(const table& value) {
     impl_->data = value;
 }
 
-compute_result::compute_result() : impl_(new compute_result_impl{}) {}
+template class ONEAPI_DAL_EXPORT compute_input<task::init>;
 
-table compute_result::get_centroids() const {
+template <typename Task>
+compute_result<Task>::compute_result() : impl_(new compute_result_impl{}) {}
+
+template <typename Task>
+table compute_result<Task>::get_centroids() const {
     return impl_->centroids;
 }
 
-void compute_result::set_centroids_impl(const table& value) {
+template <typename Task>
+void compute_result<Task>::set_centroids_impl(const table& value) {
     impl_->centroids = value;
 }
+
+template class ONEAPI_DAL_EXPORT compute_result<task::init>;
 
 } // namespace oneapi::dal::kmeans_init

--- a/cpp/oneapi/dal/algo/kmeans_init/compute_types.hpp
+++ b/cpp/oneapi/dal/algo/kmeans_init/compute_types.hpp
@@ -21,12 +21,18 @@
 namespace oneapi::dal::kmeans_init {
 
 namespace detail {
+template <typename Task = task::by_default>
 class compute_input_impl;
+
+template <typename Task = task::by_default>
 class compute_result_impl;
 } // namespace detail
 
+template <typename Task = task::by_default>
 class ONEAPI_DAL_EXPORT compute_input : public base {
 public:
+    using task_t = Task;
+
     compute_input(const table& data);
 
     table get_data() const;
@@ -39,11 +45,14 @@ public:
 private:
     void set_data_impl(const table& data);
 
-    dal::detail::pimpl<detail::compute_input_impl> impl_;
+    dal::detail::pimpl<detail::compute_input_impl<task_t>> impl_;
 };
 
+template <typename Task = task::by_default>
 class ONEAPI_DAL_EXPORT compute_result {
 public:
+    using task_t = Task;
+
     compute_result();
 
     table get_centroids() const;
@@ -56,7 +65,7 @@ public:
 private:
     void set_centroids_impl(const table&);
 
-    dal::detail::pimpl<detail::compute_result_impl> impl_;
+    dal::detail::pimpl<detail::compute_result_impl<task_t>> impl_;
 };
 
 } // namespace oneapi::dal::kmeans_init

--- a/cpp/oneapi/dal/algo/kmeans_init/detail/compute_ops.cpp
+++ b/cpp/oneapi/dal/algo/kmeans_init/detail/compute_ops.cpp
@@ -21,27 +21,27 @@
 namespace oneapi::dal::kmeans_init::detail {
 using oneapi::dal::detail::host_policy;
 
-template <typename Float, typename Method>
-struct ONEAPI_DAL_EXPORT compute_ops_dispatcher<host_policy, Float, Method> {
-    compute_result operator()(const host_policy& ctx,
-                              const descriptor_base& desc,
-                              const compute_input& input) const {
+template <typename Float, typename Method, typename Task>
+struct ONEAPI_DAL_EXPORT compute_ops_dispatcher<host_policy, Float, Method, Task> {
+    compute_result<Task> operator()(const host_policy& ctx,
+                                    const descriptor_base<Task>& desc,
+                                    const compute_input<Task>& input) const {
         using kernel_dispatcher_t =
-            dal::backend::kernel_dispatcher<backend::compute_kernel_cpu<Float, Method>>;
+            dal::backend::kernel_dispatcher<backend::compute_kernel_cpu<Float, Method, Task>>;
         return kernel_dispatcher_t()(ctx, desc, input);
     }
 };
 
-#define INSTANTIATE(F, M) \
-    template struct ONEAPI_DAL_EXPORT compute_ops_dispatcher<host_policy, F, M>;
+#define INSTANTIATE(F, M, T) \
+    template struct ONEAPI_DAL_EXPORT compute_ops_dispatcher<host_policy, F, M, T>;
 
-INSTANTIATE(float, method::dense)
-INSTANTIATE(double, method::dense)
-INSTANTIATE(float, method::random_dense)
-INSTANTIATE(double, method::random_dense)
-INSTANTIATE(float, method::plus_plus_dense)
-INSTANTIATE(double, method::plus_plus_dense)
-INSTANTIATE(float, method::parallel_plus_dense)
-INSTANTIATE(double, method::parallel_plus_dense)
+INSTANTIATE(float, method::dense, task::init)
+INSTANTIATE(double, method::dense, task::init)
+INSTANTIATE(float, method::random_dense, task::init)
+INSTANTIATE(double, method::random_dense, task::init)
+INSTANTIATE(float, method::plus_plus_dense, task::init)
+INSTANTIATE(double, method::plus_plus_dense, task::init)
+INSTANTIATE(float, method::parallel_plus_dense, task::init)
+INSTANTIATE(double, method::parallel_plus_dense, task::init)
 
 } // namespace oneapi::dal::kmeans_init::detail

--- a/cpp/oneapi/dal/algo/kmeans_init/detail/compute_ops.hpp
+++ b/cpp/oneapi/dal/algo/kmeans_init/detail/compute_ops.hpp
@@ -21,20 +21,26 @@
 
 namespace oneapi::dal::kmeans_init::detail {
 
-template <typename Context, typename... Options>
+template <typename Context,
+          typename Float,
+          typename Method = method::dense,
+          typename Task = task::by_default>
 struct compute_ops_dispatcher {
-    compute_result operator()(const Context&, const descriptor_base&, const compute_input&) const;
+    compute_result<Task> operator()(const Context&,
+                                    const descriptor_base<Task>&,
+                                    const compute_input<Task>&) const;
 };
 
 template <typename Descriptor>
 struct compute_ops {
     using float_t = typename Descriptor::float_t;
+    using task_t = typename Descriptor::task_t;
     using method_t = typename Descriptor::method_t;
-    using input_t = compute_input;
-    using result_t = compute_result;
-    using descriptor_base_t = descriptor_base;
+    using input_t = compute_input<task_t>;
+    using result_t = compute_result<task_t>;
+    using descriptor_base_t = descriptor_base<task_t>;
 
-    void check_preconditions(const Descriptor& params, const compute_input& input) const {
+    void check_preconditions(const Descriptor& params, const input_t& input) const {
         if (!(input.get_data().has_data())) {
             throw domain_error("Input data should not be empty");
         }
@@ -44,8 +50,8 @@ struct compute_ops {
     }
 
     void check_posrtconditions(const Descriptor& params,
-                               const compute_input& input,
-                               const compute_result& result) const {
+                               const input_t& input,
+                               const result_t& result) const {
         if (!(result.get_centroids().has_data())) {
             throw internal_error("Result centroids should not be empty");
         }
@@ -60,9 +66,10 @@ struct compute_ops {
     }
 
     template <typename Context>
-    auto operator()(const Context& ctx, const Descriptor& desc, const compute_input& input) const {
+    auto operator()(const Context& ctx, const Descriptor& desc, const input_t& input) const {
         check_preconditions(desc, input);
-        const auto result = compute_ops_dispatcher<Context, float_t, method_t>()(ctx, desc, input);
+        const auto result =
+            compute_ops_dispatcher<Context, float_t, method_t, task_t>()(ctx, desc, input);
         check_posrtconditions(desc, input, result);
         return result;
     }

--- a/cpp/oneapi/dal/algo/kmeans_init/detail/compute_ops_dpc.cpp
+++ b/cpp/oneapi/dal/algo/kmeans_init/detail/compute_ops_dpc.cpp
@@ -22,27 +22,27 @@
 namespace oneapi::dal::kmeans_init::detail {
 using oneapi::dal::detail::data_parallel_policy;
 
-template <typename Float, typename Method>
-struct ONEAPI_DAL_EXPORT compute_ops_dispatcher<data_parallel_policy, Float, Method> {
-    compute_result operator()(const data_parallel_policy& ctx,
-                              const descriptor_base& params,
-                              const compute_input& input) const {
+template <typename Float, typename Method, typename Task>
+struct ONEAPI_DAL_EXPORT compute_ops_dispatcher<data_parallel_policy, Float, Method, Task> {
+    compute_result<Task> operator()(const data_parallel_policy& ctx,
+                                    const descriptor_base<Task>& params,
+                                    const compute_input<Task>& input) const {
         using kernel_dispatcher_t =
-            dal::backend::kernel_dispatcher<backend::compute_kernel_cpu<Float, Method>,
-                                            backend::compute_kernel_gpu<Float, Method>>;
+            dal::backend::kernel_dispatcher<backend::compute_kernel_cpu<Float, Method, Task>,
+                                            backend::compute_kernel_gpu<Float, Method, Task>>;
         return kernel_dispatcher_t{}(ctx, params, input);
     }
 };
 
-#define INSTANTIATE(F, M) \
-    template struct ONEAPI_DAL_EXPORT compute_ops_dispatcher<data_parallel_policy, F, M>;
+#define INSTANTIATE(F, M, T) \
+    template struct ONEAPI_DAL_EXPORT compute_ops_dispatcher<data_parallel_policy, F, M, T>;
 
-INSTANTIATE(float, method::dense)
-INSTANTIATE(double, method::dense)
-INSTANTIATE(float, method::random_dense)
-INSTANTIATE(double, method::random_dense)
-INSTANTIATE(float, method::plus_plus_dense)
-INSTANTIATE(double, method::plus_plus_dense)
-INSTANTIATE(float, method::parallel_plus_dense)
-INSTANTIATE(double, method::parallel_plus_dense)
+INSTANTIATE(float, method::dense, task::init)
+INSTANTIATE(double, method::dense, task::init)
+INSTANTIATE(float, method::random_dense, task::init)
+INSTANTIATE(double, method::random_dense, task::init)
+INSTANTIATE(float, method::plus_plus_dense, task::init)
+INSTANTIATE(double, method::plus_plus_dense, task::init)
+INSTANTIATE(float, method::parallel_plus_dense, task::init)
+INSTANTIATE(double, method::parallel_plus_dense, task::init)
 } // namespace oneapi::dal::kmeans_init::detail

--- a/examples/oneapi/cpp/source/kmeans_init/kmeans_init_dense.cpp
+++ b/examples/oneapi/cpp/source/kmeans_init/kmeans_init_dense.cpp
@@ -26,9 +26,9 @@ using namespace oneapi;
 
 template <typename Method>
 void run_compute(dal::table x_train, const char *method_name) {
-    constexpr std::int64_t cluster_count       = 20;
+    constexpr std::int64_t cluster_count = 20;
     constexpr std::int64_t max_iteration_count = 1000;
-    constexpr double accuracy_threshold        = 0.01;
+    constexpr double accuracy_threshold = 0.01;
 
     const auto kmeans_init_desc =
         dal::kmeans_init::descriptor<float, Method>().set_cluster_count(cluster_count);

--- a/examples/oneapi/dpc/source/kmeans_init/kmeans_init_dense.cpp
+++ b/examples/oneapi/dpc/source/kmeans_init/kmeans_init_dense.cpp
@@ -28,9 +28,9 @@ using namespace oneapi;
 
 template <typename Method>
 void run_compute(sycl::queue &queue, dal::table x_train, const char *method_name) {
-    constexpr std::int64_t cluster_count       = 20;
+    constexpr std::int64_t cluster_count = 20;
     constexpr std::int64_t max_iteration_count = 1000;
-    constexpr double accuracy_threshold        = 0.01;
+    constexpr double accuracy_threshold = 0.01;
 
     const auto kmeans_init_desc =
         dal::kmeans_init::descriptor<float, Method>().set_cluster_count(cluster_count);


### PR DESCRIPTION
- default method: dense
- Task for `compute_input`, `compute_result` and `compute(...)`