### PR TITLE
fix broken manually doxygen in docs/Makefile

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -32,7 +32,7 @@ create_rst_examples:
 	python3 rst_examples.py
 
 doxygen:
-	doxygen doxygen/oneapi/Doxyfile
+	cd doxygen/oneapi && doxygen
 
 parse-doxygen: doxygen
 	mkdir -p build


### PR DESCRIPTION
# Description
`make doxygen` does not work as expected because invalid relative input tags.
![2021-06-16-212133_2704x1494_scrot](https://user-images.githubusercontent.com/3500109/122226826-e84c9680-cee8-11eb-80d7-1d117f389777.png)


Changes proposed in this pull request:
- fix broken doxygen in docs/Makefile
