### PR TITLE
Fix building with custom instruction set

### DIFF
--- a/cpp/daal/include/services/internal/daal_kernel_defines.h
+++ b/cpp/daal/include/services/internal/daal_kernel_defines.h
@@ -52,7 +52,8 @@ case cpuType:                                                                   
     break;                                                                                      \
 }
 
-#define DAAL_KERNEL_BUILD_MAX_INSTRACTION_SET_ID                daal::sse2
+#undef DAAL_KERNEL_BUILD_MAX_INSTRUCTION_SET_ID
+#define DAAL_KERNEL_BUILD_MAX_INSTRUCTION_SET_ID                daal::sse2
 #define DAAL_KERNEL_SSE2_ONLY(something)                        , something
 #define DAAL_KERNEL_SSE2_ONLY_CODE(...)                         __VA_ARGS__
 #define DAAL_KERNEL_SSE2_CONTAINER(ContainerTemplate, ...)      , DAAL_KERNEL_CONTAINER_TEMPL(ContainerTemplate, sse2, __VA_ARGS__)
@@ -60,8 +61,8 @@ case cpuType:                                                                   
 #define DAAL_KERNEL_SSE2_CONTAINER_CASE(ContainerTemplate, ...) DAAL_KERNEL_CONTAINER_CASE(ContainerTemplate, sse2, __VA_ARGS__)
 
 #if defined(DAAL_KERNEL_SSSE3)
-    #undef DAAL_KERNEL_BUILD_MAX_INSTRACTION_SET_ID
-    #define DAAL_KERNEL_BUILD_MAX_INSTRACTION_SET_ID            daal::ssse3
+    #undef DAAL_KERNEL_BUILD_MAX_INSTRUCTION_SET_ID
+    #define DAAL_KERNEL_BUILD_MAX_INSTRUCTION_SET_ID            daal::ssse3
     #define DAAL_KERNEL_SSSE3_ONLY(something)                   , something
     #define DAAL_KERNEL_SSSE3_ONLY_CODE(...)                    __VA_ARGS__
     #define DAAL_KERNEL_SSSE3_CONTAINER(ContainerTemplate, ...) , DAAL_KERNEL_CONTAINER_TEMPL(ContainerTemplate, ssse3, __VA_ARGS__)
@@ -79,8 +80,8 @@ case cpuType:                                                                   
 #endif
 
 #if defined(DAAL_KERNEL_SSE42)
-    #undef DAAL_KERNEL_BUILD_MAX_INSTRACTION_SET_ID
-    #define DAAL_KERNEL_BUILD_MAX_INSTRACTION_SET_ID            daal::sse42
+    #undef DAAL_KERNEL_BUILD_MAX_INSTRUCTION_SET_ID
+    #define DAAL_KERNEL_BUILD_MAX_INSTRUCTION_SET_ID            daal::sse42
     #define DAAL_KERNEL_SSE42_ONLY(something)                   , something
     #define DAAL_KERNEL_SSE42_ONLY_CODE(...)                    __VA_ARGS__
     #define DAAL_KERNEL_SSE42_CONTAINER(ContainerTemplate, ...) , DAAL_KERNEL_CONTAINER_TEMPL(ContainerTemplate, sse42, __VA_ARGS__)
@@ -98,8 +99,8 @@ case cpuType:                                                                   
 #endif
 
 #if defined(DAAL_KERNEL_AVX)
-    #undef DAAL_KERNEL_BUILD_MAX_INSTRACTION_SET_ID
-    #define DAAL_KERNEL_BUILD_MAX_INSTRACTION_SET_ID                    daal::avx
+    #undef DAAL_KERNEL_BUILD_MAX_INSTRUCTION_SET_ID
+    #define DAAL_KERNEL_BUILD_MAX_INSTRUCTION_SET_ID                    daal::avx
     #define DAAL_KERNEL_AVX_ONLY(something)                             , something
     #define DAAL_KERNEL_AVX_ONLY_CODE(...)                              __VA_ARGS__
     #define DAAL_KERNEL_AVX_CONTAINER(ContainerTemplate, ...)           , DAAL_KERNEL_CONTAINER_TEMPL(ContainerTemplate, avx, __VA_ARGS__)
@@ -116,8 +117,8 @@ case cpuType:                                                                   
 #endif
 
 #if defined(DAAL_KERNEL_AVX2)
