### PR TITLE
Add v1 to all algorithms + consistency

### DIFF
--- a/cpp/oneapi/dal/algo/decision_forest/backend/model_impl.hpp
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/model_impl.hpp
@@ -46,7 +46,10 @@ private:
     backend::model_interop* interop_ = nullptr;
 };
 
+namespace backend {
+
 using model_impl_cls = detail::model_impl<task::classification>;
 using model_impl_reg = detail::model_impl<task::regression>;
 
+} // namespace backend
 } // namespace oneapi::dal::decision_forest

--- a/cpp/oneapi/dal/algo/decision_forest/common.hpp
+++ b/cpp/oneapi/dal/algo/decision_forest/common.hpp
@@ -51,6 +51,7 @@ using v1::by_default;
 namespace detail {
 namespace v1 {
 struct tag {};
+
 template <typename Task>
 class descriptor_impl;
 
@@ -65,6 +66,16 @@ using v1::model_impl;
 template <typename T>
 using enable_if_classification_t =
     std::enable_if_t<std::is_same_v<std::decay_t<T>, task::classification>>;
+
+template <typename Float>
+constexpr bool is_valid_float_v = dal::detail::is_one_of_v<Float, float, double>;
+
+template <typename Method>
+constexpr bool is_valid_method_v = dal::detail::is_one_of_v<Method, method::dense, method::hist>;
+
+template <typename Task>
+constexpr bool is_valid_task_v =
+    dal::detail::is_one_of_v<Task, task::classification, task::regression>;
 
 } // namespace detail
 
@@ -100,6 +111,7 @@ enum class voting_mode { weighted, unweighted };
 
 template <typename Task = task::by_default>
 class descriptor_base : public base {
+    static_assert(detail::is_valid_task_v<Task>);
     friend dal::detail::pimpl_accessor;
 
 public:
@@ -182,9 +194,9 @@ template <typename Float = descriptor_base<>::float_t,
           typename Method = descriptor_base<>::method_t,
           typename Task = descriptor_base<>::task_t>
 class descriptor : public descriptor_base<Task> {
-    static_assert(dal::detail::is_one_of_v<Float, float, double>);
-    static_assert(dal::detail::is_one_of_v<Method, method::dense, method::hist>);
-    static_assert(dal::detail::is_one_of_v<Task, task::classification, task::regression>);
+    static_assert(detail::is_valid_float_v<Float>);
+    static_assert(detail::is_valid_method_v<Method>);
+    static_assert(detail::is_valid_task_v<Task>);
 
 public:
     using float_t = Float;
@@ -292,6 +304,7 @@ public:
 
 template <typename Task = task::by_default>
 class model : public base {
+    static_assert(detail::is_valid_task_v<Task>);
     friend dal::detail::pimpl_accessor;
 
 public:

--- a/cpp/oneapi/dal/algo/decision_forest/detail/infer_ops.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/detail/infer_ops.cpp
@@ -19,6 +19,8 @@
 #include "oneapi/dal/backend/dispatcher.hpp"
 
 namespace oneapi::dal::decision_forest::detail {
+namespace v1 {
+
 using oneapi::dal::detail::host_policy;
 
 template <typename Float, typename Task, typename Method>
@@ -40,4 +42,6 @@ INSTANTIATE(double, task::classification, method::dense)
 
 INSTANTIATE(float, task::regression, method::dense)
 INSTANTIATE(double, task::regression, method::dense)
+
+} // namespace v1
 } // namespace oneapi::dal::decision_forest::detail

--- a/cpp/oneapi/dal/algo/decision_forest/detail/infer_ops.hpp
+++ b/cpp/oneapi/dal/algo/decision_forest/detail/infer_ops.hpp
@@ -20,9 +20,10 @@
 #include "oneapi/dal/detail/error_messages.hpp"
 
 namespace oneapi::dal::decision_forest::detail {
+namespace v1 {
 
-template <typename Context, typename Float, typename Task, typename Method>
-struct ONEDAL_EXPORT infer_ops_dispatcher {
+template <typename Context, typename Float, typename Task, typename Method, typename... Options>
+struct infer_ops_dispatcher {
     infer_result<Task> operator()(const Context&,
                                   const descriptor_base<Task>&,
                                   const infer_input<Task>&) const;
@@ -58,5 +59,9 @@ struct infer_ops {
         return result;
     }
 };
+
+} // namespace v1
+
+using v1::infer_ops;
 
 } // namespace oneapi::dal::decision_forest::detail

--- a/cpp/oneapi/dal/algo/decision_forest/detail/infer_ops_dpc.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/detail/infer_ops_dpc.cpp
@@ -20,7 +20,9 @@
 #include "oneapi/dal/backend/dispatcher_dpc.hpp"
 
 namespace oneapi::dal::decision_forest::detail {
-using oneapi::dal::detail::data_parallel_policy;
+namespace v1 {
+
+using dal::detail::data_parallel_policy;
 
 template <typename Float, typename Task, typename Method>
 struct infer_ops_dispatcher<data_parallel_policy, Float, Task, Method> {
@@ -42,4 +44,6 @@ INSTANTIATE(double, task::classification, method::dense)
 
 INSTANTIATE(float, task::regression, method::dense)
 INSTANTIATE(double, task::regression, method::dense)
+
+} // namespace v1
 } // namespace oneapi::dal::decision_forest::detail

--- a/cpp/oneapi/dal/algo/decision_forest/detail/train_ops.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/detail/train_ops.cpp
@@ -19,6 +19,8 @@
 #include "oneapi/dal/backend/dispatcher.hpp"
 
 namespace oneapi::dal::decision_forest::detail {
+namespace v1 {
+
 using oneapi::dal::detail::host_policy;
 
 template <typename Float, typename Task, typename Method>
@@ -44,4 +46,6 @@ INSTANTIATE(float, task::regression, method::dense)
 INSTANTIATE(float, task::regression, method::hist)
 INSTANTIATE(double, task::regression, method::dense)
 INSTANTIATE(double, task::regression, method::hist)
+
+} // namespace v1
 } // namespace oneapi::dal::decision_forest::detail

--- a/cpp/oneapi/dal/algo/decision_forest/detail/train_ops.hpp
+++ b/cpp/oneapi/dal/algo/decision_forest/detail/train_ops.hpp
@@ -20,9 +20,10 @@
 #include "oneapi/dal/detail/error_messages.hpp"
 
 namespace oneapi::dal::decision_forest::detail {
+namespace v1 {
 
-template <typename Context, typename Float, typename Task, typename Method>
-struct ONEDAL_EXPORT train_ops_dispatcher {
+template <typename Context, typename Float, typename Task, typename Method, typename... Options>
+struct train_ops_dispatcher {
     train_result<Task> operator()(const Context&,
                                   const descriptor_base<Task>&,
                                   const train_input<Task>&) const;
@@ -79,5 +80,9 @@ struct train_ops {
         return result;
     }
 };
+
+} // namespace v1
+
+using v1::train_ops;
 
 } // namespace oneapi::dal::decision_forest::detail

--- a/cpp/oneapi/dal/algo/decision_forest/detail/train_ops_dpc.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/detail/train_ops_dpc.cpp
@@ -20,7 +20,9 @@
 #include "oneapi/dal/backend/dispatcher_dpc.hpp"
 
 namespace oneapi::dal::decision_forest::detail {
-using oneapi::dal::detail::data_parallel_policy;
+namespace v1 {
+
+using dal::detail::data_parallel_policy;
 
 template <typename Float, typename Task, typename Method>
 struct train_ops_dispatcher<data_parallel_policy, Float, Task, Method> {
@@ -46,4 +48,6 @@ INSTANTIATE(float, task::regression, method::dense)
 INSTANTIATE(float, task::regression, method::hist)
 INSTANTIATE(double, task::regression, method::dense)
 INSTANTIATE(double, task::regression, method::hist)
+
+} // namespace v1
 } // namespace oneapi::dal::decision_forest::detail

--- a/cpp/oneapi/dal/algo/decision_forest/infer.hpp
+++ b/cpp/oneapi/dal/algo/decision_forest/infer.hpp
@@ -21,9 +21,11 @@
 #include "oneapi/dal/infer.hpp"
 
 namespace oneapi::dal::detail {
+namespace v1 {
 
 template <typename Descriptor>
 struct infer_ops<Descriptor, dal::decision_forest::detail::tag>
         : dal::decision_forest::detail::infer_ops<Descriptor> {};
 
+} // namespace v1
 } // namespace oneapi::dal::detail

--- a/cpp/oneapi/dal/algo/decision_forest/infer_types.hpp
+++ b/cpp/oneapi/dal/algo/decision_forest/infer_types.hpp
@@ -24,6 +24,7 @@ namespace detail {
 namespace v1 {
 template <typename Task>
 class infer_input_impl;
+
 template <typename Task>
 class infer_result_impl;
 } // namespace v1
@@ -37,6 +38,8 @@ namespace v1 {
 
 template <typename Task = task::by_default>
 class infer_input : public base {
+    static_assert(detail::is_valid_task_v<Task>);
+
 public:
     using task_t = Task;
 
@@ -65,6 +68,8 @@ private:
 
 template <typename Task = task::by_default>
 class infer_result : public base {
+    static_assert(detail::is_valid_task_v<Task>);
+
 public:
     using task_t = Task;
 

--- a/cpp/oneapi/dal/algo/decision_forest/train.hpp
+++ b/cpp/oneapi/dal/algo/decision_forest/train.hpp
@@ -21,9 +21,11 @@
 #include "oneapi/dal/train.hpp"
 
 namespace oneapi::dal::detail {
+namespace v1 {
 
 template <typename Descriptor>
 struct train_ops<Descriptor, dal::decision_forest::detail::tag>
         : dal::decision_forest::detail::train_ops<Descriptor> {};
 
+} // namespace v1
 } // namespace oneapi::dal::detail

--- a/cpp/oneapi/dal/algo/decision_forest/train_types.hpp
+++ b/cpp/oneapi/dal/algo/decision_forest/train_types.hpp
@@ -22,10 +22,10 @@ namespace oneapi::dal::decision_forest {
 
 namespace detail {
 namespace v1 {
-template <typename Task = task::by_default>
+template <typename Task>
 class train_input_impl;
 
-template <typename Task = task::by_default>
+template <typename Task>
 class train_result_impl;
 } // namespace v1
 
@@ -38,6 +38,8 @@ namespace v1 {
 
 template <typename Task = task::by_default>
 class train_input : public base {
+    static_assert(detail::is_valid_task_v<Task>);
+
 public:
     using task_t = Task;
 
@@ -66,6 +68,8 @@ private:
 
 template <typename Task = task::by_default>
 class train_result {
+    static_assert(detail::is_valid_task_v<Task>);
+
 public:
     using task_t = Task;
 

--- a/cpp/oneapi/dal/algo/kmeans/common.cpp
+++ b/cpp/oneapi/dal/algo/kmeans/common.cpp
@@ -41,39 +41,39 @@ namespace v1 {
 template <typename Task>
 descriptor_base<Task>::descriptor_base() : impl_(new descriptor_impl<Task>{}) {}
 
-template <>
-std::int64_t descriptor_base<task::clustering>::get_cluster_count() const {
+template <typename Task>
+std::int64_t descriptor_base<Task>::get_cluster_count() const {
     return impl_->cluster_count;
 }
 
-template <>
-std::int64_t descriptor_base<task::clustering>::get_max_iteration_count() const {
+template <typename Task>
+std::int64_t descriptor_base<Task>::get_max_iteration_count() const {
     return impl_->max_iteration_count;
 }
 
-template <>
-double descriptor_base<task::clustering>::get_accuracy_threshold() const {
+template <typename Task>
+double descriptor_base<Task>::get_accuracy_threshold() const {
     return impl_->accuracy_threshold;
 }
 
-template <>
-void descriptor_base<task::clustering>::set_cluster_count_impl(std::int64_t value) {
+template <typename Task>
+void descriptor_base<Task>::set_cluster_count_impl(std::int64_t value) {
     if (value <= 0) {
         throw domain_error(dal::detail::error_messages::cluster_count_leq_zero());
     }
     impl_->cluster_count = value;
 }
 
-template <>
-void descriptor_base<task::clustering>::set_max_iteration_count_impl(std::int64_t value) {
+template <typename Task>
+void descriptor_base<Task>::set_max_iteration_count_impl(std::int64_t value) {
     if (value < 0) {
         throw domain_error(dal::detail::error_messages::max_iteration_count_lt_zero());
     }
     impl_->max_iteration_count = value;
 }
 
-template <>
-void descriptor_base<task::clustering>::set_accuracy_threshold_impl(double value) {
+template <typename Task>
+void descriptor_base<Task>::set_accuracy_threshold_impl(double value) {
     if (value < 0.0) {
         throw domain_error(dal::detail::error_messages::accuracy_threshold_lt_zero());
     }
@@ -83,18 +83,18 @@ void descriptor_base<task::clustering>::set_accuracy_threshold_impl(double value
 template <typename Task>
 model<Task>::model() : impl_(new model_impl<Task>{}) {}
 
-template <>
-const table& model<task::clustering>::get_centroids() const {
+template <typename Task>
+const table& model<Task>::get_centroids() const {
     return impl_->centroids;
 }
 
-template <>
-std::int64_t model<task::clustering>::get_cluster_count() const {
+template <typename Task>
+std::int64_t model<Task>::get_cluster_count() const {
     return impl_->centroids.get_row_count();
 }
 
-template <>
-void model<task::clustering>::set_centroids_impl(const table& value) {
+template <typename Task>
+void model<Task>::set_centroids_impl(const table& value) {
     impl_->centroids = value;
 }
 

--- a/cpp/oneapi/dal/algo/kmeans/common.cpp
+++ b/cpp/oneapi/dal/algo/kmeans/common.cpp
@@ -19,16 +19,16 @@
 
 namespace oneapi::dal::kmeans {
 
-template <>
-class detail::v1::descriptor_impl<task::clustering> : public base {
+template <typename Task>
+class detail::v1::descriptor_impl : public base {
 public:
     std::int64_t cluster_count = 2;
     std::int64_t max_iteration_count = 100;
     double accuracy_threshold = 0;
 };
 
-template <>
-class detail::v1::model_impl<task::clustering> : public base {
+template <typename Task>
+class detail::v1::model_impl : public base {
 public:
     table centroids;
 };

--- a/cpp/oneapi/dal/algo/kmeans/common.cpp
+++ b/cpp/oneapi/dal/algo/kmeans/common.cpp
@@ -20,7 +20,7 @@
 namespace oneapi::dal::kmeans {
 
 template <>
-class detail::descriptor_impl<task::clustering> : public base {
+class detail::v1::descriptor_impl<task::clustering> : public base {
 public:
     std::int64_t cluster_count = 2;
     std::int64_t max_iteration_count = 100;
@@ -28,16 +28,18 @@ public:
 };
 
 template <>
-class detail::model_impl<task::clustering> : public base {
+class detail::v1::model_impl<task::clustering> : public base {
 public:
     table centroids;
 };
 
-using detail::descriptor_impl;
-using detail::model_impl;
+using detail::v1::descriptor_impl;
+using detail::v1::model_impl;
+
+namespace v1 {
 
 template <typename Task>
-descriptor_base<Task>::descriptor_base() : impl_(new descriptor_impl{}) {}
+descriptor_base<Task>::descriptor_base() : impl_(new descriptor_impl<Task>{}) {}
 
 template <>
 std::int64_t descriptor_base<task::clustering>::get_cluster_count() const {
@@ -79,10 +81,10 @@ void descriptor_base<task::clustering>::set_accuracy_threshold_impl(double value
 }
 
 template <typename Task>
-model<Task>::model() : impl_(new model_impl{}) {}
+model<Task>::model() : impl_(new model_impl<Task>{}) {}
 
 template <>
-table model<task::clustering>::get_centroids() const {
+const table& model<task::clustering>::get_centroids() const {
     return impl_->centroids;
 }
 
@@ -99,4 +101,5 @@ void model<task::clustering>::set_centroids_impl(const table& value) {
 template class ONEDAL_EXPORT descriptor_base<task::clustering>;
 template class ONEDAL_EXPORT model<task::clustering>;
 
+} // namespace v1
 } // namespace oneapi::dal::kmeans

--- a/cpp/oneapi/dal/algo/kmeans/detail/infer_ops.cpp
+++ b/cpp/oneapi/dal/algo/kmeans/detail/infer_ops.cpp
@@ -19,7 +19,9 @@
 #include "oneapi/dal/backend/dispatcher.hpp"
 
 namespace oneapi::dal::kmeans::detail {
-using oneapi::dal::detail::host_policy;
+namespace v1 {
+
+using dal::detail::host_policy;
 
 template <typename Float, typename Method, typename Task>
 struct infer_ops_dispatcher<host_policy, Float, Method, Task> {
@@ -38,4 +40,5 @@ struct infer_ops_dispatcher<host_policy, Float, Method, Task> {
 INSTANTIATE(float, method::by_default, task::clustering)
 INSTANTIATE(double, method::by_default, task::clustering)
 
+} // namespace v1
 } // namespace oneapi::dal::kmeans::detail

--- a/cpp/oneapi/dal/algo/kmeans/detail/infer_ops.hpp
+++ b/cpp/oneapi/dal/algo/kmeans/detail/infer_ops.hpp
@@ -20,12 +20,10 @@
 #include "oneapi/dal/detail/error_messages.hpp"
 
 namespace oneapi::dal::kmeans::detail {
+namespace v1 {
 
-template <typename Context,
-          typename Float,
-          typename Method = method::by_default,
-          typename Task = task::by_default>
-struct ONEDAL_EXPORT infer_ops_dispatcher {
+template <typename Context, typename Float, typename Method, typename Task, typename... Options>
+struct infer_ops_dispatcher {
     infer_result<Task> operator()(const Context&,
                                   const descriptor_base<Task>&,
                                   const infer_input<Task>&) const;
@@ -75,5 +73,9 @@ struct infer_ops {
         return result;
     }
 };
+
+} // namespace v1
+
+using v1::infer_ops;
 
 } // namespace oneapi::dal::kmeans::detail

--- a/cpp/oneapi/dal/algo/kmeans/detail/infer_ops_dpc.cpp
+++ b/cpp/oneapi/dal/algo/kmeans/detail/infer_ops_dpc.cpp
@@ -20,7 +20,9 @@
 #include "oneapi/dal/backend/dispatcher_dpc.hpp"
 
 namespace oneapi::dal::kmeans::detail {
-using oneapi::dal::detail::data_parallel_policy;
+namespace v1 {
+
+using dal::detail::data_parallel_policy;
 
 template <typename Float, typename Method, typename Task>
 struct infer_ops_dispatcher<data_parallel_policy, Float, Method, Task> {
@@ -40,4 +42,5 @@ struct infer_ops_dispatcher<data_parallel_policy, Float, Method, Task> {
 INSTANTIATE(float, method::by_default, task::clustering)
 INSTANTIATE(double, method::by_default, task::clustering)
 
+} // namespace v1
 } // namespace oneapi::dal::kmeans::detail

--- a/cpp/oneapi/dal/algo/kmeans/detail/train_ops.cpp
+++ b/cpp/oneapi/dal/algo/kmeans/detail/train_ops.cpp
@@ -19,7 +19,9 @@
 #include "oneapi/dal/backend/dispatcher.hpp"
 
 namespace oneapi::dal::kmeans::detail {
-using oneapi::dal::detail::host_policy;
+namespace v1 {
+
+using dal::detail::host_policy;
 
 template <typename Float, typename Method, typename Task>
 struct train_ops_dispatcher<host_policy, Float, Method, Task> {
@@ -38,4 +40,5 @@ struct train_ops_dispatcher<host_policy, Float, Method, Task> {
 INSTANTIATE(float, method::lloyd_dense, task::clustering)
 INSTANTIATE(double, method::lloyd_dense, task::clustering)
 
+} // namespace v1
 } // namespace oneapi::dal::kmeans::detail

--- a/cpp/oneapi/dal/algo/kmeans/detail/train_ops.hpp
+++ b/cpp/oneapi/dal/algo/kmeans/detail/train_ops.hpp
@@ -20,12 +20,10 @@
 #include "oneapi/dal/detail/error_messages.hpp"
 
 namespace oneapi::dal::kmeans::detail {
+namespace v1 {
 
-template <typename Context,
-          typename Float,
-          typename Method = method::by_default,
-          typename Task = task::by_default>
-struct ONEDAL_EXPORT train_ops_dispatcher {
+template <typename Context, typename Float, typename Method, typename Task, typename... Options>
+struct train_ops_dispatcher {
     train_result<Task> operator()(const Context&,
                                   const descriptor_base<Task>&,
                                   const train_input<Task>&) const;
@@ -80,5 +78,9 @@ struct train_ops {
         return result;
     }
 };
+
+} // namespace v1
+
+using v1::train_ops;
 
 } // namespace oneapi::dal::kmeans::detail

--- a/cpp/oneapi/dal/algo/kmeans/detail/train_ops_dpc.cpp
+++ b/cpp/oneapi/dal/algo/kmeans/detail/train_ops_dpc.cpp
@@ -20,7 +20,9 @@
 #include "oneapi/dal/backend/dispatcher_dpc.hpp"
 
 namespace oneapi::dal::kmeans::detail {
-using oneapi::dal::detail::data_parallel_policy;
+namespace v1 {
+
+using dal::detail::data_parallel_policy;
 
 template <typename Float, typename Method, typename Task>
 struct train_ops_dispatcher<data_parallel_policy, Float, Method, Task> {
@@ -40,4 +42,5 @@ struct train_ops_dispatcher<data_parallel_policy, Float, Method, Task> {
 INSTANTIATE(float, method::lloyd_dense, task::clustering)
 INSTANTIATE(double, method::lloyd_dense, task::clustering)
 
+} // namespace v1
 } // namespace oneapi::dal::kmeans::detail

--- a/cpp/oneapi/dal/algo/kmeans/infer.hpp
+++ b/cpp/oneapi/dal/algo/kmeans/infer.hpp
@@ -21,9 +21,11 @@
 #include "oneapi/dal/infer.hpp"
 
 namespace oneapi::dal::detail {
+namespace v1 {
 
 template <typename Descriptor>
 struct infer_ops<Descriptor, dal::kmeans::detail::tag>
         : dal::kmeans::detail::infer_ops<Descriptor> {};
 
+} // namespace v1
 } // namespace oneapi::dal::detail

--- a/cpp/oneapi/dal/algo/kmeans/infer_types.cpp
+++ b/cpp/oneapi/dal/algo/kmeans/infer_types.cpp
@@ -21,7 +21,7 @@
 namespace oneapi::dal::kmeans {
 
 template <typename Task>
-class detail::infer_input_impl : public base {
+class detail::v1::infer_input_impl : public base {
 public:
     infer_input_impl(const model<Task>& trained_model, const table& data)
             : trained_model(trained_model),
@@ -31,26 +31,28 @@ public:
 };
 
 template <typename Task>
-class detail::infer_result_impl : public base {
+class detail::v1::infer_result_impl : public base {
 public:
     table labels;
     double objective_function_value = 0.0;
 };
 
-using detail::infer_input_impl;
-using detail::infer_result_impl;
+using detail::v1::infer_input_impl;
+using detail::v1::infer_result_impl;
+
+namespace v1 {
 
 template <typename Task>
 infer_input<Task>::infer_input(const model<Task>& trained_model, const table& data)
         : impl_(new infer_input_impl<Task>(trained_model, data)) {}
 
 template <typename Task>
-model<Task> infer_input<Task>::get_model() const {
+const model<Task>& infer_input<Task>::get_model() const {
     return impl_->trained_model;
 }
 
 template <typename Task>
-table infer_input<Task>::get_data() const {
+const table& infer_input<Task>::get_data() const {
     return impl_->data;
 }
 
@@ -65,10 +67,10 @@ void infer_input<Task>::set_data_impl(const table& value) {
 }
 
 template <typename Task>
-infer_result<Task>::infer_result() : impl_(new infer_result_impl{}) {}
+infer_result<Task>::infer_result() : impl_(new infer_result_impl<Task>{}) {}
 
 template <typename Task>
-table infer_result<Task>::get_labels() const {
+const table& infer_result<Task>::get_labels() const {
     return impl_->labels;
 }
 
@@ -93,4 +95,5 @@ void infer_result<Task>::set_objective_function_value_impl(double value) {
 template class ONEDAL_EXPORT infer_input<task::clustering>;
 template class ONEDAL_EXPORT infer_result<task::clustering>;
 
+} // namespace v1
 } // namespace oneapi::dal::kmeans

--- a/cpp/oneapi/dal/algo/kmeans/infer_types.hpp
+++ b/cpp/oneapi/dal/algo/kmeans/infer_types.hpp
@@ -21,64 +21,85 @@
 namespace oneapi::dal::kmeans {
 
 namespace detail {
-template <typename Task = task::by_default>
+namespace v1 {
+template <typename Task>
 class infer_input_impl;
 
-template <typename Task = task::by_default>
+template <typename Task>
 class infer_result_impl;
+} // namespace v1
+
+using v1::infer_input_impl;
+using v1::infer_result_impl;
+
 } // namespace detail
 
+namespace v1 {
+
 template <typename Task = task::by_default>
-class ONEDAL_EXPORT infer_input : public base {
+class infer_input : public base {
+    static_assert(detail::is_valid_task_v<Task>);
+
 public:
     using task_t = Task;
-    infer_input(const model<task_t>& trained_model, const table& data);
 
-    model<task_t> get_model() const;
+    infer_input(const model<Task>& trained_model, const table& data);
 
-    auto& set_model(const model<task_t>& value) {
+    const model<Task>& get_model() const;
+
+    auto& set_model(const model<Task>& value) {
         set_model_impl(value);
         return *this;
     }
 
-    table get_data() const;
+    const table& get_data() const;
 
     auto& set_data(const table& value) {
         set_data_impl(value);
         return *this;
     }
 
-private:
-    void set_model_impl(const model<task_t>& value);
+protected:
+    void set_model_impl(const model<Task>& value);
     void set_data_impl(const table& value);
 
-    dal::detail::pimpl<detail::infer_input_impl<task_t>> impl_;
+private:
+    dal::detail::pimpl<detail::infer_input_impl<Task>> impl_;
 };
 
 template <typename Task = task::by_default>
-class ONEDAL_EXPORT infer_result {
+class infer_result {
+    static_assert(detail::is_valid_task_v<Task>);
+
 public:
     using task_t = Task;
+
     infer_result();
 
-    table get_labels() const;
-    double get_objective_function_value() const;
-
+    const table& get_labels() const;
     auto& set_labels(const table& value) {
         set_labels_impl(value);
         return *this;
     }
+
+    double get_objective_function_value() const;
 
     auto& set_objective_function_value(double value) {
         set_objective_function_value_impl(value);
         return *this;
     }
 
-private:
+protected:
     void set_labels_impl(const table&);
     void set_objective_function_value_impl(double);
 
-    dal::detail::pimpl<detail::infer_result_impl<task_t>> impl_;
+private:
+    dal::detail::pimpl<detail::infer_result_impl<Task>> impl_;
 };
+
+} // namespace v1
+
+using v1::infer_input;
+using v1::infer_result;
 
 } // namespace oneapi::dal::kmeans

--- a/cpp/oneapi/dal/algo/kmeans/train.hpp
+++ b/cpp/oneapi/dal/algo/kmeans/train.hpp
@@ -21,9 +21,11 @@
 #include "oneapi/dal/train.hpp"
 
 namespace oneapi::dal::detail {
+namespace v1 {
 
 template <typename Descriptor>
 struct train_ops<Descriptor, dal::kmeans::detail::tag>
         : dal::kmeans::detail::train_ops<Descriptor> {};
 
+} // namespace v1
 } // namespace oneapi::dal::detail

--- a/cpp/oneapi/dal/algo/kmeans/train_types.cpp
+++ b/cpp/oneapi/dal/algo/kmeans/train_types.cpp
@@ -21,7 +21,7 @@
 namespace oneapi::dal::kmeans {
 
 template <typename Task>
-class detail::train_input_impl : public base {
+class detail::v1::train_input_impl : public base {
 public:
     train_input_impl(const table& data) : data(data) {}
     train_input_impl(const table& data, const table& initial_centroids)
@@ -33,7 +33,7 @@ public:
 };
 
 template <typename Task>
-class detail::train_result_impl : public base {
+class detail::v1::train_result_impl : public base {
 public:
     model<Task> trained_model;
     table labels;
@@ -41,23 +41,25 @@ public:
     double objective_function_value = 0.0;
 };
 
-using detail::train_input_impl;
-using detail::train_result_impl;
+using detail::v1::train_input_impl;
+using detail::v1::train_result_impl;
+
+namespace v1 {
 
 template <typename Task>
-train_input<Task>::train_input(const table& data) : impl_(new train_input_impl(data)) {}
+train_input<Task>::train_input(const table& data) : impl_(new train_input_impl<Task>{ data }) {}
 
 template <typename Task>
 train_input<Task>::train_input(const table& data, const table& initial_centroids)
         : impl_(new train_input_impl<Task>(data, initial_centroids)) {}
 
 template <typename Task>
-table train_input<Task>::get_data() const {
+const table& train_input<Task>::get_data() const {
     return impl_->data;
 }
 
 template <typename Task>
-table train_input<Task>::get_initial_centroids() const {
+const table& train_input<Task>::get_initial_centroids() const {
     return impl_->initial_centroids;
 }
 
@@ -72,15 +74,15 @@ void train_input<Task>::set_initial_centroids_impl(const table& value) {
 }
 
 template <typename Task>
-train_result<Task>::train_result() : impl_(new train_result_impl{}) {}
+train_result<Task>::train_result() : impl_(new train_result_impl<Task>{}) {}
 
 template <typename Task>
-model<Task> train_result<Task>::get_model() const {
+const model<Task>& train_result<Task>::get_model() const {
     return impl_->trained_model;
 }
 
 template <typename Task>
-table train_result<Task>::get_labels() const {
+const table& train_result<Task>::get_labels() const {
     return impl_->labels;
 }
 
@@ -123,4 +125,5 @@ void train_result<Task>::set_objective_function_value_impl(double value) {
 template class ONEDAL_EXPORT train_input<task::clustering>;
 template class ONEDAL_EXPORT train_result<task::clustering>;
 
+} // namespace v1
 } // namespace oneapi::dal::kmeans

--- a/cpp/oneapi/dal/algo/kmeans/train_types.hpp
+++ b/cpp/oneapi/dal/algo/kmeans/train_types.hpp
@@ -21,77 +21,103 @@
 namespace oneapi::dal::kmeans {
 
 namespace detail {
-template <typename Task = task::by_default>
+namespace v1 {
+template <typename Task>
 class train_input_impl;
 
-template <typename Task = task::by_default>
+template <typename Task>
 class train_result_impl;
+} // namespace v1
+
+using v1::train_input_impl;
+using v1::train_result_impl;
+
 } // namespace detail
 
+namespace v1 {
+
 template <typename Task = task::by_default>
-class ONEDAL_EXPORT train_input : public base {
+class train_input : public base {
+    static_assert(detail::is_valid_task_v<Task>);
+
 public:
     using task_t = Task;
+
     train_input(const table& data);
     train_input(const table& data, const table& initial_centroids);
 
-    table get_data() const;
-    table get_initial_centroids() const;
+    const table& get_data() const;
 
     auto& set_data(const table& data) {
         set_data_impl(data);
         return *this;
     }
 
+    const table& get_initial_centroids() const;
+
     auto& set_initial_centroids(const table& data) {
         set_initial_centroids_impl(data);
         return *this;
     }
 
-private:
+protected:
     void set_data_impl(const table& data);
     void set_initial_centroids_impl(const table& data);
 
-    dal::detail::pimpl<detail::train_input_impl<task_t>> impl_;
+private:
+    dal::detail::pimpl<detail::train_input_impl<Task>> impl_;
 };
 
 template <typename Task = task::by_default>
-class ONEDAL_EXPORT train_result {
+class train_result {
+    static_assert(detail::is_valid_task_v<Task>);
+
 public:
     using task_t = Task;
+
     train_result();
 
-    model<task_t> get_model() const;
-    table get_labels() const;
-    int64_t get_iteration_count() const;
-    double get_objective_function_value() const;
+    const model<Task>& get_model() const;
 
-    auto& set_model(const model<task_t>& value) {
+    auto& set_model(const model<Task>& value) {
         set_model_impl(value);
         return *this;
     }
+
+    const table& get_labels() const;
 
     auto& set_labels(const table& value) {
         set_labels_impl(value);
         return *this;
     }
 
+    int64_t get_iteration_count() const;
+
     auto& set_iteration_count(std::int64_t value) {
         set_iteration_count_impl(value);
         return *this;
     }
+
+    double get_objective_function_value() const;
+
     auto& set_objective_function_value(double value) {
         set_objective_function_value_impl(value);
         return *this;
     }
 
-private:
-    void set_model_impl(const model<task_t>&);
+protected:
+    void set_model_impl(const model<Task>&);
     void set_labels_impl(const table&);
     void set_iteration_count_impl(std::int64_t);
     void set_objective_function_value_impl(double);
 
-    dal::detail::pimpl<detail::train_result_impl<task_t>> impl_;
+private:
+    dal::detail::pimpl<detail::train_result_impl<Task>> impl_;
 };
+
+} // namespace v1
+
+using v1::train_input;
+using v1::train_result;
 
 } // namespace oneapi::dal::kmeans

--- a/cpp/oneapi/dal/algo/kmeans_init/common.cpp
+++ b/cpp/oneapi/dal/algo/kmeans_init/common.cpp
@@ -20,15 +20,17 @@
 namespace oneapi::dal::kmeans_init {
 
 template <>
-class detail::descriptor_impl<task::init> : public base {
+class detail::v1::descriptor_impl<task::init> : public base {
 public:
     std::int64_t cluster_count = 2;
 };
 
-using detail::descriptor_impl;
+using detail::v1::descriptor_impl;
+
+namespace v1 {
 
 template <typename Task>
-descriptor_base<Task>::descriptor_base() : impl_(new descriptor_impl{}) {}
+descriptor_base<Task>::descriptor_base() : impl_(new descriptor_impl<Task>{}) {}
 
 template <typename Task>
 std::int64_t descriptor_base<Task>::get_cluster_count() const {
@@ -45,4 +47,5 @@ void descriptor_base<Task>::set_cluster_count_impl(std::int64_t value) {
 
 template class ONEDAL_EXPORT descriptor_base<task::init>;
 
+} // namespace v1
 } // namespace oneapi::dal::kmeans_init

--- a/cpp/oneapi/dal/algo/kmeans_init/common.cpp
+++ b/cpp/oneapi/dal/algo/kmeans_init/common.cpp
@@ -19,8 +19,8 @@
 
 namespace oneapi::dal::kmeans_init {
 
-template <>
-class detail::v1::descriptor_impl<task::init> : public base {
+template <typename Task>
+class detail::v1::descriptor_impl : public base {
 public:
     std::int64_t cluster_count = 2;
 };

--- a/cpp/oneapi/dal/algo/kmeans_init/common.hpp
+++ b/cpp/oneapi/dal/algo/kmeans_init/common.hpp
@@ -22,32 +22,69 @@
 namespace oneapi::dal::kmeans_init {
 
 namespace task {
+namespace v1 {
 struct init {};
 using by_default = init;
+} // namespace v1
+
+using v1::init;
+using v1::by_default;
+
 } // namespace task
 
-namespace detail {
-struct tag {};
-
-template <typename Task = task::by_default>
-class descriptor_impl;
-} // namespace detail
-
 namespace method {
+namespace v1 {
 struct dense {};
 struct random_dense {};
 struct plus_plus_dense {};
 struct parallel_plus_dense {};
 using by_default = dense;
+} // namespace v1
+
+using v1::dense;
+using v1::random_dense;
+using v1::plus_plus_dense;
+using v1::parallel_plus_dense;
+using v1::by_default;
+
 } // namespace method
 
+namespace detail {
+namespace v1 {
+struct tag {};
+template <typename Task>
+class descriptor_impl;
+} // namespace v1
+
+using v1::tag;
+using v1::descriptor_impl;
+
+template <typename Float>
+constexpr bool is_valid_float_v = dal::detail::is_one_of_v<Float, float, double>;
+
+template <typename Method>
+constexpr bool is_valid_method_v = dal::detail::is_one_of_v<Method,
+                                                            method::dense,
+                                                            method::random_dense,
+                                                            method::plus_plus_dense,
+                                                            method::parallel_plus_dense>;
+
+template <typename Task>
+constexpr bool is_valid_task_v = dal::detail::is_one_of_v<Task, task::init>;
+
+} // namespace detail
+
+namespace v1 {
+
 template <typename Task = task::by_default>
-class ONEDAL_EXPORT descriptor_base : public base {
+class descriptor_base : public base {
+    static_assert(detail::is_valid_task_v<Task>);
+
 public:
     using tag_t = detail::tag;
-    using task_t = Task;
     using float_t = float;
     using method_t = method::by_default;
+    using task_t = Task;
 
     descriptor_base();
 
@@ -56,16 +93,22 @@ public:
 protected:
     void set_cluster_count_impl(std::int64_t);
 
-    dal::detail::pimpl<detail::descriptor_impl<task_t>> impl_;
+private:
+    dal::detail::pimpl<detail::descriptor_impl<Task>> impl_;
 };
 
-template <typename Float = descriptor_base<task::by_default>::float_t,
-          typename Method = descriptor_base<task::by_default>::method_t,
-          typename Task = task::by_default>
+template <typename Float = descriptor_base<>::float_t,
+          typename Method = descriptor_base<>::method_t,
+          typename Task = descriptor_base<>::task_t>
 class descriptor : public descriptor_base<Task> {
+    static_assert(detail::is_valid_float_v<Float>);
+    static_assert(detail::is_valid_method_v<Method>);
+    static_assert(detail::is_valid_task_v<Task>);
+
 public:
     using float_t = Float;
     using method_t = Method;
+    using task_t = Task;
 
     explicit descriptor(std::int64_t cluster_count = 2) {
         set_cluster_count(cluster_count);
@@ -76,5 +119,10 @@ public:
         return *this;
     }
 };
+
+} // namespace v1
+
+using v1::descriptor_base;
+using v1::descriptor;
 
 } // namespace oneapi::dal::kmeans_init

--- a/cpp/oneapi/dal/algo/kmeans_init/compute.hpp
+++ b/cpp/oneapi/dal/algo/kmeans_init/compute.hpp
@@ -21,9 +21,11 @@
 #include "oneapi/dal/compute.hpp"
 
 namespace oneapi::dal::detail {
+namespace v1 {
 
 template <typename Descriptor>
 struct compute_ops<Descriptor, dal::kmeans_init::detail::tag>
         : dal::kmeans_init::detail::compute_ops<Descriptor> {};
 
+} // namespace v1
 } // namespace oneapi::dal::detail

--- a/cpp/oneapi/dal/algo/kmeans_init/compute_types.cpp
+++ b/cpp/oneapi/dal/algo/kmeans_init/compute_types.cpp
@@ -20,7 +20,7 @@
 namespace oneapi::dal::kmeans_init {
 
 template <typename Task>
-class detail::compute_input_impl : public base {
+class detail::v1::compute_input_impl : public base {
 public:
     compute_input_impl(const table& data) : data(data) {}
 
@@ -28,19 +28,21 @@ public:
 };
 
 template <typename Task>
-class detail::compute_result_impl : public base {
+class detail::v1::compute_result_impl : public base {
 public:
     table centroids;
 };
 
-using detail::compute_input_impl;
-using detail::compute_result_impl;
+using detail::v1::compute_input_impl;
+using detail::v1::compute_result_impl;
+
+namespace v1 {
 
 template <typename Task>
-compute_input<Task>::compute_input(const table& data) : impl_(new compute_input_impl(data)) {}
+compute_input<Task>::compute_input(const table& data) : impl_(new compute_input_impl<Task>(data)) {}
 
 template <typename Task>
-table compute_input<Task>::get_data() const {
+const table& compute_input<Task>::get_data() const {
     return impl_->data;
 }
 
@@ -49,13 +51,11 @@ void compute_input<Task>::set_data_impl(const table& value) {
     impl_->data = value;
 }
 
-template class ONEDAL_EXPORT compute_input<task::init>;
+template <typename Task>
+compute_result<Task>::compute_result() : impl_(new compute_result_impl<Task>{}) {}
 
 template <typename Task>
-compute_result<Task>::compute_result() : impl_(new compute_result_impl{}) {}
-
-template <typename Task>
-table compute_result<Task>::get_centroids() const {
+const table& compute_result<Task>::get_centroids() const {
     return impl_->centroids;
 }
 
@@ -64,6 +64,8 @@ void compute_result<Task>::set_centroids_impl(const table& value) {
     impl_->centroids = value;
 }
 
+template class ONEDAL_EXPORT compute_input<task::init>;
 template class ONEDAL_EXPORT compute_result<task::init>;
 
+} // namespace v1
 } // namespace oneapi::dal::kmeans_init

--- a/cpp/oneapi/dal/algo/kmeans_init/compute_types.hpp
+++ b/cpp/oneapi/dal/algo/kmeans_init/compute_types.hpp
@@ -21,21 +21,31 @@
 namespace oneapi::dal::kmeans_init {
 
 namespace detail {
-template <typename Task = task::by_default>
+namespace v1 {
+template <typename Task>
 class compute_input_impl;
 
-template <typename Task = task::by_default>
+template <typename Task>
 class compute_result_impl;
+} // namespace v1
+
+using v1::compute_input_impl;
+using v1::compute_result_impl;
+
 } // namespace detail
 
+namespace v1 {
+
 template <typename Task = task::by_default>
-class ONEDAL_EXPORT compute_input : public base {
+class compute_input : public base {
+    static_assert(detail::is_valid_task_v<Task>);
+
 public:
     using task_t = Task;
 
     compute_input(const table& data);
 
-    table get_data() const;
+    const table& get_data() const;
 
     auto& set_data(const table& data) {
         set_data_impl(data);
@@ -45,27 +55,35 @@ public:
 private:
     void set_data_impl(const table& data);
 
-    dal::detail::pimpl<detail::compute_input_impl<task_t>> impl_;
+    dal::detail::pimpl<detail::compute_input_impl<Task>> impl_;
 };
 
 template <typename Task = task::by_default>
-class ONEDAL_EXPORT compute_result {
+class compute_result {
+    static_assert(detail::is_valid_task_v<Task>);
+
 public:
     using task_t = Task;
 
     compute_result();
 
-    table get_centroids() const;
+    const table& get_centroids() const;
 
     auto& set_centroids(const table& value) {
         set_centroids_impl(value);
         return *this;
     }
 
-private:
+protected:
     void set_centroids_impl(const table&);
 
-    dal::detail::pimpl<detail::compute_result_impl<task_t>> impl_;
+private:
+    dal::detail::pimpl<detail::compute_result_impl<Task>> impl_;
 };
+
+} // namespace v1
+
+using v1::compute_input;
+using v1::compute_result;
 
 } // namespace oneapi::dal::kmeans_init

--- a/cpp/oneapi/dal/algo/kmeans_init/detail/compute_ops.cpp
+++ b/cpp/oneapi/dal/algo/kmeans_init/detail/compute_ops.cpp
@@ -19,7 +19,9 @@
 #include "oneapi/dal/backend/dispatcher.hpp"
 
 namespace oneapi::dal::kmeans_init::detail {
-using oneapi::dal::detail::host_policy;
+namespace v1 {
+
+using dal::detail::host_policy;
 
 template <typename Float, typename Method, typename Task>
 struct compute_ops_dispatcher<host_policy, Float, Method, Task> {
@@ -44,4 +46,5 @@ INSTANTIATE(double, method::plus_plus_dense, task::init)
 INSTANTIATE(float, method::parallel_plus_dense, task::init)
 INSTANTIATE(double, method::parallel_plus_dense, task::init)
 
+} // namespace v1
 } // namespace oneapi::dal::kmeans_init::detail

--- a/cpp/oneapi/dal/algo/kmeans_init/detail/compute_ops.hpp
+++ b/cpp/oneapi/dal/algo/kmeans_init/detail/compute_ops.hpp
@@ -20,11 +20,9 @@
 #include "oneapi/dal/detail/error_messages.hpp"
 
 namespace oneapi::dal::kmeans_init::detail {
+namespace v1 {
 
-template <typename Context,
-          typename Float,
-          typename Method = method::dense,
-          typename Task = task::by_default>
+template <typename Context, typename Float, typename Method, typename Task, typename... Options>
 struct compute_ops_dispatcher {
     compute_result<Task> operator()(const Context&,
                                     const descriptor_base<Task>&,
@@ -66,5 +64,9 @@ struct compute_ops {
         return result;
     }
 };
+
+} // namespace v1
+
+using v1::compute_ops;
 
 } // namespace oneapi::dal::kmeans_init::detail

--- a/cpp/oneapi/dal/algo/kmeans_init/detail/compute_ops_dpc.cpp
+++ b/cpp/oneapi/dal/algo/kmeans_init/detail/compute_ops_dpc.cpp
@@ -20,7 +20,9 @@
 #include "oneapi/dal/backend/dispatcher_dpc.hpp"
 
 namespace oneapi::dal::kmeans_init::detail {
-using oneapi::dal::detail::data_parallel_policy;
+namespace v1 {
+
+using dal::detail::data_parallel_policy;
 
 template <typename Float, typename Method, typename Task>
 struct compute_ops_dispatcher<data_parallel_policy, Float, Method, Task> {
@@ -45,4 +47,6 @@ INSTANTIATE(float, method::plus_plus_dense, task::init)
 INSTANTIATE(double, method::plus_plus_dense, task::init)
 INSTANTIATE(float, method::parallel_plus_dense, task::init)
 INSTANTIATE(double, method::parallel_plus_dense, task::init)
+
+} // namespace v1
 } // namespace oneapi::dal::kmeans_init::detail

--- a/cpp/oneapi/dal/algo/knn/backend/cpu/infer_kernel_kd_tree_classification.cpp
+++ b/cpp/oneapi/dal/algo/knn/backend/cpu/infer_kernel_kd_tree_classification.cpp
@@ -62,7 +62,7 @@ static infer_result<task::classification> call_daal_kernel(
     interop::status_to_exception(interop::call_daal_kernel<Float, daal_knn_kd_tree_kernel_t>(
         ctx,
         daal_data.get(),
-        dal::detail::cast_impl<detail::model_impl>(m).get_interop()->get_daal_model().get(),
+        dal::detail::get_impl(m).get_interop()->get_daal_model().get(),
         daal_labels.get(),
         nullptr,
         nullptr,

--- a/cpp/oneapi/dal/algo/knn/backend/cpu/train_kernel_kd_tree_classification.cpp
+++ b/cpp/oneapi/dal/algo/knn/backend/cpu/train_kernel_kd_tree_classification.cpp
@@ -80,7 +80,7 @@ static train_result<task::classification> call_daal_kernel(
                                                                     *daal_parameter.engine.get()));
 
     auto interop = new daal_model_interop_t(model_ptr);
-    const auto model_impl = std::make_shared<detail::model_impl>(interop);
+    const auto model_impl = std::make_shared<model_impl_cls>(interop);
     return train_result<task::classification>().set_model(
         dal::detail::make_private<model<task::classification>>(model_impl));
 }

--- a/cpp/oneapi/dal/algo/knn/backend/gpu/train_kernel_brute_force_classification_dpc.cpp
+++ b/cpp/oneapi/dal/algo/knn/backend/gpu/train_kernel_brute_force_classification_dpc.cpp
@@ -81,7 +81,7 @@ static train_result<task::classification> call_daal_kernel(
                                                        *daal_parameter.engine.get()));
 
     auto interop = new daal_model_interop_t(model_ptr);
-    const auto model_impl = std::make_shared<detail::model_impl>(interop);
+    const auto model_impl = std::make_shared<model_impl_cls>(interop);
     return train_result<task::classification>().set_model(
         dal::detail::make_private<model<task::classification>>(model_impl));
 }

--- a/cpp/oneapi/dal/algo/knn/backend/model_impl.hpp
+++ b/cpp/oneapi/dal/algo/knn/backend/model_impl.hpp
@@ -19,9 +19,10 @@
 #include "oneapi/dal/algo/knn/common.hpp"
 #include "oneapi/dal/algo/knn/backend/model_interop.hpp"
 
-namespace oneapi::dal::knn::detail {
+namespace oneapi::dal::knn {
 
-class model_impl : public base {
+template <typename Task>
+class detail::v1::model_impl : public base {
 public:
     model_impl() : interop_(nullptr) {}
     model_impl(const model_impl&) = delete;
@@ -34,12 +35,17 @@ public:
         interop_ = nullptr;
     }
 
-    knn::backend::model_interop* get_interop() {
+    backend::model_interop* get_interop() {
         return interop_;
     }
 
 private:
-    knn::backend::model_interop* interop_;
+    backend::model_interop* interop_;
 };
 
-} // namespace oneapi::dal::knn::detail
+namespace backend {
+
+using model_impl_cls = detail::model_impl<task::classification>;
+
+} // namespace backend
+} // namespace oneapi::dal::knn

--- a/cpp/oneapi/dal/algo/knn/common.cpp
+++ b/cpp/oneapi/dal/algo/knn/common.cpp
@@ -21,14 +21,16 @@
 namespace oneapi::dal::knn {
 
 template <>
-class detail::descriptor_impl<task::classification> : public base {
+class detail::v1::descriptor_impl<task::classification> : public base {
 public:
     std::int64_t class_count = 2;
     std::int64_t neighbor_count = 1;
 };
 
-using detail::descriptor_impl;
-using detail::model_impl;
+using detail::v1::descriptor_impl;
+using detail::v1::model_impl;
+
+namespace v1 {
 
 template <typename Task>
 descriptor_base<Task>::descriptor_base() : impl_(new descriptor_impl<Task>{}) {}
@@ -60,15 +62,14 @@ ONEDAL_EXPORT void descriptor_base<task::classification>::set_neighbor_count_imp
     impl_->neighbor_count = value;
 }
 
-class empty_model_impl : public detail::model_impl {};
+template <typename Task>
+model<Task>::model() : impl_(new model_impl<Task>{}) {}
 
 template <typename Task>
-model<Task>::model() : impl_(new empty_model_impl{}) {}
-
-template <typename Task>
-model<Task>::model(const std::shared_ptr<detail::model_impl>& impl) : impl_(impl) {}
+model<Task>::model(const std::shared_ptr<detail::model_impl<Task>>& impl) : impl_(impl) {}
 
 template class ONEDAL_EXPORT descriptor_base<task::classification>;
 template class ONEDAL_EXPORT model<task::classification>;
 
+} // namespace v1
 } // namespace oneapi::dal::knn

--- a/cpp/oneapi/dal/algo/knn/common.cpp
+++ b/cpp/oneapi/dal/algo/knn/common.cpp
@@ -20,8 +20,8 @@
 
 namespace oneapi::dal::knn {
 
-template <>
-class detail::v1::descriptor_impl<task::classification> : public base {
+template <typename Task>
+class detail::v1::descriptor_impl : public base {
 public:
     std::int64_t class_count = 2;
     std::int64_t neighbor_count = 1;
@@ -35,27 +35,26 @@ namespace v1 {
 template <typename Task>
 descriptor_base<Task>::descriptor_base() : impl_(new descriptor_impl<Task>{}) {}
 
-template <>
-ONEDAL_EXPORT std::int64_t descriptor_base<task::classification>::get_class_count() const {
+template <typename Task>
+std::int64_t descriptor_base<Task>::get_class_count() const {
     return impl_->class_count;
 }
 
-template <>
-ONEDAL_EXPORT std::int64_t descriptor_base<task::classification>::get_neighbor_count() const {
-    return impl_->neighbor_count;
-}
-
-template <>
-ONEDAL_EXPORT void descriptor_base<task::classification>::set_class_count_impl(std::int64_t value) {
+template <typename Task>
+void descriptor_base<Task>::set_class_count_impl(std::int64_t value) {
     if (value < 2) {
         throw domain_error(dal::detail::error_messages::class_count_leq_one());
     }
     impl_->class_count = value;
 }
 
-template <>
-ONEDAL_EXPORT void descriptor_base<task::classification>::set_neighbor_count_impl(
-    std::int64_t value) {
+template <typename Task>
+std::int64_t descriptor_base<Task>::get_neighbor_count() const {
+    return impl_->neighbor_count;
+}
+
+template <typename Task>
+void descriptor_base<Task>::set_neighbor_count_impl(std::int64_t value) {
     if (value < 1) {
         throw domain_error(dal::detail::error_messages::neighbor_count_lt_one());
     }

--- a/cpp/oneapi/dal/algo/knn/common.hpp
+++ b/cpp/oneapi/dal/algo/knn/common.hpp
@@ -22,27 +22,61 @@
 namespace oneapi::dal::knn {
 
 namespace task {
+namespace v1 {
 struct classification {};
 using by_default = classification;
+} // namespace v1
+
+using v1::classification;
+using v1::by_default;
+
 } // namespace task
 
-namespace detail {
-struct tag {};
-
-template <typename Task = task::by_default>
-class descriptor_impl;
-
-class model_impl;
-} // namespace detail
-
 namespace method {
+namespace v1 {
 struct kd_tree {};
 struct brute_force {};
 using by_default = brute_force;
+} // namespace v1
+
+using v1::kd_tree;
+using v1::brute_force;
+using v1::by_default;
+
 } // namespace method
+
+namespace detail {
+namespace v1 {
+struct tag {};
+template <typename Task>
+class descriptor_impl;
+
+template <typename Task>
+class model_impl;
+} // namespace v1
+
+using v1::tag;
+using v1::descriptor_impl;
+using v1::model_impl;
+
+template <typename Float>
+constexpr bool is_valid_float_v = dal::detail::is_one_of_v<Float, float, double>;
+
+template <typename Method>
+constexpr bool is_valid_method_v =
+    dal::detail::is_one_of_v<Method, method::kd_tree, method::brute_force>;
+
+template <typename Task>
+constexpr bool is_valid_task_v = dal::detail::is_one_of_v<Task, task::classification>;
+
+} // namespace detail
+
+namespace v1 {
 
 template <typename Task = task::by_default>
 class descriptor_base : public base {
+    static_assert(detail::is_valid_task_v<Task>);
+
 public:
     using tag_t = detail::tag;
     using float_t = float;
@@ -58,13 +92,18 @@ protected:
     void set_class_count_impl(std::int64_t value);
     void set_neighbor_count_impl(std::int64_t value);
 
-    dal::detail::pimpl<detail::descriptor_impl<task_t>> impl_;
+private:
+    dal::detail::pimpl<detail::descriptor_impl<Task>> impl_;
 };
 
-template <typename Float = descriptor_base<task::by_default>::float_t,
-          typename Method = descriptor_base<task::by_default>::method_t,
-          typename Task = task::by_default>
+template <typename Float = descriptor_base<>::float_t,
+          typename Method = descriptor_base<>::method_t,
+          typename Task = descriptor_base<>::task_t>
 class descriptor : public descriptor_base<Task> {
+    static_assert(detail::is_valid_float_v<Float>);
+    static_assert(detail::is_valid_method_v<Method>);
+    static_assert(detail::is_valid_task_v<Task>);
+
 public:
     using tag_t = detail::tag;
     using float_t = Float;
@@ -89,14 +128,21 @@ public:
 
 template <typename Task = task::by_default>
 class model : public base {
+    static_assert(detail::is_valid_task_v<Task>);
     friend dal::detail::pimpl_accessor;
 
 public:
     model();
 
 private:
-    explicit model(const std::shared_ptr<detail::model_impl>& impl);
-    dal::detail::pimpl<detail::model_impl> impl_;
+    explicit model(const std::shared_ptr<detail::model_impl<Task>>& impl);
+    dal::detail::pimpl<detail::model_impl<Task>> impl_;
 };
+
+} // namespace v1
+
+using v1::descriptor_base;
+using v1::descriptor;
+using v1::model;
 
 } // namespace oneapi::dal::knn

--- a/cpp/oneapi/dal/algo/knn/detail/infer_ops.cpp
+++ b/cpp/oneapi/dal/algo/knn/detail/infer_ops.cpp
@@ -19,7 +19,9 @@
 #include "oneapi/dal/backend/dispatcher.hpp"
 
 namespace oneapi::dal::knn::detail {
-using oneapi::dal::detail::host_policy;
+namespace v1 {
+
+using dal::detail::host_policy;
 
 template <typename Float, typename Method, typename Task>
 struct infer_ops_dispatcher<host_policy, Float, Method, Task> {
@@ -40,4 +42,5 @@ INSTANTIATE(double, method::kd_tree, task::classification)
 INSTANTIATE(float, method::brute_force, task::classification)
 INSTANTIATE(double, method::brute_force, task::classification)
 
+} // namespace v1
 } // namespace oneapi::dal::knn::detail

--- a/cpp/oneapi/dal/algo/knn/detail/infer_ops.hpp
+++ b/cpp/oneapi/dal/algo/knn/detail/infer_ops.hpp
@@ -20,12 +20,10 @@
 #include "oneapi/dal/detail/error_messages.hpp"
 
 namespace oneapi::dal::knn::detail {
+namespace v1 {
 
-template <typename Context,
-          typename Float,
-          typename Method = method::by_default,
-          typename Task = task::by_default>
-struct ONEDAL_EXPORT infer_ops_dispatcher {
+template <typename Context, typename Float, typename Method, typename Task, typename... Options>
+struct infer_ops_dispatcher {
     infer_result<Task> operator()(const Context&,
                                   const descriptor_base<Task>&,
                                   const infer_input<Task>&) const;
@@ -64,5 +62,9 @@ struct infer_ops {
         return result;
     }
 };
+
+} // namespace v1
+
+using v1::infer_ops;
 
 } // namespace oneapi::dal::knn::detail

--- a/cpp/oneapi/dal/algo/knn/detail/infer_ops_dpc.cpp
+++ b/cpp/oneapi/dal/algo/knn/detail/infer_ops_dpc.cpp
@@ -20,7 +20,10 @@
 #include "oneapi/dal/backend/dispatcher_dpc.hpp"
 
 namespace oneapi::dal::knn::detail {
-using oneapi::dal::detail::data_parallel_policy;
+namespace v1 {
+
+using dal::detail::data_parallel_policy;
+
 template <typename Float, typename Method, typename Task>
 struct infer_ops_dispatcher<data_parallel_policy, Float, Method, Task> {
     infer_result<Task> operator()(const data_parallel_policy& ctx,
@@ -41,4 +44,5 @@ INSTANTIATE(double, method::kd_tree, task::classification)
 INSTANTIATE(float, method::brute_force, task::classification)
 INSTANTIATE(double, method::brute_force, task::classification)
 
+} // namespace v1
 } // namespace oneapi::dal::knn::detail

--- a/cpp/oneapi/dal/algo/knn/detail/train_ops.cpp
+++ b/cpp/oneapi/dal/algo/knn/detail/train_ops.cpp
@@ -19,7 +19,9 @@
 #include "oneapi/dal/backend/dispatcher.hpp"
 
 namespace oneapi::dal::knn::detail {
-using oneapi::dal::detail::host_policy;
+namespace v1 {
+
+using dal::detail::host_policy;
 
 template <typename Float, typename Method, typename Task>
 struct train_ops_dispatcher<host_policy, Float, Method, Task> {
@@ -39,5 +41,9 @@ INSTANTIATE(float, method::kd_tree, task::classification)
 INSTANTIATE(double, method::kd_tree, task::classification)
 INSTANTIATE(float, method::brute_force, task::classification)
 INSTANTIATE(double, method::brute_force, task::classification)
+
+} // namespace v1
+
+using v1::train_ops;
 
 } // namespace oneapi::dal::knn::detail

--- a/cpp/oneapi/dal/algo/knn/detail/train_ops.hpp
+++ b/cpp/oneapi/dal/algo/knn/detail/train_ops.hpp
@@ -20,12 +20,10 @@
 #include "oneapi/dal/detail/error_messages.hpp"
 
 namespace oneapi::dal::knn::detail {
+namespace v1 {
 
-template <typename Context,
-          typename Float,
-          typename Method = method::by_default,
-          typename Task = task::by_default>
-struct ONEDAL_EXPORT train_ops_dispatcher {
+template <typename Context, typename Float, typename Method, typename Task, typename... Options>
+struct train_ops_dispatcher {
     train_result<Task> operator()(const Context&,
                                   const descriptor_base<Task>&,
                                   const train_input<Task>&) const;
@@ -69,6 +67,10 @@ struct train_ops {
         check_postconditions(desc, input, result);
         return result;
     }
-}; // namespace oneapi::dal::knn::detail
+};
+
+} // namespace v1
+
+using v1::train_ops;
 
 } // namespace oneapi::dal::knn::detail

--- a/cpp/oneapi/dal/algo/knn/detail/train_ops_dpc.cpp
+++ b/cpp/oneapi/dal/algo/knn/detail/train_ops_dpc.cpp
@@ -20,7 +20,9 @@
 #include "oneapi/dal/backend/dispatcher_dpc.hpp"
 
 namespace oneapi::dal::knn::detail {
-using oneapi::dal::detail::data_parallel_policy;
+namespace v1 {
+
+using dal::detail::data_parallel_policy;
 
 template <typename Float, typename Method, typename Task>
 struct train_ops_dispatcher<data_parallel_policy, Float, Method, Task> {
@@ -42,4 +44,5 @@ INSTANTIATE(double, method::kd_tree, task::classification)
 INSTANTIATE(float, method::brute_force, task::classification)
 INSTANTIATE(double, method::brute_force, task::classification)
 
+} // namespace v1
 } // namespace oneapi::dal::knn::detail

--- a/cpp/oneapi/dal/algo/knn/infer.hpp
+++ b/cpp/oneapi/dal/algo/knn/infer.hpp
@@ -22,8 +22,10 @@
 #include "oneapi/dal/infer.hpp"
 
 namespace oneapi::dal::detail {
+namespace v1 {
 
 template <typename Descriptor>
 struct infer_ops<Descriptor, dal::knn::detail::tag> : dal::knn::detail::infer_ops<Descriptor> {};
 
+} // namespace v1
 } // namespace oneapi::dal::detail

--- a/cpp/oneapi/dal/algo/knn/infer_types.cpp
+++ b/cpp/oneapi/dal/algo/knn/infer_types.cpp
@@ -19,9 +19,8 @@
 
 namespace oneapi::dal::knn {
 
-namespace detail {
 template <typename Task>
-class infer_input_impl : public base {
+class detail::v1::infer_input_impl : public base {
 public:
     infer_input_impl(const table& data, const model<Task>& m) : data(data), trained_model(m) {}
 
@@ -30,14 +29,15 @@ public:
 };
 
 template <typename Task>
-class infer_result_impl : public base {
+class detail::v1::infer_result_impl : public base {
 public:
     table labels;
 };
-} // namespace detail
 
-using detail::infer_input_impl;
-using detail::infer_result_impl;
+using detail::v1::infer_input_impl;
+using detail::v1::infer_result_impl;
+
+namespace v1 {
 
 template <typename Task>
 infer_input<Task>::infer_input(const table& data, const model<Task>& m)
@@ -64,7 +64,7 @@ void infer_input<Task>::set_model_impl(const model<Task>& value) {
 }
 
 template <typename Task>
-infer_result<Task>::infer_result() : impl_(new infer_result_impl{}) {}
+infer_result<Task>::infer_result() : impl_(new infer_result_impl<Task>{}) {}
 
 template <typename Task>
 const table& infer_result<Task>::get_labels() const {
@@ -79,4 +79,5 @@ void infer_result<Task>::set_labels_impl(const table& value) {
 template class ONEDAL_EXPORT infer_input<task::classification>;
 template class ONEDAL_EXPORT infer_result<task::classification>;
 
+} // namespace v1
 } // namespace oneapi::dal::knn

--- a/cpp/oneapi/dal/algo/knn/infer_types.hpp
+++ b/cpp/oneapi/dal/algo/knn/infer_types.hpp
@@ -21,41 +21,59 @@
 namespace oneapi::dal::knn {
 
 namespace detail {
-template <typename Task = task::by_default>
+namespace v1 {
+template <typename Task>
 class infer_input_impl;
 
-template <typename Task = task::by_default>
+template <typename Task>
 class infer_result_impl;
+} // namespace v1
+
+using v1::infer_input_impl;
+using v1::infer_result_impl;
+
 } // namespace detail
 
+namespace v1 {
+
 template <typename Task = task::by_default>
-class ONEDAL_EXPORT infer_input : public base {
+class infer_input : public base {
+    static_assert(detail::is_valid_task_v<Task>);
+
 public:
+    using task_t = Task;
+
     infer_input(const table& data, const model<Task>& model);
 
     const table& get_data() const;
-    const model<Task>& get_model() const;
 
     auto& set_data(const table& data) {
         set_data_impl(data);
         return *this;
     }
 
+    const model<Task>& get_model() const;
+
     auto& set_model(const model<Task>& m) {
         set_model_impl(m);
         return *this;
     }
 
-private:
+protected:
     void set_data_impl(const table& data);
     void set_model_impl(const model<Task>& model);
 
+private:
     dal::detail::pimpl<detail::infer_input_impl<Task>> impl_;
 };
 
 template <typename Task = task::by_default>
-class ONEDAL_EXPORT infer_result {
+class infer_result {
+    static_assert(detail::is_valid_task_v<Task>);
+
 public:
+    using task_t = Task;
+
     infer_result();
 
     const table& get_labels() const;
@@ -65,10 +83,17 @@ public:
         return *this;
     }
 
-private:
+protected:
     void set_labels_impl(const table&);
     const table& get_labels_impl() const;
+
+private:
     dal::detail::pimpl<detail::infer_result_impl<Task>> impl_;
 };
+
+} // namespace v1
+
+using v1::infer_input;
+using v1::infer_result;
 
 } // namespace oneapi::dal::knn

--- a/cpp/oneapi/dal/algo/knn/train.hpp
+++ b/cpp/oneapi/dal/algo/knn/train.hpp
@@ -22,8 +22,10 @@
 #include "oneapi/dal/train.hpp"
 
 namespace oneapi::dal::detail {
+namespace v1 {
 
 template <typename Descriptor>
 struct train_ops<Descriptor, dal::knn::detail::tag> : dal::knn::detail::train_ops<Descriptor> {};
 
+} // namespace v1
 } // namespace oneapi::dal::detail

--- a/cpp/oneapi/dal/algo/knn/train_types.cpp
+++ b/cpp/oneapi/dal/algo/knn/train_types.cpp
@@ -19,9 +19,8 @@
 
 namespace oneapi::dal::knn {
 
-namespace detail {
 template <typename Task>
-class train_input_impl : public base {
+class detail::v1::train_input_impl : public base {
 public:
     train_input_impl(const table& data, const table& labels) : data(data), labels(labels) {}
 
@@ -30,14 +29,15 @@ public:
 };
 
 template <typename Task>
-class train_result_impl : public base {
+class detail::v1::train_result_impl : public base {
 public:
     model<Task> trained_model;
 };
-} // namespace detail
 
-using detail::train_input_impl;
-using detail::train_result_impl;
+using detail::v1::train_input_impl;
+using detail::v1::train_result_impl;
+
+namespace v1 {
 
 template <typename Task>
 train_input<Task>::train_input(const table& data, const table& labels)
@@ -64,7 +64,7 @@ void train_input<Task>::set_labels_impl(const table& value) {
 }
 
 template <typename Task>
-train_result<Task>::train_result() : impl_(new train_result_impl{}) {}
+train_result<Task>::train_result() : impl_(new train_result_impl<Task>{}) {}
 
 template <typename Task>
 const model<Task>& train_result<Task>::get_model() const {
@@ -79,4 +79,5 @@ void train_result<Task>::set_model_impl(const model<Task>& value) {
 template class ONEDAL_EXPORT train_input<task::classification>;
 template class ONEDAL_EXPORT train_result<task::classification>;
 
+} // namespace v1
 } // namespace oneapi::dal::knn

--- a/cpp/oneapi/dal/algo/knn/train_types.hpp
+++ b/cpp/oneapi/dal/algo/knn/train_types.hpp
@@ -21,41 +21,59 @@
 namespace oneapi::dal::knn {
 
 namespace detail {
-template <typename Task = task::by_default>
+namespace v1 {
+template <typename Task>
 class train_input_impl;
 
-template <typename Task = task::by_default>
+template <typename Task>
 class train_result_impl;
+} // namespace v1
+
+using v1::train_input_impl;
+using v1::train_result_impl;
+
 } // namespace detail
 
+namespace v1 {
+
 template <typename Task = task::by_default>
-class ONEDAL_EXPORT train_input : public base {
+class train_input : public base {
+    static_assert(detail::is_valid_task_v<Task>);
+
 public:
+    using task_t = Task;
+
     train_input(const table& data, const table& labels);
 
     const table& get_data() const;
-    const table& get_labels() const;
 
     auto& set_data(const table& data) {
         set_data_impl(data);
         return *this;
     }
 
+    const table& get_labels() const;
+
     auto& set_labels(const table& labels) {
         set_data_impl(labels);
         return *this;
     }
 
-private:
+protected:
     void set_data_impl(const table& data);
     void set_labels_impl(const table& labels);
 
+private:
     dal::detail::pimpl<detail::train_input_impl<Task>> impl_;
 };
 
 template <typename Task = task::by_default>
-class ONEDAL_EXPORT train_result {
+class train_result {
+    static_assert(detail::is_valid_task_v<Task>);
+
 public:
+    using task_t = Task;
+
     train_result();
 
     const model<Task>& get_model() const;
@@ -65,9 +83,16 @@ public:
         return *this;
     }
 
-private:
+protected:
     void set_model_impl(const model<Task>&);
+
+private:
     dal::detail::pimpl<detail::train_result_impl<Task>> impl_;
 };
+
+} // namespace v1
+
+using v1::train_input;
+using v1::train_result;
 
 } // namespace oneapi::dal::knn

--- a/cpp/oneapi/dal/algo/linear_kernel/common.cpp
+++ b/cpp/oneapi/dal/algo/linear_kernel/common.cpp
@@ -19,13 +19,15 @@
 namespace oneapi::dal::linear_kernel {
 
 template <>
-class detail::descriptor_impl<task::compute> : public base {
+class detail::v1::descriptor_impl<task::compute> : public base {
 public:
     double scale = 1.0;
     double shift = 0.0;
 };
 
-using detail::descriptor_impl;
+using detail::v1::descriptor_impl;
+
+namespace v1 {
 
 template <typename Task>
 descriptor_base<Task>::descriptor_base() : impl_(new descriptor_impl<Task>{}) {}
@@ -52,4 +54,5 @@ void descriptor_base<Task>::set_shift_impl(double value) {
 
 template class ONEDAL_EXPORT descriptor_base<task::compute>;
 
+} // namespace v1
 } // namespace oneapi::dal::linear_kernel

--- a/cpp/oneapi/dal/algo/linear_kernel/common.cpp
+++ b/cpp/oneapi/dal/algo/linear_kernel/common.cpp
@@ -18,8 +18,8 @@
 
 namespace oneapi::dal::linear_kernel {
 
-template <>
-class detail::v1::descriptor_impl<task::compute> : public base {
+template <typename Task>
+class detail::v1::descriptor_impl : public base {
 public:
     double scale = 1.0;
     double shift = 0.0;

--- a/cpp/oneapi/dal/algo/linear_kernel/compute.hpp
+++ b/cpp/oneapi/dal/algo/linear_kernel/compute.hpp
@@ -21,9 +21,11 @@
 #include "oneapi/dal/compute.hpp"
 
 namespace oneapi::dal::detail {
+namespace v1 {
 
 template <typename Descriptor>
 struct compute_ops<Descriptor, dal::linear_kernel::detail::tag>
         : dal::linear_kernel::detail::compute_ops<Descriptor> {};
 
+} // namespace v1
 } // namespace oneapi::dal::detail

--- a/cpp/oneapi/dal/algo/linear_kernel/compute_types.cpp
+++ b/cpp/oneapi/dal/algo/linear_kernel/compute_types.cpp
@@ -20,7 +20,7 @@
 namespace oneapi::dal::linear_kernel {
 
 template <typename Task>
-class detail::compute_input_impl : public base {
+class detail::v1::compute_input_impl : public base {
 public:
     compute_input_impl(const table& x, const table& y) : x(x), y(y) {}
     table x;
@@ -28,25 +28,27 @@ public:
 };
 
 template <typename Task>
-class detail::compute_result_impl : public base {
+class detail::v1::compute_result_impl : public base {
 public:
     table values;
 };
 
-using detail::compute_input_impl;
-using detail::compute_result_impl;
+using detail::v1::compute_input_impl;
+using detail::v1::compute_result_impl;
+
+namespace v1 {
 
 template <typename Task>
 compute_input<Task>::compute_input(const table& x, const table& y)
         : impl_(new compute_input_impl<Task>(x, y)) {}
 
 template <typename Task>
-table compute_input<Task>::get_x() const {
+const table& compute_input<Task>::get_x() const {
     return impl_->x;
 }
 
 template <typename Task>
-table compute_input<Task>::get_y() const {
+const table& compute_input<Task>::get_y() const {
     return impl_->y;
 }
 
@@ -60,13 +62,11 @@ void compute_input<Task>::set_y_impl(const table& value) {
     impl_->y = value;
 }
 
-template class ONEDAL_EXPORT compute_input<task::compute>;
-
 template <typename Task>
 compute_result<Task>::compute_result() : impl_(new compute_result_impl<Task>{}) {}
 
 template <typename Task>
-table compute_result<Task>::get_values() const {
+const table& compute_result<Task>::get_values() const {
     return impl_->values;
 }
 
@@ -75,6 +75,8 @@ void compute_result<Task>::set_values_impl(const table& value) {
     impl_->values = value;
 }
 
+template class ONEDAL_EXPORT compute_input<task::compute>;
 template class ONEDAL_EXPORT compute_result<task::compute>;
 
+} // namespace v1
 } // namespace oneapi::dal::linear_kernel

--- a/cpp/oneapi/dal/algo/linear_kernel/compute_types.hpp
+++ b/cpp/oneapi/dal/algo/linear_kernel/compute_types.hpp
@@ -21,58 +21,78 @@
 namespace oneapi::dal::linear_kernel {
 
 namespace detail {
-template <typename Task = task::by_default>
+namespace v1 {
+template <typename Task>
 class compute_input_impl;
 
-template <typename Task = task::by_default>
+template <typename Task>
 class compute_result_impl;
+} // namespace v1
+
+using v1::compute_input_impl;
+using v1::compute_result_impl;
+
 } // namespace detail
 
+namespace v1 {
+
 template <typename Task = task::by_default>
-class ONEDAL_EXPORT compute_input : public base {
+class compute_input : public base {
+    static_assert(detail::is_valid_task_v<Task>);
+
 public:
     using task_t = Task;
 
     compute_input(const table& x, const table& y);
 
-    table get_x() const;
-    table get_y() const;
+    const table& get_x() const;
 
     auto& set_x(const table& data) {
         set_x_impl(data);
         return *this;
     }
 
+    const table& get_y() const;
+
     auto& set_y(const table& data) {
         set_y_impl(data);
         return *this;
     }
 
-private:
+protected:
     void set_x_impl(const table& data);
     void set_y_impl(const table& data);
 
-    dal::detail::pimpl<detail::compute_input_impl<task_t>> impl_;
+private:
+    dal::detail::pimpl<detail::compute_input_impl<Task>> impl_;
 };
 
 template <typename Task = task::by_default>
-class ONEDAL_EXPORT compute_result : public base {
+class compute_result : public base {
+    static_assert(detail::is_valid_task_v<Task>);
+
 public:
     using task_t = Task;
 
     compute_result();
 
-    table get_values() const;
+    const table& get_values() const;
 
     auto& set_values(const table& value) {
         set_values_impl(value);
         return *this;
     }
 
-private:
+protected:
     void set_values_impl(const table&);
 
-    dal::detail::pimpl<detail::compute_result_impl<task_t>> impl_;
+private:
+    dal::detail::pimpl<detail::compute_result_impl<Task>> impl_;
 };
+
+} // namespace v1
+
+using v1::compute_input;
+using v1::compute_result;
 
 } // namespace oneapi::dal::linear_kernel

--- a/cpp/oneapi/dal/algo/linear_kernel/detail/compute_ops.cpp
+++ b/cpp/oneapi/dal/algo/linear_kernel/detail/compute_ops.cpp
@@ -19,7 +19,9 @@
 #include "oneapi/dal/backend/dispatcher.hpp"
 
 namespace oneapi::dal::linear_kernel::detail {
-using oneapi::dal::detail::host_policy;
+namespace v1 {
+
+using dal::detail::host_policy;
 
 template <typename Float, typename Method, typename Task>
 struct compute_ops_dispatcher<host_policy, Float, Method, Task> {
@@ -38,4 +40,5 @@ struct compute_ops_dispatcher<host_policy, Float, Method, Task> {
 INSTANTIATE(float, method::dense, task::compute)
 INSTANTIATE(double, method::dense, task::compute)
 
+} // namespace v1
 } // namespace oneapi::dal::linear_kernel::detail

--- a/cpp/oneapi/dal/algo/linear_kernel/detail/compute_ops.hpp
+++ b/cpp/oneapi/dal/algo/linear_kernel/detail/compute_ops.hpp
@@ -20,12 +20,9 @@
 #include "oneapi/dal/detail/error_messages.hpp"
 
 namespace oneapi::dal::linear_kernel::detail {
+namespace v1 {
 
-template <typename Context,
-          typename Float,
-          typename Method = method::dense,
-          typename Task = task::by_default,
-          typename... Options>
+template <typename Context, typename Float, typename Method, typename Task, typename... Options>
 struct compute_ops_dispatcher {
     compute_result<Task> operator()(const Context&,
                                     const descriptor_base<Task>&,
@@ -72,5 +69,9 @@ struct compute_ops {
         return result;
     }
 };
+
+} // namespace v1
+
+using v1::compute_ops;
 
 } // namespace oneapi::dal::linear_kernel::detail

--- a/cpp/oneapi/dal/algo/linear_kernel/detail/compute_ops_dpc.cpp
+++ b/cpp/oneapi/dal/algo/linear_kernel/detail/compute_ops_dpc.cpp
@@ -20,7 +20,9 @@
 #include "oneapi/dal/backend/dispatcher_dpc.hpp"
 
 namespace oneapi::dal::linear_kernel::detail {
-using oneapi::dal::detail::data_parallel_policy;
+namespace v1 {
+
+using dal::detail::data_parallel_policy;
 
 template <typename Float, typename Method, typename Task>
 struct compute_ops_dispatcher<data_parallel_policy, Float, Method, Task> {
@@ -39,4 +41,5 @@ struct compute_ops_dispatcher<data_parallel_policy, Float, Method, Task> {
 INSTANTIATE(float, method::dense, task::compute)
 INSTANTIATE(double, method::dense, task::compute)
 
+} // namespace v1
 } // namespace oneapi::dal::linear_kernel::detail

--- a/cpp/oneapi/dal/algo/pca/common.cpp
+++ b/cpp/oneapi/dal/algo/pca/common.cpp
@@ -20,23 +20,25 @@
 namespace oneapi::dal::pca {
 
 template <>
-class detail::descriptor_impl<task::dim_reduction> : public base {
+class detail::v1::descriptor_impl<task::dim_reduction> : public base {
 public:
     std::int64_t component_count = -1;
     bool deterministic = false;
 };
 
 template <>
-class detail::model_impl<task::dim_reduction> : public base {
+class detail::v1::model_impl<task::dim_reduction> : public base {
 public:
     table eigenvectors;
 };
 
-using detail::descriptor_impl;
-using detail::model_impl;
+using detail::v1::descriptor_impl;
+using detail::v1::model_impl;
+
+namespace v1 {
 
 template <typename Task>
-descriptor_base<Task>::descriptor_base() : impl_(new descriptor_impl{}) {}
+descriptor_base<Task>::descriptor_base() : impl_(new descriptor_impl<Task>{}) {}
 
 template <>
 std::int64_t descriptor_base<task::dim_reduction>::get_component_count() const {
@@ -62,10 +64,10 @@ void descriptor_base<task::dim_reduction>::set_deterministic_impl(bool value) {
 }
 
 template <typename Task>
-model<Task>::model() : impl_(new model_impl{}) {}
+model<Task>::model() : impl_(new model_impl<Task>{}) {}
 
 template <typename Task>
-table model<Task>::get_eigenvectors() const {
+const table& model<Task>::get_eigenvectors() const {
     return impl_->eigenvectors;
 }
 
@@ -77,4 +79,5 @@ void model<Task>::set_eigenvectors_impl(const table& value) {
 template class ONEDAL_EXPORT descriptor_base<task::dim_reduction>;
 template class ONEDAL_EXPORT model<task::dim_reduction>;
 
+} // namespace v1
 } // namespace oneapi::dal::pca

--- a/cpp/oneapi/dal/algo/pca/common.cpp
+++ b/cpp/oneapi/dal/algo/pca/common.cpp
@@ -19,15 +19,15 @@
 
 namespace oneapi::dal::pca {
 
-template <>
-class detail::v1::descriptor_impl<task::dim_reduction> : public base {
+template <typename Task>
+class detail::v1::descriptor_impl : public base {
 public:
     std::int64_t component_count = -1;
     bool deterministic = false;
 };
 
-template <>
-class detail::v1::model_impl<task::dim_reduction> : public base {
+template <typename Task>
+class detail::v1::model_impl : public base {
 public:
     table eigenvectors;
 };
@@ -40,26 +40,26 @@ namespace v1 {
 template <typename Task>
 descriptor_base<Task>::descriptor_base() : impl_(new descriptor_impl<Task>{}) {}
 
-template <>
-std::int64_t descriptor_base<task::dim_reduction>::get_component_count() const {
+template <typename Task>
+std::int64_t descriptor_base<Task>::get_component_count() const {
     return impl_->component_count;
 }
 
-template <>
-bool descriptor_base<task::dim_reduction>::get_deterministic() const {
+template <typename Task>
+bool descriptor_base<Task>::get_deterministic() const {
     return impl_->deterministic;
 }
 
-template <>
-void descriptor_base<task::dim_reduction>::set_component_count_impl(std::int64_t value) {
+template <typename Task>
+void descriptor_base<Task>::set_component_count_impl(std::int64_t value) {
     if (value < 0) {
         throw domain_error(dal::detail::error_messages::component_count_lt_zero());
     }
     impl_->component_count = value;
 }
 
-template <>
-void descriptor_base<task::dim_reduction>::set_deterministic_impl(bool value) {
+template <typename Task>
+void descriptor_base<Task>::set_deterministic_impl(bool value) {
     impl_->deterministic = value;
 }
 

--- a/cpp/oneapi/dal/algo/pca/common.hpp
+++ b/cpp/oneapi/dal/algo/pca/common.hpp
@@ -22,53 +22,91 @@
 namespace oneapi::dal::pca {
 
 namespace task {
+namespace v1 {
 struct dim_reduction {};
 using by_default = dim_reduction;
+} // namespace v1
+
+using v1::dim_reduction;
+using v1::by_default;
+
 } // namespace task
 
-namespace detail {
-struct tag {};
-
-template <typename Task = task::by_default>
-class descriptor_impl;
-
-template <typename Task = task::by_default>
-class model_impl;
-} // namespace detail
-
 namespace method {
+namespace v1 {
 struct cov {};
 struct svd {};
 using by_default = cov;
+} // namespace v1
+
+using v1::cov;
+using v1::svd;
+using v1::by_default;
+
 } // namespace method
 
+namespace detail {
+namespace v1 {
+struct tag {};
+template <typename Task>
+class descriptor_impl;
+
+template <typename Task>
+class model_impl;
+} // namespace v1
+
+using v1::tag;
+using v1::descriptor_impl;
+using v1::model_impl;
+
+template <typename Float>
+constexpr bool is_valid_float_v = dal::detail::is_one_of_v<Float, float, double>;
+
+template <typename Method>
+constexpr bool is_valid_method_v = dal::detail::is_one_of_v<Method, method::cov, method::svd>;
+
+template <typename Task>
+constexpr bool is_valid_task_v = dal::detail::is_one_of_v<Task, task::dim_reduction>;
+
+} // namespace detail
+
+namespace v1 {
+
 template <typename Task = task::by_default>
-class ONEDAL_EXPORT descriptor_base : public base {
+class descriptor_base : public base {
+    static_assert(detail::is_valid_task_v<Task>);
+
 public:
     using tag_t = detail::tag;
-    using task_t = Task;
     using float_t = float;
     using method_t = method::by_default;
+    using task_t = Task;
 
     descriptor_base();
 
-    auto get_component_count() const -> std::int64_t;
-    auto get_deterministic() const -> bool;
+    std::int64_t get_component_count() const;
+    bool get_deterministic() const;
 
 protected:
     void set_component_count_impl(std::int64_t value);
     void set_deterministic_impl(bool value);
 
-    dal::detail::pimpl<detail::descriptor_impl<task_t>> impl_;
+private:
+    dal::detail::pimpl<detail::descriptor_impl<Task>> impl_;
 };
 
-template <typename Float = descriptor_base<task::by_default>::float_t,
-          typename Method = descriptor_base<task::by_default>::method_t,
-          typename Task = task::by_default>
+template <typename Float = descriptor_base<>::float_t,
+          typename Method = descriptor_base<>::method_t,
+          typename Task = descriptor_base<>::task_t>
 class descriptor : public descriptor_base<Task> {
+    static_assert(detail::is_valid_float_v<Float>);
+    static_assert(detail::is_valid_method_v<Method>);
+    static_assert(detail::is_valid_task_v<Task>);
+
 public:
     using float_t = Float;
     using method_t = Method;
+    using task_t = Task;
 
     explicit descriptor(std::int64_t component_count = 0) {
         set_component_count(component_count);
@@ -86,24 +124,33 @@ public:
 };
 
 template <typename Task = task::by_default>
-class ONEDAL_EXPORT model : public base {
+class model : public base {
+    static_assert(detail::is_valid_task_v<Task>);
     friend dal::detail::pimpl_accessor;
 
 public:
     using task_t = Task;
+
     model();
 
-    table get_eigenvectors() const;
+    const table& get_eigenvectors() const;
 
     auto& set_eigenvectors(const table& value) {
         set_eigenvectors_impl(value);
         return *this;
     }
 
-private:
+protected:
     void set_eigenvectors_impl(const table&);
 
-    dal::detail::pimpl<detail::model_impl<task_t>> impl_;
+private:
+    dal::detail::pimpl<detail::model_impl<Task>> impl_;
 };
+
+} // namespace v1
+
+using v1::descriptor_base;
+using v1::descriptor;
+using v1::model;
 
 } // namespace oneapi::dal::pca

--- a/cpp/oneapi/dal/algo/pca/detail/infer_ops.cpp
+++ b/cpp/oneapi/dal/algo/pca/detail/infer_ops.cpp
@@ -19,7 +19,9 @@
 #include "oneapi/dal/backend/dispatcher.hpp"
 
 namespace oneapi::dal::pca::detail {
-using oneapi::dal::detail::host_policy;
+namespace v1 {
+
+using dal::detail::host_policy;
 
 template <typename Float, typename Method, typename Task>
 struct infer_ops_dispatcher<host_policy, Float, Method, Task> {
@@ -40,4 +42,5 @@ INSTANTIATE(float, method::svd, task::dim_reduction)
 INSTANTIATE(double, method::cov, task::dim_reduction)
 INSTANTIATE(double, method::svd, task::dim_reduction)
 
+} // namespace v1
 } // namespace oneapi::dal::pca::detail

--- a/cpp/oneapi/dal/algo/pca/detail/infer_ops.hpp
+++ b/cpp/oneapi/dal/algo/pca/detail/infer_ops.hpp
@@ -20,12 +20,10 @@
 #include "oneapi/dal/detail/error_messages.hpp"
 
 namespace oneapi::dal::pca::detail {
+namespace v1 {
 
-template <typename Context,
-          typename Float,
-          typename Method = method::by_default,
-          typename Task = task::by_default>
-struct ONEDAL_EXPORT infer_ops_dispatcher {
+template <typename Context, typename Float, typename Method, typename Task, typename... Options>
+struct infer_ops_dispatcher {
     infer_result<Task> operator()(const Context&,
                                   const descriptor_base<Task>&,
                                   const infer_input<Task>&) const;
@@ -74,5 +72,9 @@ struct infer_ops {
         return result;
     }
 };
+
+} // namespace v1
+
+using v1::infer_ops;
 
 } // namespace oneapi::dal::pca::detail

--- a/cpp/oneapi/dal/algo/pca/detail/infer_ops_dpc.cpp
+++ b/cpp/oneapi/dal/algo/pca/detail/infer_ops_dpc.cpp
@@ -20,7 +20,9 @@
 #include "oneapi/dal/backend/dispatcher_dpc.hpp"
 
 namespace oneapi::dal::pca::detail {
-using oneapi::dal::detail::data_parallel_policy;
+namespace v1 {
+
+using dal::detail::data_parallel_policy;
 
 template <typename Float, typename Method, typename Task>
 struct infer_ops_dispatcher<data_parallel_policy, Float, Method, Task> {
@@ -42,4 +44,5 @@ INSTANTIATE(float, method::svd, task::dim_reduction)
 INSTANTIATE(double, method::cov, task::dim_reduction)
 INSTANTIATE(double, method::svd, task::dim_reduction)
 
+} // namespace v1
 } // namespace oneapi::dal::pca::detail

--- a/cpp/oneapi/dal/algo/pca/detail/train_ops.cpp
+++ b/cpp/oneapi/dal/algo/pca/detail/train_ops.cpp
@@ -19,7 +19,9 @@
 #include "oneapi/dal/backend/dispatcher.hpp"
 
 namespace oneapi::dal::pca::detail {
-using oneapi::dal::detail::host_policy;
+namespace v1 {
+
+using dal::detail::host_policy;
 
 template <typename Float, typename Method, typename Task>
 struct train_ops_dispatcher<host_policy, Float, Method, Task> {
@@ -40,4 +42,5 @@ INSTANTIATE(float, method::svd, task::dim_reduction)
 INSTANTIATE(double, method::cov, task::dim_reduction)
 INSTANTIATE(double, method::svd, task::dim_reduction)
 
+} // namespace v1
 } // namespace oneapi::dal::pca::detail

--- a/cpp/oneapi/dal/algo/pca/detail/train_ops.hpp
+++ b/cpp/oneapi/dal/algo/pca/detail/train_ops.hpp
@@ -21,12 +21,10 @@
 #include "oneapi/dal/detail/error_messages.hpp"
 
 namespace oneapi::dal::pca::detail {
+namespace v1 {
 
-template <typename Context,
-          typename Float,
-          typename Method = method::by_default,
-          typename Task = task::by_default>
-struct ONEDAL_EXPORT train_ops_dispatcher {
+template <typename Context, typename Float, typename Method, typename Task, typename... Options>
+struct train_ops_dispatcher {
     train_result<Task> operator()(const Context&,
                                   const descriptor_base<Task>&,
                                   const train_input<Task>&) const;
@@ -74,5 +72,9 @@ struct train_ops {
         return result;
     }
 };
+
+} // namespace v1
+
+using v1::train_ops;
 
 } // namespace oneapi::dal::pca::detail

--- a/cpp/oneapi/dal/algo/pca/detail/train_ops_dpc.cpp
+++ b/cpp/oneapi/dal/algo/pca/detail/train_ops_dpc.cpp
@@ -20,7 +20,9 @@
 #include "oneapi/dal/backend/dispatcher_dpc.hpp"
 
 namespace oneapi::dal::pca::detail {
-using oneapi::dal::detail::data_parallel_policy;
+namespace v1 {
+
+using dal::detail::data_parallel_policy;
 
 template <typename Float, typename Method, typename Task>
 struct train_ops_dispatcher<data_parallel_policy, Float, Method, Task> {
@@ -42,4 +44,5 @@ INSTANTIATE(float, method::svd, task::dim_reduction)
 INSTANTIATE(double, method::cov, task::dim_reduction)
 INSTANTIATE(double, method::svd, task::dim_reduction)
 
+} // namespace v1
 } // namespace oneapi::dal::pca::detail

--- a/cpp/oneapi/dal/algo/pca/infer.hpp
+++ b/cpp/oneapi/dal/algo/pca/infer.hpp
@@ -21,8 +21,10 @@
 #include "oneapi/dal/infer.hpp"
 
 namespace oneapi::dal::detail {
+namespace v1 {
 
 template <typename Descriptor>
 struct infer_ops<Descriptor, dal::pca::detail::tag> : dal::pca::detail::infer_ops<Descriptor> {};
 
+} // namespace v1
 } // namespace oneapi::dal::detail

--- a/cpp/oneapi/dal/algo/pca/infer_types.cpp
+++ b/cpp/oneapi/dal/algo/pca/infer_types.cpp
@@ -21,7 +21,7 @@
 namespace oneapi::dal::pca {
 
 template <typename Task>
-class detail::infer_input_impl : public base {
+class detail::v1::infer_input_impl : public base {
 public:
     infer_input_impl(const model<Task>& trained_model, const table& data)
             : trained_model(trained_model),
@@ -31,25 +31,27 @@ public:
 };
 
 template <typename Task>
-class detail::infer_result_impl : public base {
+class detail::v1::infer_result_impl : public base {
 public:
     table transformed_data;
 };
 
-using detail::infer_input_impl;
-using detail::infer_result_impl;
+using detail::v1::infer_input_impl;
+using detail::v1::infer_result_impl;
+
+namespace v1 {
 
 template <typename Task>
 infer_input<Task>::infer_input(const model<Task>& trained_model, const table& data)
         : impl_(new infer_input_impl<Task>(trained_model, data)) {}
 
 template <typename Task>
-model<Task> infer_input<Task>::get_model() const {
+const model<Task>& infer_input<Task>::get_model() const {
     return impl_->trained_model;
 }
 
 template <typename Task>
-table infer_input<Task>::get_data() const {
+const table& infer_input<Task>::get_data() const {
     return impl_->data;
 }
 
@@ -64,10 +66,10 @@ void infer_input<Task>::set_data_impl(const table& value) {
 }
 
 template <typename Task>
-infer_result<Task>::infer_result() : impl_(new infer_result_impl{}) {}
+infer_result<Task>::infer_result() : impl_(new infer_result_impl<Task>{}) {}
 
 template <typename Task>
-table infer_result<Task>::get_transformed_data() const {
+const table& infer_result<Task>::get_transformed_data() const {
     return impl_->transformed_data;
 }
 
@@ -79,4 +81,5 @@ void infer_result<Task>::set_transformed_data_impl(const table& value) {
 template class ONEDAL_EXPORT infer_input<task::dim_reduction>;
 template class ONEDAL_EXPORT infer_result<task::dim_reduction>;
 
+} // namespace v1
 } // namespace oneapi::dal::pca

--- a/cpp/oneapi/dal/algo/pca/infer_types.hpp
+++ b/cpp/oneapi/dal/algo/pca/infer_types.hpp
@@ -21,57 +21,78 @@
 namespace oneapi::dal::pca {
 
 namespace detail {
-template <typename Task = task::by_default>
+namespace v1 {
+template <typename Task>
 class infer_input_impl;
 
-template <typename Task = task::by_default>
+template <typename Task>
 class infer_result_impl;
+} // namespace v1
+
+using v1::infer_input_impl;
+using v1::infer_result_impl;
+
 } // namespace detail
 
+namespace v1 {
+
 template <typename Task = task::by_default>
-class ONEDAL_EXPORT infer_input : public base {
+class infer_input : public base {
+    static_assert(detail::is_valid_task_v<Task>);
+
 public:
     using task_t = Task;
-    infer_input(const model<task_t>& trained_model, const table& data);
 
-    model<task_t> get_model() const;
+    infer_input(const model<Task>& trained_model, const table& data);
 
-    auto& set_model(const model<task_t>& value) {
+    const model<Task>& get_model() const;
+
+    auto& set_model(const model<Task>& value) {
         set_model_impl(value);
         return *this;
     }
 
-    table get_data() const;
+    const table& get_data() const;
 
     auto& set_data(const table& value) {
         set_data_impl(value);
         return *this;
     }
 
-private:
-    void set_model_impl(const model<task_t>& value);
+protected:
+    void set_model_impl(const model<Task>& value);
     void set_data_impl(const table& value);
 
-    dal::detail::pimpl<detail::infer_input_impl<task_t>> impl_;
+private:
+    dal::detail::pimpl<detail::infer_input_impl<Task>> impl_;
 };
 
 template <typename Task = task::by_default>
-class ONEDAL_EXPORT infer_result {
+class infer_result {
+    static_assert(detail::is_valid_task_v<Task>);
+
 public:
     using task_t = Task;
+
     infer_result();
 
-    table get_transformed_data() const;
+    const table& get_transformed_data() const;
 
     auto& set_transformed_data(const table& value) {
         set_transformed_data_impl(value);
         return *this;
     }
 
-private:
+protected:
     void set_transformed_data_impl(const table&);
 
-    dal::detail::pimpl<detail::infer_result_impl<task_t>> impl_;
+private:
+    dal::detail::pimpl<detail::infer_result_impl<Task>> impl_;
 };
+
+} // namespace v1
+
+using v1::infer_input;
+using v1::infer_result;
 
 } // namespace oneapi::dal::pca

--- a/cpp/oneapi/dal/algo/pca/train.hpp
+++ b/cpp/oneapi/dal/algo/pca/train.hpp
@@ -21,8 +21,10 @@
 #include "oneapi/dal/train.hpp"
 
 namespace oneapi::dal::detail {
+namespace v1 {
 
 template <typename Descriptor>
 struct train_ops<Descriptor, dal::pca::detail::tag> : dal::pca::detail::train_ops<Descriptor> {};
 
+} // namespace v1
 } // namespace oneapi::dal::detail

--- a/cpp/oneapi/dal/algo/pca/train_types.cpp
+++ b/cpp/oneapi/dal/algo/pca/train_types.cpp
@@ -20,7 +20,7 @@
 namespace oneapi::dal::pca {
 
 template <typename Task>
-class detail::train_input_impl : public base {
+class detail::v1::train_input_impl : public base {
 public:
     train_input_impl(const table& data) : data(data) {}
 
@@ -28,7 +28,7 @@ public:
 };
 
 template <typename Task>
-class detail::train_result_impl : public base {
+class detail::v1::train_result_impl : public base {
 public:
     model<Task> trained_model;
     table eigenvalues;
@@ -36,14 +36,16 @@ public:
     table means;
 };
 
-using detail::train_input_impl;
-using detail::train_result_impl;
+using detail::v1::train_input_impl;
+using detail::v1::train_result_impl;
+
+namespace v1 {
 
 template <typename Task>
-train_input<Task>::train_input(const table& data) : impl_(new train_input_impl(data)) {}
+train_input<Task>::train_input(const table& data) : impl_(new train_input_impl<Task>(data)) {}
 
 template <typename Task>
-table train_input<Task>::get_data() const {
+const table& train_input<Task>::get_data() const {
     return impl_->data;
 }
 
@@ -53,30 +55,30 @@ void train_input<Task>::set_data_impl(const table& value) {
 }
 
 template <typename Task>
-train_result<Task>::train_result() : impl_(new train_result_impl{}) {}
+train_result<Task>::train_result() : impl_(new train_result_impl<Task>{}) {}
 
 template <typename Task>
-model<Task> train_result<Task>::get_model() const {
+const model<Task>& train_result<Task>::get_model() const {
     return impl_->trained_model;
 }
 
 template <typename Task>
-table train_result<Task>::get_eigenvalues() const {
+const table& train_result<Task>::get_eigenvalues() const {
     return impl_->eigenvalues;
 }
 
 template <typename Task>
-table train_result<Task>::get_eigenvectors() const {
+const table& train_result<Task>::get_eigenvectors() const {
     return impl_->trained_model.get_eigenvectors();
 }
 
 template <typename Task>
-table train_result<Task>::get_variances() const {
+const table& train_result<Task>::get_variances() const {
     return impl_->variances;
 }
 
 template <typename Task>
-table train_result<Task>::get_means() const {
+const table& train_result<Task>::get_means() const {
     return impl_->means;
 }
 
@@ -103,4 +105,5 @@ void train_result<Task>::set_means_impl(const table& value) {
 template class ONEDAL_EXPORT train_input<task::dim_reduction>;
 template class ONEDAL_EXPORT train_result<task::dim_reduction>;
 
+} // namespace v1
 } // namespace oneapi::dal::pca

--- a/cpp/oneapi/dal/algo/pca/train_types.hpp
+++ b/cpp/oneapi/dal/algo/pca/train_types.hpp
@@ -21,72 +21,97 @@
 namespace oneapi::dal::pca {
 
 namespace detail {
-template <typename Task = task::by_default>
+namespace v1 {
+template <typename Task>
 class train_input_impl;
 
-template <typename Task = task::by_default>
+template <typename Task>
 class train_result_impl;
+} // namespace v1
+
+using v1::train_input_impl;
+using v1::train_result_impl;
+
 } // namespace detail
 
+namespace v1 {
+
 template <typename Task = task::by_default>
-class ONEDAL_EXPORT train_input : public base {
+class train_input : public base {
+    static_assert(detail::is_valid_task_v<Task>);
+
 public:
     using task_t = Task;
+
     train_input(const table& data);
 
-    table get_data() const;
+    const table& get_data() const;
 
     auto& set_data(const table& data) {
         set_data_impl(data);
         return *this;
     }
 
-private:
+protected:
     void set_data_impl(const table& data);
 
-    dal::detail::pimpl<detail::train_input_impl<task_t>> impl_;
+private:
+    dal::detail::pimpl<detail::train_input_impl<Task>> impl_;
 };
 
 template <typename Task = task::by_default>
-class ONEDAL_EXPORT train_result {
+class train_result {
+    static_assert(detail::is_valid_task_v<Task>);
+
 public:
     using task_t = Task;
+
     train_result();
 
-    model<task_t> get_model() const;
-    table get_eigenvalues() const;
-    table get_eigenvectors() const;
-    table get_variances() const;
-    table get_means() const;
+    const table& get_eigenvectors() const;
 
-    auto& set_model(const model<task_t>& value) {
+    const model<Task>& get_model() const;
+
+    auto& set_model(const model<Task>& value) {
         set_model_impl(value);
         return *this;
     }
+
+    const table& get_eigenvalues() const;
 
     auto& set_eigenvalues(const table& value) {
         set_eigenvalues_impl(value);
         return *this;
     }
 
+    const table& get_variances() const;
+
     auto& set_variances(const table& value) {
         set_variances_impl(value);
         return *this;
     }
+
+    const table& get_means() const;
 
     auto& set_means(const table& value) {
         set_means_impl(value);
         return *this;
     }
 
-private:
-    void set_model_impl(const model<task_t>&);
+protected:
+    void set_model_impl(const model<Task>&);
     void set_eigenvalues_impl(const table&);
     void set_eigenvectors_impl(const table&);
     void set_variances_impl(const table&);
     void set_means_impl(const table&);
 
-    dal::detail::pimpl<detail::train_result_impl<task_t>> impl_;
+private:
+    dal::detail::pimpl<detail::train_result_impl<Task>> impl_;
 };
+
+} // namespace v1
+
+using v1::train_input;
+using v1::train_result;
 
 } // namespace oneapi::dal::pca

--- a/cpp/oneapi/dal/algo/rbf_kernel/common.cpp
+++ b/cpp/oneapi/dal/algo/rbf_kernel/common.cpp
@@ -20,12 +20,14 @@
 namespace oneapi::dal::rbf_kernel {
 
 template <>
-class detail::descriptor_impl<task::compute> : public base {
+class detail::v1::descriptor_impl<task::compute> : public base {
 public:
     double sigma = 1.0;
 };
 
-using detail::descriptor_impl;
+using detail::v1::descriptor_impl;
+
+namespace v1 {
 
 template <typename Task>
 descriptor_base<Task>::descriptor_base() : impl_(new descriptor_impl<Task>{}) {}
@@ -45,4 +47,5 @@ void descriptor_base<Task>::set_sigma_impl(double value) {
 
 template class ONEDAL_EXPORT descriptor_base<task::compute>;
 
+} // namespace v1
 } // namespace oneapi::dal::rbf_kernel

--- a/cpp/oneapi/dal/algo/rbf_kernel/common.cpp
+++ b/cpp/oneapi/dal/algo/rbf_kernel/common.cpp
@@ -19,8 +19,8 @@
 
 namespace oneapi::dal::rbf_kernel {
 
-template <>
-class detail::v1::descriptor_impl<task::compute> : public base {
+template <typename Task>
+class detail::v1::descriptor_impl : public base {
 public:
     double sigma = 1.0;
 };

--- a/cpp/oneapi/dal/algo/rbf_kernel/common.hpp
+++ b/cpp/oneapi/dal/algo/rbf_kernel/common.hpp
@@ -22,25 +22,54 @@
 namespace oneapi::dal::rbf_kernel {
 
 namespace task {
+namespace v1 {
 struct compute {};
 using by_default = compute;
+} // namespace v1
+
+using v1::compute;
+using v1::by_default;
+
 } // namespace task
 
-namespace detail {
-struct tag {};
-
-template <typename Task = task::by_default>
-class descriptor_impl;
-} // namespace detail
-
 namespace method {
+namespace v1 {
 struct dense {};
-struct csr {};
 using by_default = dense;
+} // namespace v1
+
+using v1::dense;
+using v1::by_default;
+
 } // namespace method
 
+namespace detail {
+namespace v1 {
+struct tag {};
+template <typename Task>
+class descriptor_impl;
+} // namespace v1
+
+using v1::tag;
+using v1::descriptor_impl;
+
+template <typename Float>
+constexpr bool is_valid_float_v = dal::detail::is_one_of_v<Float, float, double>;
+
+template <typename Method>
+constexpr bool is_valid_method_v = dal::detail::is_one_of_v<Method, method::dense>;
+
+template <typename Task>
+constexpr bool is_valid_task_v = dal::detail::is_one_of_v<Task, task::compute>;
+
+} // namespace detail
+
+namespace v1 {
+
 template <typename Task = task::by_default>
-class ONEDAL_EXPORT descriptor_base : public base {
+class descriptor_base : public base {
+    static_assert(detail::is_valid_task_v<Task>);
+
 public:
     using tag_t = detail::tag;
     using float_t = float;
@@ -54,22 +83,32 @@ public:
 protected:
     void set_sigma_impl(double);
 
-    dal::detail::pimpl<detail::descriptor_impl<task_t>> impl_;
+private:
+    dal::detail::pimpl<detail::descriptor_impl<Task>> impl_;
 };
 
-template <typename Float = descriptor_base<task::by_default>::float_t,
-          typename Method = descriptor_base<task::by_default>::method_t,
-          typename Task = task::by_default>
+template <typename Float = descriptor_base<>::float_t,
+          typename Method = descriptor_base<>::method_t,
+          typename Task = descriptor_base<>::task_t>
 class descriptor : public descriptor_base<Task> {
+    static_assert(detail::is_valid_float_v<Float>);
+    static_assert(detail::is_valid_method_v<Method>);
+    static_assert(detail::is_valid_task_v<Task>);
+
 public:
     using float_t = Float;
     using method_t = Method;
     using task_t = Task;
 
     auto& set_sigma(double value) {
-        descriptor_base<task_t>::set_sigma_impl(value);
+        descriptor_base<Task>::set_sigma_impl(value);
         return *this;
     }
 };
+
+} // namespace v1
+
+using v1::descriptor_base;
+using v1::descriptor;
 
 } // namespace oneapi::dal::rbf_kernel

--- a/cpp/oneapi/dal/algo/rbf_kernel/compute.hpp
+++ b/cpp/oneapi/dal/algo/rbf_kernel/compute.hpp
@@ -21,9 +21,11 @@
 #include "oneapi/dal/compute.hpp"
 
 namespace oneapi::dal::detail {
+namespace v1 {
 
 template <typename Descriptor>
 struct compute_ops<Descriptor, dal::rbf_kernel::detail::tag>
         : dal::rbf_kernel::detail::compute_ops<Descriptor> {};
 
+} // namespace v1
 } // namespace oneapi::dal::detail

--- a/cpp/oneapi/dal/algo/rbf_kernel/compute_types.cpp
+++ b/cpp/oneapi/dal/algo/rbf_kernel/compute_types.cpp
@@ -20,7 +20,7 @@
 namespace oneapi::dal::rbf_kernel {
 
 template <typename Task>
-class detail::compute_input_impl : public base {
+class detail::v1::compute_input_impl : public base {
 public:
     compute_input_impl(const table& x, const table& y) : x(x), y(y) {}
     table x;
@@ -28,25 +28,27 @@ public:
 };
 
 template <typename Task>
-class detail::compute_result_impl : public base {
+class detail::v1::compute_result_impl : public base {
 public:
     table values;
 };
 
-using detail::compute_input_impl;
-using detail::compute_result_impl;
+using detail::v1::compute_input_impl;
+using detail::v1::compute_result_impl;
+
+namespace v1 {
 
 template <typename Task>
 compute_input<Task>::compute_input(const table& x, const table& y)
         : impl_(new compute_input_impl<Task>(x, y)) {}
 
 template <typename Task>
-table compute_input<Task>::get_x() const {
+const table& compute_input<Task>::get_x() const {
     return impl_->x;
 }
 
 template <typename Task>
-table compute_input<Task>::get_y() const {
+const table& compute_input<Task>::get_y() const {
     return impl_->y;
 }
 
@@ -66,7 +68,7 @@ template <typename Task>
 compute_result<Task>::compute_result() : impl_(new compute_result_impl<Task>{}) {}
 
 template <typename Task>
-table compute_result<Task>::get_values() const {
+const table& compute_result<Task>::get_values() const {
     return impl_->values;
 }
 
@@ -77,4 +79,5 @@ void compute_result<Task>::set_values_impl(const table& value) {
 
 template class ONEDAL_EXPORT compute_result<task::compute>;
 
+} // namespace v1
 } // namespace oneapi::dal::rbf_kernel

--- a/cpp/oneapi/dal/algo/rbf_kernel/compute_types.hpp
+++ b/cpp/oneapi/dal/algo/rbf_kernel/compute_types.hpp
@@ -21,58 +21,78 @@
 namespace oneapi::dal::rbf_kernel {
 
 namespace detail {
-template <typename Task = task::by_default>
+namespace v1 {
+template <typename Task>
 class compute_input_impl;
 
-template <typename Task = task::by_default>
+template <typename Task>
 class compute_result_impl;
+} // namespace v1
+
+using v1::compute_input_impl;
+using v1::compute_result_impl;
+
 } // namespace detail
 
+namespace v1 {
+
 template <typename Task = task::by_default>
-class ONEDAL_EXPORT compute_input : public base {
+class compute_input : public base {
+    static_assert(detail::is_valid_task_v<Task>);
+
 public:
     using task_t = Task;
 
     compute_input(const table& x, const table& y);
 
-    table get_x() const;
-    table get_y() const;
+    const table& get_y() const;
 
     auto& set_x(const table& data) {
         set_x_impl(data);
         return *this;
     }
 
+    const table& get_x() const;
+
     auto& set_y(const table& data) {
         set_y_impl(data);
         return *this;
     }
 
-private:
+protected:
     void set_x_impl(const table& data);
     void set_y_impl(const table& data);
 
-    dal::detail::pimpl<detail::compute_input_impl<task_t>> impl_;
+private:
+    dal::detail::pimpl<detail::compute_input_impl<Task>> impl_;
 };
 
 template <typename Task = task::by_default>
-class ONEDAL_EXPORT compute_result : public base {
+class compute_result : public base {
+    static_assert(detail::is_valid_task_v<Task>);
+
 public:
     using task_t = Task;
 
     compute_result();
 
-    table get_values() const;
+    const table& get_values() const;
 
     auto& set_values(const table& value) {
         set_values_impl(value);
         return *this;
     }
 
-private:
+protected:
     void set_values_impl(const table&);
 
-    dal::detail::pimpl<detail::compute_result_impl<task_t>> impl_;
+private:
+    dal::detail::pimpl<detail::compute_result_impl<Task>> impl_;
 };
+
+} // namespace v1
+
+using v1::compute_input;
+using v1::compute_result;
 
 } // namespace oneapi::dal::rbf_kernel

--- a/cpp/oneapi/dal/algo/rbf_kernel/detail/compute_ops.cpp
+++ b/cpp/oneapi/dal/algo/rbf_kernel/detail/compute_ops.cpp
@@ -19,7 +19,9 @@
 #include "oneapi/dal/backend/dispatcher.hpp"
 
 namespace oneapi::dal::rbf_kernel::detail {
-using oneapi::dal::detail::host_policy;
+namespace v1 {
+
+using dal::detail::host_policy;
 
 template <typename Float, typename Method, typename Task>
 struct compute_ops_dispatcher<host_policy, Float, Method, Task> {
@@ -38,4 +40,5 @@ struct compute_ops_dispatcher<host_policy, Float, Method, Task> {
 INSTANTIATE(float, method::dense, task::compute)
 INSTANTIATE(double, method::dense, task::compute)
 
+} // namespace v1
 } // namespace oneapi::dal::rbf_kernel::detail

--- a/cpp/oneapi/dal/algo/rbf_kernel/detail/compute_ops.hpp
+++ b/cpp/oneapi/dal/algo/rbf_kernel/detail/compute_ops.hpp
@@ -20,12 +20,9 @@
 #include "oneapi/dal/detail/error_messages.hpp"
 
 namespace oneapi::dal::rbf_kernel::detail {
+namespace v1 {
 
-template <typename Context,
-          typename Float,
-          typename Method = method::dense,
-          typename Task = task::by_default,
-          typename... Options>
+template <typename Context, typename Float, typename Method, typename Task, typename... Options>
 struct compute_ops_dispatcher {
     compute_result<Task> operator()(const Context&,
                                     const descriptor_base<Task>&,
@@ -72,5 +69,9 @@ struct compute_ops {
         return result;
     }
 };
+
+} // namespace v1
+
+using v1::compute_ops;
 
 } // namespace oneapi::dal::rbf_kernel::detail

--- a/cpp/oneapi/dal/algo/rbf_kernel/detail/compute_ops_dpc.cpp
+++ b/cpp/oneapi/dal/algo/rbf_kernel/detail/compute_ops_dpc.cpp
@@ -20,7 +20,9 @@
 #include "oneapi/dal/backend/dispatcher_dpc.hpp"
 
 namespace oneapi::dal::rbf_kernel::detail {
-using oneapi::dal::detail::data_parallel_policy;
+namespace v1 {
+
+using dal::detail::data_parallel_policy;
 
 template <typename Float, typename Method, typename Task>
 struct compute_ops_dispatcher<data_parallel_policy, Float, Method, Task> {
@@ -40,4 +42,5 @@ struct compute_ops_dispatcher<data_parallel_policy, Float, Method, Task> {
 INSTANTIATE(float, method::dense, task::compute)
 INSTANTIATE(double, method::dense, task::compute)
 
+} // namespace v1
 } // namespace oneapi::dal::rbf_kernel::detail

--- a/cpp/oneapi/dal/algo/svm/backend/cpu/infer_kernel.cpp
+++ b/cpp/oneapi/dal/algo/svm/backend/cpu/infer_kernel.cpp
@@ -17,7 +17,7 @@
 #include <daal/src/algorithms/svm/svm_predict_kernel.h>
 
 #include "oneapi/dal/algo/svm/backend/cpu/infer_kernel.hpp"
-#include "oneapi/dal/algo/svm/backend/interop_model.hpp"
+#include "oneapi/dal/algo/svm/backend/model_interop.hpp"
 #include "oneapi/dal/algo/svm/backend/kernel_function_impl.hpp"
 #include "oneapi/dal/backend/interop/common.hpp"
 #include "oneapi/dal/backend/interop/error_converter.hpp"
@@ -69,7 +69,10 @@ static result_t call_daal_kernel(const context_cpu& ctx,
                           .set_coeffs(daal_coeffs)
                           .set_bias(trained_model.get_bias());
 
-    auto kernel_impl = desc.get_kernel_impl()->get_impl();
+    auto kernel_impl = detail::get_kernel_function_impl(desc);
+    if (!kernel_impl) {
+        throw internal_error{ dal::detail::error_messages::unknown_kernel_function_type() };
+    }
     const auto daal_kernel = kernel_impl->get_daal_kernel_function();
 
     daal_svm::Parameter daal_parameter(daal_kernel);

--- a/cpp/oneapi/dal/algo/svm/backend/cpu/train_kernel.cpp
+++ b/cpp/oneapi/dal/algo/svm/backend/cpu/train_kernel.cpp
@@ -18,7 +18,7 @@
 #include <daal/src/algorithms/svm/svm_train_thunder_kernel.h>
 
 #include "oneapi/dal/algo/svm/backend/cpu/train_kernel.hpp"
-#include "oneapi/dal/algo/svm/backend/interop_model.hpp"
+#include "oneapi/dal/algo/svm/backend/model_interop.hpp"
 #include "oneapi/dal/algo/svm/backend/kernel_function_impl.hpp"
 #include "oneapi/dal/algo/svm/backend/utils.hpp"
 
@@ -67,7 +67,10 @@ static result_t call_daal_kernel(const context_cpu& ctx,
     const auto daal_labels = interop::convert_to_daal_homogen_table(arr_new_label, row_count, 1);
     const auto daal_weights = interop::convert_to_daal_homogen_table(arr_weights, row_count, 1);
 
-    auto kernel_impl = desc.get_kernel_impl()->get_impl();
+    auto kernel_impl = detail::get_kernel_function_impl(desc);
+    if (!kernel_impl) {
+        throw internal_error{ dal::detail::error_messages::unknown_kernel_function_type() };
+    }
     const auto daal_kernel = kernel_impl->get_daal_kernel_function();
 
     const std::uint64_t cache_megabyte = static_cast<std::uint64_t>(desc.get_cache_size());

--- a/cpp/oneapi/dal/algo/svm/backend/gpu/infer_kernel_dpc.cpp
+++ b/cpp/oneapi/dal/algo/svm/backend/gpu/infer_kernel_dpc.cpp
@@ -15,7 +15,7 @@
 *******************************************************************************/
 
 #include "oneapi/dal/algo/svm/backend/gpu/infer_kernel.hpp"
-#include "oneapi/dal/algo/svm/backend/interop_model.hpp"
+#include "oneapi/dal/algo/svm/backend/model_interop.hpp"
 #include "oneapi/dal/algo/svm/backend/kernel_function_impl.hpp"
 #include "oneapi/dal/backend/interop/common_dpc.hpp"
 #include "oneapi/dal/backend/interop/error_converter.hpp"
@@ -74,7 +74,10 @@ static result_t call_daal_kernel(const context_gpu& ctx,
                           .set_coeffs(daal_coeffs)
                           .set_bias(trained_model.get_bias());
 
-    auto kernel_impl = desc.get_kernel_impl()->get_impl();
+    auto kernel_impl = detail::get_kernel_function_impl(desc);
+    if (!kernel_impl) {
+        throw internal_error{ dal::detail::error_messages::unknown_kernel_function_type() };
+    }
     const auto daal_kernel = kernel_impl->get_daal_kernel_function();
 
     daal_svm::Parameter daal_parameter(daal_kernel);

--- a/cpp/oneapi/dal/algo/svm/backend/gpu/train_kernel_thunder_dpc.cpp
+++ b/cpp/oneapi/dal/algo/svm/backend/gpu/train_kernel_thunder_dpc.cpp
@@ -15,7 +15,7 @@
 *******************************************************************************/
 
 #include "oneapi/dal/algo/svm/backend/gpu/train_kernel.hpp"
-#include "oneapi/dal/algo/svm/backend/interop_model.hpp"
+#include "oneapi/dal/algo/svm/backend/model_interop.hpp"
 #include "oneapi/dal/algo/svm/backend/kernel_function_impl.hpp"
 #include "oneapi/dal/algo/svm/backend/utils.hpp"
 
@@ -67,7 +67,10 @@ static result_t call_daal_kernel(const context_gpu& ctx,
     const auto daal_labels =
         interop::convert_to_daal_sycl_homogen_table(queue, arr_new_label, row_count, 1);
 
-    auto kernel_impl = desc.get_kernel_impl()->get_impl();
+    auto kernel_impl = detail::get_kernel_function_impl(desc);
+    if (!kernel_impl) {
+        throw internal_error{ dal::detail::error_messages::unknown_kernel_function_type() };
+    }
     const auto daal_kernel = kernel_impl->get_daal_kernel_function();
 
     const std::uint64_t cache_megabyte = static_cast<std::uint64_t>(desc.get_cache_size());

--- a/cpp/oneapi/dal/algo/svm/backend/kernel_function_impl.hpp
+++ b/cpp/oneapi/dal/algo/svm/backend/kernel_function_impl.hpp
@@ -22,6 +22,7 @@
 #include <daal/include/algorithms/kernel_function/kernel_function_rbf.h>
 
 namespace oneapi::dal::svm::detail {
+namespace v1 {
 
 class kernel_function_impl : public base {
 public:
@@ -29,5 +30,9 @@ public:
 
     virtual daal::algorithms::kernel_function::KernelIfacePtr get_daal_kernel_function() = 0;
 };
+
+} // namespace v1
+
+using v1::kernel_function_impl;
 
 } // namespace oneapi::dal::svm::detail

--- a/cpp/oneapi/dal/algo/svm/backend/model_interop.hpp
+++ b/cpp/oneapi/dal/algo/svm/backend/model_interop.hpp
@@ -53,13 +53,11 @@ inline auto convert_from_daal_model(daal_svm::Model& model) {
     auto table_classification_coeffs =
         interop::convert_from_daal_homogen_table<Float>(model.getClassificationCoefficients());
     const double bias = model.getBias();
-    const std::int64_t support_vector_count = table_support_vectors.get_row_count();
 
     return dal::svm::model<Task>()
         .set_support_vectors(table_support_vectors)
         .set_coeffs(table_classification_coeffs)
-        .set_bias(bias)
-        .set_support_vector_count(support_vector_count);
+        .set_bias(bias);
 }
 
 } // namespace oneapi::dal::svm::backend

--- a/cpp/oneapi/dal/algo/svm/common.cpp
+++ b/cpp/oneapi/dal/algo/svm/common.cpp
@@ -20,8 +20,8 @@
 
 namespace oneapi::dal::svm {
 
-template <>
-class detail::v1::descriptor_impl<task::classification> : public base {
+template <typename Task>
+class detail::v1::descriptor_impl : public base {
 public:
     explicit descriptor_impl(const detail::kernel_function_ptr& kernel) : kernel(kernel) {}
 
@@ -34,8 +34,8 @@ public:
     bool shrinking = true;
 };
 
-template <>
-class detail::v1::model_impl<task::classification> : public base {
+template <typename Task>
+class detail::v1::model_impl : public base {
 public:
     table support_vectors;
     table coeffs;

--- a/cpp/oneapi/dal/algo/svm/common.hpp
+++ b/cpp/oneapi/dal/algo/svm/common.hpp
@@ -16,96 +16,77 @@
 
 #pragma once
 
-#include "oneapi/dal/algo/linear_kernel.hpp"
-#include "oneapi/dal/algo/rbf_kernel.hpp"
 #include "oneapi/dal/detail/common.hpp"
 #include "oneapi/dal/table/common.hpp"
+#include "oneapi/dal/algo/svm/detail/kernel_function.hpp"
 
 namespace oneapi::dal::svm {
 
 namespace task {
+namespace v1 {
 struct classification {};
 using by_default = classification;
+} // namespace v1
+
+using v1::classification;
+using v1::by_default;
+
 } // namespace task
 
-namespace detail {
-struct tag {};
-
-template <typename Task = task::by_default>
-class descriptor_impl;
-
-template <typename Task = task::by_default>
-class model_impl;
-
-class kernel_function_impl;
-
-class kernel_function_iface {
-public:
-    virtual ~kernel_function_iface() {}
-    virtual kernel_function_impl *get_impl() const = 0;
-};
-
-using kf_iface_ptr = std::shared_ptr<kernel_function_iface>;
-
-template <typename Kernel>
-class ONEDAL_EXPORT kernel_function : public base, public kernel_function_iface {
-public:
-    explicit kernel_function(const Kernel &kernel) : kernel_(kernel) {}
-
-    kernel_function_impl *get_impl() const override {
-        return nullptr;
-    }
-
-    const Kernel &get_kernel() const {
-        return kernel_;
-    }
-
-private:
-    Kernel kernel_;
-    dal::detail::pimpl<kernel_function_impl> impl_;
-};
-
-template <typename Float, typename Method>
-class kernel_function<linear_kernel::descriptor<Float, Method>> : public base,
-                                                                  public kernel_function_iface {
-public:
-    using kernel_t = linear_kernel::descriptor<Float, Method>;
-    explicit kernel_function(const kernel_t &kernel);
-    kernel_function_impl *get_impl() const override;
-
-private:
-    kernel_t kernel_;
-    dal::detail::pimpl<kernel_function_impl> impl_;
-};
-
-template <typename Float, typename Method>
-class kernel_function<rbf_kernel::descriptor<Float, Method>> : public base,
-                                                               public kernel_function_iface {
-public:
-    using kernel_t = rbf_kernel::descriptor<Float, Method>;
-    explicit kernel_function(const kernel_t &kernel);
-    kernel_function_impl *get_impl() const override;
-
-private:
-    kernel_t kernel_;
-    dal::detail::pimpl<kernel_function_impl> impl_;
-};
-
-} // namespace detail
-
 namespace method {
+namespace v1 {
 struct thunder {};
 struct smo {};
 using by_default = thunder;
+} // namespace v1
+
+using v1::thunder;
+using v1::smo;
+using v1::by_default;
+
 } // namespace method
 
+namespace detail {
+namespace v1 {
+struct tag {};
+template <typename Task>
+class descriptor_impl;
+
+template <typename Task>
+class model_impl;
+} // namespace v1
+
+using v1::tag;
+using v1::descriptor_impl;
+using v1::model_impl;
+
+template <typename Float>
+constexpr bool is_valid_float_v = dal::detail::is_one_of_v<Float, float, double>;
+
+template <typename Method>
+constexpr bool is_valid_method_v = dal::detail::is_one_of_v<Method, method::smo, method::thunder>;
+
+template <typename Task>
+constexpr bool is_valid_task_v = dal::detail::is_one_of_v<Task, task::classification>;
+
+template <typename Kernel>
+constexpr bool is_valid_kernel_v =
+    dal::detail::is_tag_one_of_v<Kernel, linear_kernel::detail::tag, rbf_kernel::detail::tag>;
+
+} // namespace detail
+
+namespace v1 {
+
 template <typename Task = task::by_default>
-class ONEDAL_EXPORT descriptor_base : public base {
+class descriptor_base : public base {
+    static_assert(detail::is_valid_task_v<Task>);
+    friend detail::kernel_function_accessor;
+
 public:
     using tag_t = detail::tag;
     using float_t = float;
-    using task_t = Task;
     using method_t = method::by_default;
+    using task_t = Task;
     using kernel_t = linear_kernel::descriptor<float_t>;
 
     double get_c() const;
@@ -114,10 +95,9 @@ public:
     double get_cache_size() const;
     double get_tau() const;
     bool get_shrinking() const;
-    const detail::kf_iface_ptr &get_kernel_impl() const;
 
 protected:
-    explicit descriptor_base(const detail::kf_iface_ptr &kernel);
+    explicit descriptor_base(const detail::kernel_function_ptr& kernel);
 
     void set_c_impl(double);
     void set_accuracy_threshold_impl(double);
@@ -125,127 +105,140 @@ protected:
     void set_cache_size_impl(double);
     void set_tau_impl(double);
     void set_shrinking_impl(bool);
-    void set_kernel_impl(const detail::kf_iface_ptr &);
 
+    void set_kernel_impl(const detail::kernel_function_ptr&);
+    const detail::kernel_function_ptr& get_kernel_impl() const;
+
+private:
     dal::detail::pimpl<detail::descriptor_impl<Task>> impl_;
 };
 
-template <typename Float = descriptor_base<task::by_default>::float_t,
-          typename Method = descriptor_base<task::by_default>::method_t,
-          typename Task = task::by_default,
-          typename Kernel = descriptor_base<task::by_default>::kernel_t>
+template <typename Float = descriptor_base<>::float_t,
+          typename Method = descriptor_base<>::method_t,
+          typename Task = descriptor_base<>::task_t,
+          typename Kernel = descriptor_base<>::kernel_t>
 class descriptor : public descriptor_base<Task> {
+    static_assert(detail::is_valid_float_v<Float>);
+    static_assert(detail::is_valid_method_v<Method>);
+    static_assert(detail::is_valid_task_v<Task>);
+    static_assert(detail::is_valid_kernel_v<Kernel>,
+                  "Custom kernel for SVM is not supported. "
+                  "Use one of the predefined kernels.");
+
 public:
     using float_t = Float;
     using method_t = Method;
     using task_t = Task;
     using kernel_t = Kernel;
 
-    explicit descriptor(const Kernel &kernel = kernel_t{})
+    explicit descriptor(const Kernel& kernel = kernel_t{})
             : descriptor_base<Task>(std::make_shared<detail::kernel_function<Kernel>>(kernel)) {}
 
-    const Kernel &get_kernel() const {
+    const Kernel& get_kernel() const {
         using kf_t = detail::kernel_function<Kernel>;
         const auto kf = std::static_pointer_cast<kf_t>(descriptor_base<Task>::get_kernel_impl());
         return kf->get_kernel();
     }
 
-    auto &set_kernel(const Kernel &kernel) {
+    auto& set_kernel(const Kernel& kernel) {
         descriptor_base<Task>::set_kernel_impl(
             std::make_shared<detail::kernel_function<Kernel>>(kernel));
         return *this;
     }
 
-    auto &set_c(double value) {
+    auto& set_c(double value) {
         descriptor_base<Task>::set_c_impl(value);
         return *this;
     }
 
-    auto &set_accuracy_threshold(double value) {
+    auto& set_accuracy_threshold(double value) {
         descriptor_base<Task>::set_accuracy_threshold_impl(value);
         return *this;
     }
 
-    auto &set_max_iteration_count(std::int64_t value) {
+    auto& set_max_iteration_count(std::int64_t value) {
         descriptor_base<Task>::set_max_iteration_count_impl(value);
         return *this;
     }
 
-    auto &set_cache_size(double value) {
+    auto& set_cache_size(double value) {
         descriptor_base<Task>::set_cache_size_impl(value);
         return *this;
     }
 
-    auto &set_tau(double value) {
+    auto& set_tau(double value) {
         descriptor_base<Task>::set_tau_impl(value);
         return *this;
     }
 
-    auto &set_shrinking(bool value) {
+    auto& set_shrinking(bool value) {
         descriptor_base<Task>::set_shrinking_impl(value);
         return *this;
     }
 };
 
 template <typename Task = task::by_default>
-class ONEDAL_EXPORT model : public base {
+class model : public base {
+    static_assert(detail::is_valid_task_v<Task>);
     friend dal::detail::pimpl_accessor;
 
 public:
     using task_t = Task;
+
     model();
 
-    table get_support_vectors() const;
+    std::int64_t get_support_vector_count() const;
 
-    auto &set_support_vectors(const table &value) {
+    const table& get_support_vectors() const;
+
+    auto& set_support_vectors(const table& value) {
         set_support_vectors_impl(value);
         return *this;
     }
 
-    table get_coeffs() const;
+    const table& get_coeffs() const;
 
-    auto &set_coeffs(const table &value) {
+    auto& set_coeffs(const table& value) {
         set_coeffs_impl(value);
         return *this;
     }
 
     double get_bias() const;
 
-    auto &set_bias(double value) {
+    auto& set_bias(double value) {
         set_bias_impl(value);
-        return *this;
-    }
-
-    std::int64_t get_support_vector_count() const;
-
-    auto &set_support_vector_count(std::int64_t value) {
-        set_support_vector_count_impl(value);
         return *this;
     }
 
     std::int64_t get_first_class_label() const;
 
-    auto &set_first_class_label(std::int64_t value) {
+    auto& set_first_class_label(std::int64_t value) {
         set_first_class_label_impl(value);
         return *this;
     }
 
     std::int64_t get_second_class_label() const;
 
-    auto &set_second_class_label(std::int64_t value) {
+    auto& set_second_class_label(std::int64_t value) {
         set_second_class_label_impl(value);
         return *this;
     }
 
-private:
-    void set_support_vectors_impl(const table &);
-    void set_coeffs_impl(const table &);
+protected:
+    void set_support_vectors_impl(const table&);
+    void set_coeffs_impl(const table&);
     void set_bias_impl(double);
-    void set_support_vector_count_impl(std::int64_t);
     void set_first_class_label_impl(std::int64_t);
     void set_second_class_label_impl(std::int64_t);
 
-    dal::detail::pimpl<detail::model_impl<task_t>> impl_;
+private:
+    dal::detail::pimpl<detail::model_impl<Task>> impl_;
 };
+
+} // namespace v1
+
+using v1::descriptor_base;
+using v1::descriptor;
+using v1::model;
 
 } // namespace oneapi::dal::svm

--- a/cpp/oneapi/dal/algo/svm/detail/infer_ops.cpp
+++ b/cpp/oneapi/dal/algo/svm/detail/infer_ops.cpp
@@ -19,7 +19,9 @@
 #include "oneapi/dal/backend/dispatcher.hpp"
 
 namespace oneapi::dal::svm::detail {
-using oneapi::dal::detail::host_policy;
+namespace v1 {
+
+using dal::detail::host_policy;
 
 template <typename Float, typename Method, typename Task>
 struct infer_ops_dispatcher<host_policy, Float, Method, Task> {
@@ -38,4 +40,5 @@ struct infer_ops_dispatcher<host_policy, Float, Method, Task> {
 INSTANTIATE(float, method::by_default, task::classification)
 INSTANTIATE(double, method::by_default, task::classification)
 
+} // namespace v1
 } // namespace oneapi::dal::svm::detail

--- a/cpp/oneapi/dal/algo/svm/detail/infer_ops.hpp
+++ b/cpp/oneapi/dal/algo/svm/detail/infer_ops.hpp
@@ -20,13 +20,10 @@
 #include "oneapi/dal/detail/error_messages.hpp"
 
 namespace oneapi::dal::svm::detail {
+namespace v1 {
 
-template <typename Context,
-          typename Float,
-          typename Method = method::by_default,
-          typename Task = task::by_default,
-          typename... Options>
-struct ONEDAL_EXPORT infer_ops_dispatcher {
+template <typename Context, typename Float, typename Method, typename Task, typename... Options>
+struct infer_ops_dispatcher {
     infer_result<Task> operator()(const Context&,
                                   const descriptor_base<Task>&,
                                   const infer_input<Task>&) const;
@@ -43,12 +40,6 @@ struct infer_ops {
 
     void check_preconditions(const Descriptor& params, const input_t& input) const {
         using msg = dal::detail::error_messages;
-
-        // TODO: Should be invariant of model
-        ONEDAL_ASSERT(input.get_model().get_support_vector_count() >= 0);
-
-        // TODO: Should be invariant of kernel
-        ONEDAL_ASSERT(params.get_kernel_impl()->get_impl());
 
         if (!input.get_data().has_data()) {
             throw domain_error(msg::input_data_is_empty());
@@ -93,5 +84,9 @@ struct infer_ops {
         return result;
     }
 };
+
+} // namespace v1
+
+using v1::infer_ops;
 
 } // namespace oneapi::dal::svm::detail

--- a/cpp/oneapi/dal/algo/svm/detail/infer_ops_dpc.cpp
+++ b/cpp/oneapi/dal/algo/svm/detail/infer_ops_dpc.cpp
@@ -20,7 +20,10 @@
 #include "oneapi/dal/backend/dispatcher_dpc.hpp"
 
 namespace oneapi::dal::svm::detail {
-using oneapi::dal::detail::data_parallel_policy;
+namespace v1 {
+
+using dal::detail::data_parallel_policy;
+
 template <typename Float, typename Method, typename Task>
 struct infer_ops_dispatcher<data_parallel_policy, Float, Method, Task> {
     infer_result<Task> operator()(const data_parallel_policy& ctx,
@@ -39,4 +42,5 @@ struct infer_ops_dispatcher<data_parallel_policy, Float, Method, Task> {
 INSTANTIATE(float, method::by_default, task::classification)
 INSTANTIATE(double, method::by_default, task::classification)
 
+} // namespace v1
 } // namespace oneapi::dal::svm::detail

--- a/cpp/oneapi/dal/algo/svm/detail/kernel_function.cpp
+++ b/cpp/oneapi/dal/algo/svm/detail/kernel_function.cpp
@@ -1,0 +1,126 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "oneapi/dal/algo/svm/detail/kernel_function.hpp"
+#include "oneapi/dal/algo/svm/backend/kernel_function_impl.hpp"
+
+namespace oneapi::dal::svm::detail {
+namespace v1 {
+
+using daal_kf_t = daal::algorithms::kernel_function::KernelIfacePtr;
+namespace daal_linear_kernel = daal::algorithms::kernel_function::linear;
+namespace daal_rbf_kernel = daal::algorithms::kernel_function::rbf;
+
+template <typename F, typename M>
+using linear_kernel_t = linear_kernel::descriptor<F, M>;
+
+template <typename F, typename M>
+using rbf_kernel_t = rbf_kernel::descriptor<F, M>;
+
+template <typename Float, typename Method>
+class daal_interop_linear_kernel_impl : public kernel_function_impl {
+public:
+    daal_interop_linear_kernel_impl(double scale, double shift) : scale_(scale), shift_(shift) {}
+
+    daal_kf_t get_daal_kernel_function() override {
+        constexpr daal_linear_kernel::Method daal_method = get_daal_method();
+        auto alg = new daal_linear_kernel::Batch<Float, daal_method>;
+        alg->parameter.k = scale_;
+        alg->parameter.b = shift_;
+        return daal_kf_t(alg);
+    }
+
+private:
+    static constexpr daal_linear_kernel::Method get_daal_method() {
+        static_assert(dal::detail::is_one_of_v<Method, linear_kernel::method::dense>);
+
+        if constexpr (std::is_same_v<Method, linear_kernel::method::dense>) {
+            return daal_linear_kernel::Method::defaultDense;
+        }
+        // TODO: Comment out once CSR method is supported
+        // else if constexpr (std::is_same_v<Method, linear_kernel::method::csr>) {
+        //     return daal_linear_kernel::Method::fastCSR;
+        // }
+        return daal_linear_kernel::Method::defaultDense;
+    }
+
+    double scale_;
+    double shift_;
+};
+
+template <typename Float, typename Method>
+class daal_interop_rbf_kernel_impl : public kernel_function_impl {
+public:
+    daal_interop_rbf_kernel_impl(double sigma) : sigma_(sigma) {}
+
+    daal_kf_t get_daal_kernel_function() override {
+        constexpr daal_rbf_kernel::Method daal_method = get_daal_method();
+        auto alg = new daal_rbf_kernel::Batch<Float, daal_method>;
+        alg->parameter.sigma = sigma_;
+        return daal_kf_t(alg);
+    }
+
+private:
+    static constexpr daal_rbf_kernel::Method get_daal_method() {
+        static_assert(dal::detail::is_one_of_v<Method, rbf_kernel::method::dense>);
+
+        if constexpr (std::is_same_v<Method, rbf_kernel::method::dense>) {
+            return daal_rbf_kernel::Method::defaultDense;
+        }
+        // TODO: Comment out once CSR method is supported
+        // else if constexpr (std::is_same_v<Method, rbf_kernel::method::csr>) {
+        //     return daal_rbf_kernel::Method::fastCSR;
+        // }
+        return daal_rbf_kernel::Method::defaultDense;
+    }
+
+    double sigma_;
+};
+
+template <typename F, typename M>
+kernel_function<linear_kernel_t<F, M>>::kernel_function(const linear_kernel_t<F, M> &kernel)
+        : kernel_(kernel),
+          impl_(new daal_interop_linear_kernel_impl<F, M>{ kernel.get_scale(),
+                                                           kernel.get_shift() }) {}
+
+template <typename F, typename M>
+kernel_function_impl *kernel_function<linear_kernel_t<F, M>>::get_impl() const {
+    return impl_.get();
+}
+
+template <typename F, typename M>
+kernel_function<rbf_kernel_t<F, M>>::kernel_function(const rbf_kernel_t<F, M> &kernel)
+        : kernel_(kernel),
+          impl_(new daal_interop_rbf_kernel_impl<F, M>{ kernel.get_sigma() }) {}
+
+template <typename F, typename M>
+kernel_function_impl *kernel_function<rbf_kernel_t<F, M>>::get_impl() const {
+    return impl_.get();
+}
+
+#define INSTANTIATE_LINEAR(F, M) \
+    template class ONEDAL_EXPORT kernel_function<linear_kernel_t<F, M>>;
+
+#define INSTANTIATE_RBF(F, M) template class ONEDAL_EXPORT kernel_function<rbf_kernel_t<F, M>>;
+
+INSTANTIATE_LINEAR(float, linear_kernel::method::dense)
+INSTANTIATE_LINEAR(double, linear_kernel::method::dense)
+
+INSTANTIATE_RBF(float, rbf_kernel::method::dense)
+INSTANTIATE_RBF(double, rbf_kernel::method::dense)
+
+} // namespace v1
+} // namespace oneapi::dal::svm::detail

--- a/cpp/oneapi/dal/algo/svm/detail/kernel_function.hpp
+++ b/cpp/oneapi/dal/algo/svm/detail/kernel_function.hpp
@@ -1,0 +1,102 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#pragma once
+
+#include "oneapi/dal/algo/linear_kernel.hpp"
+#include "oneapi/dal/algo/rbf_kernel.hpp"
+
+namespace oneapi::dal::svm::detail {
+namespace v1 {
+
+class kernel_function_impl;
+
+class kernel_function_iface {
+public:
+    virtual ~kernel_function_iface() {}
+    virtual kernel_function_impl* get_impl() const = 0;
+};
+
+using kernel_function_ptr = std::shared_ptr<kernel_function_iface>;
+
+template <typename Kernel>
+class kernel_function : public base, public kernel_function_iface {
+public:
+    explicit kernel_function(const Kernel& kernel) : kernel_(kernel) {}
+
+    kernel_function_impl* get_impl() const override {
+        return nullptr;
+    }
+
+    const Kernel& get_kernel() const {
+        return kernel_;
+    }
+
+private:
+    Kernel kernel_;
+    dal::detail::pimpl<kernel_function_impl> impl_;
+};
+
+template <typename Float, typename Method>
+class kernel_function<linear_kernel::descriptor<Float, Method>> : public base,
+                                                                  public kernel_function_iface {
+public:
+    using kernel_t = linear_kernel::descriptor<Float, Method>;
+    explicit kernel_function(const kernel_t& kernel);
+    kernel_function_impl* get_impl() const override;
+
+private:
+    kernel_t kernel_;
+    dal::detail::pimpl<kernel_function_impl> impl_;
+};
+
+template <typename Float, typename Method>
+class kernel_function<rbf_kernel::descriptor<Float, Method>> : public base,
+                                                               public kernel_function_iface {
+public:
+    using kernel_t = rbf_kernel::descriptor<Float, Method>;
+    explicit kernel_function(const kernel_t& kernel);
+    kernel_function_impl* get_impl() const override;
+
+private:
+    kernel_t kernel_;
+    dal::detail::pimpl<kernel_function_impl> impl_;
+};
+
+struct kernel_function_accessor {
+    template <typename Descriptor>
+    const kernel_function_ptr& get_kernel_impl(Descriptor&& desc) const {
+        return desc.get_kernel_impl();
+    }
+};
+
+template <typename Descriptor>
+kernel_function_impl* get_kernel_function_impl(Descriptor&& desc) {
+    const auto& kernel =
+        kernel_function_accessor{}.template get_kernel_impl(std::forward<Descriptor>(desc));
+    return kernel ? kernel->get_impl() : nullptr;
+}
+
+} // namespace v1
+
+using v1::kernel_function_impl;
+using v1::kernel_function_iface;
+using v1::kernel_function_ptr;
+using v1::kernel_function;
+using v1::kernel_function_accessor;
+using v1::get_kernel_function_impl;
+
+} // namespace oneapi::dal::svm::detail

--- a/cpp/oneapi/dal/algo/svm/detail/train_ops.cpp
+++ b/cpp/oneapi/dal/algo/svm/detail/train_ops.cpp
@@ -19,7 +19,9 @@
 #include "oneapi/dal/backend/dispatcher.hpp"
 
 namespace oneapi::dal::svm::detail {
-using oneapi::dal::detail::host_policy;
+namespace v1 {
+
+using dal::detail::host_policy;
 
 template <typename Float, typename Method, typename Task>
 struct train_ops_dispatcher<host_policy, Float, Method, Task> {
@@ -40,4 +42,5 @@ INSTANTIATE(float, method::thunder, task::classification)
 INSTANTIATE(double, method::smo, task::classification)
 INSTANTIATE(double, method::thunder, task::classification)
 
+} // namespace v1
 } // namespace oneapi::dal::svm::detail

--- a/cpp/oneapi/dal/algo/svm/detail/train_ops.hpp
+++ b/cpp/oneapi/dal/algo/svm/detail/train_ops.hpp
@@ -20,13 +20,10 @@
 #include "oneapi/dal/detail/error_messages.hpp"
 
 namespace oneapi::dal::svm::detail {
+namespace v1 {
 
-template <typename Context,
-          typename Float,
-          typename Method = method::by_default,
-          typename Task = task::by_default,
-          typename... Options>
-struct ONEDAL_EXPORT train_ops_dispatcher {
+template <typename Context, typename Float, typename Method, typename Task, typename... Options>
+struct train_ops_dispatcher {
     train_result<Task> operator()(const Context&,
                                   const descriptor_base<Task>&,
                                   const train_input<Task>&) const;
@@ -58,9 +55,6 @@ struct train_ops {
             input.get_data().get_row_count() != input.get_weights().get_row_count()) {
             throw invalid_argument(msg::input_data_rc_neq_input_weights_rc());
         }
-        if (!params.get_kernel_impl()->get_impl()) {
-            throw domain_error(msg::input_kernel_is_empty());
-        }
     }
 
     void check_postconditions(const Descriptor& params,
@@ -89,5 +83,9 @@ struct train_ops {
         return result;
     }
 };
+
+} // namespace v1
+
+using v1::train_ops;
 
 } // namespace oneapi::dal::svm::detail

--- a/cpp/oneapi/dal/algo/svm/detail/train_ops_dpc.cpp
+++ b/cpp/oneapi/dal/algo/svm/detail/train_ops_dpc.cpp
@@ -20,7 +20,9 @@
 #include "oneapi/dal/backend/dispatcher_dpc.hpp"
 
 namespace oneapi::dal::svm::detail {
-using oneapi::dal::detail::data_parallel_policy;
+namespace v1 {
+
+using dal::detail::data_parallel_policy;
 
 template <typename Float, typename Method, typename Task>
 struct train_ops_dispatcher<data_parallel_policy, Float, Method, Task> {
@@ -42,4 +44,5 @@ INSTANTIATE(float, method::thunder, task::classification)
 INSTANTIATE(double, method::smo, task::classification)
 INSTANTIATE(double, method::thunder, task::classification)
 
+} // namespace v1
 } // namespace oneapi::dal::svm::detail

--- a/cpp/oneapi/dal/algo/svm/infer.hpp
+++ b/cpp/oneapi/dal/algo/svm/infer.hpp
@@ -21,8 +21,10 @@
 #include "oneapi/dal/infer.hpp"
 
 namespace oneapi::dal::detail {
+namespace v1 {
 
 template <typename Descriptor>
 struct infer_ops<Descriptor, dal::svm::detail::tag> : dal::svm::detail::infer_ops<Descriptor> {};
 
+} // namespace v1
 } // namespace oneapi::dal::detail

--- a/cpp/oneapi/dal/algo/svm/infer_types.cpp
+++ b/cpp/oneapi/dal/algo/svm/infer_types.cpp
@@ -20,7 +20,7 @@
 namespace oneapi::dal::svm {
 
 template <typename Task>
-class detail::infer_input_impl : public base {
+class detail::v1::infer_input_impl : public base {
 public:
     infer_input_impl(const model<Task>& trained_model, const table& data)
             : trained_model(trained_model),
@@ -30,26 +30,28 @@ public:
 };
 
 template <typename Task>
-class detail::infer_result_impl : public base {
+class detail::v1::infer_result_impl : public base {
 public:
     table labels;
     table decision_function;
 };
 
-using detail::infer_input_impl;
-using detail::infer_result_impl;
+using detail::v1::infer_input_impl;
+using detail::v1::infer_result_impl;
+
+namespace v1 {
 
 template <typename Task>
 infer_input<Task>::infer_input(const model<Task>& trained_model, const table& data)
         : impl_(new infer_input_impl<Task>(trained_model, data)) {}
 
 template <typename Task>
-model<Task> infer_input<Task>::get_model() const {
+const model<Task>& infer_input<Task>::get_model() const {
     return impl_->trained_model;
 }
 
 template <typename Task>
-table infer_input<Task>::get_data() const {
+const table& infer_input<Task>::get_data() const {
     return impl_->data;
 }
 
@@ -64,15 +66,15 @@ void infer_input<Task>::set_data_impl(const table& value) {
 }
 
 template <typename Task>
-infer_result<Task>::infer_result() : impl_(new infer_result_impl{}) {}
+infer_result<Task>::infer_result() : impl_(new infer_result_impl<Task>{}) {}
 
 template <typename Task>
-table infer_result<Task>::get_labels() const {
+const table& infer_result<Task>::get_labels() const {
     return impl_->labels;
 }
 
 template <typename Task>
-table infer_result<Task>::get_decision_function() const {
+const table& infer_result<Task>::get_decision_function() const {
     return impl_->decision_function;
 }
 
@@ -89,4 +91,5 @@ void infer_result<Task>::set_decision_function_impl(const table& value) {
 template class ONEDAL_EXPORT infer_input<task::classification>;
 template class ONEDAL_EXPORT infer_result<task::classification>;
 
+} // namespace v1
 } // namespace oneapi::dal::svm

--- a/cpp/oneapi/dal/algo/svm/infer_types.hpp
+++ b/cpp/oneapi/dal/algo/svm/infer_types.hpp
@@ -21,64 +21,86 @@
 namespace oneapi::dal::svm {
 
 namespace detail {
-template <typename Task = task::by_default>
+namespace v1 {
+template <typename Task>
 class infer_input_impl;
 
-template <typename Task = task::by_default>
+template <typename Task>
 class infer_result_impl;
+} // namespace v1
+
+using v1::infer_input_impl;
+using v1::infer_result_impl;
+
 } // namespace detail
 
+namespace v1 {
+
 template <typename Task = task::by_default>
-class ONEDAL_EXPORT infer_input : public base {
+class infer_input : public base {
+    static_assert(detail::is_valid_task_v<Task>);
+
 public:
     using task_t = Task;
-    infer_input(const model<task_t>& trained_model, const table& data);
 
-    model<task_t> get_model() const;
+    infer_input(const model<Task>& trained_model, const table& data);
 
-    auto& set_model(const model<task_t>& value) {
+    const model<Task>& get_model() const;
+
+    auto& set_model(const model<Task>& value) {
         set_model_impl(value);
         return *this;
     }
 
-    table get_data() const;
+    const table& get_data() const;
 
     auto& set_data(const table& value) {
         set_data_impl(value);
         return *this;
     }
 
-private:
-    void set_model_impl(const model<task_t>& value);
+protected:
+    void set_model_impl(const model<Task>& value);
     void set_data_impl(const table& value);
 
-    dal::detail::pimpl<detail::infer_input_impl<task_t>> impl_;
+private:
+    dal::detail::pimpl<detail::infer_input_impl<Task>> impl_;
 };
 
 template <typename Task = task::by_default>
-class ONEDAL_EXPORT infer_result : public base {
+class infer_result : public base {
+    static_assert(detail::is_valid_task_v<Task>);
+
 public:
     using task_t = Task;
+
     infer_result();
 
-    table get_labels() const;
-    table get_decision_function() const;
+    const table& get_labels() const;
 
     auto& set_labels(const table& value) {
         set_labels_impl(value);
         return *this;
     }
 
+    const table& get_decision_function() const;
+
     auto& set_decision_function(const table& value) {
         set_decision_function_impl(value);
         return *this;
     }
 
-private:
+protected:
     void set_labels_impl(const table&);
     void set_decision_function_impl(const table&);
 
-    dal::detail::pimpl<detail::infer_result_impl<task_t>> impl_;
+private:
+    dal::detail::pimpl<detail::infer_result_impl<Task>> impl_;
 };
+
+} // namespace v1
+
+using v1::infer_input;
+using v1::infer_result;
 
 } // namespace oneapi::dal::svm

--- a/cpp/oneapi/dal/algo/svm/train.hpp
+++ b/cpp/oneapi/dal/algo/svm/train.hpp
@@ -21,8 +21,10 @@
 #include "oneapi/dal/train.hpp"
 
 namespace oneapi::dal::detail {
+namespace v1 {
 
 template <typename Descriptor>
 struct train_ops<Descriptor, dal::svm::detail::tag> : dal::svm::detail::train_ops<Descriptor> {};
 
+} // namespace v1
 } // namespace oneapi::dal::detail

--- a/cpp/oneapi/dal/algo/svm/train_types.cpp
+++ b/cpp/oneapi/dal/algo/svm/train_types.cpp
@@ -20,7 +20,7 @@
 namespace oneapi::dal::svm {
 
 template <typename Task>
-class detail::train_input_impl : public base {
+class detail::v1::train_input_impl : public base {
 public:
     train_input_impl(const table& data, const table& labels, const table& weights)
             : data(data),
@@ -32,31 +32,33 @@ public:
 };
 
 template <typename Task>
-class detail::train_result_impl : public base {
+class detail::v1::train_result_impl : public base {
 public:
     model<Task> trained_model;
     table support_indices;
 };
 
-using detail::train_input_impl;
-using detail::train_result_impl;
+using detail::v1::train_input_impl;
+using detail::v1::train_result_impl;
+
+namespace v1 {
 
 template <typename Task>
 train_input<Task>::train_input(const table& data, const table& labels, const table& weights)
         : impl_(new train_input_impl<Task>(data, labels, weights)) {}
 
 template <typename Task>
-table train_input<Task>::get_data() const {
+const table& train_input<Task>::get_data() const {
     return impl_->data;
 }
 
 template <typename Task>
-table train_input<Task>::get_labels() const {
+const table& train_input<Task>::get_labels() const {
     return impl_->labels;
 }
 
 template <typename Task>
-table train_input<Task>::get_weights() const {
+const table& train_input<Task>::get_weights() const {
     return impl_->weights;
 }
 
@@ -76,25 +78,25 @@ void train_input<Task>::set_weights_impl(const table& value) {
 }
 
 template <typename Task>
-train_result<Task>::train_result() : impl_(new train_result_impl{}) {}
+train_result<Task>::train_result() : impl_(new train_result_impl<Task>{}) {}
 
 template <typename Task>
-model<Task> train_result<Task>::get_model() const {
+const model<Task>& train_result<Task>::get_model() const {
     return impl_->trained_model;
 }
 
 template <typename Task>
-table train_result<Task>::get_support_vectors() const {
+const table& train_result<Task>::get_support_vectors() const {
     return impl_->trained_model.get_support_vectors();
 }
 
 template <typename Task>
-table train_result<Task>::get_support_indices() const {
+const table& train_result<Task>::get_support_indices() const {
     return impl_->support_indices;
 }
 
 template <typename Task>
-table train_result<Task>::get_coeffs() const {
+const table& train_result<Task>::get_coeffs() const {
     return impl_->trained_model.get_coeffs();
 }
 
@@ -133,12 +135,8 @@ void train_result<Task>::set_bias_impl(double value) {
     impl_->trained_model.set_bias(value);
 }
 
-template <typename Task>
-void train_result<Task>::set_support_vector_count_impl(std::int64_t value) {
-    impl_->trained_model.set_support_vector_count(value);
-}
-
 template class ONEDAL_EXPORT train_input<task::classification>;
 template class ONEDAL_EXPORT train_result<task::classification>;
 
+} // namespace v1
 } // namespace oneapi::dal::svm

--- a/cpp/oneapi/dal/algo/svm/train_types.hpp
+++ b/cpp/oneapi/dal/algo/svm/train_types.hpp
@@ -21,100 +21,120 @@
 namespace oneapi::dal::svm {
 
 namespace detail {
-template <typename Task = task::by_default>
+namespace v1 {
+template <typename Task>
 class train_input_impl;
 
-template <typename Task = task::by_default>
+template <typename Task>
 class train_result_impl;
+} // namespace v1
+
+using v1::train_input_impl;
+using v1::train_result_impl;
+
 } // namespace detail
 
+namespace v1 {
+
 template <typename Task = task::by_default>
-class ONEDAL_EXPORT train_input : public base {
+class train_input : public base {
+    static_assert(detail::is_valid_task_v<Task>);
+
 public:
     using task_t = Task;
+
     train_input(const table& data, const table& labels, const table& weights = table{});
 
-    table get_data() const;
+    const table& get_data() const;
 
     auto& set_data(const table& value) {
         set_data_impl(value);
         return *this;
     }
 
-    table get_labels() const;
+    const table& get_labels() const;
 
     auto& set_labels(const table& value) {
         set_labels_impl(value);
         return *this;
     }
 
-    table get_weights() const;
+    const table& get_weights() const;
 
     auto& set_weights(const table& value) {
         set_weights_impl(value);
         return *this;
     }
 
-private:
+protected:
     void set_data_impl(const table& value);
     void set_labels_impl(const table& value);
     void set_weights_impl(const table& value);
 
-    dal::detail::pimpl<detail::train_input_impl<task_t>> impl_;
+private:
+    dal::detail::pimpl<detail::train_input_impl<Task>> impl_;
 };
 
 template <typename Task = task::by_default>
-class ONEDAL_EXPORT train_result : public base {
+class train_result : public base {
+    static_assert(detail::is_valid_task_v<Task>);
+
 public:
     using task_t = Task;
+
     train_result();
 
-    model<task_t> get_model() const;
-    table get_support_vectors() const;
-    table get_support_indices() const;
-    table get_coeffs() const;
-    double get_bias() const;
     std::int64_t get_support_vector_count() const;
 
-    auto& set_model(const model<task_t>& value) {
+    const model<Task>& get_model() const;
+
+    auto& set_model(const model<Task>& value) {
         set_model_impl(value);
         return *this;
     }
+
+    const table& get_support_vectors() const;
 
     auto& set_support_vectors(const table& value) {
         set_support_vectors_impl(value);
         return *this;
     }
 
+    const table& get_support_indices() const;
+
     auto& set_support_indices(const table& value) {
         set_support_indices_impl(value);
         return *this;
     }
+
+    const table& get_coeffs() const;
 
     auto& set_coeffs(const table& value) {
         set_coeffs_impl(value);
         return *this;
     }
 
+    double get_bias() const;
+
     auto& set_bias(double value) {
         set_bias_impl(value);
         return *this;
     }
 
-    auto& set_support_vector_count(std::int64_t value) {
-        set_support_vector_count_impl(value);
-        return *this;
-    }
-
-private:
-    void set_model_impl(const model<task_t>&);
+protected:
+    void set_model_impl(const model<Task>&);
     void set_support_vectors_impl(const table&);
     void set_support_indices_impl(const table&);
     void set_coeffs_impl(const table&);
     void set_bias_impl(double);
-    void set_support_vector_count_impl(std::int64_t);
 
-    dal::detail::pimpl<detail::train_result_impl<task_t>> impl_;
+private:
+    dal::detail::pimpl<detail::train_result_impl<Task>> impl_;
 };
+
+} // namespace v1
+
+using v1::train_input;
+using v1::train_result;
 
 } // namespace oneapi::dal::svm

--- a/cpp/oneapi/dal/compute.hpp
+++ b/cpp/oneapi/dal/compute.hpp
@@ -23,14 +23,14 @@ namespace v1 {
 
 template <typename... Args>
 auto compute(Args&&... args) {
-    return detail::compute_dispatch(std::forward<Args>(args)...);
+    return dal::detail::compute_dispatch(std::forward<Args>(args)...);
 }
 
 #ifdef ONEDAL_DATA_PARALLEL
 template <typename... Args>
 auto compute(sycl::queue& queue, Args&&... args) {
-    return detail::compute_dispatch(detail::data_parallel_policy{ queue },
-                                    std::forward<Args>(args)...);
+    return dal::detail::compute_dispatch(detail::data_parallel_policy{ queue },
+                                         std::forward<Args>(args)...);
 }
 #endif
 

--- a/cpp/oneapi/dal/detail/compute_ops.hpp
+++ b/cpp/oneapi/dal/detail/compute_ops.hpp
@@ -19,6 +19,7 @@
 #include "oneapi/dal/detail/ops_dispatcher.hpp"
 
 namespace oneapi::dal::detail {
+namespace v1 {
 
 template <typename Descriptor, typename Tag = typename Descriptor::tag_t>
 struct compute_ops;
@@ -31,5 +32,9 @@ auto compute_dispatch(Head&& head, Tail&&... tail) {
     using dispatcher_t = ops_policy_dispatcher<std::decay_t<Head>, tagged_compute_ops>;
     return dispatcher_t{}(std::forward<Head>(head), std::forward<Tail>(tail)...);
 }
+
+} // namespace v1
+
+using v1::compute_dispatch;
 
 } // namespace oneapi::dal::detail

--- a/cpp/oneapi/dal/detail/error_messages.cpp
+++ b/cpp/oneapi/dal/detail/error_messages.cpp
@@ -131,7 +131,6 @@ MSG(pca_svd_based_method_is_not_implemented_for_gpu,
 /* SVM */
 MSG(c_leq_zero, "C is lower than or equal to zero")
 MSG(cache_size_leq_zero, "Cache size lower that or equal to zero")
-MSG(input_kernel_is_empty, "Input kernel function is empty")
 MSG(input_model_coeffs_are_empty, "Input model coeffs are empty")
 MSG(input_model_coeffs_rc_neq_input_model_support_vector_count,
     "Input model coeffs row count is not equal to support vector count provided in input model")
@@ -144,6 +143,7 @@ MSG(input_model_support_vectors_rc_neq_input_model_support_vector_count,
 MSG(sigma_leq_zero, "Sigma lower than or equal to zero")
 MSG(svm_smo_method_is_not_implemented_for_gpu, "SVM SMO method is not implemented for GPU")
 MSG(tau_leq_zero, "Tau is lower than or equal to zero")
+MSG(unknown_kernel_function_type, "Unknown kernel function type")
 
 /* Kernel Functions */
 MSG(input_x_cc_neq_y_cc, "Input x column count is not qual to y column count")

--- a/cpp/oneapi/dal/detail/error_messages.hpp
+++ b/cpp/oneapi/dal/detail/error_messages.hpp
@@ -159,7 +159,6 @@ public:
     /* SVM */
     MSG(c_leq_zero);
     MSG(cache_size_leq_zero);
-    MSG(input_kernel_is_empty);
     MSG(input_model_coeffs_are_empty);
     MSG(input_model_coeffs_rc_neq_input_model_support_vector_count);
     MSG(input_model_does_not_match_kernel_function);
@@ -169,6 +168,7 @@ public:
     MSG(sigma_leq_zero);
     MSG(svm_smo_method_is_not_implemented_for_gpu);
     MSG(tau_leq_zero);
+    MSG(unknown_kernel_function_type);
 };
 
 #undef MSG

--- a/cpp/oneapi/dal/detail/infer_ops.hpp
+++ b/cpp/oneapi/dal/detail/infer_ops.hpp
@@ -19,6 +19,7 @@
 #include "oneapi/dal/detail/ops_dispatcher.hpp"
 
 namespace oneapi::dal::detail {
+namespace v1 {
 
 template <typename Descriptor, typename Tag = typename Descriptor::tag_t>
 struct infer_ops;
@@ -31,5 +32,9 @@ auto infer_dispatch(Head&& head, Tail&&... tail) {
     using dispatcher_t = ops_policy_dispatcher<std::decay_t<Head>, tagged_infer_ops>;
     return dispatcher_t{}(std::forward<Head>(head), std::forward<Tail>(tail)...);
 }
+
+} // namespace v1
+
+using v1::infer_dispatch;
 
 } // namespace oneapi::dal::detail

--- a/cpp/oneapi/dal/detail/train_ops.hpp
+++ b/cpp/oneapi/dal/detail/train_ops.hpp
@@ -19,6 +19,7 @@
 #include "oneapi/dal/detail/ops_dispatcher.hpp"
 
 namespace oneapi::dal::detail {
+namespace v1 {
 
 template <typename Descriptor, typename Tag>
 struct train_ops;
@@ -31,5 +32,9 @@ auto train_dispatch(Head&& head, Tail&&... tail) {
     using dispatcher_t = ops_policy_dispatcher<std::decay_t<Head>, tagged_train_ops>;
     return dispatcher_t{}(std::forward<Head>(head), std::forward<Tail>(tail)...);
 }
+
+} // namespace v1
+
+using v1::train_dispatch;
 
 } // namespace oneapi::dal::detail

--- a/cpp/oneapi/dal/infer.hpp
+++ b/cpp/oneapi/dal/infer.hpp
@@ -23,14 +23,14 @@ namespace v1 {
 
 template <typename... Args>
 auto infer(Args&&... args) {
-    return detail::infer_dispatch(std::forward<Args>(args)...);
+    return dal::detail::infer_dispatch(std::forward<Args>(args)...);
 }
 
 #ifdef ONEDAL_DATA_PARALLEL
 template <typename... Args>
 auto infer(sycl::queue& queue, Args&&... args) {
-    return detail::infer_dispatch(detail::data_parallel_policy{ queue },
-                                  std::forward<Args>(args)...);
+    return dal::detail::infer_dispatch(detail::data_parallel_policy{ queue },
+                                       std::forward<Args>(args)...);
 }
 #endif
 

--- a/cpp/oneapi/dal/train.hpp
+++ b/cpp/oneapi/dal/train.hpp
@@ -23,14 +23,14 @@ namespace v1 {
 
 template <typename... Args>
 auto train(Args&&... args) {
-    return detail::train_dispatch(std::forward<Args>(args)...);
+    return dal::detail::train_dispatch(std::forward<Args>(args)...);
 }
 
 #ifdef ONEDAL_DATA_PARALLEL
 template <typename... Args>
 auto train(sycl::queue& queue, Args&&... args) {
-    return detail::train_dispatch(detail::data_parallel_policy{ queue },
-                                  std::forward<Args>(args)...);
+    return dal::detail::train_dispatch(detail::data_parallel_policy{ queue },
+                                       std::forward<Args>(args)...);
 }
 #endif
 


### PR DESCRIPTION
- Add v1 namespace to all algorithms
- Fix variadic templates in `train_ops`/`infer_op`/`compute_ops` to prevent future backward compatibility problem
- Add `static_assert` to validate template parameters to all algorithms
- Add `task_t` type alias to all algorithms including inputs and results
- Consistent approach for returning tables from inputs/results via const reference
- Slightly refactored kernel function handling in SVM 
- Correct `private`/`protected` visibility
- Add type traits to validate tags of the descriptors
- Remove redundant `ONEDAL_EXPORT`