### PR TITLE
Fix wrong dependency in Bazel test module

### DIFF
--- a/cpp/oneapi/dal/test/engine/BUILD
+++ b/cpp/oneapi/dal/test/engine/BUILD
@@ -13,10 +13,10 @@ dal_test_module(
     dal_deps = [
         "@onedal//cpp/oneapi/dal:common",
         "@onedal//cpp/oneapi/dal:table",
+        "@onedal//cpp/oneapi/dal/io:csv",
     ],
     dal_test_deps = [
         "@onedal//cpp/oneapi/dal/test/engine/linalg",
-        "@onedal//cpp/oneapi/dal/io:csv",
     ],
     extra_deps = [
         "@catch2//:catch2",


### PR DESCRIPTION
- This issue sometimes causes multiple definition of symbols when tests are built with `--test_link_mode=release_static`.