-    #undef DAAL_KERNEL_BUILD_MAX_INSTRACTION_SET_ID
-    #define DAAL_KERNEL_BUILD_MAX_INSTRACTION_SET_ID           daal::avx2
+    #undef DAAL_KERNEL_BUILD_MAX_INSTRUCTION_SET_ID
+    #define DAAL_KERNEL_BUILD_MAX_INSTRUCTION_SET_ID           daal::avx2
     #define DAAL_KERNEL_AVX2_ONLY(something)                   , something
     #define DAAL_KERNEL_AVX2_ONLY_CODE(...)                    __VA_ARGS__
     #define DAAL_KERNEL_AVX2_CONTAINER(ContainerTemplate, ...) , DAAL_KERNEL_CONTAINER_TEMPL(ContainerTemplate, avx2, __VA_ARGS__)
@@ -135,8 +136,8 @@ case cpuType:                                                                   
 #endif
 
 #if defined(DAAL_KERNEL_AVX512_MIC)
-    #undef DAAL_KERNEL_BUILD_MAX_INSTRACTION_SET_ID
-    #define DAAL_KERNEL_BUILD_MAX_INSTRACTION_SET_ID                 daal::avx512_mic
+    #undef DAAL_KERNEL_BUILD_MAX_INSTRUCTION_SET_ID
+    #define DAAL_KERNEL_BUILD_MAX_INSTRUCTION_SET_ID                 daal::avx512_mic
     #define DAAL_KERNEL_AVX512_MIC_ONLY(something)                   , something
     #define DAAL_KERNEL_AVX512_MIC_ONLY_CODE(...)                    __VA_ARGS__
     #define DAAL_KERNEL_AVX512_MIC_CONTAINER(ContainerTemplate, ...) , DAAL_KERNEL_CONTAINER_TEMPL(ContainerTemplate, avx512_mic, __VA_ARGS__)
@@ -155,8 +156,8 @@ case cpuType:                                                                   
 #endif
 
 #if defined(DAAL_KERNEL_AVX512)
-    #undef DAAL_KERNEL_BUILD_MAX_INSTRACTION_SET_ID
-    #define DAAL_KERNEL_BUILD_MAX_INSTRACTION_SET_ID             daal::avx512
+    #undef DAAL_KERNEL_BUILD_MAX_INSTRUCTION_SET_ID
+    #define DAAL_KERNEL_BUILD_MAX_INSTRUCTION_SET_ID             daal::avx512
     #define DAAL_KERNEL_AVX512_ONLY(something)                   , something
     #define DAAL_KERNEL_AVX512_ONLY_CODE(...)                    __VA_ARGS__
     #define DAAL_KERNEL_AVX512_CONTAINER(ContainerTemplate, ...) , DAAL_KERNEL_CONTAINER_TEMPL(ContainerTemplate, avx512, __VA_ARGS__)

--- a/cpp/daal/include/services/internal/daal_kernel_defines.h
+++ b/cpp/daal/include/services/internal/daal_kernel_defines.h
@@ -24,6 +24,8 @@
 #ifndef __DAAL_KERNEL_DEFINES_H__
 #define __DAAL_KERNEL_DEFINES_H__
 
