### PR TITLE
Test bazel cache in Azure pipelines

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -7,7 +7,7 @@ build -c opt \
 build --flag_alias=test_link_mode=@config//:test_link_mode
 build --flag_alias=test_thread_mode=@config//:test_thread_mode
 build --flag_alias=release_dpc=@config//:release_dpc
-
+build --flag_alias=cpu=@config//:cpu
 
 # Configuration: 'host'
 build:host \

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -80,7 +80,7 @@ jobs:
       .ci/env/oneapi.sh mkl
 
       # Create .bazelrc and set cache directory
-      echo "startup --output_user_root=$(BAZEL_CACHE_DIR)" > ~/.bazelrc
+      echo "build --disk_cache=$(BAZEL_CACHE_DIR)" > ~/.bazelrc
 
       # Display oneDAL build configuration
       bazel build @config//:dump
@@ -89,7 +89,7 @@ jobs:
 
   - task: Cache@2
     inputs:
-      key: '"$(BAZEL_VERSION)" | "$(Agent.OS)"'
+      key: '"$(BAZEL_VERSION)" | "$(Agent.OS)" | "v1"'
       path: $(BAZEL_CACHE_DIR)
     displayName: 'bazel-cache'
 

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -89,7 +89,7 @@ jobs:
 
   - task: Cache@2
     inputs:
-      key: '$(BAZEL_VERSION) | "$(Agent.OS)"'
+      key: '"$(BAZEL_VERSION)" | "$(Agent.OS)"'
       path: $(BAZEL_CACHE_DIR)
     displayName: bazel-cache
 

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -58,6 +58,9 @@ jobs:
   timeoutInMinutes: 0
   pool:
     vmImage: 'ubuntu-20.04'
+  variables:
+    BAZEL_VERSION: bazel-4.0.0
+    BAZEL_CACHE_DIR: $(Pipeline.Workspace)/.bazel-cache
   steps:
   - script: |
       # Add bazel repository
@@ -72,15 +75,23 @@ jobs:
                            g++-multilib \
                            binutils \
                            openjdk-11-jdk \
-                           bazel-4.0.0
+                           $(BAZEL_VERSION)
 
       .ci/env/oneapi.sh mkl
-    displayName: 'apt-get'
 
-  - script: |
+      # Create .bazelrc and set cache directory
+      echo "startup --output_user_root=$(BAZEL_CACHE_DIR)" > ~/.bazelrc
+
+      # Display oneDAL build configuration
       bazel build @config//:dump
       cat bazel-bin/external/config/config.json
-    displayName: 'config-dump'
+    displayName: 'configure'
+
+  - task: Cache@2
+    inputs:
+      key: '$(BAZEL_VERSION) | "$(Agent.OS)"'
+      path: $(BAZEL_CACHE_DIR)
+    displayName: bazel-cache
 
   - script: |
       bazel build :release

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -80,7 +80,8 @@ jobs:
       .ci/env/oneapi.sh mkl
 
       # Create .bazelrc and set cache directory
-      echo "build --disk_cache=$(BAZEL_CACHE_DIR)" > ~/.bazelrc
+      # Minimal CPU instruction set in Azure is AVX2
+      echo "build --disk_cache=$(BAZEL_CACHE_DIR) --cpu=avx2" > ~/.bazelrc
 
       # Display oneDAL build configuration
       bazel build @config//:dump

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -91,7 +91,7 @@ jobs:
     inputs:
       key: '"$(BAZEL_VERSION)" | "$(Agent.OS)"'
       path: $(BAZEL_CACHE_DIR)
-    displayName: bazel-cache
+    displayName: 'bazel-cache'
 
   - script: |
       bazel build :release

--- a/cpp/oneapi/dal/algo/pca/test/badarg.cpp
+++ b/cpp/oneapi/dal/algo/pca/test/badarg.cpp
@@ -106,4 +106,8 @@ PCA_BADARG_TEST("throws if infer data column count neq eigenvector columns") {
     REQUIRE_THROWS_AS(this->infer(pca_desc, model, infer_data), invalid_argument);
 }
 
+TEST("dummy test") {
+    // Test to check if CI cache works
+}
+
 } // namespace oneapi::dal::pca::test

--- a/cpp/oneapi/dal/algo/pca/test/badarg.cpp
+++ b/cpp/oneapi/dal/algo/pca/test/badarg.cpp
@@ -108,6 +108,8 @@ PCA_BADARG_TEST("throws if infer data column count neq eigenvector columns") {
 
 TEST("dummy test") {
     // Test to check if CI cache works
+    // Iter 1
+    // Iter 2
 }
 
 } // namespace oneapi::dal::pca::test

--- a/cpp/oneapi/dal/algo/pca/test/badarg.cpp
+++ b/cpp/oneapi/dal/algo/pca/test/badarg.cpp
@@ -106,10 +106,4 @@ PCA_BADARG_TEST("throws if infer data column count neq eigenvector columns") {
     REQUIRE_THROWS_AS(this->infer(pca_desc, model, infer_data), invalid_argument);
 }
 
-TEST("dummy test") {
-    // Test to check if CI cache works
-    // Iter 1
-    // Iter 2
-}
-
 } // namespace oneapi::dal::pca::test


### PR DESCRIPTION
Test [cache feature](https://docs.microsoft.com/en-us/azure/devops/pipelines/release/caching?view=azure-devops) of Azure pipelines on Bazel.

**Results:** LinuxBazel pipeline run time reduced from **36 min** to **6 min** :fire:

@napetrov, have a look: [before caching](https://dev.azure.com/daal/DAAL/_build/results?buildId=8460&view=logs&jobId=7b57b3de-9813-5583-aff5-3419092f5c46) vs [after caching](https://dev.azure.com/daal/DAAL/_build/results?buildId=8512&view=logs&jobId=7b57b3de-9813-5583-aff5-3419092f5c46).

<img width="700" src="https://user-images.githubusercontent.com/5404873/107119531-3a294400-6899-11eb-91f5-109c38e1f7f3.png" />
