### PR TITLE
Support more switches to control tests configurations

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -6,7 +6,9 @@ build -c opt \
 # Aliases for user-defined flags
 build --flag_alias=test_link_mode=@config//:test_link_mode
 build --flag_alias=test_thread_mode=@config//:test_thread_mode
+build --flag_alias=test_external_datasets=@config//:test_external_datasets
 build --flag_alias=release_dpc=@config//:release_dpc
+build --flag_alias=device=@config//:device
 build --flag_alias=cpu=@config//:cpu
 
 # Always pass this env variable to test rules, because SYCL
@@ -31,53 +33,19 @@ test:host-public \
     --test_tag_filters="host,-private"
 
 
-# Configuration: 'dpc-cpu'
-# Build & run all DPC++ tests on CPU
-build:dpc-cpu \
+# Configuration: 'dpc'
+# Build & run all DPC++ tests
+build:dpc \
     --build_tag_filters="dpc"
 
-run:dpc-cpu \
-    -- --device=cpu
-
-test:dpc-cpu \
-    --test_tag_filters="dpc" \
-    --test_arg="--device=cpu"
+test:dpc \
+    --test_tag_filters="dpc"
 
 
-# Configuration: 'dpc-cpu-public'
-# Build & run all DPC++ tests on CPU for public interface
-build:dpc-cpu-public \
+# Configuration: 'dpc-public'
+# Build & run all DPC++ tests for public interface
+build:dpc-public \
     --build_tag_filters="dpc,-private"
 
-run:dpc-cpu-public \
-    -- --device=cpu
-
-test:dpc-cpu-public \
-    --test_tag_filters="dpc,-private" \
-    --test_arg="--device=cpu"
-
-
-# Configuration: 'dpc-gpu'
-# Build & run all DPC++ tests on GPU
-build:dpc-gpu \
-    --build_tag_filters="dpc"
-
-run:dpc-gpu \
-    -- --device=gpu
-
-test:dpc-gpu \
-    --test_tag_filters="dpc" \
-    --test_arg="--device=gpu"
-
-
-# Configuration: 'dpc-gpu-public'
-# Build & run all DPC++ tests on GPU for public interface
-build:dpc-gpu-public \
-    --build_tag_filters="dpc,-private"
-
-run:dpc-gpu-public \
-    -- --device=gpu
-
-test:dpc-gpu-public \
-    --test_tag_filters="dpc,-private" \
-    --test_arg="--device=gpu"
+test:dpc-public \
+    --test_tag_filters="dpc,-private"

