### PR TITLE
Fix Chebyshev distance naming

### DIFF
--- a/cpp/daal/src/algorithms/k_nearest_neighbors/bf_knn_classification_predict_kernel.h
+++ b/cpp/daal/src/algorithms/k_nearest_neighbors/bf_knn_classification_predict_kernel.h
@@ -38,7 +38,7 @@ using namespace daal::data_management;
 enum class PairwiseDistanceType
 {
     minkowski,
-    chebychev
+    chebyshev
 };
 
 struct KernelParameter : bf_knn_classification::Parameter

--- a/cpp/daal/src/algorithms/k_nearest_neighbors/bf_knn_impl.i
+++ b/cpp/daal/src/algorithms/k_nearest_neighbors/bf_knn_impl.i
@@ -91,8 +91,8 @@ public:
                 dist.reset(new daal::algorithms::internal::MinkowskiDistances<FPType, cpu>(*testTable, *trainTable, true, minkowskiDegree));
             }
             break;
-        case bf_knn_classification::prediction::internal::PairwiseDistanceType::chebychev:
-            dist.reset(new daal::algorithms::internal::ChebychevDistances<FPType, cpu>(*testTable, *trainTable));
+        case bf_knn_classification::prediction::internal::PairwiseDistanceType::chebyshev:
+            dist.reset(new daal::algorithms::internal::ChebyshevDistances<FPType, cpu>(*testTable, *trainTable));
             break;
         default: dist.reset(new daal::algorithms::internal::EuclideanDistances<FPType, cpu>(*testTable, *trainTable, true)); break;
         }

--- a/cpp/daal/src/algorithms/service_kernel_math.h
+++ b/cpp/daal/src/algorithms/service_kernel_math.h
@@ -357,12 +357,12 @@ private:
 };
 
 template <typename FPType, CpuType cpu>
