### PR TITLE
New library versioning

### DIFF
--- a/cpp/daal/include/services/library_version_info.h
+++ b/cpp/daal/include/services/library_version_info.h
@@ -33,6 +33,11 @@
 
 #define INTEL_DAAL_VERSION (__INTEL_DAAL__ * 10000 + __INTEL_DAAL_MINOR__ * 100 + __INTEL_DAAL_UPDATE__)
 
+#define __INTEL_DAAL_MAJOR_BINARY__ 999
+#define __INTEL_DAAL_MINOR_BINARY__ 999
+
+#define INTEL_DAAL_BINARY_VERSION (__INTEL_DAAL_MAJOR_BINARY__ * 1000 + __INTEL_DAAL_MINOR_BINARY__)
+
 #include "services/base.h"
 
 namespace daal

--- a/examples/daal/cpp/daal_win.vcxproj.tpl
+++ b/examples/daal/cpp/daal_win.vcxproj.tpl
@@ -168,7 +168,7 @@
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>onedal_core_dll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>onedal_core_dll_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Console</SubSystem>
     </Link>
   </ItemDefinitionGroup>
@@ -193,7 +193,7 @@
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>onedal_core.lib;onedal_thread.lib;tbb.lib;tbbmalloc.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>onedal_core.1.lib;onedal_thread.1.lib;tbb.lib;tbbmalloc.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalOptions>%(AdditionalOptions)</AdditionalOptions>
       <SubSystem>Console</SubSystem>
     </Link>
@@ -219,7 +219,7 @@
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>onedal_core.lib;onedal_sequential.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>onedal_core.1.lib;onedal_sequential.1.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalOptions>%(AdditionalOptions)</AdditionalOptions>
       <SubSystem>Console</SubSystem>
     </Link>
@@ -244,7 +244,7 @@
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>onedal_core_dll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>onedal_core_dll.1.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Console</SubSystem>
     </Link>
   </ItemDefinitionGroup>
@@ -269,7 +269,7 @@
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>onedal_core_dll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>onedal_core_dll.1.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Console</SubSystem>
     </Link>
   </ItemDefinitionGroup>

--- a/examples/daal/cpp/daal_win.vcxproj.tpl
+++ b/examples/daal/cpp/daal_win.vcxproj.tpl
@@ -147,7 +147,7 @@
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>onedal_core_dll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>onedal_core_dll.1.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Console</SubSystem>
     </Link>
   </ItemDefinitionGroup>
@@ -168,7 +168,7 @@
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>onedal_core_dll_1.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>onedal_core_dll.1.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Console</SubSystem>
     </Link>
   </ItemDefinitionGroup>
@@ -193,7 +193,7 @@
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>onedal_core.1.lib;onedal_thread.1.lib;tbb.lib;tbbmalloc.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>onedal_core.lib;onedal_thread.lib;tbb.lib;tbbmalloc.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalOptions>%(AdditionalOptions)</AdditionalOptions>
       <SubSystem>Console</SubSystem>
     </Link>
@@ -219,7 +219,7 @@
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>onedal_core.1.lib;onedal_sequential.1.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>onedal_core.lib;onedal_sequential.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalOptions>%(AdditionalOptions)</AdditionalOptions>
       <SubSystem>Console</SubSystem>
     </Link>

--- a/examples/daal/cpp/makefile_win
+++ b/examples/daal/cpp/makefile_win
@@ -125,10 +125,10 @@ COPTS=-W3 -EHsc $(COPTS)
 
 !IF ("$(RES_EXT)"=="lib")
 !IF ("$(threading)"=="sequential")
-DAAL_LIB_T = "$(DAAL_PATH)\onedal_sequential.lib"
+DAAL_LIB_T = "$(DAAL_PATH)\onedal_sequential.1.lib"
 !ELSE
 threading = parallel
-DAAL_LIB_T = "$(DAAL_PATH)\onedal_thread.lib"
+DAAL_LIB_T = "$(DAAL_PATH)\onedal_thread.1.lib"
 EXT_LIB = tbb.lib tbbmalloc.lib
 !ENDIF
 !ENDIF
@@ -140,9 +140,9 @@ LOPTS = $(DAAL_LIB) $(EXT_LIB)
 RES_DIR  =_results\$(compiler)_intel64_$(threading)_$(RES_EXT)
 
 lib libintel64:
