### PR TITLE
KDTree kNN indices type fix

### DIFF
--- a/cpp/daal/src/algorithms/k_nearest_neighbors/kdtree_knn_classification_predict_dense_default_batch.h
+++ b/cpp/daal/src/algorithms/k_nearest_neighbors/kdtree_knn_classification_predict_dense_default_batch.h
@@ -76,8 +76,8 @@ protected:
 
     services::Status predict(algorithmFpType * predictedClass, const Heap<GlobalNeighbors<algorithmFpType, cpu>, cpu> & heap,
                              const NumericTable * labels, size_t k, VoteWeights voteWeights, const NumericTable * modelIndices,
-                             data_management::BlockDescriptor<algorithmFpType> & indices,
-                             data_management::BlockDescriptor<algorithmFpType> & distances, size_t index, const size_t nClasses);
+                             data_management::BlockDescriptor<int> & indices, data_management::BlockDescriptor<algorithmFpType> & distances,
+                             size_t index, const size_t nClasses);
 };
 
 } // namespace internal

--- a/cpp/daal/src/algorithms/k_nearest_neighbors/kdtree_knn_classification_predict_dense_default_batch_impl.i
+++ b/cpp/daal/src/algorithms/k_nearest_neighbors/kdtree_knn_classification_predict_dense_default_batch_impl.i
@@ -392,7 +392,8 @@ Status KNNClassificationPredictKernel<algorithmFpType, defaultDense, cpu>::compu
             const_cast<NumericTable &>(*x).getBlockOfRows(first, last - first, readOnly, xBD);
             const algorithmFpType * const dx = xBD.getBlockPtr();
 
-            data_management::BlockDescriptor<algorithmFpType> indicesBD, distancesBD;
+            data_management::BlockDescriptor<int> indicesBD;
+            data_management::BlockDescriptor<algorithmFpType> distancesBD;
             if (indices)
             {
                 s = indices->getBlockOfRows(first, last - first, writeOnly, indicesBD);
@@ -605,7 +606,7 @@ void KNNClassificationPredictKernel<algorithmFpType, defaultDense, cpu>::findNea
 template <typename algorithmFpType, CpuType cpu>
 services::Status KNNClassificationPredictKernel<algorithmFpType, defaultDense, cpu>::predict(
     algorithmFpType * predictedClass, const Heap<GlobalNeighbors<algorithmFpType, cpu>, cpu> & heap, const NumericTable * labels, size_t k,
-    VoteWeights voteWeights, const NumericTable * modelIndices, data_management::BlockDescriptor<algorithmFpType> & indices,
+    VoteWeights voteWeights, const NumericTable * modelIndices, data_management::BlockDescriptor<int> & indices,
     data_management::BlockDescriptor<algorithmFpType> & distances, size_t index, const size_t nClasses)
 {
     typedef daal::internal::Math<algorithmFpType, cpu> Math;
@@ -618,12 +619,12 @@ services::Status KNNClassificationPredictKernel<algorithmFpType, defaultDense, c
         DAAL_ASSERT(modelIndices);
 
         services::Status s;
-        data_management::BlockDescriptor<algorithmFpType> modelIndicesBD;
+        data_management::BlockDescriptor<int> modelIndicesBD;
 
         const auto nIndices = indices.getNumberOfColumns();
         DAAL_ASSERT(heapSize <= nIndices);
 
-        algorithmFpType * const indicesPtr = indices.getBlockPtr() + index * nIndices;
+        int * const indicesPtr = indices.getBlockPtr() + index * nIndices;
 
         for (size_t i = 0; i < heapSize; ++i)
         {
@@ -634,11 +635,6 @@ services::Status KNNClassificationPredictKernel<algorithmFpType, defaultDense, c
 
             s |= const_cast<NumericTable *>(modelIndices)->releaseBlockOfRows(modelIndicesBD);
             DAAL_ASSERT(s.ok());
-        }
-
-        for (size_t i = heapSize; i < nIndices; ++i)
-        {
-            indicesPtr[i] = static_cast<size_t>(-1);
         }
     }
 

--- a/cpp/daal/src/algorithms/k_nearest_neighbors/kdtree_knn_classification_predict_result.h
+++ b/cpp/daal/src/algorithms/k_nearest_neighbors/kdtree_knn_classification_predict_result.h
@@ -59,7 +59,7 @@ DAAL_EXPORT services::Status Result::allocate(const daal::algorithms::Input * in
 
     if (s.ok() && (par->resultsToCompute & computeIndicesOfNeighbors))
     {
-        set(indices, data_management::HomogenNumericTable<size_t>::create(par->k, nRows, data_management::NumericTableIface::doAllocate, 0, &s));
+        set(indices, data_management::HomogenNumericTable<int>::create(par->k, nRows, data_management::NumericTableIface::doAllocate, 0, &s));
     }
 
     if (s.ok() && (par->resultsToCompute & computeDistances))


### PR DESCRIPTION
# Description
KDTree kNN indices type fix to prevent warning with clang compiler.