### PR TITLE
Add Bazel config to filter out public interface tests

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -14,6 +14,7 @@ build --flag_alias=cpu=@config//:cpu
 test --test_env=OCL_ICD_FILENAMES
 
 # Configuration: 'host'
+# Build & run all host tests
 build:host \
     --build_tag_filters="host"
 
@@ -22,6 +23,7 @@ test:host \
 
 
 # Configuration: host-public
+# Build & run all host tests for public interface
 build:host-public \
     --build_tag_filters="host,-private"
 
@@ -30,6 +32,7 @@ test:host-public \
 
 
 # Configuration: 'dpc-cpu'
+# Build & run all DPC++ tests on CPU
 build:dpc-cpu \
     --build_tag_filters="dpc"
 
@@ -41,7 +44,21 @@ test:dpc-cpu \
     --test_arg="--device=cpu"
 
 
+# Configuration: 'dpc-cpu-public'
+# Build & run all DPC++ tests on CPU for public interface
+build:dpc-cpu-public \
+    --build_tag_filters="dpc,-private"
+
+run:dpc-cpu-public \
+    -- --device=cpu
+
+test:dpc-cpu-public \
+    --test_tag_filters="dpc,-private" \
+    --test_arg="--device=cpu"
+
+
 # Configuration: 'dpc-gpu'
+# Build & run all DPC++ tests on GPU
 build:dpc-gpu \
     --build_tag_filters="dpc"
 
@@ -50,4 +67,17 @@ run:dpc-gpu \
 
 test:dpc-gpu \
     --test_tag_filters="dpc" \
+    --test_arg="--device=gpu"
+
+
+# Configuration: 'dpc-gpu-pulbic'
+# Build & run all DPC++ tests on GPU for public interface
+build:dpc-gpu-public \
+    --build_tag_filters="dpc,-private"
+
+run:dpc-gpu-public \
+    -- --device=gpu
+
+test:dpc-gpu-public \
+    --test_tag_filters="dpc,-private" \
     --test_arg="--device=gpu"

--- a/.bazelrc
+++ b/.bazelrc
@@ -70,7 +70,7 @@ test:dpc-gpu \
     --test_arg="--device=gpu"
 
 
-# Configuration: 'dpc-gpu-pulbic'
+# Configuration: 'dpc-gpu-public'
 # Build & run all DPC++ tests on GPU for public interface
 build:dpc-gpu-public \
     --build_tag_filters="dpc,-private"

--- a/.bazelrc
+++ b/.bazelrc
@@ -17,6 +17,14 @@ test:host \
     --test_tag_filters="host"
 
 
+# Configuration: host-public
+build:host-public \
+    --build_tag_filters="host,-private"
+
+test:host-public \
+    --test_tag_filters="host,-private"
+
+
 # Configuration: 'dpc-cpu'
 build:dpc-cpu \
     --build_tag_filters="dpc"

