### PR TITLE
Fix array size in sycl SOA

### DIFF
--- a/cpp/daal/include/data_management/data/internal/numeric_table_sycl_soa.h
+++ b/cpp/daal/include/data_management/data/internal/numeric_table_sycl_soa.h
@@ -382,7 +382,7 @@ protected:
     void freeDataMemoryImpl() DAAL_C11_OVERRIDE
     {
         _cpuTable.reset();
-        _arrays = services::Collection<services::internal::sycl::UniversalBuffer>(_ddict->getNumberOfFeatures());
+        _arrays            = services::Collection<services::internal::sycl::UniversalBuffer>(_ddict->getNumberOfFeatures());
         _arraysInitialized = 0;
 
         _partialMemStatus = notAllocated;

--- a/cpp/daal/include/data_management/data/internal/numeric_table_sycl_soa.h
+++ b/cpp/daal/include/data_management/data/internal/numeric_table_sycl_soa.h
@@ -382,8 +382,7 @@ protected:
     void freeDataMemoryImpl() DAAL_C11_OVERRIDE
     {
         _cpuTable.reset();
-        _arrays.clear();
-        _arrays.resize(_ddict->getNumberOfFeatures());
+        _arrays = services::Collection<services::internal::sycl::UniversalBuffer>(_ddict->getNumberOfFeatures());
         _arraysInitialized = 0;
 
         _partialMemStatus = notAllocated;


### PR DESCRIPTION
After resize _arrays still had a size of 0. Because of this, there were problems with MergedTable in benchmarks