### PR TITLE
Random Forest: run-to-run stability

### DIFF
--- a/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_model.cpp
+++ b/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_model.cpp
@@ -306,10 +306,11 @@ services::Status ModelImpl::deserializeImpl(const data_management::OutputDataArc
     return s;
 }
 
-bool ModelImpl::add(const TreeType & tree, size_t nClasses)
+bool ModelImpl::add(const TreeType & tree, size_t nClasses, size_t iTree)
 {
     DAAL_CHECK_STATUS_VAR(!(size() >= _serializationData->size()));
-    size_t i           = _nTree.inc();
+    size_t i = iTree;
+    _nTree.inc();
     const size_t nNode = tree.getNumberOfNodes();
 
     auto pTbl           = new DecisionTreeTable(nNode);
@@ -327,10 +328,10 @@ bool ModelImpl::add(const TreeType & tree, size_t nClasses)
     }
 
     tree.convertToTable(pTbl, impTbl, nodeSamplesTbl, probTbl, nClasses);
-    (*_serializationData)[i - 1].reset(pTbl);
-    (*_impurityTables)[i - 1].reset(impTbl);
-    (*_nNodeSampleTables)[i - 1].reset(nodeSamplesTbl);
-    (*_probTbl)[i - 1].reset(probTbl);
+    (*_serializationData)[i].reset(pTbl);
+    (*_impurityTables)[i].reset(impTbl);
+    (*_nNodeSampleTables)[i].reset(nodeSamplesTbl);
+    (*_probTbl)[i].reset(probTbl);
     return true;
 }
 

--- a/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_model_impl.h
+++ b/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_model_impl.h
@@ -70,7 +70,7 @@ public:
     virtual services::Status serializeImpl(data_management::InputDataArchive * arch) DAAL_C11_OVERRIDE;
     virtual services::Status deserializeImpl(const data_management::OutputDataArchive * arch) DAAL_C11_OVERRIDE;
 
-    bool add(const TreeType & tree, size_t nClasses);
+    bool add(const TreeType & tree, size_t nClasses, size_t iTree);
 
     virtual size_t getNumberOfTrees() const DAAL_C11_OVERRIDE;
 

--- a/cpp/daal/src/algorithms/dtrees/forest/classification/oneapi/df_classification_train_hist_oneapi_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/classification/oneapi/df_classification_train_hist_oneapi_impl.i
@@ -1007,7 +1007,7 @@ services::Status ClassificationTrainBatchKernelOneAPI<algorithmFPType, hist>::co
         DFTreeConverterType converter;
         DAAL_CHECK_STATUS_VAR(converter.convertToDFDecisionTree(DFTreeRecords, binValues.data(), mTreeHelper, _nClasses));
 
