### PR TITLE
Add --test_disable_fp64 option

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -9,6 +9,7 @@ build --flag_alias=test_thread_mode=@config//:test_thread_mode
 build --flag_alias=test_external_datasets=@config//:test_external_datasets
 build --flag_alias=test_nightly=@config//:test_nightly
 build --flag_alias=test_weekly=@config//:test_weekly
+build --flag_alias=test_disable_fp64=@config//:test_disable_fp64
 build --flag_alias=release_dpc=@config//:release_dpc
 build --flag_alias=device=@config//:device
 build --flag_alias=cpu=@config//:cpu

--- a/cpp/oneapi/dal/test/engine/common_dpc.cpp
+++ b/cpp/oneapi/dal/test/engine/common_dpc.cpp
@@ -37,22 +37,26 @@ static bool check_if_env_knob_is_enabled(const char* env_var) {
     }
 }
 
-static bool check_if_env_overrides_fp64_settings() {
+[[maybe_unused]] static bool check_if_env_overrides_fp64_settings() {
     return check_if_env_knob_is_enabled("OverrideDefaultFP64Settings");
 }
 
-static bool check_if_env_forces_dp_emulation() {
+[[maybe_unused]] static bool check_if_env_forces_dp_emulation() {
     return check_if_env_knob_is_enabled("IGC_EnableDPEmulation") ||
            check_if_env_knob_is_enabled("IGC_ForceDPEmulation");
 }
 
 bool device_test_policy::has_native_float64() const {
+#ifdef ONEDAL_DISABLE_FP64_TESTS
+    return false;
+#else
     const auto device = queue_.get_device();
     const auto fp_config = device.get_info<sycl::info::device::double_fp_config>();
     const bool float64_support = !fp_config.empty();
     const bool emulated = check_if_env_overrides_fp64_settings() && //
                           check_if_env_forces_dp_emulation();
     return float64_support && !emulated;
+#endif
 }
 
 INSTANTIATE_TYPE_MAP(float)

--- a/dev/bazel/HOWTO.md
+++ b/dev/bazel/HOWTO.md
@@ -211,6 +211,13 @@ The most used Bazel commands are `build`, `test` and `run`.
    bazel test --test_thread_mode=seq //cpp/oneapi/dal:tests
    ```
 
+- `--test_disable_fp64` Flag that disables tests for double precision (`fp64`).
+
+  Example:
+  ```sh
+  bazel test --test_disable_fp64 //cpp/oneapi/dal/algo/pca:tests
+  ```
+
 ## Build recipes for oneDAL
 ### Run oneAPI examples
 - To run all oneAPI C++ example use the following commands:

--- a/dev/bazel/HOWTO.md
+++ b/dev/bazel/HOWTO.md
@@ -211,7 +211,7 @@ The most used Bazel commands are `build`, `test` and `run`.
    bazel test --test_thread_mode=seq //cpp/oneapi/dal:tests
    ```
 
-- `--test_disable_fp64` Flag that disables tests for double precision (`fp64`).
+- `--test_disable_fp64` A switch that disables tests for double precision (`fp64`).
 
   Example:
   ```sh

--- a/dev/bazel/config/config.tpl.BUILD
+++ b/dev/bazel/config/config.tpl.BUILD
@@ -89,6 +89,18 @@ config_setting(
 )
 
 config_bool_flag(
+    name = "test_disable_fp64",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "test_fp64_enabled",
+    flag_values  = {
+        ":test_disable_fp64": "False",
+    },
+)
+
+config_bool_flag(
     name = "release_dpc",
     build_setting_default = False,
 )

--- a/dev/bazel/config/config.tpl.BUILD
+++ b/dev/bazel/config/config.tpl.BUILD
@@ -94,9 +94,9 @@ config_bool_flag(
 )
 
 config_setting(
-    name = "test_fp64_enabled",
+    name = "test_fp64_disabled",
     flag_values  = {
-        ":test_disable_fp64": "False",
+        ":test_disable_fp64": "True",
     },
 )
 

--- a/dev/bazel/dal.bzl
+++ b/dev/bazel/dal.bzl
@@ -474,7 +474,12 @@ def _dal_module(name, lib_tag="dal", is_dpc=False, features=[],
         local_defines = local_defines + ([
             "DAAL_SYCL_INTERFACE",
             "ONEDAL_DATA_PARALLEL"
-        ] if is_dpc else []),
+        ] if is_dpc else []) + select({
+            "@config//:test_fp64_enabled": [],
+            "//conditions:default": [
+                "ONEDAL_DISABLE_FP64_TESTS=1",
+            ],
+        }),
         deps = _expand_select(deps),
         **kwargs,
     )

--- a/dev/bazel/dal.bzl
+++ b/dev/bazel/dal.bzl
@@ -475,10 +475,10 @@ def _dal_module(name, lib_tag="dal", is_dpc=False, features=[],
             "DAAL_SYCL_INTERFACE",
             "ONEDAL_DATA_PARALLEL"
         ] if is_dpc else []) + select({
-            "@config//:test_fp64_enabled": [],
-            "//conditions:default": [
+            "@config//:test_fp64_disabled": [
                 "ONEDAL_DISABLE_FP64_TESTS=1",
             ],
+            "//conditions:default": [],
         }),
         deps = _expand_select(deps),
         **kwargs,


### PR DESCRIPTION
- Add flag to disable double precision tests in Bazel