+#include "services/env_detect.h"
+
 /** \file daal_kernel_defines.h */
 /**
  * @ingroup services
@@ -50,6 +52,7 @@ case cpuType:                                                                   
     break;                                                                                      \
 }
 
+#define DAAL_KERNEL_BUILD_MAX_INSTRACTION_SET_ID                daal::sse2
 #define DAAL_KERNEL_SSE2_ONLY(something)                        , something
 #define DAAL_KERNEL_SSE2_ONLY_CODE(...)                         __VA_ARGS__
 #define DAAL_KERNEL_SSE2_CONTAINER(ContainerTemplate, ...)      , DAAL_KERNEL_CONTAINER_TEMPL(ContainerTemplate, sse2, __VA_ARGS__)
@@ -57,6 +60,8 @@ case cpuType:                                                                   
 #define DAAL_KERNEL_SSE2_CONTAINER_CASE(ContainerTemplate, ...) DAAL_KERNEL_CONTAINER_CASE(ContainerTemplate, sse2, __VA_ARGS__)
 
 #if defined(DAAL_KERNEL_SSSE3)
+    #undef DAAL_KERNEL_BUILD_MAX_INSTRACTION_SET_ID
+    #define DAAL_KERNEL_BUILD_MAX_INSTRACTION_SET_ID            daal::ssse3
     #define DAAL_KERNEL_SSSE3_ONLY(something)                   , something
     #define DAAL_KERNEL_SSSE3_ONLY_CODE(...)                    __VA_ARGS__
     #define DAAL_KERNEL_SSSE3_CONTAINER(ContainerTemplate, ...) , DAAL_KERNEL_CONTAINER_TEMPL(ContainerTemplate, ssse3, __VA_ARGS__)
@@ -74,6 +79,8 @@ case cpuType:                                                                   
 #endif
 
 #if defined(DAAL_KERNEL_SSE42)
+    #undef DAAL_KERNEL_BUILD_MAX_INSTRACTION_SET_ID
+    #define DAAL_KERNEL_BUILD_MAX_INSTRACTION_SET_ID            daal::sse42
     #define DAAL_KERNEL_SSE42_ONLY(something)                   , something
     #define DAAL_KERNEL_SSE42_ONLY_CODE(...)                    __VA_ARGS__
     #define DAAL_KERNEL_SSE42_CONTAINER(ContainerTemplate, ...) , DAAL_KERNEL_CONTAINER_TEMPL(ContainerTemplate, sse42, __VA_ARGS__)
@@ -91,6 +98,8 @@ case cpuType:                                                                   
 #endif
 
 #if defined(DAAL_KERNEL_AVX)
+    #undef DAAL_KERNEL_BUILD_MAX_INSTRACTION_SET_ID
+    #define DAAL_KERNEL_BUILD_MAX_INSTRACTION_SET_ID                    daal::avx
     #define DAAL_KERNEL_AVX_ONLY(something)                             , something
     #define DAAL_KERNEL_AVX_ONLY_CODE(...)                              __VA_ARGS__
     #define DAAL_KERNEL_AVX_CONTAINER(ContainerTemplate, ...)           , DAAL_KERNEL_CONTAINER_TEMPL(ContainerTemplate, avx, __VA_ARGS__)
@@ -107,6 +116,8 @@ case cpuType:                                                                   
 #endif
 
 #if defined(DAAL_KERNEL_AVX2)
+    #undef DAAL_KERNEL_BUILD_MAX_INSTRACTION_SET_ID
+    #define DAAL_KERNEL_BUILD_MAX_INSTRACTION_SET_ID           daal::avx2
     #define DAAL_KERNEL_AVX2_ONLY(something)                   , something
     #define DAAL_KERNEL_AVX2_ONLY_CODE(...)                    __VA_ARGS__
     #define DAAL_KERNEL_AVX2_CONTAINER(ContainerTemplate, ...) , DAAL_KERNEL_CONTAINER_TEMPL(ContainerTemplate, avx2, __VA_ARGS__)
@@ -124,6 +135,8 @@ case cpuType:                                                                   
 #endif
 
 #if defined(DAAL_KERNEL_AVX512_MIC)
+    #undef DAAL_KERNEL_BUILD_MAX_INSTRACTION_SET_ID
+    #define DAAL_KERNEL_BUILD_MAX_INSTRACTION_SET_ID                 daal::avx512_mic
     #define DAAL_KERNEL_AVX512_MIC_ONLY(something)                   , something
     #define DAAL_KERNEL_AVX512_MIC_ONLY_CODE(...)                    __VA_ARGS__
     #define DAAL_KERNEL_AVX512_MIC_CONTAINER(ContainerTemplate, ...) , DAAL_KERNEL_CONTAINER_TEMPL(ContainerTemplate, avx512_mic, __VA_ARGS__)
@@ -142,6 +155,8 @@ case cpuType:                                                                   
 #endif
 
 #if defined(DAAL_KERNEL_AVX512)
+    #undef DAAL_KERNEL_BUILD_MAX_INSTRACTION_SET_ID
+    #define DAAL_KERNEL_BUILD_MAX_INSTRACTION_SET_ID             daal::avx512
     #define DAAL_KERNEL_AVX512_ONLY(something)                   , something
     #define DAAL_KERNEL_AVX512_ONLY_CODE(...)                    __VA_ARGS__
     #define DAAL_KERNEL_AVX512_CONTAINER(ContainerTemplate, ...) , DAAL_KERNEL_CONTAINER_TEMPL(ContainerTemplate, avx512, __VA_ARGS__)

--- a/cpp/daal/src/algorithms/kernel.h
+++ b/cpp/daal/src/algorithms/kernel.h
@@ -95,7 +95,7 @@
                             DAAL_KERNEL_AVX512_CONTAINER(ContainerTemplate, __VA_ARGS__)>::ClassName(daal::services::Environment::env * daalEnv)    \
         : BaseClassName(daalEnv), _cntr(nullptr)                                                                                                    \
     {                                                                                                                                               \
-        GetCpuid switch (__DAAL_KERNEL_MIN(DAAL_KERNEL_BUILD_MAX_INSTRACTION_SET_ID, cpuid))                                                        \
+        GetCpuid switch (__DAAL_KERNEL_MIN(DAAL_KERNEL_BUILD_MAX_INSTRUCTION_SET_ID, cpuid))                                                        \
         {                                                                                                                                           \
             DAAL_KERNEL_SSSE3_CONTAINER_CASE(ContainerTemplate, __VA_ARGS__)                                                                        \
             DAAL_KERNEL_SSE42_CONTAINER_CASE(ContainerTemplate, __VA_ARGS__)                                                                        \
@@ -124,7 +124,7 @@
                             DAAL_KERNEL_AVX512_CONTAINER(ContainerTemplate, __VA_ARGS__)>::ClassName(daal::services::Environment::env * daalEnv)    \
         : BaseClassName(daalEnv), _cntr(nullptr)                                                                                                    \
     {                                                                                                                                               \
-        switch (__DAAL_KERNEL_MIN(DAAL_KERNEL_BUILD_MAX_INSTRACTION_SET_ID, daalEnv->cpuid))                                                        \
+        switch (__DAAL_KERNEL_MIN(DAAL_KERNEL_BUILD_MAX_INSTRUCTION_SET_ID, daalEnv->cpuid))                                                        \
         {                                                                                                                                           \
             DAAL_KERNEL_SSSE3_CONTAINER_CASE(ContainerTemplate, __VA_ARGS__)                                                                        \
             DAAL_KERNEL_SSE42_CONTAINER_CASE(ContainerTemplate, __VA_ARGS__)                                                                        \
@@ -181,7 +181,7 @@
                             DAAL_KERNEL_AVX512_CONTAINER(ContainerTemplate, __VA_ARGS__)>::ClassName(daal::services::Environment::env * daalEnv)    \
         : BaseClassName(daalEnv), _cntr(NULL)                                                                                                       \
     {                                                                                                                                               \
-        GetCpuid switch (__DAAL_KERNEL_MIN(DAAL_KERNEL_BUILD_MAX_INSTRACTION_SET_ID, cpuid))                                                        \
+        GetCpuid switch (__DAAL_KERNEL_MIN(DAAL_KERNEL_BUILD_MAX_INSTRUCTION_SET_ID, cpuid))                                                        \
         {                                                                                                                                           \
             DAAL_KERNEL_SSSE3_CONTAINER_CASE_SYCL(ContainerTemplate, __VA_ARGS__)                                                                   \
             DAAL_KERNEL_SSE42_CONTAINER_CASE_SYCL(ContainerTemplate, __VA_ARGS__)                                                                   \

--- a/cpp/daal/src/algorithms/kernel.h
+++ b/cpp/daal/src/algorithms/kernel.h
@@ -124,17 +124,16 @@
                             DAAL_KERNEL_AVX512_CONTAINER(ContainerTemplate, __VA_ARGS__)>::ClassName(daal::services::Environment::env * daalEnv)    \
         : BaseClassName(daalEnv), _cntr(nullptr)                                                                                                    \
     {                                                                                                                                               \
-        switch                                                                                                                                      \
-            switch (__DAAL_KERNEL_MIN(DAAL_KERNEL_BUILD_MAX_INSTRACTION_SET_ID, cpuid))                                                             \
-            {                                                                                                                                       \
-                DAAL_KERNEL_SSSE3_CONTAINER_CASE(ContainerTemplate, __VA_ARGS__)                                                                    \
-                DAAL_KERNEL_SSE42_CONTAINER_CASE(ContainerTemplate, __VA_ARGS__)                                                                    \
-                DAAL_KERNEL_AVX_CONTAINER_CASE(ContainerTemplate, __VA_ARGS__)                                                                      \
-                DAAL_KERNEL_AVX2_CONTAINER_CASE(ContainerTemplate, __VA_ARGS__)                                                                     \
-                DAAL_KERNEL_AVX512_MIC_CONTAINER_CASE(ContainerTemplate, __VA_ARGS__)                                                               \
-                DAAL_KERNEL_AVX512_CONTAINER_CASE(ContainerTemplate, __VA_ARGS__)                                                                   \
-            default: _cntr = (new ContainerTemplate<__VA_ARGS__, sse2>(daalEnv)); break;                                                            \
-            }                                                                                                                                       \
+        switch (__DAAL_KERNEL_MIN(DAAL_KERNEL_BUILD_MAX_INSTRACTION_SET_ID, cpuid))                                                                 \
+        {                                                                                                                                           \
+            DAAL_KERNEL_SSSE3_CONTAINER_CASE(ContainerTemplate, __VA_ARGS__)                                                                        \
+            DAAL_KERNEL_SSE42_CONTAINER_CASE(ContainerTemplate, __VA_ARGS__)                                                                        \
+            DAAL_KERNEL_AVX_CONTAINER_CASE(ContainerTemplate, __VA_ARGS__)                                                                          \
+            DAAL_KERNEL_AVX2_CONTAINER_CASE(ContainerTemplate, __VA_ARGS__)                                                                         \
+            DAAL_KERNEL_AVX512_MIC_CONTAINER_CASE(ContainerTemplate, __VA_ARGS__)                                                                   \
+            DAAL_KERNEL_AVX512_CONTAINER_CASE(ContainerTemplate, __VA_ARGS__)                                                                       \
+        default: _cntr = (new ContainerTemplate<__VA_ARGS__, sse2>(daalEnv)); break;                                                                \
+        }                                                                                                                                           \
     }                                                                                                                                               \
                                                                                                                                                     \
     template class ClassName<Mode, ContainerTemplate<__VA_ARGS__, sse2> DAAL_KERNEL_SSSE3_CONTAINER(ContainerTemplate, __VA_ARGS__)                 \

--- a/cpp/daal/src/algorithms/kernel.h
+++ b/cpp/daal/src/algorithms/kernel.h
@@ -95,7 +95,7 @@
                             DAAL_KERNEL_AVX512_CONTAINER(ContainerTemplate, __VA_ARGS__)>::ClassName(daal::services::Environment::env * daalEnv)    \
         : BaseClassName(daalEnv), _cntr(nullptr)                                                                                                    \
     {                                                                                                                                               \
-        GetCpuid switch (__DAAL_KERNEL_MIN(DAAL_KERNEL_BUILD_MAX_INSTRACTION_SET_ID, cpuid))                                                                                                                     \
+        GetCpuid switch (__DAAL_KERNEL_MIN(DAAL_KERNEL_BUILD_MAX_INSTRACTION_SET_ID, cpuid))                                                        \
         {                                                                                                                                           \
             DAAL_KERNEL_SSSE3_CONTAINER_CASE(ContainerTemplate, __VA_ARGS__)                                                                        \
             DAAL_KERNEL_SSE42_CONTAINER_CASE(ContainerTemplate, __VA_ARGS__)                                                                        \
@@ -124,16 +124,17 @@
                             DAAL_KERNEL_AVX512_CONTAINER(ContainerTemplate, __VA_ARGS__)>::ClassName(daal::services::Environment::env * daalEnv)    \
         : BaseClassName(daalEnv), _cntr(nullptr)                                                                                                    \
     {                                                                                                                                               \
-        switch switch (__DAAL_KERNEL_MIN(DAAL_KERNEL_BUILD_MAX_INSTRACTION_SET_ID, cpuid))                                                                                                                   \
-        {                                                                                                                                           \
-            DAAL_KERNEL_SSSE3_CONTAINER_CASE(ContainerTemplate, __VA_ARGS__)                                                                        \
-            DAAL_KERNEL_SSE42_CONTAINER_CASE(ContainerTemplate, __VA_ARGS__)                                                                        \
-            DAAL_KERNEL_AVX_CONTAINER_CASE(ContainerTemplate, __VA_ARGS__)                                                                          \
-            DAAL_KERNEL_AVX2_CONTAINER_CASE(ContainerTemplate, __VA_ARGS__)                                                                         \
-            DAAL_KERNEL_AVX512_MIC_CONTAINER_CASE(ContainerTemplate, __VA_ARGS__)                                                                   \
-            DAAL_KERNEL_AVX512_CONTAINER_CASE(ContainerTemplate, __VA_ARGS__)                                                                       \
-        default: _cntr = (new ContainerTemplate<__VA_ARGS__, sse2>(daalEnv)); break;                                                                \
-        }                                                                                                                                           \
+        switch                                                                                                                                      \
+            switch (__DAAL_KERNEL_MIN(DAAL_KERNEL_BUILD_MAX_INSTRACTION_SET_ID, cpuid))                                                             \
+            {                                                                                                                                       \
+                DAAL_KERNEL_SSSE3_CONTAINER_CASE(ContainerTemplate, __VA_ARGS__)                                                                    \
+                DAAL_KERNEL_SSE42_CONTAINER_CASE(ContainerTemplate, __VA_ARGS__)                                                                    \
+                DAAL_KERNEL_AVX_CONTAINER_CASE(ContainerTemplate, __VA_ARGS__)                                                                      \
+                DAAL_KERNEL_AVX2_CONTAINER_CASE(ContainerTemplate, __VA_ARGS__)                                                                     \
+                DAAL_KERNEL_AVX512_MIC_CONTAINER_CASE(ContainerTemplate, __VA_ARGS__)                                                               \
+                DAAL_KERNEL_AVX512_CONTAINER_CASE(ContainerTemplate, __VA_ARGS__)                                                                   \
+            default: _cntr = (new ContainerTemplate<__VA_ARGS__, sse2>(daalEnv)); break;                                                            \
+            }                                                                                                                                       \
     }                                                                                                                                               \
                                                                                                                                                     \
     template class ClassName<Mode, ContainerTemplate<__VA_ARGS__, sse2> DAAL_KERNEL_SSSE3_CONTAINER(ContainerTemplate, __VA_ARGS__)                 \
@@ -181,7 +182,7 @@
                             DAAL_KERNEL_AVX512_CONTAINER(ContainerTemplate, __VA_ARGS__)>::ClassName(daal::services::Environment::env * daalEnv)    \
         : BaseClassName(daalEnv), _cntr(NULL)                                                                                                       \
     {                                                                                                                                               \
-        GetCpuid switch (__DAAL_KERNEL_MIN(DAAL_KERNEL_BUILD_MAX_INSTRACTION_SET_ID, cpuid))                                                                                                                     \
+        GetCpuid switch (__DAAL_KERNEL_MIN(DAAL_KERNEL_BUILD_MAX_INSTRACTION_SET_ID, cpuid))                                                        \
         {                                                                                                                                           \
             DAAL_KERNEL_SSSE3_CONTAINER_CASE_SYCL(ContainerTemplate, __VA_ARGS__)                                                                   \
             DAAL_KERNEL_SSE42_CONTAINER_CASE_SYCL(ContainerTemplate, __VA_ARGS__)                                                                   \

--- a/cpp/daal/src/algorithms/kernel.h
+++ b/cpp/daal/src/algorithms/kernel.h
@@ -76,6 +76,8 @@
     int cpuid = daal::sse2;   \
     DAAL_SAFE_CPU_CALL((cpuid = daalEnv->cpuid), (cpuid = daal::sse2))
 
+#define __DAAL_KERNEL_MIN(a, b) ((a) < (b) ? (a) : (b))
+
 #define __DAAL_INSTANTIATE_DISPATCH_IMPL(ContainerTemplate, Mode, ClassName, BaseClassName, GetCpuid, ...)                                          \
     DAAL_KERNEL_SSE2_CONTAINER1(ContainerTemplate, __VA_ARGS__)                                                                                     \
     DAAL_KERNEL_SSSE3_CONTAINER1(ContainerTemplate, __VA_ARGS__)                                                                                    \
@@ -93,7 +95,7 @@
                             DAAL_KERNEL_AVX512_CONTAINER(ContainerTemplate, __VA_ARGS__)>::ClassName(daal::services::Environment::env * daalEnv)    \
         : BaseClassName(daalEnv), _cntr(nullptr)                                                                                                    \
     {                                                                                                                                               \
-        GetCpuid switch (cpuid)                                                                                                                     \
+        GetCpuid switch (__DAAL_KERNEL_MIN(DAAL_KERNEL_BUILD_MAX_INSTRACTION_SET_ID, cpuid))                                                                                                                     \
         {                                                                                                                                           \
             DAAL_KERNEL_SSSE3_CONTAINER_CASE(ContainerTemplate, __VA_ARGS__)                                                                        \
             DAAL_KERNEL_SSE42_CONTAINER_CASE(ContainerTemplate, __VA_ARGS__)                                                                        \
@@ -122,7 +124,7 @@
                             DAAL_KERNEL_AVX512_CONTAINER(ContainerTemplate, __VA_ARGS__)>::ClassName(daal::services::Environment::env * daalEnv)    \
         : BaseClassName(daalEnv), _cntr(nullptr)                                                                                                    \
     {                                                                                                                                               \
-        switch (daalEnv->cpuid)                                                                                                                     \
+        switch switch (__DAAL_KERNEL_MIN(DAAL_KERNEL_BUILD_MAX_INSTRACTION_SET_ID, cpuid))                                                                                                                   \
         {                                                                                                                                           \
             DAAL_KERNEL_SSSE3_CONTAINER_CASE(ContainerTemplate, __VA_ARGS__)                                                                        \
             DAAL_KERNEL_SSE42_CONTAINER_CASE(ContainerTemplate, __VA_ARGS__)                                                                        \
@@ -179,7 +181,7 @@
                             DAAL_KERNEL_AVX512_CONTAINER(ContainerTemplate, __VA_ARGS__)>::ClassName(daal::services::Environment::env * daalEnv)    \
         : BaseClassName(daalEnv), _cntr(NULL)                                                                                                       \
     {                                                                                                                                               \
-        GetCpuid switch (cpuid)                                                                                                                     \
+        GetCpuid switch (__DAAL_KERNEL_MIN(DAAL_KERNEL_BUILD_MAX_INSTRACTION_SET_ID, cpuid))                                                                                                                     \
         {                                                                                                                                           \
             DAAL_KERNEL_SSSE3_CONTAINER_CASE_SYCL(ContainerTemplate, __VA_ARGS__)                                                                   \
             DAAL_KERNEL_SSE42_CONTAINER_CASE_SYCL(ContainerTemplate, __VA_ARGS__)                                                                   \

--- a/cpp/daal/src/algorithms/kernel.h
+++ b/cpp/daal/src/algorithms/kernel.h
@@ -124,7 +124,7 @@
                             DAAL_KERNEL_AVX512_CONTAINER(ContainerTemplate, __VA_ARGS__)>::ClassName(daal::services::Environment::env * daalEnv)    \
         : BaseClassName(daalEnv), _cntr(nullptr)                                                                                                    \
     {                                                                                                                                               \
-        switch (__DAAL_KERNEL_MIN(DAAL_KERNEL_BUILD_MAX_INSTRACTION_SET_ID, cpuid))                                                                 \
+        switch (__DAAL_KERNEL_MIN(DAAL_KERNEL_BUILD_MAX_INSTRACTION_SET_ID, daalEnv->cpuid))                                                        \
         {                                                                                                                                           \
             DAAL_KERNEL_SSSE3_CONTAINER_CASE(ContainerTemplate, __VA_ARGS__)                                                                        \
             DAAL_KERNEL_SSE42_CONTAINER_CASE(ContainerTemplate, __VA_ARGS__)                                                                        \

--- a/cpp/oneapi/dal/backend/dispatcher.hpp
+++ b/cpp/oneapi/dal/backend/dispatcher.hpp
@@ -69,7 +69,7 @@ struct kernel_dispatcher<CpuKernel> {
 };
 
 inline bool test_cpu_extension(detail::cpu_extension mask, detail::cpu_extension test) {
-    return ((std::uint64_t)mask & (std::uint64_t)test) > 0;
+    return mask >= test;
 }
 
 template <typename Op>


### PR DESCRIPTION
### Problem
When we building of oneDAL with custom IS (Instruction Set), for example:
```bash
make onedal REQCPU=avx2
```
Kernels implementation use the selected custom IS, only on the machine that has the top cpu extension (_kernels will run with avx2 only on Haswell or Broadwell IA_), in other cases, kernels work only with sse2 code, even on SKX, CLX, etc IA.

This is because we have a similar code with the dispatcher
```c++
cpuid = avx512
switch (cpuid):
// case avx512: ... (not compiler code for custom build with avx2)
   case avx2: ... // <-avx2 kernel
   default: ...   // <-sse2 kernel

```

### Solution
Use minimal between custom IS (from make) and top cpu extension from run on IA