-        mdImpl.add(mTreeHelper._tree, _nClasses);
+        mdImpl.add(mTreeHelper._tree, _nClasses, iter);
 
         DAAL_CHECK_STATUS_VAR(computeResults(mTreeHelper._tree, dataBlock.getBlockPtr(), responseBlock.getBlockPtr(), _nSelectedRows, _nFeatures,
                                              oobRows, nOOBRows, oobBufferPerObs, varImpBlock.getBlockPtr(), varImpVariance.get(), iter + 1,

--- a/cpp/daal/src/algorithms/dtrees/forest/df_train_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/df_train_dense_default_impl.i
@@ -419,7 +419,7 @@ services::Status computeImpl(HostAppIface * pHostApp, const NumericTable * x, co
         DAAL_CHECK_STATUS_THR(s);
         if (pTree)
         {
-            md.add((typename ModelType::TreeType &)*pTree, nClasses);
+            md.add((typename ModelType::TreeType &)*pTree, nClasses, i);
         }
     });
     s = safeStat.detach();

--- a/cpp/daal/src/algorithms/dtrees/forest/regression/df_regression_model.cpp
+++ b/cpp/daal/src/algorithms/dtrees/forest/regression/df_regression_model.cpp
@@ -161,10 +161,11 @@ services::Status ModelImpl::deserializeImpl(const data_management::OutputDataArc
     return s.add(ImplType::serialImpl<const data_management::OutputDataArchive, true>(arch));
 }
 
-bool ModelImpl::add(const TreeType & tree, size_t nClasses)
+bool ModelImpl::add(const TreeType & tree, size_t nClasses, size_t iTree)
 {
     DAAL_CHECK_STATUS_VAR(!(size() >= _serializationData->size()));
-    size_t i           = _nTree.inc();
+    size_t i = iTree;
+    _nTree.inc();
     const size_t nNode = tree.getNumberOfNodes();
 
     auto pTbl           = new DecisionTreeTable(nNode);
@@ -183,10 +184,10 @@ bool ModelImpl::add(const TreeType & tree, size_t nClasses)
 
     tree.convertToTable(pTbl, impTbl, nodeSamplesTbl, probTbl, 0);
 
-    (*_serializationData)[i - 1].reset(pTbl);
-    (*_impurityTables)[i - 1].reset(impTbl);
-    (*_nNodeSampleTables)[i - 1].reset(nodeSamplesTbl);
-    (*_probTbl)[i - 1].reset(probTbl);
+    (*_serializationData)[i].reset(pTbl);
+    (*_impurityTables)[i].reset(impTbl);
+    (*_nNodeSampleTables)[i].reset(nodeSamplesTbl);
+    (*_probTbl)[i].reset(probTbl);
 
     return true;
 }

--- a/cpp/daal/src/algorithms/dtrees/forest/regression/df_regression_model_impl.h
+++ b/cpp/daal/src/algorithms/dtrees/forest/regression/df_regression_model_impl.h
@@ -64,7 +64,7 @@ public:
     virtual services::Status serializeImpl(data_management::InputDataArchive * arch) DAAL_C11_OVERRIDE;
     virtual services::Status deserializeImpl(const data_management::OutputDataArchive * arch) DAAL_C11_OVERRIDE;
 
-    bool add(const TreeType & tree, size_t nClasses);
+    bool add(const TreeType & tree, size_t nClasses, size_t iTree);
 
     virtual size_t getNumberOfTrees() const DAAL_C11_OVERRIDE;
 };

--- a/cpp/daal/src/algorithms/dtrees/forest/regression/oneapi/df_regression_train_hist_oneapi_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/regression/oneapi/df_regression_train_hist_oneapi_impl.i
@@ -985,7 +985,7 @@ services::Status RegressionTrainBatchKernelOneAPI<algorithmFPType, hist>::comput
         DFTreeConverterType converter;
         DAAL_CHECK_STATUS_VAR(converter.convertToDFDecisionTree(DFTreeRecords, binValues.data(), mTreeHelper));
 
