### PR TITLE
Internal API to get original data from homogen_table

### DIFF
--- a/cpp/oneapi/dal/table/BUILD
+++ b/cpp/oneapi/dal/table/BUILD
@@ -21,6 +21,7 @@ dal_test_suite(
         # TODO: Move conversion tests to backend folder
         "test/convert.cpp",
         "test/table_builder.cpp",
+        "detail/test/homogen_utils.cpp",
     ],
     dal_deps = [":table"],
     framework = "catch2",

--- a/cpp/oneapi/dal/table/backend/homogen_table_impl.hpp
+++ b/cpp/oneapi/dal/table/backend/homogen_table_impl.hpp
@@ -148,6 +148,10 @@ public:
         return data_.get_data();
     }
 
+    array<byte_t> get_data_array() const {
+        return data_;
+    }
+
     data_layout get_data_layout() const {
         return layout_;
     }

--- a/cpp/oneapi/dal/table/detail/homogen_utils.cpp
+++ b/cpp/oneapi/dal/table/detail/homogen_utils.cpp
@@ -1,0 +1,37 @@
+/*******************************************************************************
+* Copyright 2021 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "oneapi/dal/table/detail/homogen_utils.hpp"
+#include "oneapi/dal/table/backend/homogen_table_impl.hpp"
+
+namespace oneapi::dal::detail::v1 {
+
+array<byte_t> get_original_data(const homogen_table& t) {
+    using impl_t = backend::homogen_table_impl;
+    using wrapper_t = homogen_table_impl_wrapper<impl_t>;
+
+    const auto& pimpl = pimpl_accessor{}.get_pimpl(t);
+    auto* impl_raw_ptr = dynamic_cast<wrapper_t*>(pimpl.get());
+    if (impl_raw_ptr != nullptr) {
+        auto& homogen_impl = impl_raw_ptr->get();
+        return homogen_impl.get_data_array();
+    }
+    else {
+        return array<byte_t>{};
+    }
+}
+
+} // namespace oneapi::dal::detail::v1

--- a/cpp/oneapi/dal/table/detail/homogen_utils.cpp
+++ b/cpp/oneapi/dal/table/detail/homogen_utils.cpp
@@ -23,8 +23,7 @@ array<byte_t> get_original_data(const homogen_table& t) {
     using impl_t = backend::homogen_table_impl;
     using wrapper_t = homogen_table_impl_wrapper<impl_t>;
 
-    const auto& pimpl = pimpl_accessor{}.get_pimpl(t);
-    auto* impl_raw_ptr = dynamic_cast<wrapper_t*>(pimpl.get());
+    auto* impl_raw_ptr = dynamic_cast<wrapper_t*>(&get_impl(t));
     if (impl_raw_ptr != nullptr) {
         auto& homogen_impl = impl_raw_ptr->get();
         return homogen_impl.get_data_array();

--- a/cpp/oneapi/dal/table/detail/homogen_utils.hpp
+++ b/cpp/oneapi/dal/table/detail/homogen_utils.hpp
@@ -29,7 +29,7 @@ namespace v1 {
 /// @return      Original array of bytes held in the table.
 ///              If the table was created from mutable data object,
 ///              this array contains mutable data.
-array<byte_t> get_original_data(const homogen_table& t);
+ONEDAL_EXPORT array<byte_t> get_original_data(const homogen_table& t);
 
 } // namespace v1
 

--- a/cpp/oneapi/dal/table/detail/homogen_utils.hpp
+++ b/cpp/oneapi/dal/table/detail/homogen_utils.hpp
@@ -1,0 +1,38 @@
+/*******************************************************************************
+* Copyright 2021 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#pragma once
+
+#include "oneapi/dal/table/homogen.hpp"
+
+namespace oneapi::dal::detail {
+namespace v1 {
+
+/// Retrieves original data from homogen table including information about
+/// mutability. If the table was created from custom implementation, returns
+/// empty array.
+///
+/// @param[in] t Table to extract the data from
+/// @return      Original array of bytes held in the table.
+///              If the table was created from mutable data object,
+///              this array contains mutable data.
+array<byte_t> get_original_data(const homogen_table& t);
+
+} // namespace v1
+
+using v1::get_original_data;
+
+} // namespace oneapi::dal::detail

--- a/cpp/oneapi/dal/table/detail/test/homogen_utils.cpp
+++ b/cpp/oneapi/dal/table/detail/test/homogen_utils.cpp
@@ -1,0 +1,89 @@
+/*******************************************************************************
+* Copyright 2020-2021 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "oneapi/dal/table/detail/homogen_utils.hpp"
+#include "oneapi/dal/table/detail/table_builder.hpp"
+#include "oneapi/dal/backend/memory.hpp"
+#include "oneapi/dal/test/engine/common.hpp"
+
+namespace oneapi::dal::detail {
+
+TEST("can get original data from homogen table constructed from const raw pointer") {
+    float data[] = { 1.0, 2.0, 3.0, -1.0, -2.0, -3.0 };
+
+    homogen_table t{ data, 2, 3, empty_delete<const float>() };
+
+    auto bytes_array = get_original_data(t);
+    REQUIRE(bytes_array.get_data() == (byte_t*)data);
+    REQUIRE(bytes_array.get_size() == sizeof(float)*2*3);
+    REQUIRE(bytes_array.has_mutable_data() == false);
+}
+
+TEST("can get original data from homogen table constructed from builder") {
+    auto t = homogen_table_builder{}
+        .set_data_type(data_type::float32)
+        .set_layout(data_layout::row_major)
+        .allocate(3, 2)
+        .build();
+
+    auto bytes_array = get_original_data(t);
+    REQUIRE(bytes_array.get_data() == t.get_data());
+    REQUIRE(bytes_array.get_size() == sizeof(float)*2*3);
+    REQUIRE(bytes_array.has_mutable_data() == true);
+}
+
+#ifdef ONEDAL_DATA_PARALLEL
+TEST("can get original data from homogen table constructed from array with device data") {
+    DECLARE_TEST_POLICY(policy);
+    auto& q = policy.get_queue();
+
+    constexpr std::int64_t row_count = 3;
+    constexpr std::int64_t col_count = 2;
+    auto data = array<float>::zeros(q, row_count * col_count, sycl::usm::alloc::device);
+
+    auto t = homogen_table::wrap(q, data.get_data(), row_count, col_count);
+
+    auto bytes_array = get_original_data(t);
+    REQUIRE(bytes_array.get_data() == (byte_t*)data.get_data());
+    REQUIRE(backend::is_device_usm(q, bytes_array.get_data()) == true);
+    REQUIRE(bytes_array.get_size() == sizeof(float) * row_count * col_count);
+    REQUIRE(bytes_array.has_mutable_data() == false);
+}
+
+TEST("can get original data from homogen table constructed from builder with device data") {
+    DECLARE_TEST_POLICY(policy);
+    auto& q = policy.get_queue();
+
+    constexpr std::int64_t row_count = 3;
+    constexpr std::int64_t col_count = 2;
+    auto data = array<float>::zeros(q, row_count * col_count, sycl::usm::alloc::device);
+
+    auto t = homogen_table_builder{}
+        .set_layout(data_layout::row_major)
+        .reset(data, row_count, col_count)
+        .build();
+
+    auto bytes_array = get_original_data(t);
+    REQUIRE(bytes_array.get_data() == t.get_data());
+    REQUIRE(bytes_array.get_data() == (byte_t*)data.get_data());
+    REQUIRE(backend::is_device_usm(q, bytes_array.get_data()) == true);
+    REQUIRE(bytes_array.get_size() == sizeof(float) * row_count * col_count);
+    REQUIRE(bytes_array.has_mutable_data() == true);
+}
+#endif
+
+} // namespace oneapi::dal::detail
+

--- a/cpp/oneapi/dal/table/detail/test/homogen_utils.cpp
+++ b/cpp/oneapi/dal/table/detail/test/homogen_utils.cpp
@@ -28,20 +28,20 @@ TEST("can get original data from homogen table constructed from const raw pointe
 
     auto bytes_array = get_original_data(t);
     REQUIRE(bytes_array.get_data() == (byte_t*)data);
-    REQUIRE(bytes_array.get_size() == sizeof(float)*2*3);
+    REQUIRE(bytes_array.get_size() == sizeof(float) * 2 * 3);
     REQUIRE(bytes_array.has_mutable_data() == false);
 }
 
 TEST("can get original data from homogen table constructed from builder") {
     auto t = homogen_table_builder{}
-        .set_data_type(data_type::float32)
-        .set_layout(data_layout::row_major)
-        .allocate(3, 2)
-        .build();
+                 .set_data_type(data_type::float32)
+                 .set_layout(data_layout::row_major)
+                 .allocate(3, 2)
+                 .build();
 
     auto bytes_array = get_original_data(t);
     REQUIRE(bytes_array.get_data() == t.get_data());
-    REQUIRE(bytes_array.get_size() == sizeof(float)*2*3);
+    REQUIRE(bytes_array.get_size() == sizeof(float) * 2 * 3);
     REQUIRE(bytes_array.has_mutable_data() == true);
 }
 
@@ -72,9 +72,9 @@ TEST("can get original data from homogen table constructed from builder with dev
     auto data = array<float>::zeros(q, row_count * col_count, sycl::usm::alloc::device);
 
     auto t = homogen_table_builder{}
-        .set_layout(data_layout::row_major)
-        .reset(data, row_count, col_count)
-        .build();
+                 .set_layout(data_layout::row_major)
+                 .reset(data, row_count, col_count)
+                 .build();
 
     auto bytes_array = get_original_data(t);
     REQUIRE(bytes_array.get_data() == t.get_data());
@@ -86,4 +86,3 @@ TEST("can get original data from homogen table constructed from builder with dev
 #endif
 
 } // namespace oneapi::dal::detail
-

--- a/cpp/oneapi/dal/table/detail/test/homogen_utils.cpp
+++ b/cpp/oneapi/dal/table/detail/test/homogen_utils.cpp
@@ -57,7 +57,7 @@ TEST("can get original data from homogen table constructed from array with devic
     auto t = homogen_table::wrap(q, data.get_data(), row_count, col_count);
 
     auto bytes_array = get_original_data(t);
-    REQUIRE(bytes_array.get_data() == (byte_t*)data.get_data());
+    REQUIRE(bytes_array.get_data() == (const byte_t*)data.get_data());
     REQUIRE(backend::is_device_usm(q, bytes_array.get_data()) == true);
     REQUIRE(bytes_array.get_size() == sizeof(float) * row_count * col_count);
     REQUIRE(bytes_array.has_mutable_data() == false);
@@ -78,7 +78,7 @@ TEST("can get original data from homogen table constructed from builder with dev
 
     auto bytes_array = get_original_data(t);
     REQUIRE(bytes_array.get_data() == t.get_data());
-    REQUIRE(bytes_array.get_data() == (byte_t*)data.get_data());
+    REQUIRE(bytes_array.get_data() == (const byte_t*)data.get_data());
     REQUIRE(backend::is_device_usm(q, bytes_array.get_data()) == true);
     REQUIRE(bytes_array.get_size() == sizeof(float) * row_count * col_count);
     REQUIRE(bytes_array.has_mutable_data() == true);


### PR DESCRIPTION
Created function ``detail::get_original_data()`` that allows getting an array with data located directly in the homogen table without any copies. This is required for Python API to get a mutable pointer from a resulting table without unnecessary data copies.