--- a/cpp/daal/BUILD
+++ b/cpp/daal/BUILD
@@ -285,10 +285,10 @@ daal_dynamic_lib(
 daal_module(
     name = "threading_static",
     deps = select({
-        "@config//:par_test_thread_mode": [
+        "@config//:test_thread_mode_par": [
             "@onedal//cpp/daal:thread_static",
         ],
-        "@config//:seq_test_thread_mode": [
+        "@config//:test_thread_mode_seq": [
             "@onedal//cpp/daal:sequential_static",
         ],
     }),
@@ -297,10 +297,10 @@ daal_module(
 daal_module(
     name = "threading_dynamic",
     deps = select({
-        "@config//:par_test_thread_mode": [
+        "@config//:test_thread_mode_par": [
             "@onedal//cpp/daal:thread_dynamic",
         ],
-        "@config//:seq_test_thread_mode": [
+        "@config//:test_thread_mode_seq": [
             "@onedal//cpp/daal:sequential_dynamic",
         ],
     }),
@@ -309,10 +309,10 @@ daal_module(
 daal_module(
     name = "threading_release_static",
     deps = select({
-        "@config//:par_test_thread_mode": [
+        "@config//:test_thread_mode_par": [
             "@onedal_release//:thread_static",
         ],
-        "@config//:seq_test_thread_mode": [
+        "@config//:test_thread_mode_seq": [
             "@onedal_release//:sequential_static",
         ],
     }),
@@ -321,10 +321,10 @@ daal_module(
 daal_module(
     name = "threading_release_dynamic",
     deps = select({
-        "@config//:par_test_thread_mode": [
+        "@config//:test_thread_mode_par": [
             "@onedal_release//:thread_dynamic",
         ],
-        "@config//:seq_test_thread_mode": [
+        "@config//:test_thread_mode_seq": [
             "@onedal_release//:sequential_dynamic",
         ],
     }),

--- a/dev/bazel/HOWTO.md
+++ b/dev/bazel/HOWTO.md
@@ -27,21 +27,6 @@
    bazel --version # Should be "bazel 4.0.0"
    ```
 
-## Build options
-### Debug vs Release mode
-Bazel comes with three build modes `opt`, `dbg` and `fastbuild`.
-- `opt` compiles everything with optimizations `-O2`. **This is default.**
-- `dbg` enables `-g`, `-O0` compiler switches and **enables assertions**.
-- `fastbuild` optimizes build time, no optimizations, no debug information.
-  Useful when one introduces massive changes and wants to check whether
-  they break the build.
-
-One of three build modes can be used together with Bazel commands
-described bellow.
-```sh
-bazel <bazel-command> -c dbg <target-names>
-```
-
 ### Compiler choice
 Be default our build system configures Bazel to use Intel(R) C++ Compiler
 in case of normal C++ code and Intel(R) oneAPI DPC++ Compiler in case of
@@ -54,7 +39,7 @@ export CC=gcc
 bazel <bazel-command> ... # Will use GCC for normal C++ code
 ```
 
-## Common Bazel command
+## Common Bazel commands
 The most used Bazel commands are `build`, `test` and `run`.
 - `build` builds specified target.
   ```sh
@@ -69,11 +54,7 @@ The most used Bazel commands are `build`, `test` and `run`.
 
   For simplicity, you can use relative target names.
   For example, if you are already in the repository root,
-  you can simply use `cpp/oneapi/dal:array_test`, or
-  ```sh
-  cd cpp/oneapi
-  bazel build dal:array_test
-  ```
+  you can simply use `cpp/oneapi/dal:array_test`.
 
 - `run` builds and runs specified target
   ```sh
@@ -95,49 +76,225 @@ The most used Bazel commands are `build`, `test` and `run`.
   but test targets may contain a set of multiple executables
   called *test suite*.
 
+- `clean` removes built artifacts and cleans the cache.
+  ```sh
+  bazel clean
+  ```
+
+  When you update Bazel version, want to shutdown Bazel server or suspect that
+  something went wrong it is recommended to add `--expunge` option.
+  ```sh
+  bazel clean --expunge
+  ```
+
+## Bazel options
+- `--compilation_mode [-c]` Bazel comes with three compilation modes `opt`,
+  `dbg` and `fastbuild`. \
+  Possible values:
+   - `opt` _(default)_ compiles everything with optimizations `-O2`.
+   - `dbg` enables `-g`, `-O0` compiler switches and **enables assertions**.
+   - `fastbuild` optimizes build time, no optimizations, no debug information.
+     Useful when one introduces massive changes and wants to check whether they
+     break the build.
+
+   Example:
+   ```sh
+   bazel test -c dbg //cpp/oneapi/dal:tests
+   ```
+
+   It's highly encouraged to run newly added tests on the local machine with
+   `-c dbg` option to test assertions.
+
+- `--config` Takes effect only for `run` or `test` commands. Specifies
+  interface that is used to build and run tests. \
+  Possible values:
+  - `<not specified>` _(default)_ Build and run all tests.
+  - `host` Build and run tests for HOST interface without dependencies on DPC++
+    runtime. Uses regular C++ compiler.
+  - `dpc` Build and run tests for DPC++ interface. Uses Intel(R) DPC++ Compiler.
+  - `host-public` Build and run tests only for public part of C++ interfaces.
+  - `dpc-public` Build and run tests only for public part of DPC++ interfaces.
+
+   Example:
+   ```sh
+   bazel test --config=host //cpp/oneapi/dal:tests
+   ```
+
+- `--device` Takes effect only for `run` or `test` commands and option
+  `--config` that implies build of DPC++ interfaces. Specifies device to create
+  a queue and run tests. \
+  Possible values:
+  - `auto` _(default)_ Automatically detects available device. Tries to detect
+    GPU first, if no GPUs available tries to use CPU. If no device runtimes
+    found, uses `host_selector`.
+  - `cpu` Creates queue using `cpu_selector`.
+  - `gpu` Creates queue using `gpu_selector`.
+
+   Example:
+   ```sh
+   bazel test --config=dpc --device=gpu //cpp/oneapi/dal:tests
+   ```
+
+- `--cpu` CPU instruction sets to compile library for. \
+  Possible values:
+  - `auto` _(default)_ Automatically detects highest available instruction set
+    on the local machine. If detection failed, uses `avx2`.
+  - `modern` Compiles for `sse2`, `avx`, `avx2`, `avx512`.
+  - `all` Compiles for all instruction sets listed below.
+  - Any comma-separated combination of the following values:
+    - `sse2`
+    - `ssse3`
+    - `sse42`
+    - `avx`
+    - `avx2`
+    - `avx512`
+    - `avx512_mic`
+
+   Example:
+   ```sh
+   bazel test --cpu="avx,avx512" //cpp/oneapi/dal:tests
+   ```
+
+- `--test_external_datasets` TBD
+- `--test_nightly` TBD
+- `--test_weekly` TBD
+- `--test_link_mode` TBD
+- `--test_thread_mode` TBD
+
 
 ## Build recipes for oneDAL
 ### Run oneAPI examples
 - To run all oneAPI C++ example use the following commands:
-```sh
-bazel test //examples/oneapi/cpp:all
-```
+  ```sh
+  bazel test //examples/oneapi/cpp:all
+  ```
 
 - To run all oneAPI DPC++ examples ... It's not implemented yet...
 
 ### Run oneAPI tests
 - To run all test use the following commands:
   ```sh
-  bazel test //cpp/oneapi/dal:tests      # Runs all C++ tests
-  bazel test //cpp/oneapi/dal:tests_dpc  # Runs all DPC++ tests
-  bazel test //cpp/oneapi/dal:all        # Runs both C++ and DPC++
+  bazel test //cpp/oneapi/dal:tests
   ```
 
-- To run specific set of tests, e.g., for specific algorithm:
+  This will run all tests including HOST and DPC++ interfaces. In case of DPC++
+  tests, queue will be created depending machine configuration. If there is a
+  GPU, `sycl::gpu_selector` is used, otherwise queue is created with
+  `sycl::cpu_selector`.
+
+- To run all HOST tests use the following commands:
   ```sh
-  bazel test //cpp/oneapi/dal/algo/svm:tests     # For C++
-  bazel test //cpp/oneapi/dal/algo/svm:tests_dpc # For DPC++
-  bazel test //cpp/oneapi/dal/algo/svm:all       # For both C++ and DPC++
+  bazel test --config=host //cpp/oneapi/dal:tests
   ```
 
-- To run specific test and see output in stdout:
+- To run all DPC++ tests use the following commands:
   ```sh
-  bazel run //cpp/oneapi/dal/algo/svm:<specific_test_name>
+  bazel test --config=dpc //cpp/oneapi/dal:tests
   ```
 
-  This is useful when one tests is failed on `bazel test` and
-  you want to focus on one particular test to fix the problem. The
-  name of the test can be taken from `bazel test //cpp/oneapi/dal:tests`
-  output as it prints names of all test targets.
+  If you need run DPC++ tests on specific device use the `device` option:
+  ```sh
+  bazel test --config=dpc --device=gpu //cpp/oneapi/dal:tests
+  ```
 
-- You can run test executables produced by Bazel manually. The
-  compiled executables are stored in corresponding `bazel-bin` subdirectory.
-  For example, if the test target name is `//cpp/oneapi/dal/table:common_test`,
-  the executable `common_test` will be stored in `<repo-root>/bazel-bin/cpp/oneapi/dal/table`
-  directory.
+- To run specific **set of tests**, e.g., for specific algorithm:
+  ```sh
+  bazel test //cpp/oneapi/dal/algo/svm:tests
+  ```
+
+  This will run all tests for SVM algorithm including HOST and DPC++ interfaces.
+  To control type of interfaces and target device, use the `--config` and
+  `--device` options described above.
+
+- To run specific **test** and see output in stdout:
+  ```sh
+  # Use HOST interface to build and run the test
+  bazel run //cpp/oneapi/dal/algo/pca:test_batch_host
+
+  # Use DPC++ interface to build and run the test
+  bazel run //cpp/oneapi/dal/algo/pca:test_batch_dpc
+  ```
+
+  This is useful when one tests is failed on `bazel test` and you want to focus
+  on one particular test to fix the problem. The name of the test can be taken
+  from `bazel test //cpp/oneapi/dal:tests` output as it prints names of all test
+  targets.
+
+- You can run test executables produced by Bazel manually. The compiled
+  executables are stored in corresponding `bazel-bin` subdirectory. For example,
+  if the test target name is `//cpp/oneapi/dal/pca:test_batch_host`, the
+  executable `test_batch_host` will be stored in
+  `<repo-root>/bazel-bin/cpp/oneapi/dal/algo/pca` directory.
+
+## Advanced testing
+### Tests that use external datasets
+Some tests may depend on quite large datasets that cannot be stored in the Git
+repository. In that case test should read dataset from `$DAAL_DATASETS`
+directory that could point to datasets storage on local disk. We call such
+datasets _external_.
+
+Such test cases are disabled by default, but can be enabled using
+`--test_external_datasets` switch.
+```sh
+bazel test --test_external_datasets //cpp/oneapi/dal:tests
+```
+
+Test cases with external datasets must be marked by `[external-dataset]` tag,
+which is used to filter out tests at runtime if no `--test_external_datasets`
+provided.
+```c++
+TEST("my test that uses external dataset", "[external-dataset]") {
+    // Code that reads some external dataset
+}
+```
+
+### Nightly tests
+Nightly tests are disabled by default. The `--test_nightly` option enables tests
+marked with `[nightly]` tags.
+```sh
+bazel test --test_nightly //cpp/oneapi/dal:tests
+```
+
+Mark nightly test cases with `[nightly]` tag:
+```c++
+TEST("my test that takes long time", "[nightly]") { /* ... */ }
+```
+
+### Weekly tests
+Weekly tests are disabled by default. The `--test_weekly` option enables tests
+marked with `[weekly]` or `[nightly]` tags. **Weekly tests include nightly.**
+```sh
+bazel test --test_weekly //cpp/oneapi/dal:tests
+```
+
+Mark weekly test cases with `[weekly]` tag:
+```c++
+TEST("my test that takes very long time", "[weekly]") { /* ... */ }
+```
+
+### Tests for public interface
+Sometimes it is necessary to build and run only part of tests responsible for
+public interface testing, for example, to test backward compatibility. There is
+the `host-public` config designed for that use case.
+```sh
+bazel test --config=host-public //cpp/oneapi/dal:tests
+```
+
+Test is categorized to public or private using the `private` flag of the
+`dal_tst_suite` rule. By default, all test suites are public, if the new test
+suite for the private functionality is defined, the flag should be turned on.
+```py
+dal_test_suite(
+    name = "my_tests",
+    private = True,
+    ...
+)
+```
+
+### Run tests for the existing oneDAL build
+TBD
 
 
-### What is missing in this guide
+## What is missing in this guide
 - Choice of threading layer
 - How to get make-like release structure
-- How to use binaries build by make to run Bazel tests

--- a/dev/bazel/config/config.bzl
+++ b/dev/bazel/config/config.bzl
@@ -34,13 +34,27 @@ def _config_flag_impl(ctx):
         allowed = allowed,
     )
 
-config_flag = rule(
+_config_flag = rule(
     implementation = _config_flag_impl,
     build_setting = config.string(flag = True),
     attrs = {
         "allowed_build_setting_values": attr.string_list(),
     },
 )
+
+def config_flag(name, build_setting_default, allowed_build_setting_values):
+    _config_flag(
+        name = name,
+        build_setting_default = build_setting_default,
+        allowed_build_setting_values = allowed_build_setting_values,
+    )
+    for value in allowed_build_setting_values:
+        native.config_setting(
+            name = "{}_{}".format(name, value),
+            flag_values  = {
+                ":" + name: value,
+            },
+        )
 
 def _config_bool_flag_impl(ctx):
     return ConfigFlagInfo(

--- a/dev/bazel/config/config.tpl.BUILD
+++ b/dev/bazel/config/config.tpl.BUILD
@@ -33,27 +33,6 @@ config_flag(
     ],
 )
 
-config_setting(
-    name = "dev_test_link_mode",
-    flag_values  = {
-        ":test_link_mode": "dev",
-    },
-)
-
-config_setting(
-    name = "release_static_test_link_mode",
-    flag_values  = {
-        ":test_link_mode": "release_static",
-    },
-)
-
-config_setting(
-    name = "release_dynamic_test_link_mode",
-    flag_values  = {
-        ":test_link_mode": "release_dynamic",
-    },
-)
-
 config_flag(
     name = "test_thread_mode",
     build_setting_default = "par",
@@ -63,17 +42,25 @@ config_flag(
     ],
 )
 
-config_setting(
-    name = "par_test_thread_mode",
-    flag_values  = {
-        ":test_thread_mode": "par",
-    },
+config_flag(
+    name = "device",
+    build_setting_default = "auto",
+    allowed_build_setting_values = [
+        "auto",
+        "cpu",
+        "gpu",
+    ],
+)
+
+config_bool_flag(
+    name = "test_external_datasets",
+    build_setting_default = False,
 )
 
 config_setting(
-    name = "seq_test_thread_mode",
+    name = "test_external_datasets_enabled",
     flag_values  = {
-        ":test_thread_mode": "seq",
+        ":test_external_datasets": "True",
     },
 )
 


### PR DESCRIPTION
- Split `dpc-cpu` and `dpc-gpu` configs into two options:
  - `--config` can be either `host` or `dpc`.
  - Add one more parameter `--device`, can be `cpu` or `gpu`. 
- Add `--test_external_datasets` option to enable tests tagged with `[external-dataset]`
- Update bazel HOWTO
- Refactor and simplify `.bazelrc` and options definitions