-        mdImpl.add(mTreeHelper._tree, 0 /*nClasses*/);
+        mdImpl.add(mTreeHelper._tree, 0 /*nClasses*/, iter);
 
         DAAL_CHECK_STATUS_VAR(computeResults(mTreeHelper._tree, dataBlock.getBlockPtr(), responseBlock.getBlockPtr(), _nSelectedRows, _nFeatures,
                                              oobRows, nOOBRows, oobBufferPerObs, varImpBlock.getBlockPtr(), varImpVariance.get(), iter + 1,

--- a/cpp/daal/src/algorithms/linear_model/linear_model_train_normeq_update_impl.i
+++ b/cpp/daal/src/algorithms/linear_model/linear_model_train_normeq_update_impl.i
@@ -200,11 +200,11 @@ Status UpdateKernel<algorithmFPType, cpu>::compute(const NumericTable & xTable, 
     }
 
     /* Create TLS */
-    daal::tls<ThreadingTaskType *> tls([=]() -> ThreadingTaskType * { return ThreadingTaskType::create(nBetasIntercept, nResponses); });
+    daal::static_tls<ThreadingTaskType *> tls([=]() -> ThreadingTaskType * { return ThreadingTaskType::create(nBetasIntercept, nResponses); });
 
     SafeStatus safeStat;
-    daal::threader_for(nBlocks, nBlocks, [=, &tls, &xTable, &yTable, &safeStat](int iBlock) {
-        ThreadingTaskType * tlsLocal = tls.local();
+    daal::static_threader_for(nBlocks, [=, &tls, &xTable, &yTable, &safeStat](int iBlock, size_t tid) {
+        ThreadingTaskType * tlsLocal = tls.local(tid);
 
         if (!tlsLocal)
         {

--- a/cpp/daal/src/externals/core_threading_win_dll.cpp
+++ b/cpp/daal/src/externals/core_threading_win_dll.cpp
@@ -246,6 +246,7 @@ typedef void * (*_threaded_malloc_t)(const size_t, const size_t);
 typedef void (*_threaded_free_t)(void *);
 
 typedef void (*_daal_threader_for_t)(int, int, const void *, daal::functype);
+typedef void (*_daal_static_threader_for_t)(size_t, const void *, daal::functype_static);
 typedef void (*_daal_threader_for_blocked_t)(int, int, const void *, daal::functype2);
 typedef int (*_daal_threader_get_max_threads_t)(void);
 typedef void (*_daal_threader_for_break_t)(int, int, const void *, daal::functype_break);
@@ -298,6 +299,7 @@ static _threaded_malloc_t _threaded_malloc_ptr = NULL;
 static _threaded_free_t _threaded_free_ptr     = NULL;
 
 static _daal_threader_for_t _daal_threader_for_ptr                         = NULL;
+static _daal_threader_for_t _daal_static_threader_for_ptr                  = NULL;
 static _daal_threader_for_blocked_t _daal_threader_for_blocked_ptr         = NULL;
 static _daal_threader_for_t _daal_threader_for_optional_ptr                = NULL;
 static _daal_threader_get_max_threads_t _daal_threader_get_max_threads_ptr = NULL;
@@ -375,6 +377,16 @@ DAAL_EXPORT void _daal_threader_for(int n, int threads_request, const void * a, 
         _daal_threader_for_ptr = (_daal_threader_for_t)load_daal_thr_func("_daal_threader_for");
     }
     _daal_threader_for_ptr(n, threads_request, a, func);
+}
+
+DAAL_EXPORT void _daal_static_threader_for(size_t n, const void * a, daal::functype_static func)
+{
+    load_daal_thr_dll();
+    if (_daal_static_threader_for_ptr == NULL)
+    {
+        _daal_static_threader_for_ptr = (_daal_static_threader_for_t)load_daal_thr_func("_daal_static_threader_for");
+    }
+    _daal_static_threader_for_ptr(n, a, func);
 }
 
 DAAL_EXPORT void _daal_parallel_sort_int32(int * begin_ptr, int * end_ptr)

--- a/cpp/daal/src/externals/core_threading_win_dll.cpp
+++ b/cpp/daal/src/externals/core_threading_win_dll.cpp
@@ -299,7 +299,7 @@ static _threaded_malloc_t _threaded_malloc_ptr = NULL;
 static _threaded_free_t _threaded_free_ptr     = NULL;
 
 static _daal_threader_for_t _daal_threader_for_ptr                         = NULL;
-static _daal_threader_for_t _daal_static_threader_for_ptr                  = NULL;
+static _daal_static_threader_for_t _daal_static_threader_for_ptr           = NULL;
 static _daal_threader_for_blocked_t _daal_threader_for_blocked_ptr         = NULL;
 static _daal_threader_for_t _daal_threader_for_optional_ptr                = NULL;
 static _daal_threader_get_max_threads_t _daal_threader_get_max_threads_ptr = NULL;

--- a/cpp/daal/src/threading/threading.cpp
+++ b/cpp/daal/src/threading/threading.cpp
@@ -117,16 +117,19 @@ DAAL_EXPORT void _daal_static_threader_for(size_t n, const void * a, daal::funct
     const size_t nthreads           = _daal_threader_get_max_threads();
     const size_t nblocks_per_thread = n / nthreads + !!(n % nthreads);
 
-    tbb::parallel_for(tbb::blocked_range<size_t>(0, nthreads, 1), [&](tbb::blocked_range<size_t> r) {
-        const size_t tid   = r.begin();
-        const size_t begin = tid * nblocks_per_thread;
-        const size_t end   = n < begin + nblocks_per_thread ? n : begin + nblocks_per_thread;
+    tbb::parallel_for(
+        tbb::blocked_range<size_t>(0, nthreads, 1),
+        [&](tbb::blocked_range<size_t> r) {
+            const size_t tid   = r.begin();
+            const size_t begin = tid * nblocks_per_thread;
+            const size_t end   = n < begin + nblocks_per_thread ? n : begin + nblocks_per_thread;
 
-        for (size_t i = begin; i < end; ++i)
-        {
-            func(i, tid, a);
-        }
-    }, tbb::static_partitioner());
+            for (size_t i = begin; i < end; ++i)
+            {
+                func(i, tid, a);
+            }
+        },
+        tbb::static_partitioner());
 #elif defined(__DO_SEQ_LAYER__)
     for (size_t i = 0; i < n; i++)
     {

--- a/cpp/daal/src/threading/threading.h
+++ b/cpp/daal/src/threading/threading.h
@@ -375,6 +375,8 @@ public:
         }
     }
 
+    size_t nthreads() const { return _nThreads; }
+
 private:
     F * _storage                     = nullptr;
     size_t _nThreads                 = 0;

--- a/cpp/daal/src/threading/threading.h
+++ b/cpp/daal/src/threading/threading.h
@@ -25,7 +25,6 @@
 #define __THREADING_H__
 
 #include "services/daal_defines.h"
-#include <tbb/tbb.h>
 
 namespace daal
 {
@@ -40,6 +39,7 @@ struct IdxValType
     bool operator<=(const IdxValType & o) const { return value < o.value || (value == o.value && index == o.index); }
 };
 typedef void (*functype)(int i, const void * a);
+typedef void (*functype_static)(size_t i, size_t tid, const void * a);
 typedef void (*functype2)(int i, int n, const void * a);
 typedef void * (*tls_functype)(const void * a);
 typedef void (*tls_reduce_functype)(void * p, const void * a);
@@ -51,6 +51,7 @@ extern "C"
 {
     DAAL_EXPORT int _daal_threader_get_max_threads();
     DAAL_EXPORT void _daal_threader_for(int n, int threads_request, const void * a, daal::functype func);
+    DAAL_EXPORT void _daal_static_threader_for(size_t n, const void * a, daal::functype_static func);
     DAAL_EXPORT void _daal_threader_for_blocked(int n, int threads_request, const void * a, daal::functype2 func);
     DAAL_EXPORT void _daal_threader_for_optional(int n, int threads_request, const void * a, daal::functype func);
     DAAL_EXPORT void _daal_threader_for_break(int n, int threads_request, const void * a, daal::functype_break func);
@@ -161,6 +162,13 @@ inline void threader_func(int i, const void * a)
 }
 
 template <typename F>
+inline void static_threader_func(size_t i, size_t tid, const void * a)
+{
+    const F & lambda = *static_cast<const F *>(a);
+    lambda(i, tid);
+}
+
+template <typename F>
 inline void threader_func_b(int i0, int in, const void * a)
 {
     const F & lambda = *static_cast<const F *>(a);
@@ -183,20 +191,11 @@ inline void threader_for(int n, int threads_request, const F & lambda)
 }
 
 template <typename F>
-void static_threader_for(size_t nBlocks, F func)
+inline void static_threader_for(size_t n, const F &lambda)
 {
-    const size_t nThreads         = threader_get_max_threads_number();
-    const size_t nBlocksPerThread = nBlocks / nThreads + !!(nBlocks % nThreads);
+    const void * a = static_cast<const void *>(&lambda);
 
-    daal::threader_for(nThreads, nThreads, [&](const size_t tid) {
-        const size_t begin = tid * nBlocksPerThread;
-        const size_t end   = nBlocks < begin + nBlocksPerThread ? nBlocks : begin + nBlocksPerThread;
-
-        for (size_t i = begin; i < end; ++i)
-        {
-            func(i, tid);
-        }
-    });
+    _daal_static_threader_for(n, a, static_threader_func<F>);
 }
 
 template <typename F>
@@ -310,6 +309,13 @@ private:
     tls_deleter * d;
 };
 
+template <typename F, typename lambdaType>
+inline void * creater_func(const void * a)
+{
+    const lambdaType & lambda = *static_cast<const lambdaType *>(a);
+    return lambda();
+}
+
 template <typename F>
 class static_tls
 {
@@ -322,8 +328,15 @@ public:
         _storage = new F[_nThreads];
         for (size_t i = 0; i < _nThreads; ++i)
         {
-            _storage[i] = lambda();
+            _storage[i] = nullptr;
         }
+
+        lambdaType * locall = new lambdaType(lambda);
+        const void * ac = static_cast<const void *>(locall);
+        void * a        = const_cast<void *>(ac);
+        _creater        = a;
+
+        _creater_func = creater_func<F, lambdaType>;
     }
 
     virtual ~static_tls() { delete _storage; }
@@ -332,6 +345,11 @@ public:
     {
         if (_storage)
         {
+            if (!_storage[tid])
+            {
+                _storage[tid] = static_cast<F>(_creater_func(_creater));
+            }
+
             return _storage[tid];
         }
         else
@@ -355,6 +373,8 @@ public:
 private:
     F * _storage     = nullptr;
     size_t _nThreads = 0;
+    void * _creater  = nullptr;
+    daal::tls_functype _creater_func = nullptr;
 };
 
 template <typename F>

--- a/cpp/daal/src/threading/threading.h
+++ b/cpp/daal/src/threading/threading.h
@@ -191,7 +191,7 @@ inline void threader_for(int n, int threads_request, const F & lambda)
 }
 
 template <typename F>
-inline void static_threader_for(size_t n, const F &lambda)
+inline void static_threader_for(size_t n, const F & lambda)
 {
     const void * a = static_cast<const void *>(&lambda);
 
@@ -332,9 +332,9 @@ public:
         }
 
         lambdaType * locall = new lambdaType(lambda);
-        const void * ac = static_cast<const void *>(locall);
-        void * a        = const_cast<void *>(ac);
-        _creater        = a;
+        const void * ac     = static_cast<const void *>(locall);
+        void * a            = const_cast<void *>(ac);
+        _creater            = a;
 
         _creater_func = creater_func<F, lambdaType>;
     }
@@ -371,9 +371,9 @@ public:
     }
 
 private:
-    F * _storage     = nullptr;
-    size_t _nThreads = 0;
-    void * _creater  = nullptr;
+    F * _storage                     = nullptr;
+    size_t _nThreads                 = 0;
+    void * _creater                  = nullptr;
     daal::tls_functype _creater_func = nullptr;
 };
 

--- a/cpp/daal/src/threading/threading.h
+++ b/cpp/daal/src/threading/threading.h
@@ -337,8 +337,7 @@ public:
             _storage[i] = nullptr;
         }
 