-	nmake comm_func $(RES) $(CLEAN) EXT=.lib RES_EXT=lib compiler=$(compiler) threading=$(threading)
+	nmake comm_func $(RES) $(CLEAN) EXT=.1.lib RES_EXT=lib compiler=$(compiler) threading=$(threading)
 dll dllintel64:
-	nmake comm_func $(RES) $(CLEAN) EXT=_dll.lib RES_EXT=dll compiler=$(compiler) threading=$(threading)
+	nmake comm_func $(RES) $(CLEAN) EXT=_dll.1.lib RES_EXT=dll compiler=$(compiler) threading=$(threading)
 
 comm_func:
 	if not exist _results md _results

--- a/examples/daal/cpp/makefile_win
+++ b/examples/daal/cpp/makefile_win
@@ -125,10 +125,10 @@ COPTS=-W3 -EHsc $(COPTS)
 
 !IF ("$(RES_EXT)"=="lib")
 !IF ("$(threading)"=="sequential")
-DAAL_LIB_T = "$(DAAL_PATH)\onedal_sequential.1.lib"
+DAAL_LIB_T = "$(DAAL_PATH)\onedal_sequential.lib"
 !ELSE
 threading = parallel
-DAAL_LIB_T = "$(DAAL_PATH)\onedal_thread.1.lib"
+DAAL_LIB_T = "$(DAAL_PATH)\onedal_thread.lib"
 EXT_LIB = tbb.lib tbbmalloc.lib
 !ENDIF
 !ENDIF
@@ -140,7 +140,7 @@ LOPTS = $(DAAL_LIB) $(EXT_LIB)
 RES_DIR  =_results\$(compiler)_intel64_$(threading)_$(RES_EXT)
 
 lib libintel64:
-	nmake comm_func $(RES) $(CLEAN) EXT=.1.lib RES_EXT=lib compiler=$(compiler) threading=$(threading)
+	nmake comm_func $(RES) $(CLEAN) EXT=.lib RES_EXT=lib compiler=$(compiler) threading=$(threading)
 dll dllintel64:
 	nmake comm_func $(RES) $(CLEAN) EXT=_dll.1.lib RES_EXT=dll compiler=$(compiler) threading=$(threading)
 

--- a/examples/daal/cpp_sycl/daal_win.vcxproj.tpl
+++ b/examples/daal/cpp_sycl/daal_win.vcxproj.tpl
@@ -46,7 +46,7 @@
     <Link>
       <TreatWarningAsError />
       <SYCLShowVerboseInformation>false</SYCLShowVerboseInformation>
-      <AdditionalDependencies>onedal_sycl.lib;onedal_core_dll.lib;OpenCL.lib</AdditionalDependencies>
+      <AdditionalDependencies>onedal_sycl.lib;onedal_core_dll.1.lib;OpenCL.lib</AdditionalDependencies>
       <AdditionalOptions>/link /ignore:4078 %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>

--- a/examples/daal/cpp_sycl/makefile_win
+++ b/examples/daal/cpp_sycl/makefile_win
@@ -103,7 +103,7 @@ COPTS=-m64 $(COPTS)
 ERROR  Sequential version is not supported. To run sequential version please refer to 'examples/daal/cpp'
 !ELSE
 threading = parallel
-DAAL_LIB_T = "$(DAAL_PATH)\onedal_thread.1.lib"
+DAAL_LIB_T = "$(DAAL_PATH)\onedal_thread.lib"
 EXT_LIB = tbb.lib tbbmalloc.lib
 !ENDIF
 !ENDIF

--- a/examples/daal/cpp_sycl/makefile_win
+++ b/examples/daal/cpp_sycl/makefile_win
@@ -103,7 +103,7 @@ COPTS=-m64 $(COPTS)
 ERROR  Sequential version is not supported. To run sequential version please refer to 'examples/daal/cpp'
 !ELSE
 threading = parallel
-DAAL_LIB_T = "$(DAAL_PATH)\onedal_thread.lib"
+DAAL_LIB_T = "$(DAAL_PATH)\onedal_thread.1.lib"
 EXT_LIB = tbb.lib tbbmalloc.lib
 !ENDIF
 !ENDIF
