### PR TITLE
Knn: set_data_use_in_model parameter removed

### DIFF
--- a/cpp/oneapi/dal/algo/knn/backend/cpu/infer_kernel_kd_tree.cpp
+++ b/cpp/oneapi/dal/algo/knn/backend/cpu/infer_kernel_kd_tree.cpp
@@ -51,11 +51,12 @@ static infer_result call_daal_kernel(const context_cpu &ctx,
     const auto daal_labels = interop::convert_to_daal_homogen_table(arr_labels, row_count, 1);
 
     const std::int64_t dummy_seed = 777;
+    const auto data_use_in_model = daal_knn::doNotUse;
     daal_knn::Parameter daal_parameter(
         desc.get_class_count(),
         desc.get_neighbor_count(),
         dummy_seed,
-        desc.get_data_use_in_model() ? daal_knn::doUse : daal_knn::doNotUse);
+        data_use_in_model);
 
     interop::status_to_exception(interop::call_daal_kernel<Float, daal_knn_kd_tree_kernel_t>(
         ctx,

--- a/cpp/oneapi/dal/algo/knn/backend/cpu/infer_kernel_kd_tree.cpp
+++ b/cpp/oneapi/dal/algo/knn/backend/cpu/infer_kernel_kd_tree.cpp
@@ -52,11 +52,10 @@ static infer_result call_daal_kernel(const context_cpu &ctx,
 
     const std::int64_t dummy_seed = 777;
     const auto data_use_in_model = daal_knn::doNotUse;
-    daal_knn::Parameter daal_parameter(
-        desc.get_class_count(),
-        desc.get_neighbor_count(),
-        dummy_seed,
-        data_use_in_model);
+    daal_knn::Parameter daal_parameter(desc.get_class_count(),
+                                       desc.get_neighbor_count(),
+                                       dummy_seed,
+                                       data_use_in_model);
 
     interop::status_to_exception(interop::call_daal_kernel<Float, daal_knn_kd_tree_kernel_t>(
         ctx,

--- a/cpp/oneapi/dal/algo/knn/backend/cpu/train_kernel_kd_tree.cpp
+++ b/cpp/oneapi/dal/algo/knn/backend/cpu/train_kernel_kd_tree.cpp
@@ -54,11 +54,12 @@ static train_result call_daal_kernel(const context_cpu& ctx,
     const auto daal_labels = interop::convert_to_daal_homogen_table(arr_labels, row_count, 1);
 
     const std::int64_t dummy_seed = 777;
+    const auto data_use_in_model = daal_knn::doNotUse;
     daal_knn::Parameter daal_parameter(
         desc.get_class_count(),
         desc.get_neighbor_count(),
         dummy_seed,
-        desc.get_data_use_in_model() ? daal_knn::doUse : daal_knn::doNotUse);
+        data_use_in_model);
 
     Status status;
     const daal::algorithms::classifier::ModelPtr model_ptr =
@@ -66,8 +67,9 @@ static train_result call_daal_kernel(const context_cpu& ctx,
     interop::status_to_exception(status);
 
     auto knn_model = static_cast<daal_knn::Model*>(model_ptr.get());
-    knn_model->impl()->setData<Float>(daal_data, desc.get_data_use_in_model());
-    knn_model->impl()->setLabels<Float>(daal_labels, desc.get_data_use_in_model());
+    const bool copy_data_labels = true;
+    knn_model->impl()->setData<Float>(daal_data, copy_data_labels);
+    knn_model->impl()->setLabels<Float>(daal_labels, copy_data_labels);
 
     interop::status_to_exception(
         interop::call_daal_kernel<Float, daal_knn_kd_tree_kernel_t>(ctx,

--- a/cpp/oneapi/dal/algo/knn/backend/cpu/train_kernel_kd_tree.cpp
+++ b/cpp/oneapi/dal/algo/knn/backend/cpu/train_kernel_kd_tree.cpp
@@ -55,11 +55,10 @@ static train_result call_daal_kernel(const context_cpu& ctx,
 
     const std::int64_t dummy_seed = 777;
     const auto data_use_in_model = daal_knn::doNotUse;
-    daal_knn::Parameter daal_parameter(
-        desc.get_class_count(),
-        desc.get_neighbor_count(),
-        dummy_seed,
-        data_use_in_model);
+    daal_knn::Parameter daal_parameter(desc.get_class_count(),
+                                       desc.get_neighbor_count(),
+                                       dummy_seed,
+                                       data_use_in_model);
 
     Status status;
     const daal::algorithms::classifier::ModelPtr model_ptr =

--- a/cpp/oneapi/dal/algo/knn/backend/gpu/infer_kernel_brute_force_dpc.cpp
+++ b/cpp/oneapi/dal/algo/knn/backend/gpu/infer_kernel_brute_force_dpc.cpp
@@ -59,10 +59,9 @@ static infer_result call_daal_kernel(const context_gpu& ctx,
         interop::convert_to_daal_sycl_homogen_table(queue, arr_labels, row_count, 1);
 
     const auto data_use_in_model = daal_knn::doNotUse;
-    daal_knn::Parameter daal_parameter(
-        desc.get_class_count(),
-        desc.get_neighbor_count(),
-        data_use_in_model);
+    daal_knn::Parameter daal_parameter(desc.get_class_count(),
+                                       desc.get_neighbor_count(),
+                                       data_use_in_model);
 
     interop::status_to_exception(daal_knn_brute_force_kernel_t<Float>().compute(
         daal_data.get(),

--- a/cpp/oneapi/dal/algo/knn/backend/gpu/infer_kernel_brute_force_dpc.cpp
+++ b/cpp/oneapi/dal/algo/knn/backend/gpu/infer_kernel_brute_force_dpc.cpp
@@ -58,10 +58,11 @@ static infer_result call_daal_kernel(const context_gpu& ctx,
     const auto daal_labels =
         interop::convert_to_daal_sycl_homogen_table(queue, arr_labels, row_count, 1);
 
+    const auto data_use_in_model = daal_knn::doNotUse;
     daal_knn::Parameter daal_parameter(
         desc.get_class_count(),
         desc.get_neighbor_count(),
-        desc.get_data_use_in_model() ? daal_knn::doUse : daal_knn::doNotUse);
+        data_use_in_model);
 
     interop::status_to_exception(daal_knn_brute_force_kernel_t<Float>().compute(
         daal_data.get(),

--- a/cpp/oneapi/dal/algo/knn/backend/gpu/train_kernel_brute_force_dpc.cpp
+++ b/cpp/oneapi/dal/algo/knn/backend/gpu/train_kernel_brute_force_dpc.cpp
@@ -61,10 +61,9 @@ static train_result call_daal_kernel(const context_gpu& ctx,
         interop::convert_to_daal_sycl_homogen_table(queue, arr_labels, row_count, 1);
 
     const auto data_use_in_model = daal_knn::doNotUse;
-    daal_knn::Parameter daal_parameter(
-        desc.get_class_count(),
-        desc.get_neighbor_count(),
-        data_use_in_model);
+    daal_knn::Parameter daal_parameter(desc.get_class_count(),
+                                       desc.get_neighbor_count(),
+                                       data_use_in_model);
 
     daal::algorithms::classifier::ModelPtr model_ptr(new daal_knn::Model(column_count));
     if (!model_ptr) {

--- a/cpp/oneapi/dal/algo/knn/backend/gpu/train_kernel_brute_force_dpc.cpp
+++ b/cpp/oneapi/dal/algo/knn/backend/gpu/train_kernel_brute_force_dpc.cpp
@@ -60,10 +60,11 @@ static train_result call_daal_kernel(const context_gpu& ctx,
     const auto daal_labels =
         interop::convert_to_daal_sycl_homogen_table(queue, arr_labels, row_count, 1);
 
+    const auto data_use_in_model = daal_knn::doNotUse;
     daal_knn::Parameter daal_parameter(
         desc.get_class_count(),
         desc.get_neighbor_count(),
-        desc.get_data_use_in_model() ? daal_knn::doUse : daal_knn::doNotUse);
+        data_use_in_model);
 
     daal::algorithms::classifier::ModelPtr model_ptr(new daal_knn::Model(column_count));
     if (!model_ptr) {
@@ -71,9 +72,9 @@ static train_result call_daal_kernel(const context_gpu& ctx,
     }
 
     auto knn_model = static_cast<daal_knn::Model*>(model_ptr.get());
-
-    knn_model->impl()->setData<Float>(daal_data, desc.get_data_use_in_model());
-    knn_model->impl()->setLabels<Float>(daal_labels, desc.get_data_use_in_model());
+    const bool copy_data_labels = true;
+    knn_model->impl()->setData<Float>(daal_data, copy_data_labels);
+    knn_model->impl()->setLabels<Float>(daal_labels, copy_data_labels);
 
     interop::status_to_exception(
         daal_knn_brute_force_kernel_t<Float>().compute(daal_data.get(),

--- a/cpp/oneapi/dal/algo/knn/common.cpp
+++ b/cpp/oneapi/dal/algo/knn/common.cpp
@@ -24,7 +24,6 @@ class detail::descriptor_impl : public base {
 public:
     std::int64_t class_count = 2;
     std::int64_t neighbor_count = 1;
-    bool data_use_in_model = false;
 };
 
 using detail::descriptor_impl;
@@ -40,10 +39,6 @@ std::int64_t descriptor_base::get_neighbor_count() const {
     return impl_->neighbor_count;
 }
 
-bool descriptor_base::get_data_use_in_model() const {
-    return impl_->data_use_in_model;
-}
-
 void descriptor_base::set_class_count_impl(std::int64_t value) {
     if (value < 2) {
         throw domain_error("class_count should be > 1");
@@ -56,10 +51,6 @@ void descriptor_base::set_neighbor_count_impl(std::int64_t value) {
         throw domain_error("neighbor_count should be > 0");
     }
     impl_->neighbor_count = value;
-}
-
-void descriptor_base::set_data_use_in_model_impl(bool value) {
-    impl_->data_use_in_model = value;
 }
 
 class empty_model_impl : public detail::model_impl {};

--- a/cpp/oneapi/dal/algo/knn/common.hpp
+++ b/cpp/oneapi/dal/algo/knn/common.hpp
@@ -43,12 +43,10 @@ public:
 
     auto get_class_count() const -> std::int64_t;
     auto get_neighbor_count() const -> std::int64_t;
-    auto get_data_use_in_model() const -> bool;
 
 protected:
     void set_class_count_impl(std::int64_t value);
     void set_neighbor_count_impl(std::int64_t value);
-    void set_data_use_in_model_impl(bool value);
 
     dal::detail::pimpl<detail::descriptor_impl> impl_;
 };
@@ -67,11 +65,6 @@ public:
 
     auto& set_neighbor_count(std::int64_t value) {
         set_neighbor_count_impl(value);
-        return *this;
-    }
-
-    auto& set_data_use_in_model(bool value) {
-        set_data_use_in_model_impl(value);
         return *this;
     }
 };

--- a/examples/oneapi/cpp/source/knn/knn_cls_kd_tree_dense_batch.cpp
+++ b/examples/oneapi/cpp/source/knn/knn_cls_kd_tree_dense_batch.cpp
@@ -36,8 +36,7 @@ int main(int argc, char const *argv[]) {
   const auto knn_desc =
       dal::knn::descriptor<float, oneapi::dal::knn::method::kd_tree>()
           .set_class_count(5)
-          .set_neighbor_count(1)
-          .set_data_use_in_model(false);
+          .set_neighbor_count(1);
 
   const auto train_result = dal::train(knn_desc, x_train, y_train);
 

--- a/examples/oneapi/dpc/source/knn/knn_cls_brute_force_dense_batch.cpp
+++ b/examples/oneapi/dpc/source/knn/knn_cls_brute_force_dense_batch.cpp
@@ -35,8 +35,7 @@ void run(sycl::queue& queue) {
     const auto knn_desc =
         dal::knn::descriptor<float, oneapi::dal::knn::method::brute_force>()
             .set_class_count(5)
-            .set_neighbor_count(1)
-            .set_data_use_in_model(false);
+            .set_neighbor_count(1);
 
     const auto x_test = dal::read<dal::table>(queue, dal::csv::data_source{test_data_file_name});
     const auto y_test = dal::read<dal::table>(queue, dal::csv::data_source{test_label_file_name});


### PR DESCRIPTION
`data_use_in_model` parameter removed from new Knn interfaces since it makes no sense with the accordance of input table immutability.