### PR TITLE
[DRAFT] Prototype of centralized error generator

### DIFF
--- a/cpp/oneapi/dal/detail/error_reporting.cpp
+++ b/cpp/oneapi/dal/detail/error_reporting.cpp
@@ -1,0 +1,34 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "oneapi/dal/detail/error_reporting.hpp"
+
+#define DEFINE_MESSAGE(id, text)                \
+    static const char* _##id = text;            \
+    const char* error_messages::id() noexcept { \
+        return _##id;                           \
+    }
+
+namespace oneapi::dal::detail {
+
+DEFINE_MESSAGE(input_data_is_empty, "Input data is empty")
+DEFINE_MESSAGE(input_labels_are_empty, "Input labels are empty")
+DEFINE_MESSAGE(input_data_row_count_is_not_equal_to_input_labels_row_count,
+               "Input data row count is not equal to input labels row count")
+DEFINE_MESSAGE(bootstrap_is_incompatible_with_variable_importance_mode,
+               "Parameter `bootstrap` is incompatible with requested variable importance mode")
+
+} // namespace oneapi::dal::detail

--- a/cpp/oneapi/dal/detail/error_reporting.hpp
+++ b/cpp/oneapi/dal/detail/error_reporting.hpp
@@ -1,0 +1,64 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#pragma once
+
+#include "oneapi/dal/exceptions.hpp"
+
+namespace oneapi::dal::detail {
+
+#define DECLARE_MESSAGE(id) static const char* id() noexcept
+
+class error_messages {
+public:
+    error_messages() = delete;
+    error_messages(const error_messages&) = delete;
+    error_messages& operator=(const error_messages&) = delete;
+
+    DECLARE_MESSAGE(input_data_is_empty);
+    DECLARE_MESSAGE(input_labels_are_empty);
+    DECLARE_MESSAGE(input_data_row_count_is_not_equal_to_input_labels_row_count);
+    DECLARE_MESSAGE(bootstrap_is_incompatible_with_variable_importance_mode);
+};
+
+#undef DECLARE_MESSAGE
+
+#define DEFINE_EXCEPTION(ExceptionType, id)              \
+    static ExceptionType id() noexcept {                 \
+        return ExceptionType(error_messages::id());      \
+    }                                                    \
+                                                         \
+    static void report_##id##_if_false(bool condition) { \
+        if (!condition) {                                \
+            throw id();                                  \
+        }                                                \
+    }
+
+class exception_generator {
+public:
+    exception_generator() = delete;
+    exception_generator(const exception_generator&) = delete;
+    exception_generator& operator=(const exception_generator&) = delete;
+
+    DEFINE_EXCEPTION(domain_error, input_data_is_empty)
+    DEFINE_EXCEPTION(domain_error, input_labels_are_empty)
+    DEFINE_EXCEPTION(invalid_argument, input_data_row_count_is_not_equal_to_input_labels_row_count)
+    DEFINE_EXCEPTION(invalid_argument, bootstrap_is_incompatible_with_variable_importance_mode)
+};
+
+#undef DEFINE_EXCEPTION
+
+} // namespace oneapi::dal::detail


### PR DESCRIPTION
Current:
- Introduce `error_messages` class with the static functions returning `const char *`  for all possible error messages, name of the function reflects content of the message, but not tightly coupled with it to have flexibility in changing error message content.
-  Introduce `exception_generator` that simplifies throwing exceptions with particular error messages.

Future:
- Support [messages formatting](https://en.cppreference.com/w/cpp/utility/format)
- Generate `error_messages` and `exception_generator` from YAML:
```yaml
input_data_is_empty: >
   Input data is empty

input_labels_are_empty: >
   Input labels are empty
``` 