@@ -115,7 +115,7 @@ LOPTS = $(DAAL_LIB) $(EXT_LIB) $(RT_LIB)
 RES_DIR  =_results\$(compiler)_$(_IA)_$(threading)_$(RES_EXT)
 
 dll dllintel64:
-	nmake comm_func $(RES) EXT=_dll.lib _IA=intel64 RES_EXT=dll compiler=$(compiler) threading=$(threading)
+	nmake comm_func $(RES) EXT=_dll.1.lib _IA=intel64 RES_EXT=dll compiler=$(compiler) threading=$(threading)
 
 comm_func:
 	if not exist _results md _results

--- a/examples/oneapi/cpp/makefile_win
+++ b/examples/oneapi/cpp/makefile_win
@@ -133,7 +133,7 @@ LOPTS = $(DAAL_LIB) $(EXT_LIB)
 lib libintel64:
 	nmake comm_func $(RES) $(CLEAN) EXT=.lib _IA=intel64 RES_EXT=lib compiler=$(compiler) threading=$(threading)
 dll dllintel64:
-	nmake comm_func $(RES) $(CLEAN) EXT=_dll.lib _IA=intel64 RES_EXT=dll compiler=$(compiler) threading=$(threading)
+	nmake comm_func $(RES) $(CLEAN) EXT=_dll.1.lib _IA=intel64 RES_EXT=dll compiler=$(compiler) threading=$(threading)
 
 comm_func:
 	if not exist _results md _results

--- a/examples/oneapi/cpp/onedal_win.vcxproj.tpl
+++ b/examples/oneapi/cpp/onedal_win.vcxproj.tpl
@@ -148,7 +148,7 @@
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>onedal_dll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>onedal_dll.1.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Console</SubSystem>
     </Link>
   </ItemDefinitionGroup>
@@ -170,7 +170,7 @@
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>onedal_dll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>onedal_dll.1.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Console</SubSystem>
     </Link>
   </ItemDefinitionGroup>
@@ -196,7 +196,7 @@
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>onedal.lib;onedal_core.lib;onedal_thread.lib;tbb.lib;tbbmalloc.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>onedal.1.lib;onedal_core.1.lib;onedal_thread.1.lib;tbb.lib;tbbmalloc.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalOptions>%(AdditionalOptions)</AdditionalOptions>
       <SubSystem>Console</SubSystem>
     </Link>
@@ -223,7 +223,7 @@
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>onedal.lib;onedal_core.lib;onedal_sequential.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>onedal.1.lib;onedal_core.1.lib;onedal_sequential.1.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalOptions>%(AdditionalOptions)</AdditionalOptions>
       <SubSystem>Console</SubSystem>
     </Link>

--- a/examples/oneapi/cpp/onedal_win.vcxproj.tpl
+++ b/examples/oneapi/cpp/onedal_win.vcxproj.tpl
@@ -196,7 +196,7 @@
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>onedal.1.lib;onedal_core.1.lib;onedal_thread.1.lib;tbb.lib;tbbmalloc.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>onedal.lib;onedal_core.lib;onedal_thread.lib;tbb.lib;tbbmalloc.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalOptions>%(AdditionalOptions)</AdditionalOptions>
       <SubSystem>Console</SubSystem>
     </Link>
@@ -223,7 +223,7 @@
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>onedal.1.lib;onedal_core.1.lib;onedal_sequential.1.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>onedal.lib;onedal_core.lib;onedal_sequential.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalOptions>%(AdditionalOptions)</AdditionalOptions>
       <SubSystem>Console</SubSystem>
     </Link>
@@ -249,7 +249,7 @@
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>onedal_dll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>onedal_dll.1.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Console</SubSystem>
     </Link>
   </ItemDefinitionGroup>
@@ -275,7 +275,7 @@
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>onedal_dll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>onedal_dll.1.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Console</SubSystem>
     </Link>
   </ItemDefinitionGroup>

--- a/examples/oneapi/dpc/makefile_win
+++ b/examples/oneapi/dpc/makefile_win
@@ -95,7 +95,7 @@ EXT_LIB = tbb.lib tbbmalloc.lib
 !ENDIF
 
 !ELSE
-DAAL_LIB="$(DAAL_PATH)\onedal_dpc_dll.lib"
+DAAL_LIB="$(DAAL_PATH)\onedal_dpc_dll.1.lib"
 RT_LIB=/link /ignore:4078
 !ENDIF
 

