### PR TITLE
Cleanup a few makefile issues for examples/oneapi/dpc

### DIFF
--- a/examples/oneapi/dpc/makefile_lnx
+++ b/examples/oneapi/dpc/makefile_lnx
@@ -45,7 +45,7 @@ help:
 ##
 ##------------------------------------------------------------------------------
 
-include onedal.lst
+include onedal_lnx.lst
 
 ifndef example
     example = $(ONEDAL)
@@ -116,9 +116,9 @@ endif
 CC := $(if $(COVFILE), cov01 -1; covc -i  $(CC),$(CC))
 
 lib libintel64:
-	$(MAKE) _make_ex RES_EXT=a
+	$(MAKE) -f makefile_lnx _make_ex RES_EXT=a
 so sointel64:
-	$(MAKE) _make_ex RES_EXT=so
+	$(MAKE) -f makefile_lnx _make_ex RES_EXT=so
 
 _make_ex: $(RES)
 

--- a/examples/oneapi/dpc/makefile_lnx
+++ b/examples/oneapi/dpc/makefile_lnx
@@ -22,9 +22,9 @@ help:
 	@echo "Usage: make {lib|so|help}"
 	@echo "[example=name] [compiler=compiler_name] [mode=mode_name]"
 	@echo
-	@echo "name              - example name. Please see onedal.lst file"
+	@echo "name              - example name. Please see onedal_lnx.lst file"
 	@echo
-	@echo "compiler_name     - currently can be dpcpp only that stands
+	@echo "compiler_name     - currently can be dpcpp only that stands"
 	@echo "                    for Intel(R) oneAPI DPC++ Compiler."
 	@echo
 	@echo "mode_name         - can be build or run. Default is run"


### PR DESCRIPTION
There was a syntax error, which prevents the Linux Makefile working, and also several files appear to have been renamed recently.  These changes adapt to those issues.