-        lambdaType * locall = new lambdaType(lambda);
-        const void * ac     = static_cast<const void *>(locall);
+        const void * ac     = static_cast<const void *>(&lambda);
         void * a            = const_cast<void *>(ac);
         _creater            = a;
 

--- a/cpp/daal/src/threading/threading.h
+++ b/cpp/daal/src/threading/threading.h
@@ -326,6 +326,12 @@ public:
         _nThreads = threader_get_max_threads_number();
 
         _storage = new F[_nThreads];
+
+        if (!_storage)
+        {
+            return;
+        }
+
         for (size_t i = 0; i < _nThreads; ++i)
         {
             _storage[i] = nullptr;

--- a/cpp/daal/src/threading/threading.h
+++ b/cpp/daal/src/threading/threading.h
@@ -337,9 +337,9 @@ public:
             _storage[i] = nullptr;
         }
 
-        const void * ac     = static_cast<const void *>(&lambda);
-        void * a            = const_cast<void *>(ac);
-        _creater            = a;
+        const void * ac = static_cast<const void *>(&lambda);
+        void * a        = const_cast<void *>(ac);
+        _creater        = a;
 
         _creater_func = creater_func<F, lambdaType>;
     }


### PR DESCRIPTION
1) Fixed instability in training due to undefined order of pushing trees into a model
2) Fixed instability in prediction due to usage of TLS with undefined order of reduction in one of code branches. + possible optimizations for this case.
3) More accurate summation for probabilities in prediction to avoid cases, when sum of probabilities > 1.0

It contains #1316, will be rebased after merging the last one.