### PR TITLE
Fix stability in decision forest prediction

### DIFF
--- a/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_model.cpp
+++ b/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_model.cpp
@@ -306,10 +306,10 @@ services::Status ModelImpl::deserializeImpl(const data_management::OutputDataArc
     return s;
 }
 
-bool ModelImpl::add(const TreeType & tree, size_t nClasses)
+bool ModelImpl::add(const TreeType & tree, size_t nClasses, size_t iTree)
 {
     DAAL_CHECK_STATUS_VAR(!(size() >= _serializationData->size()));
-    size_t i           = _nTree.inc();
+    _nTree.inc();
     const size_t nNode = tree.getNumberOfNodes();
 
     auto pTbl           = new DecisionTreeTable(nNode);
@@ -327,10 +327,10 @@ bool ModelImpl::add(const TreeType & tree, size_t nClasses)
     }
 
     tree.convertToTable(pTbl, impTbl, nodeSamplesTbl, probTbl, nClasses);
-    (*_serializationData)[i - 1].reset(pTbl);
-    (*_impurityTables)[i - 1].reset(impTbl);
-    (*_nNodeSampleTables)[i - 1].reset(nodeSamplesTbl);
-    (*_probTbl)[i - 1].reset(probTbl);
+    (*_serializationData)[iTree].reset(pTbl);
+    (*_impurityTables)[iTree].reset(impTbl);
+    (*_nNodeSampleTables)[iTree].reset(nodeSamplesTbl);
+    (*_probTbl)[iTree].reset(probTbl);
     return true;
 }
 

--- a/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_model_impl.h
+++ b/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_model_impl.h
@@ -70,7 +70,7 @@ public:
     virtual services::Status serializeImpl(data_management::InputDataArchive * arch) DAAL_C11_OVERRIDE;
     virtual services::Status deserializeImpl(const data_management::OutputDataArchive * arch) DAAL_C11_OVERRIDE;
 
-    bool add(const TreeType & tree, size_t nClasses);
+    bool add(const TreeType & tree, size_t nClasses, size_t iTree);
 
     virtual size_t getNumberOfTrees() const DAAL_C11_OVERRIDE;
 

--- a/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_predict_dense_default_batch_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_predict_dense_default_batch_impl.i
@@ -256,8 +256,7 @@ template <typename algorithmFPType, CpuType cpu>
 void PredictClassificationTask<algorithmFPType, cpu>::predictByTrees(const size_t iFirstTree, const size_t nTrees, const algorithmFPType * const x,
                                                                      algorithmFPType * const resPtr, const size_t nTreesTotal)
 {
-    const algorithmFPType inverseTreesCount = 1.0 / algorithmFPType(nTreesTotal);
-    const size_t iLastTree                  = iFirstTree + nTrees;
+    const size_t iLastTree = iFirstTree + nTrees;
     for (size_t iTree = iFirstTree; iTree < iLastTree; ++iTree)
     {
         const dtrees::internal::DecisionTreeNode * const pNode =
@@ -270,6 +269,7 @@ void PredictClassificationTask<algorithmFPType, cpu>::predictByTrees(const size_
 
         if (_votingMethod == VotingMethod::unweighted || probas == nullptr)
         {
+            const algorithmFPType inverseTreesCount = 1.0 / algorithmFPType(nTreesTotal);
             resPtr[pNode->leftIndexOrClass] += inverseTreesCount;
         }
         else if (_votingMethod == VotingMethod::weighted)
@@ -278,7 +278,25 @@ void PredictClassificationTask<algorithmFPType, cpu>::predictByTrees(const size_
             PRAGMA_VECTOR_ALWAYS
             for (size_t i = 0; i < _nClasses; ++i)
             {
-                resPtr[i] += probas[idx * _nClasses + i] * inverseTreesCount;
+                resPtr[i] += probas[idx * _nClasses + i];
+            }
+
+            if (iTree + 1 == nTreesTotal)
+            {
+                algorithmFPType sum(0);
+
+                PRAGMA_VECTOR_ALWAYS
+                for (size_t i = 0; i < _nClasses; ++i)
+                {
+                    sum += resPtr[i];
+                }
+
+                PRAGMA_IVDEP
+                PRAGMA_VECTOR_ALWAYS
+                for (size_t i = 0; i < _nClasses; ++i)
+                {
+                    resPtr[i] = resPtr[i] / sum;
+                }
             }
         }
     }
@@ -322,6 +340,24 @@ void PredictClassificationTask<algorithmFPType, cpu>::predictByTreesWithoutConve
             for (size_t i = 0; i < _nClasses; ++i)
             {
                 resPtr[i] += probas[idx * _nClasses + i];
+            }
+
+            if (iTree + 1 == nTreesTotal)
+            {
+                algorithmFPType sum(0);
+
+                PRAGMA_VECTOR_ALWAYS
+                for (size_t i = 0; i < _nClasses; ++i)
+                {
+                    sum += resPtr[i];
+                }
+
+                PRAGMA_IVDEP
+                PRAGMA_VECTOR_ALWAYS
+                for (size_t i = 0; i < _nClasses; ++i)
+                {
+                    resPtr[i] = resPtr[i] / sum;
+                }
             }
         }
     }