--- a/cpp/oneapi/dal/algo/pca/BUILD
+++ b/cpp/oneapi/dal/algo/pca/BUILD
@@ -19,31 +19,25 @@ dal_module(
 dal_test_suite(
     name = "cpu_tests",
     dpc = False,
+    private = True,
     srcs = glob([
         "backend/cpu/test/*.cpp",
     ]),
     dal_deps = [
         ":pca",
     ],
-    tags = [
-        "backend",
-        "cpu-only",
-    ]
 )
 
 dal_test_suite(
     name = "gpu_tests_dpc",
     host = False,
+    private = True,
     srcs = glob([
         "backend/gpu/test/*.cpp",
     ]),
     dal_deps = [
         ":pca",
     ],
-    tags = [
-        "backend",
-        "gpu-only",
-    ]
 )
 
 dal_test_suite(
@@ -55,9 +49,6 @@ dal_test_suite(
     dal_deps = [
         ":pca",
     ],
-    tags = [
-        "interface",
-    ]
 )
 
 dal_test_suite(

--- a/cpp/oneapi/dal/backend/primitives/BUILD
+++ b/cpp/oneapi/dal/backend/primitives/BUILD
@@ -28,6 +28,7 @@ dal_collect_modules(
 
 dal_test_suite(
     name = "common_tests",
+    private = True,
     framework = "catch2",
     srcs = glob([
         "test/*.cpp",

--- a/cpp/oneapi/dal/backend/primitives/blas/BUILD
+++ b/cpp/oneapi/dal/backend/primitives/blas/BUILD
@@ -14,6 +14,7 @@ dal_module(
 
 dal_test_suite(
     name = "tests",
+    private = True,
     framework = "catch2",
     compile_as = [ "dpc++" ],
     srcs = glob([

--- a/cpp/oneapi/dal/test/engine/config.cpp
+++ b/cpp/oneapi/dal/test/engine/config.cpp
@@ -20,7 +20,11 @@
 
 #ifdef ONEDAL_DATA_PARALLEL
 #include "oneapi/dal/test/engine/common.hpp"
-#include "oneapi/dal/backend/interop/common_dpc.hpp"
+
+namespace oneapi::dal::backend::interop {
+void enable_daal_sycl_execution_context_cache();
+void cleanup_daal_sycl_execution_context_cache();
+} // namespace oneapi::dal::backend::interop
 #endif
 
 namespace oneapi::dal::test::engine {

--- a/dev/bazel/cc/common.bzl
+++ b/dev/bazel/cc/common.bzl
@@ -88,8 +88,11 @@ def _unpack_linking_contexts(linking_contexts):
     pic_objects = []
     dynamic_libs = []
     static_libs = []
+    libs_to_link = []
     dynamic_libs_to_link = []
     static_libs_to_link = []
+    # IMPORTANT: We need to preserve order of objects when
+    #            iterate over linking contexts
     for linking_context in linking_contexts:
         for linker_input in linking_context.linker_inputs.to_list():
             for lib_to_link in linker_input.libraries:
@@ -98,9 +101,11 @@ def _unpack_linking_contexts(linking_contexts):
                 elif lib_to_link.pic_objects:
                     pic_objects += lib_to_link.pic_objects
                 elif lib_to_link.dynamic_library:
+                    libs_to_link.append(lib_to_link)
                     dynamic_libs_to_link.append(lib_to_link)
                     dynamic_libs.append(lib_to_link.dynamic_library)
                 elif lib_to_link.static_library or lib_to_link.pic_static_library:
+                    libs_to_link.append(lib_to_link)
                     static_libs_to_link.append(lib_to_link)
                     static_libs.append(lib_to_link.static_library or
                                        lib_to_link.pic_static_library)
@@ -112,7 +117,7 @@ def _unpack_linking_contexts(linking_contexts):
         dynamic_libraries_to_link = dynamic_libs_to_link,
         static_libraries = depset(static_libs).to_list(),
         static_libraries_to_link = static_libs_to_link,
-        libraries_to_link = static_libs_to_link + dynamic_libs_to_link,
+        libraries_to_link = libs_to_link,
         user_link_flags = utils.unique(link_flags),
     )
 

--- a/dev/bazel/dal.bzl
+++ b/dev/bazel/dal.bzl
@@ -150,7 +150,7 @@ def dal_test(name, hdrs=[], srcs=[],
              host_hdrs=[], host_srcs=[], host_deps=[],
              dpc_hdrs=[], dpc_srcs=[], dpc_deps=[],
              host=True, dpc=True, framework="gtest",
-             data=[], tags=[], **kwargs):
+             data=[], tags=[], private=False, **kwargs):
     # TODO: Refactor this rule once decision on the tests structure is made
     if not framework in ["gtest", "catch2", "none"]:
         fail("Unknown test framework '{}' in test rule '{}'".format(framework, name))
@@ -184,12 +184,13 @@ def dal_test(name, hdrs=[], srcs=[],
         testonly = True,
         **kwargs,
     )
+    iface_access_tag = "private" if private else "public"
     if host:
         cc_test(
             name = name,
             deps = [ ":" + module_name ],
             data = data,
-            tags = tags + ["host"],
+            tags = tags + ["host", iface_access_tag],
         )
     if dpc:
         cc_test(
@@ -201,7 +202,7 @@ def dal_test(name, hdrs=[], srcs=[],
                 "@opencl//:opencl_binary",
             ],
             data = data,
-            tags = tags + ["dpc"],
+            tags = tags + ["dpc", iface_access_tag],
         )
 
 def dal_test_suite(name, srcs=[], tests=[],

--- a/dev/bazel/deps/onedal.tpl.BUILD
+++ b/dev/bazel/deps/onedal.tpl.BUILD
@@ -45,6 +45,16 @@ cc_library(
 )
 
 cc_library(
+    name = "onedal_sycl",
+    srcs = [
+        "lib/intel64/libonedal_sycl.a",
+    ],
+    deps = [
+        ":headers",
+    ],
+)
+
+cc_library(
     name = "onedal_static",
     srcs = [
         "lib/intel64/libonedal.a",
@@ -61,6 +71,7 @@ cc_library(
     ],
     deps = [
         ":headers",
+        ":onedal_sycl",
     ],
 )
 
@@ -116,5 +127,6 @@ cc_library(
     ],
     deps = [
         ":headers",
+        ":onedal_sycl",
     ],
 )

--- a/makefile
+++ b/makefile
@@ -796,7 +796,7 @@ $(WORKDIR.lib)/$(oneapi_y.dpc): LOPT += $(daaldep.rt.dpc)
 $(WORKDIR.lib)/$(oneapi_y.dpc): LOPT += $(if $(OS_is_win),-IMPLIB:$(@:%.$(MAJORBINARY).dll=%_dll.lib),)
 $(WORKDIR.lib)/$(oneapi_y.dpc): LOPT += $(if $(OS_is_win),$(WORKDIR.lib)/$(core_y:%.$(MAJORBINARY).dll=%_dll.lib))
 $(WORKDIR.lib)/$(oneapi_y.dpc): LOPT += $(if $(OS_is_win),sycl.lib OpenCL.lib)
-$(WORKDIR.lib)/$(oneapi_y.dpc): LOPT += $(if $(OS_is_win),$(mklgpufpk.LIBS_A))
+$(WORKDIR.lib)/$(oneapi_y.dpc): LOPT += $(mklgpufpk.LIBS_A)
 ifdef OS_is_win
 $(WORKDIR.lib)/$(oneapi_y.dpc:%.$(MAJORBINARY).dll=%_dll.lib): $(WORKDIR.lib)/$(oneapi_y.dpc)
 endif


### PR DESCRIPTION
- Add \*-public configs (public stands for public C++ interface):
  - host-public
  - dpc-cpu-public
  - dpc-gpu-public
- Bugfixes to make `--test_link_mode=release_*` work with DPC++