--- a/examples/oneapi/dpc/onedal_win.vcxproj.tpl
+++ b/examples/oneapi/dpc/onedal_win.vcxproj.tpl
@@ -66,7 +66,7 @@
     <Link>
       <TreatWarningAsError />
       <SYCLShowVerboseInformation>false</SYCLShowVerboseInformation>
-      <AdditionalDependencies>onedal_dpc_dll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>onedal_dpc_dll.1.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalOptions>/link /ignore:4078 %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
@@ -83,7 +83,7 @@
     <Link>
       <TreatWarningAsError />
       <SYCLShowVerboseInformation>false</SYCLShowVerboseInformation>
-      <AdditionalDependencies>onedal_dpc_dll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>onedal_dpc_dll.1.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalOptions>/link /ignore:4078 %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>

--- a/makefile
+++ b/makefile
@@ -266,12 +266,10 @@ mklgpufpk.HEADERS := $(MKLGPUFPKDIR.include)/mkl_dal_sycl.hpp $(MKLGPUFPKDIR.inc
 #===============================================================================
 # Release library names
 #===============================================================================
+include makefile.ver
 
-major_version := 1
-minor_version := 0
-
-y_full_name_postfix := $(if $(OS_is_win),,$(if $(OS_is_mac),.$(major_version).$(minor_version).$(y),.$(y).$(major_version).$(minor_version)))
-y_major_name_postfix := $(if $(OS_is_win),,$(if $(OS_is_mac),.$(major_version).$(y),.$(y).$(major_version)))
+y_full_name_postfix := $(if $(OS_is_win),,$(if $(OS_is_mac),.$(MAJORBINARY).$(MINORBINARY).$(y),.$(y).$(MAJORBINARY).$(MINORBINARY)))
+y_major_name_postfix := $(if $(OS_is_win),,$(if $(OS_is_mac),.$(MAJORBINARY).$(y),.$(y).$(MAJORBINARY)))
 
 core_a       := $(plib)onedal_core.$a
 core_y       := $(plib)onedal_core.$y
@@ -426,7 +424,6 @@ release.DOC.OSSPEC := $(foreach fn,$(release.DOC),$(if $(filter %$(_OS),$(basena
 #===============================================================================
 # Core part
 #===============================================================================
-include makefile.ver
 include makefile.lst
 
 THR.srcdir       := $(CPPDIR.daal)/src/threading
@@ -990,7 +987,7 @@ define .release.ay_win
 $3: $2/$1
 $(if $(phony-upd),$(eval .PHONY: $2/$1))
 $2/$1: $(WORKDIR.lib)/$1 | $2/.
-	cp -fp $(WORKDIR.lib)/$1 $2/$(subst dll.,dll.$(major_version).,$1)
+	cp -fp $(WORKDIR.lib)/$1 $2/$(subst dll.,dll.$(MAJORBINARY).,$1)
 endef
 define .release.y_link
 $3: $2/$1

--- a/makefile
+++ b/makefile
@@ -985,13 +985,13 @@ $3: $2/$1
 $(if $(phony-upd),$(eval .PHONY: $2/$1))
 $2/$1: $(WORKDIR.lib)/$1 | $2/. ; $(value upd)
 endef
-$(foreach a,$(release.LIBS_A),$(eval $(call .release.ay,$a,$(RELEASEDIR.libia),_release_c)))
-$(foreach y,$(release.LIBS_Y),$(eval $(call .release.ay,$y,$(RELEASEDIR.soia),_release_c)))
-$(foreach j,$(release.LIBS_J),$(eval $(call .release.ay,$j,$(RELEASEDIR.soia),_release_jj)))
-$(foreach a,$(release.ONEAPI.LIBS_A),$(eval $(call .release.ay,$a,$(RELEASEDIR.libia),_release_oneapi_c)))
-$(foreach y,$(release.ONEAPI.LIBS_Y),$(eval $(call .release.ay,$y,$(RELEASEDIR.soia),_release_oneapi_c)))
-$(foreach a,$(release.ONEAPI.LIBS_A.dpc),$(eval $(call .release.ay,$a,$(RELEASEDIR.libia),_release_oneapi_dpc)))
-$(foreach y,$(release.ONEAPI.LIBS_Y.dpc),$(eval $(call .release.ay,$y,$(RELEASEDIR.soia),_release_oneapi_dpc)))
+$(foreach x,$(release.LIBS_A),$(eval $(call .release.ay,$x,$(RELEASEDIR.libia),_release_c)))
+$(foreach x,$(release.LIBS_Y),$(eval $(call .release.ay,$x,$(RELEASEDIR.soia),_release_c)))
+$(foreach x,$(release.LIBS_J),$(eval $(call .release.ay,$x,$(RELEASEDIR.soia),_release_jj)))
+$(foreach x,$(release.ONEAPI.LIBS_A),$(eval $(call .release.ay,$x,$(RELEASEDIR.libia),_release_oneapi_c)))
+$(foreach x,$(release.ONEAPI.LIBS_Y),$(eval $(call .release.ay,$x,$(RELEASEDIR.soia),_release_oneapi_c)))
+$(foreach x,$(release.ONEAPI.LIBS_A.dpc),$(eval $(call .release.ay,$x,$(RELEASEDIR.libia),_release_oneapi_dpc)))
+$(foreach x,$(release.ONEAPI.LIBS_Y.dpc),$(eval $(call .release.ay,$x,$(RELEASEDIR.soia),_release_oneapi_dpc)))
 
 ifneq ($(MKLGPUFPKDIR),)
 # Copies the file to the destination directory and renames daal -> onedal
@@ -1019,8 +1019,8 @@ $2/$(subst onedal,daal,$1): $2/$1
 endef
 
 ifeq ($(if $(or $(OS_is_lnx),$(OS_is_mac)),yes,),yes)
-$(foreach a,$(release.LIBS_A),$(eval $(call .release.add_compat_symlink,$a,$(RELEASEDIR.libia),_release_c)))
-$(foreach y,$(release.LIBS_Y),$(eval $(call .release.add_compat_symlink,$y,$(RELEASEDIR.soia),_release_c)))
+$(foreach x,$(release.LIBS_A),$(eval $(call .release.add_compat_symlink,$x,$(RELEASEDIR.libia),_release_c)))
+$(foreach x,$(release.LIBS_Y),$(eval $(call .release.add_compat_symlink,$x,$(RELEASEDIR.soia),_release_c)))
 endif
 
 # Adds copy to the old library name
@@ -1033,7 +1033,7 @@ $2/$(subst onedal,daal,$1): $(WORKDIR.lib)/$1 ; $(value cpy)
 endef
 
 ifeq ($(OS_is_win),yes)
-$(foreach a,$(filter %_dll.$a,$(release.LIBS_A)),$(eval $(call .release.add_compat_copy,$a,$(RELEASEDIR.libia),_release_c)))
+$(foreach x,$(filter %_dll.$a,$(release.LIBS_A)),$(eval $(call .release.add_compat_copy,$x,$(RELEASEDIR.libia),_release_c)))
 endif
 
 #----- releasing jar files

--- a/makefile.ver
+++ b/makefile.ver
@@ -63,6 +63,7 @@ update_headers_version:
 	@file=$(RELEASEDIR.include)/services/library_version_info.h && mark="#define __INTEL_DAAL" && \
 	sed $(sed.-b) $(sed.-i) -e "s/_DAAL_BUILD_DATE.*/_DAAL_BUILD_DATE $(BUILD)$(sed.eol)/" \
 		-e "s/\($${mark}__\).*/\1 $(MAJOR)$(sed.eol)/;s/\($${mark}_MINOR__\).*/\1 $(MINOR)$(sed.eol)/" \
+		-e "s/\($${mark}_MAJOR_BINARY__\).*/\1 $(MAJORBINARY)$(sed.eol)/;s/\($${mark}_MINOR_BINARY__\).*/\1 $(MINORBINARY)$(sed.eol)/" \
 		-e "s/\($${mark}_UPDATE__\).*/\1 $(UPDATE)$(sed.eol)/" \
 		-e "s/\($${mark}_STATUS__\).*/\1 \"$(STATUS)\"$(sed.eol)/" $$file && \
         rm -f $$file.bak

--- a/makefile.ver
+++ b/makefile.ver
@@ -21,6 +21,9 @@ BUILD   =       $(shell date +'%Y%m%d')
 STATUS  =       P
 BUILDREV ?=     work
 
+MAJORBINARY = 1
+MINORBINARY = 0
+
 #-------------------------------------------------------------------------------
 # Declarations
 #

--- a/samples/daal/cpp/arrow/launcher.bat
+++ b/samples/daal/cpp/arrow/launcher.bat
@@ -54,7 +54,7 @@ echo %RESULT_DIR%
 
 set CFLAGS=-nologo -w -DDAAL_CHECK_PARAMETER -std=c++14 /I %ARROWROOT%\cpp\src /I %ARROWROOT%\cpp\%ARROWCONFIG%\src /I %DAALROOT%\include
 set LFLAGS=-nologo
-set LIB_DAAL=onedal_core.1.lib onedal_thread.1.lib
+set LIB_DAAL=onedal_core.lib onedal_thread.lib
 set LIB_DAAL_DLL=onedal_core_dll.1.lib
 set LFLAGS_DAAL=%LIB_DAAL% tbb.lib tbbmalloc.lib
 set LFLAGS_DAAL_DLL=onedal_core_dll.1.lib

--- a/samples/daal/cpp/arrow/launcher.bat
+++ b/samples/daal/cpp/arrow/launcher.bat
@@ -54,10 +54,10 @@ echo %RESULT_DIR%
 
 set CFLAGS=-nologo -w -DDAAL_CHECK_PARAMETER -std=c++14 /I %ARROWROOT%\cpp\src /I %ARROWROOT%\cpp\%ARROWCONFIG%\src /I %DAALROOT%\include
 set LFLAGS=-nologo
-set LIB_DAAL=onedal_core.lib onedal_thread.lib
-set LIB_DAAL_DLL=onedal_core_dll.lib
+set LIB_DAAL=onedal_core.1.lib onedal_thread.1.lib
+set LIB_DAAL_DLL=onedal_core_dll.1.lib
 set LFLAGS_DAAL=%LIB_DAAL% tbb.lib tbbmalloc.lib
-set LFLAGS_DAAL_DLL=onedal_core_dll.lib
+set LFLAGS_DAAL_DLL=onedal_core_dll.1.lib
 set ARROW_LOGFILE=.\%RESULT_DIR%\build_arrow.log
 set LIB_DOUBLE_CONV=%ARROWROOT%\cpp\%ARROWCONFIG%\double-conversion_ep\src\double-conversion_ep\lib\double-conversion.lib
 set ARROW_LIBRARIES=%ARROWROOT%\cpp\%ARROWCONFIG%\%ARROWCONFIG%\Release\arrow.lib

--- a/samples/daal/cpp/kdb/launcher.bat
+++ b/samples/daal/cpp/kdb/launcher.bat
@@ -50,7 +50,7 @@ echo %RESULT_DIR%
 
 set CFLAGS=-nologo -w -DDAAL_CHECK_PARAMETER /I %KDB_HEADER_PATH%
 set LFLAGS=-nologo
-set LIB_DAAL=onedal_core.1.lib onedal_thread.1.lib
+set LIB_DAAL=onedal_core.lib onedal_thread.lib
 set LIB_DAAL_DLL=onedal_core_dll.1.lib
 set LFLAGS_DAAL=%LIB_DAAL% tbb.lib tbbmalloc.lib impi.lib
 set LFLAGS_DAAL_DLL=onedal_core_dll.1.lib

--- a/samples/daal/cpp/kdb/launcher.bat
+++ b/samples/daal/cpp/kdb/launcher.bat
@@ -50,10 +50,10 @@ echo %RESULT_DIR%
 
 set CFLAGS=-nologo -w -DDAAL_CHECK_PARAMETER /I %KDB_HEADER_PATH%
 set LFLAGS=-nologo
-set LIB_DAAL=onedal_core.lib onedal_thread.lib
-set LIB_DAAL_DLL=onedal_core_dll.lib
+set LIB_DAAL=onedal_core.1.lib onedal_thread.1.lib
+set LIB_DAAL_DLL=onedal_core_dll.1.lib
 set LFLAGS_DAAL=%LIB_DAAL% tbb.lib tbbmalloc.lib impi.lib
-set LFLAGS_DAAL_DLL=onedal_core_dll.lib
+set LFLAGS_DAAL_DLL=onedal_core_dll.1.lib
 set KDB_LOGFILE=.\%RESULT_DIR%\build_kdb.log
 if not "%RMODE%"=="run" (
     if exist %KDB_LOGFILE% del /Q /F %KDB_LOGFILE%

--- a/samples/daal/cpp/mpi/launcher.bat
+++ b/samples/daal/cpp/mpi/launcher.bat
@@ -45,7 +45,7 @@ echo %RESULT_DIR%
 
 set CFLAGS=-nologo -w
 set LFLAGS=-nologo
-set LIB_DAAL=onedal_core.1.lib onedal_thread.1.lib
+set LIB_DAAL=onedal_core.lib onedal_thread.lib
 set LIB_DAAL_DLL=onedal_core_dll.1.lib
 set LFLAGS_DAAL=%LIB_DAAL% tbb.lib tbbmalloc.lib impi.lib
 set LFLAGS_DAAL_DLL=onedal_core_dll.1.lib

--- a/samples/daal/cpp/mpi/launcher.bat
+++ b/samples/daal/cpp/mpi/launcher.bat
@@ -45,10 +45,10 @@ echo %RESULT_DIR%
 
 set CFLAGS=-nologo -w
 set LFLAGS=-nologo
-set LIB_DAAL=onedal_core.lib onedal_thread.lib
-set LIB_DAAL_DLL=onedal_core_dll.lib
+set LIB_DAAL=onedal_core.1.lib onedal_thread.1.lib
+set LIB_DAAL_DLL=onedal_core_dll.1.lib
 set LFLAGS_DAAL=%LIB_DAAL% tbb.lib tbbmalloc.lib impi.lib
-set LFLAGS_DAAL_DLL=onedal_core_dll.lib
+set LFLAGS_DAAL_DLL=onedal_core_dll.1.lib
 set MPI_LOGFILE=.\%RESULT_DIR%\build_mpi.log
 if not "%RMODE%"=="run" (
     if exist %MPI_LOGFILE% del /Q /F %MPI_LOGFILE%

--- a/samples/daal/cpp/mysql/launcher.bat
+++ b/samples/daal/cpp/mysql/launcher.bat
@@ -52,7 +52,7 @@ echo %RESULT_DIR%
 
 set CFLAGS=-nologo -w
 set LFLAGS=-nologo
-set LIB_DAAL=onedal_core.1.lib onedal_thread.1.lib
+set LIB_DAAL=onedal_core.lib onedal_thread.lib
 set LIB_DAAL_DLL=onedal_core_dll.1.lib
 set LFLAGS_DAAL=%LIB_DAAL% tbb.lib tbbmalloc.lib impi.lib
 set LFLAGS_DAAL_DLL=onedal_core_dll.1.lib

--- a/samples/daal/cpp/mysql/launcher.bat
+++ b/samples/daal/cpp/mysql/launcher.bat
@@ -52,10 +52,10 @@ echo %RESULT_DIR%
 
 set CFLAGS=-nologo -w
 set LFLAGS=-nologo
-set LIB_DAAL=onedal_core.lib onedal_thread.lib
-set LIB_DAAL_DLL=onedal_core_dll.lib
+set LIB_DAAL=onedal_core.1.lib onedal_thread.1.lib
+set LIB_DAAL_DLL=onedal_core_dll.1.lib
 set LFLAGS_DAAL=%LIB_DAAL% tbb.lib tbbmalloc.lib impi.lib
-set LFLAGS_DAAL_DLL=onedal_core_dll.lib
+set LFLAGS_DAAL_DLL=onedal_core_dll.1.lib
 set ODBC_LIB=%ODBC_PATH%/Odbc32.lib
 echo %ODBC_LIB%
 set MYSQL_LOGFILE=.\%RESULT_DIR%\build_mysql.log


### PR DESCRIPTION
Rename dynamic library files and create new chain of links:

1. Linux:
   - Old: libdaal*.so -> libonedal*.so
   - New: libonedal*.so -> libonedal*.so.{major version} -> libonedal*.so.{major version}.{minor version}
2. MacOS:
   - Old: libdaal*.dylib -> libonedal*.dylib
   - New: libonedal*.dylib -> libonedal*.{major version}.dylib -> libonedal*.{major version}.{minor version}.dylib
3. Windows:
   - Old: onedal_dll.lib
   - New: onedal_dll.{major version}.lib