### PR TITLE
Fix of check in Implicit ALS Init

### DIFF
--- a/cpp/daal/src/algorithms/implicit_als/implicit_als_train_init_partial_result.cpp
+++ b/cpp/daal/src/algorithms/implicit_als/implicit_als_train_init_partial_result.cpp
@@ -146,7 +146,8 @@ Status PartialResult::check(const daal::algorithms::Input * input, const daal::a
 
     const DistributedInput<step1Local> * algInput = static_cast<const DistributedInput<step1Local> *>(input);
     size_t nRows                                  = algInput->get(data)->getNumberOfRows();
-    DAAL_CHECK_EX(algParameter->fullNUsers >= nRows, ErrorIncorrectParameter, ParameterName, fullNUsersStr());
+    size_t nCols                                  = algInput->get(data)->getNumberOfColumns();
+    DAAL_CHECK_EX(algParameter->fullNUsers >= nCols, ErrorIncorrectParameter, ParameterName, fullNUsersStr());
 
     PartialModelPtr model = get(partialModel);
     DAAL_CHECK(model, ErrorNullPartialModel);


### PR DESCRIPTION
# Description

Fix of check in Implicit ALS Init reported in https://github.com/oneapi-src/oneDAL/issues/1304. According to ALS documentation ([general](https://software.intel.com/content/www/us/en/develop/documentation/onedal-developer-guide-and-reference/top/daal-interfaces/training-and-prediction/implicit-alternating-least-squares.html) and for [Init Step 1](https://software.intel.com/content/www/us/en/develop/documentation/onedal-developer-guide-and-reference/top/daal-interfaces/training-and-prediction/implicit-alternating-least-squares/distributed-processing-2.html#distributed-processing_step-1-on-local-nodes)), column index in input data table is user ID and number of columns in this table should be compared with fullNUsers parameter while number of rows is compared to it and leads to unexpected exception for some cases.