@@ -644,14 +680,12 @@ Status PredictClassificationTask<algorithmFPType, cpu>::predictOneRowByAllTrees(
     {
         resPtr[0] = algorithmFPType(services::internal::getMaxElementIndex<double, cpu>(prob_d, _nClasses));
     }
-    algorithmFPType inverseTreesCount = 1.0 / algorithmFPType(nTreesTotal);
     if (probPtr != nullptr)
     {
         PRAGMA_IVDEP
         PRAGMA_VECTOR_ALWAYS
         for (size_t j = 0; j < _nClasses; ++j)
         {
-            prob_d[j] *= inverseTreesCount;
             probPtr[j] = prob_d[j];
         }
     }
@@ -879,14 +913,12 @@ Status PredictClassificationTask<float, avx512>::predictOneRowByAllTrees(size_t 
     {
         resPtr[0] = float(services::internal::getMaxElementIndex<double, avx512>(prob_d, _nClasses));
     }
-    float inverseTreesCount = 1.0 / float(nTreesTotal);
     if (probPtr != nullptr)
     {
         PRAGMA_IVDEP
         PRAGMA_VECTOR_ALWAYS
         for (size_t j = 0; j < _nClasses; ++j)
         {
-            prob_d[j] *= inverseTreesCount;
             probPtr[j] = prob_d[j];
         }
     }
@@ -923,101 +955,119 @@ Status PredictClassificationTask<algorithmFPType, cpu>::predictAllPointsByAllTre
     {
         commonBufVal = prob;
     }
-    services::internal::service_memset<algorithmFPType, cpu>(commonBufVal, algorithmFPType(0), _nClasses * nRowsOfRes);
 
     ReadRows<algorithmFPType, cpu> xBD(const_cast<NumericTable *>(_data), 0, nRowsOfRes);
     DAAL_CHECK_BLOCK_STATUS(xBD);
-    const algorithmFPType * const aX         = xBD.get();
-    const algorithmFPType inverseNTreesTotal = (algorithmFPType)1.0 / algorithmFPType(nTreesTotal);
-    daal::TlsMem<algorithmFPType, cpu, services::internal::ScalableCalloc<algorithmFPType, cpu> > * tlsDataPtr = nullptr;
+    const algorithmFPType * const aX = xBD.get();
     if (numberOfTrees > _MIN_TREES_FOR_THREADING)
     {
-        tlsDataPtr     = new daal::TlsMem<algorithmFPType, cpu, services::internal::ScalableCalloc<algorithmFPType, cpu> >(_nClasses * nRowsOfRes);
-        auto & tlsData = *tlsDataPtr;
-        daal::threader_for(numberOfTrees, numberOfTrees, [&, nCols](const size_t iTree) {
+        daal::static_tls<algorithmFPType *> tlsData([=]() { return service_scalable_calloc<algorithmFPType, cpu>(_nClasses * nRowsOfRes); });
+
+        daal::static_threader_for(numberOfTrees, [&, nCols](const size_t iTree, size_t tid) {
             const size_t treeSize                = _aTree[iTree]->getNumberOfRows();
             const DecisionTreeNode * const aNode = (const DecisionTreeNode *)(*_aTree[iTree]).getArray();
-            parallelPredict(aX, aNode, treeSize, nBlocks, nCols, blockSize, residualSize, tlsData.local(), iTree);
+            parallelPredict(aX, aNode, treeSize, nBlocks, nCols, blockSize, residualSize, tlsData.local(tid), iTree);
         });
-        if (threader_get_threads_number())
-        {
-            if (prob == nullptr)
+
+        const size_t nThreads  = tlsData.nthreads();
+        const size_t blockSize = 256;
+        const size_t nBlocks   = nRowsOfRes / blockSize + !!(nRowsOfRes % blockSize);
+
+        daal::threader_for(nBlocks, nBlocks, [&](const size_t iBlock) {
+            const size_t begin = iBlock * blockSize;
+            const size_t end   = services::internal::min<cpu, size_t>(nRowsOfRes, begin + blockSize);
+
+            services::internal::service_memset_seq<algorithmFPType, cpu>(commonBufVal + begin * _nClasses, algorithmFPType(0),
+                                                                         (end - begin) * _nClasses);
+
+            for (size_t tid = 0; tid < nThreads; ++tid)
             {
-                tlsData.reduce([&](algorithmFPType * buf) {
-                    for (size_t i = 0; i < nRowsOfRes; ++i)
-                    {
-                        PRAGMA_IVDEP
-                        PRAGMA_VECTOR_ALWAYS
-                        for (size_t j = 0; j < _nClasses; ++j)
-                        {
-                            commonBufVal[i * _nClasses + j] += buf[i * _nClasses + j];
-                        }
-                    }
-                });
-            }
-            else
-            {
-                tlsData.reduce([&](algorithmFPType * buf) {
-                    for (size_t i = 0; i < nRowsOfRes; ++i)
-                    {
-                        PRAGMA_IVDEP
-                        PRAGMA_VECTOR_ALWAYS
-                        for (size_t j = 0; j < _nClasses; ++j)
-                        {
-                            commonBufVal[i * _nClasses + j] += buf[i * _nClasses + j] * inverseNTreesTotal;
-                        }
-                    }
-                });
-            }
-        }
-        else
-        {
-            algorithmFPType * const localPtr = tlsData.local();
-            if (prob == nullptr)
-            {
-                commonBufVal = tlsData.local();
-            }
-            else
-            {
-                for (size_t i = 0; i < nRowsOfRes; ++i)
+                algorithmFPType * buf = tlsData.local(tid);
+                for (size_t i = begin; i < end; ++i)
                 {
-                    PRAGMA_IVDEP
-                    PRAGMA_VECTOR_ALWAYS
                     for (size_t j = 0; j < _nClasses; ++j)
                     {
-                        commonBufVal[i * _nClasses + j] += localPtr[i * _nClasses + j] * inverseNTreesTotal;
+                        commonBufVal[i * _nClasses + j] += buf[i * _nClasses + j];
                     }
                 }
             }
-        }
+
+            if (prob != nullptr)
+            {
+                for (size_t i = begin; i < end; ++i)
+                {
+                    algorithmFPType sum(0);
+
+                    for (size_t j = 0; j < _nClasses; ++j)
+                    {
+                        sum += commonBufVal[i * _nClasses + j];
+                    }
+
+                    for (size_t j = 0; j < _nClasses; ++j)
+                    {
+                        commonBufVal[i * _nClasses + j] = commonBufVal[i * _nClasses + j] / sum;
+                    }
+                }
+            }
+
+            if (res != nullptr)
+            {
+                for (size_t i = begin; i < end; ++i)
+                {
+                    res[i] = algorithmFPType(getMaxClass(commonBufVal + i * _nClasses));
+                }
+            }
+        });
+
+        tlsData.reduce([&](algorithmFPType * buf) { service_scalable_free<algorithmFPType, cpu>(buf); });
     }
     else
     {
+        services::internal::service_memset<algorithmFPType, cpu>(commonBufVal, algorithmFPType(0), nRowsOfRes * _nClasses);
+
         for (size_t iTree = 0; iTree < numberOfTrees; ++iTree)
         {
             const size_t treeSize                = _aTree[iTree]->getNumberOfRows();
             const DecisionTreeNode * const aNode = (const DecisionTreeNode *)(*_aTree[iTree]).getArray();
             parallelPredict(aX, aNode, treeSize, nBlocks, nCols, blockSize, residualSize, commonBufVal, iTree);
         }
-        if (prob != nullptr)
+        if (prob != nullptr || res != nullptr)
         {
-            for (size_t i = 0; i < nRowsOfRes; ++i)
-            {
-                PRAGMA_IVDEP
-                PRAGMA_VECTOR_ALWAYS
-                for (size_t j = 0; j < _nClasses; ++j)
+            const size_t blockSize = 256;
+            const size_t nBlocks   = nRowsOfRes / blockSize + !!(nRowsOfRes % blockSize);
+
+            daal::threader_for(nBlocks, nBlocks, [&, nCols](const size_t iBlock) {
+                const size_t begin = iBlock * blockSize;
+                const size_t end   = services::internal::min<cpu, size_t>(nRowsOfRes, begin + blockSize);
+
+                if (prob != nullptr)
                 {
-                    commonBufVal[i * _nClasses + j] *= inverseNTreesTotal;
+                    for (size_t i = begin; i < end; ++i)
+                    {
+                        algorithmFPType sum(0);
+
+                        for (size_t j = 0; j < _nClasses; ++j)
+                        {
+                            sum += commonBufVal[i * _nClasses + j];
+                        }
+
+                        for (size_t j = 0; j < _nClasses; ++j)
+                        {
+                            commonBufVal[i * _nClasses + j] = commonBufVal[i * _nClasses + j] / sum;
+                        }
+                    }
                 }
-            }
+
+                if (res != nullptr)
+                {
+                    for (size_t i = begin; i < end; ++i)
+                    {
+                        res[i] = algorithmFPType(getMaxClass(commonBufVal + i * _nClasses));
+                    }
+                }
+            });
         }
     }
-    if (res != nullptr)
-    {
-        daal::threader_for(nRowsOfRes, nRowsOfRes,
-                           [&](const size_t iRes) { res[iRes] = algorithmFPType(getMaxClass(commonBufVal + iRes * _nClasses)); });
-    }
-    delete tlsDataPtr;
     return safeStat.detach();
 }
 

--- a/cpp/daal/src/algorithms/dtrees/forest/classification/oneapi/df_classification_train_hist_oneapi_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/classification/oneapi/df_classification_train_hist_oneapi_impl.i
@@ -1007,7 +1007,7 @@ services::Status ClassificationTrainBatchKernelOneAPI<algorithmFPType, hist>::co
         DFTreeConverterType converter;
         DAAL_CHECK_STATUS_VAR(converter.convertToDFDecisionTree(DFTreeRecords, binValues.data(), mTreeHelper, _nClasses));
 
-        mdImpl.add(mTreeHelper._tree, _nClasses);
+        mdImpl.add(mTreeHelper._tree, _nClasses, iter);
 
         DAAL_CHECK_STATUS_VAR(computeResults(mTreeHelper._tree, dataBlock.getBlockPtr(), responseBlock.getBlockPtr(), _nSelectedRows, _nFeatures,
                                              oobRows, nOOBRows, oobBufferPerObs, varImpBlock.getBlockPtr(), varImpVariance.get(), iter + 1,

--- a/cpp/daal/src/algorithms/dtrees/forest/df_train_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/df_train_dense_default_impl.i
@@ -419,7 +419,7 @@ services::Status computeImpl(HostAppIface * pHostApp, const NumericTable * x, co
         DAAL_CHECK_STATUS_THR(s);
         if (pTree)
         {
-            md.add((typename ModelType::TreeType &)*pTree, nClasses);
+            md.add((typename ModelType::TreeType &)*pTree, nClasses, i);
         }
     });
     s = safeStat.detach();

--- a/cpp/daal/src/algorithms/dtrees/forest/regression/df_regression_model.cpp
+++ b/cpp/daal/src/algorithms/dtrees/forest/regression/df_regression_model.cpp
@@ -161,10 +161,10 @@ services::Status ModelImpl::deserializeImpl(const data_management::OutputDataArc
     return s.add(ImplType::serialImpl<const data_management::OutputDataArchive, true>(arch));
 }
 
-bool ModelImpl::add(const TreeType & tree, size_t nClasses)
+bool ModelImpl::add(const TreeType & tree, size_t nClasses, size_t iTree)
 {
     DAAL_CHECK_STATUS_VAR(!(size() >= _serializationData->size()));
-    size_t i           = _nTree.inc();
+    _nTree.inc();
     const size_t nNode = tree.getNumberOfNodes();
 
     auto pTbl           = new DecisionTreeTable(nNode);
@@ -183,10 +183,10 @@ bool ModelImpl::add(const TreeType & tree, size_t nClasses)
 
     tree.convertToTable(pTbl, impTbl, nodeSamplesTbl, probTbl, 0);
 
-    (*_serializationData)[i - 1].reset(pTbl);
-    (*_impurityTables)[i - 1].reset(impTbl);
-    (*_nNodeSampleTables)[i - 1].reset(nodeSamplesTbl);
-    (*_probTbl)[i - 1].reset(probTbl);
+    (*_serializationData)[iTree].reset(pTbl);
+    (*_impurityTables)[iTree].reset(impTbl);
+    (*_nNodeSampleTables)[iTree].reset(nodeSamplesTbl);
+    (*_probTbl)[iTree].reset(probTbl);
 
     return true;
 }

--- a/cpp/daal/src/algorithms/dtrees/forest/regression/df_regression_model_impl.h
+++ b/cpp/daal/src/algorithms/dtrees/forest/regression/df_regression_model_impl.h
@@ -64,7 +64,7 @@ public:
     virtual services::Status serializeImpl(data_management::InputDataArchive * arch) DAAL_C11_OVERRIDE;
     virtual services::Status deserializeImpl(const data_management::OutputDataArchive * arch) DAAL_C11_OVERRIDE;
 
-    bool add(const TreeType & tree, size_t nClasses);
+    bool add(const TreeType & tree, size_t nClasses, size_t iTree);
 
     virtual size_t getNumberOfTrees() const DAAL_C11_OVERRIDE;
 };

--- a/cpp/daal/src/algorithms/dtrees/forest/regression/oneapi/df_regression_train_hist_oneapi_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/regression/oneapi/df_regression_train_hist_oneapi_impl.i
@@ -985,7 +985,7 @@ services::Status RegressionTrainBatchKernelOneAPI<algorithmFPType, hist>::comput
         DFTreeConverterType converter;
         DAAL_CHECK_STATUS_VAR(converter.convertToDFDecisionTree(DFTreeRecords, binValues.data(), mTreeHelper));
 
-        mdImpl.add(mTreeHelper._tree, 0 /*nClasses*/);
+        mdImpl.add(mTreeHelper._tree, 0 /*nClasses*/, iter);
 
         DAAL_CHECK_STATUS_VAR(computeResults(mTreeHelper._tree, dataBlock.getBlockPtr(), responseBlock.getBlockPtr(), _nSelectedRows, _nFeatures,
                                              oobRows, nOOBRows, oobBufferPerObs, varImpBlock.getBlockPtr(), varImpVariance.get(), iter + 1,

--- a/cpp/daal/src/externals/core_threading_win_dll.cpp
+++ b/cpp/daal/src/externals/core_threading_win_dll.cpp
@@ -246,6 +246,7 @@ typedef void * (*_threaded_malloc_t)(const size_t, const size_t);
 typedef void (*_threaded_free_t)(void *);
 
 typedef void (*_daal_threader_for_t)(int, int, const void *, daal::functype);
+typedef void (*_daal_static_threader_for_t)(size_t, const void *, daal::functype_static);
 typedef void (*_daal_threader_for_blocked_t)(int, int, const void *, daal::functype2);
 typedef int (*_daal_threader_get_max_threads_t)(void);
 typedef void (*_daal_threader_for_break_t)(int, int, const void *, daal::functype_break);
@@ -298,6 +299,7 @@ static _threaded_malloc_t _threaded_malloc_ptr = NULL;
 static _threaded_free_t _threaded_free_ptr     = NULL;
 
 static _daal_threader_for_t _daal_threader_for_ptr                         = NULL;
+static _daal_static_threader_for_t _daal_static_threader_for_ptr           = NULL;
 static _daal_threader_for_blocked_t _daal_threader_for_blocked_ptr         = NULL;
 static _daal_threader_for_t _daal_threader_for_optional_ptr                = NULL;
 static _daal_threader_get_max_threads_t _daal_threader_get_max_threads_ptr = NULL;
@@ -375,6 +377,16 @@ DAAL_EXPORT void _daal_threader_for(int n, int threads_request, const void * a, 
         _daal_threader_for_ptr = (_daal_threader_for_t)load_daal_thr_func("_daal_threader_for");
     }
     _daal_threader_for_ptr(n, threads_request, a, func);
+}
+
+DAAL_EXPORT void _daal_static_threader_for(size_t n, const void * a, daal::functype_static func)
+{
+    load_daal_thr_dll();
+    if (_daal_static_threader_for_ptr == NULL)
+    {
+        _daal_static_threader_for_ptr = (_daal_static_threader_for_t)load_daal_thr_func("_daal_static_threader_for");
+    }
+    _daal_static_threader_for_ptr(n, a, func);
 }
 
 DAAL_EXPORT void _daal_parallel_sort_int32(int * begin_ptr, int * end_ptr)

--- a/cpp/daal/src/threading/threading.cpp
+++ b/cpp/daal/src/threading/threading.cpp
@@ -111,6 +111,33 @@ DAAL_EXPORT void _daal_threader_for(int n, int threads_request, const void * a, 
 #endif
 }
 
+DAAL_EXPORT void _daal_static_threader_for(size_t n, const void * a, daal::functype_static func)
+{
+#if defined(__DO_TBB_LAYER__)
+    const size_t nthreads           = _daal_threader_get_max_threads();
+    const size_t nblocks_per_thread = n / nthreads + !!(n % nthreads);
+
+    tbb::parallel_for(
+        tbb::blocked_range<size_t>(0, nthreads, 1),
+        [&](tbb::blocked_range<size_t> r) {
+            const size_t tid   = r.begin();
+            const size_t begin = tid * nblocks_per_thread;
+            const size_t end   = n < begin + nblocks_per_thread ? n : begin + nblocks_per_thread;
+
+            for (size_t i = begin; i < end; ++i)
+            {
+                func(i, tid, a);
+            }
+        },
+        tbb::static_partitioner());
+#elif defined(__DO_SEQ_LAYER__)
+    for (size_t i = 0; i < n; i++)
+    {
+        func(i, 0, a);
+    }
+#endif
+}
+
 template <typename F>
 DAAL_EXPORT void _daal_parallel_sort_template(F * begin_p, F * end_p)
 {


### PR DESCRIPTION
1. Fixed instability in training due to undefined order of pushing trees into a model.
2. Fixed instability in prediction due to usage of TLS with undefined order of reduction in one of code branches. + possible optimizations for this case.
3. More accurate summation for probabilities in prediction to avoid cases, when sum of probabilities > 1.0