-class ChebychevDistances : public PairwiseDistances<FPType, cpu>
+class ChebyshevDistances : public PairwiseDistances<FPType, cpu>
 {
 public:
-    ChebychevDistances(const NumericTable & a, const NumericTable & b) : _a(a), _b(b) {}
+    ChebyshevDistances(const NumericTable & a, const NumericTable & b) : _a(a), _b(b) {}
 
-    virtual ~ChebychevDistances() {}
+    virtual ~ChebyshevDistances() {}
 
     virtual services::Status init()
     {
@@ -528,7 +528,7 @@ double MinkowskiDistances<double, avx512>::computeDistance(const double * x, con
 }
 
 template <>
-float ChebychevDistances<float, avx512>::computeDistance(const float * x, const float * y, const size_t n)
+float ChebyshevDistances<float, avx512>::computeDistance(const float * x, const float * y, const size_t n)
 {
     daal::internal::mkl::MklMath<float, avx512> math;
 
@@ -565,7 +565,7 @@ float ChebychevDistances<float, avx512>::computeDistance(const float * x, const 
 }
 
 template <>
-double ChebychevDistances<double, avx512>::computeDistance(const double * x, const double * y, const size_t n)
+double ChebyshevDistances<double, avx512>::computeDistance(const double * x, const double * y, const size_t n)
 {
     daal::internal::mkl::MklMath<double, avx512> math;
 

--- a/cpp/oneapi/dal/algo/BUILD
+++ b/cpp/oneapi/dal/algo/BUILD
@@ -5,7 +5,7 @@ load("@onedal//dev/bazel:dal.bzl",
 )
 
 ALGOS = [
-    "chebychev_distance",
+    "chebyshev_distance",
     "decision_forest",
     "decision_tree",
     "jaccard",

--- a/cpp/oneapi/dal/algo/chebyshev_distance/BUILD
+++ b/cpp/oneapi/dal/algo/chebyshev_distance/BUILD
@@ -5,7 +5,7 @@ load("@onedal//dev/bazel:dal.bzl",
 )
 
 dal_module(
-    name = "chebychev_distance",
+    name = "chebyshev_distance",
     auto = True,
     dal_deps = [
         "@onedal//cpp/oneapi/dal:core",

--- a/cpp/oneapi/dal/algo/chebyshev_distance/common.cpp
+++ b/cpp/oneapi/dal/algo/chebyshev_distance/common.cpp
@@ -14,9 +14,9 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include "oneapi/dal/algo/chebychev_distance/common.hpp"
+#include "oneapi/dal/algo/chebyshev_distance/common.hpp"
 
-namespace oneapi::dal::chebychev_distance::detail {
+namespace oneapi::dal::chebyshev_distance::detail {
 namespace v1 {
 
 template <typename Task>
@@ -28,4 +28,4 @@ descriptor_base<Task>::descriptor_base() : impl_(new descriptor_impl<Task>{}) {}
 template class ONEDAL_EXPORT descriptor_base<task::compute>;
 
 } // namespace v1
-} // namespace oneapi::dal::chebychev_distance::detail
+} // namespace oneapi::dal::chebyshev_distance::detail

--- a/cpp/oneapi/dal/algo/chebyshev_distance/common.hpp
+++ b/cpp/oneapi/dal/algo/chebyshev_distance/common.hpp
@@ -19,7 +19,7 @@
 #include "oneapi/dal/detail/common.hpp"
 #include "oneapi/dal/table/common.hpp"
 
-namespace oneapi::dal::chebychev_distance {
+namespace oneapi::dal::chebyshev_distance {
 
 namespace task {
 namespace v1 {
@@ -124,4 +124,4 @@ public:
 
 using v1::descriptor;
 
-} // namespace oneapi::dal::chebychev_distance
+} // namespace oneapi::dal::chebyshev_distance

--- a/cpp/oneapi/dal/algo/knn/BUILD
+++ b/cpp/oneapi/dal/algo/knn/BUILD
@@ -10,7 +10,7 @@ dal_module(
     dal_deps = [
         "@onedal//cpp/oneapi/dal:core",
         "@onedal//cpp/oneapi/dal/algo:minkowski_distance",
-        "@onedal//cpp/oneapi/dal/algo:chebychev_distance",
+        "@onedal//cpp/oneapi/dal/algo:chebyshev_distance",
     ],
     extra_deps = [
         "@onedal//cpp/daal/src/algorithms/k_nearest_neighbors:kernel",

--- a/cpp/oneapi/dal/algo/knn/backend/gpu/infer_kernel_brute_force_classification_dpc.cpp
+++ b/cpp/oneapi/dal/algo/knn/backend/gpu/infer_kernel_brute_force_classification_dpc.cpp
@@ -18,6 +18,7 @@
 
 #include "oneapi/dal/algo/knn/backend/gpu/infer_kernel.hpp"
 #include "oneapi/dal/algo/knn/backend/model_impl.hpp"
+#include "oneapi/dal/algo/knn/backend/distance_impl.hpp"
 #include "oneapi/dal/backend/interop/common_dpc.hpp"
 #include "oneapi/dal/backend/interop/error_converter.hpp"
 #include "oneapi/dal/backend/interop/table_conversion.hpp"
@@ -55,6 +56,15 @@ static infer_result<task::classification> call_daal_kernel(const context_gpu& ct
         dal::detail::integral_cast<std::size_t>(desc.get_class_count()),
         dal::detail::integral_cast<std::size_t>(desc.get_neighbor_count()),
         data_use_in_model);
+
+    auto distance_impl = detail::get_distance_impl(desc);
+    if (!distance_impl) {
+        throw internal_error{ dal::detail::error_messages::unknown_distance_type() };
+    }
+    else if (distance_impl->get_daal_distance_type() != detail::v1::daal_distance_t::minkowski &&
+             distance_impl->get_degree() != 2.0) {
+        throw internal_error{ dal::detail::error_messages::distance_is_not_supported_for_gpu() };
+    }
 
     interop::status_to_exception(daal_knn_brute_force_kernel_t<Float>().compute(
         daal_data.get(),

--- a/cpp/oneapi/dal/algo/knn/backend/gpu/infer_kernel_brute_force_classification_dpc.cpp
+++ b/cpp/oneapi/dal/algo/knn/backend/gpu/infer_kernel_brute_force_classification_dpc.cpp
@@ -61,7 +61,7 @@ static infer_result<task::classification> call_daal_kernel(const context_gpu& ct
     if (!distance_impl) {
         throw internal_error{ dal::detail::error_messages::unknown_distance_type() };
     }
-    else if (distance_impl->get_daal_distance_type() != detail::v1::daal_distance_t::minkowski &&
+    else if (distance_impl->get_daal_distance_type() != detail::v1::daal_distance_t::minkowski ||
              distance_impl->get_degree() != 2.0) {
         throw internal_error{ dal::detail::error_messages::distance_is_not_supported_for_gpu() };
     }

--- a/cpp/oneapi/dal/algo/knn/backend/gpu/train_kernel_brute_force_classification_dpc.cpp
+++ b/cpp/oneapi/dal/algo/knn/backend/gpu/train_kernel_brute_force_classification_dpc.cpp
@@ -61,7 +61,7 @@ static train_result<task::classification> call_daal_kernel(const context_gpu& ct
     if (!distance_impl) {
         throw internal_error{ dal::detail::error_messages::unknown_distance_type() };
     }
-    else if (distance_impl->get_daal_distance_type() != detail::v1::daal_distance_t::minkowski &&
+    else if (distance_impl->get_daal_distance_type() != detail::v1::daal_distance_t::minkowski ||
              distance_impl->get_degree() != 2.0) {
         throw internal_error{ dal::detail::error_messages::distance_is_not_supported_for_gpu() };
     }

--- a/cpp/oneapi/dal/algo/knn/backend/gpu/train_kernel_brute_force_classification_dpc.cpp
+++ b/cpp/oneapi/dal/algo/knn/backend/gpu/train_kernel_brute_force_classification_dpc.cpp
@@ -19,6 +19,7 @@
 
 #include "oneapi/dal/algo/knn/backend/gpu/train_kernel.hpp"
 #include "oneapi/dal/algo/knn/backend/model_impl.hpp"
+#include "oneapi/dal/algo/knn/backend/distance_impl.hpp"
 #include "oneapi/dal/backend/interop/common_dpc.hpp"
 #include "oneapi/dal/backend/interop/error_converter.hpp"
 #include "oneapi/dal/backend/interop/table_conversion.hpp"
@@ -55,6 +56,15 @@ static train_result<task::classification> call_daal_kernel(const context_gpu& ct
         dal::detail::integral_cast<std::size_t>(desc.get_class_count()),
         dal::detail::integral_cast<std::size_t>(desc.get_neighbor_count()),
         data_use_in_model);
+
+    auto distance_impl = detail::get_distance_impl(desc);
+    if (!distance_impl) {
+        throw internal_error{ dal::detail::error_messages::unknown_distance_type() };
+    }
+    else if (distance_impl->get_daal_distance_type() != detail::v1::daal_distance_t::minkowski &&
+             distance_impl->get_degree() != 2.0) {
+        throw internal_error{ dal::detail::error_messages::distance_is_not_supported_for_gpu() };
+    }
 
     daal::algorithms::classifier::ModelPtr model_ptr(new daal_knn::Model(column_count));
     if (!model_ptr) {

--- a/cpp/oneapi/dal/algo/knn/common.hpp
+++ b/cpp/oneapi/dal/algo/knn/common.hpp
@@ -92,7 +92,7 @@ template <typename Distance>
 constexpr bool is_valid_distance_v =
     dal::detail::is_tag_one_of_v<Distance,
                                  minkowski_distance::detail::descriptor_tag,
-                                 chebychev_distance::detail::descriptor_tag>;
+                                 chebyshev_distance::detail::descriptor_tag>;
 
 template <typename T>
 using enable_if_brute_force_t =
@@ -153,7 +153,7 @@ namespace v1 {
 ///                     be :expr:`task::classification`.
 /// @tparam Distance    The descriptor of the distance used for computations. Can be
 ///                     :expr:`minkowski_distance::descriptor` or
-///                     :expr:`chebychev_distance::descriptor`
+///                     :expr:`chebyshev_distance::descriptor`
 template <typename Float = float,
           typename Method = method::by_default,
           typename Task = task::by_default,

--- a/cpp/oneapi/dal/algo/knn/detail/distance.cpp
+++ b/cpp/oneapi/dal/algo/knn/detail/distance.cpp
@@ -24,14 +24,14 @@ template <typename F, typename M>
 using minkowski_distance_t = minkowski_distance::descriptor<F, M>;
 
 template <typename F, typename M>
-using chebychev_distance_t = chebychev_distance::descriptor<F, M>;
+using chebyshev_distance_t = chebyshev_distance::descriptor<F, M>;
 
-class daal_interop_chebychev_distance_impl : public distance_impl {
+class daal_interop_chebyshev_distance_impl : public distance_impl {
 public:
-    daal_interop_chebychev_distance_impl() = default;
+    daal_interop_chebyshev_distance_impl() = default;
 
     daal_distance_t get_daal_distance_type() override {
-        return daal_distance_t::chebychev;
+        return daal_distance_t::chebyshev;
     }
 
     double get_degree() override {
@@ -66,26 +66,26 @@ distance_impl *distance<minkowski_distance_t<F, M>>::get_impl() const {
 }
 
 template <typename F, typename M>
-distance<chebychev_distance_t<F, M>>::distance(const chebychev_distance_t<F, M> &dist)
+distance<chebyshev_distance_t<F, M>>::distance(const chebyshev_distance_t<F, M> &dist)
         : distance_(dist),
-          impl_(new daal_interop_chebychev_distance_impl{}) {}
+          impl_(new daal_interop_chebyshev_distance_impl{}) {}
 
 template <typename F, typename M>
-distance_impl *distance<chebychev_distance_t<F, M>>::get_impl() const {
+distance_impl *distance<chebyshev_distance_t<F, M>>::get_impl() const {
     return impl_.get();
 }
 
 #define INSTANTIATE_MINKOWSKI(F, M) \
     template class ONEDAL_EXPORT distance<minkowski_distance_t<F, M>>;
 
-#define INSTANTIATE_CHEBYCHEV(F, M) \
-    template class ONEDAL_EXPORT distance<chebychev_distance_t<F, M>>;
+#define INSTANTIATE_CHEBYSHEV(F, M) \
+    template class ONEDAL_EXPORT distance<chebyshev_distance_t<F, M>>;
 
 INSTANTIATE_MINKOWSKI(float, minkowski_distance::method::dense)
 INSTANTIATE_MINKOWSKI(double, minkowski_distance::method::dense)
 
-INSTANTIATE_CHEBYCHEV(float, chebychev_distance::method::dense)
-INSTANTIATE_CHEBYCHEV(double, chebychev_distance::method::dense)
+INSTANTIATE_CHEBYSHEV(float, chebyshev_distance::method::dense)
+INSTANTIATE_CHEBYSHEV(double, chebyshev_distance::method::dense)
 
 } // namespace v1
 } // namespace oneapi::dal::knn::detail

--- a/cpp/oneapi/dal/algo/knn/detail/distance.hpp
+++ b/cpp/oneapi/dal/algo/knn/detail/distance.hpp
@@ -17,7 +17,7 @@
 #pragma once
 
 #include "oneapi/dal/algo/minkowski_distance/common.hpp"
-#include "oneapi/dal/algo/chebychev_distance/common.hpp"
+#include "oneapi/dal/algo/chebyshev_distance/common.hpp"
 
 namespace oneapi::dal::knn::detail {
 namespace v1 {
@@ -63,9 +63,9 @@ private:
 };
 
 template <typename Float, typename Method>
-class distance<chebychev_distance::descriptor<Float, Method>> : public base, public distance_iface {
+class distance<chebyshev_distance::descriptor<Float, Method>> : public base, public distance_iface {
 public:
-    using distance_t = chebychev_distance::descriptor<Float, Method>;
+    using distance_t = chebyshev_distance::descriptor<Float, Method>;
     explicit distance(const distance_t& dist);
     distance_impl* get_impl() const override;
 

--- a/cpp/oneapi/dal/algo/knn/test/batch.cpp
+++ b/cpp/oneapi/dal/algo/knn/test/batch.cpp
@@ -417,7 +417,7 @@ KNN_BF_EXTERNAL_TEST("knn classification hepmass 50kx10k with Minkowski distance
     REQUIRE(score >= target_score);
 }
 
-KNN_BF_EXTERNAL_TEST("knn classification hepmass 50kx10k with Chebychev distance") {
+KNN_BF_EXTERNAL_TEST("knn classification hepmass 50kx10k with Chebyshev distance") {
     SKIP_IF(this->not_available_on_device());
     SKIP_IF(this->not_float64_friendly());
 
@@ -443,7 +443,7 @@ KNN_BF_EXTERNAL_TEST("knn classification hepmass 50kx10k with Chebychev distance
     const table y_infer_table = infer_dataframe.get_table(this->get_homogen_table_id(),
                                                           range(feature_count, feature_count + 1));
 
-    using distance_t = oneapi::dal::chebychev_distance::descriptor<>;
+    using distance_t = oneapi::dal::chebyshev_distance::descriptor<>;
     const auto score = this->classification(x_train_table,
                                             y_train_table,
                                             x_infer_table,

--- a/cpp/oneapi/dal/detail/error_messages.cpp
+++ b/cpp/oneapi/dal/detail/error_messages.cpp
@@ -157,6 +157,7 @@ MSG(knn_kd_tree_method_is_not_implemented_for_gpu,
 MSG(neighbor_count_lt_one, "Neighbor count lower than one")
 MSG(unknown_distance_type,
     "Custom distances for k-NN is not supported, use one of the predefined distances instead.")
+MSG(distance_is_not_supported_for_gpu, "Only Euclidean distances for k-NN is supported for GPU")
 
 /* Minkowski distance */
 MSG(invalid_minkowski_degree, "Minkowski degree should be greater than zero")

--- a/cpp/oneapi/dal/detail/error_messages.hpp
+++ b/cpp/oneapi/dal/detail/error_messages.hpp
@@ -189,6 +189,7 @@ public:
     MSG(knn_kd_tree_method_is_not_implemented_for_gpu);
     MSG(neighbor_count_lt_one);
     MSG(unknown_distance_type);
+    MSG(distance_is_not_supported_for_gpu);
 
     /* Linear and RBF Kernels */
     MSG(input_x_cc_neq_y_cc);

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -171,14 +171,14 @@ nitpick_ignore = [
     ('cpp:identifier', 'knn::infer_result'),
     ('cpp:identifier', 'knn::infer_input'),
     ('cpp:identifier', 'detail::enable_if_brute_force_t<M>'),
-    # chebychev_distance
+    # minkowski_distance
     ('cpp:identifier', 'minkowski_distance'),
     ('cpp:identifier', 'minkowski_distance::descriptor'),
     ('cpp:identifier', 'oneapi::dal::minkowski_distance'),
     ('cpp:identifier', 'oneapi::dal::minkowski_distance::descriptor<Float>'),
-    # minkowski_distance
-    ('cpp:identifier', 'chebychev_distance'),
-    ('cpp:identifier', 'chebychev_distance::descriptor'),
+    # chebyshev_distance
+    ('cpp:identifier', 'chebyshev_distance'),
+    ('cpp:identifier', 'chebyshev_distance::descriptor'),
     # kmeans
     ('cpp:identifier', 'kmeans'),
     ('cpp:identifier', 'kmeans::descriptor'),

--- a/makefile.lst
+++ b/makefile.lst
@@ -236,7 +236,7 @@ ONEAPI.ALGOS.svm           := CORE.svm
 # List of algorithms in oneAPI part
 
 ONEAPI.ALGOS :=          \
-    chebychev_distance   \
+    chebyshev_distance   \
     decision_forest      \
     decision_tree        \
     kmeans               \


### PR DESCRIPTION
# Description
Chebychev -> Chebyshev
In original scikit-learn it is named as "chebyshev"