### PR TITLE
[DOC] Update doc configurations

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -38,10 +38,9 @@ sys.path.insert(0, os.path.abspath('../'))
 
 project = 'oneDAL'
 copyright = '2014 - 2021, Intel Corporation' # pylint: disable=redefined-builtin
-author = 'Intel'
 
 # The full version, including alpha/beta/rc tags
-release = '2021'
+# release = '2021'
 
 rst_prolog = """
 .. |short_name| replace:: oneDAL
@@ -127,7 +126,8 @@ html_theme_options = {
     'path_to_docs': 'docs/source',
     'use_issues_button': True,
     'use_edit_page_button': True,
-    'repository_branch': 'master'
+    'repository_branch': 'master',
+    'extra_footer': '<p align="right"><a href="https://www.intel.com/content/www/us/en/privacy/intel-cookie-notice.html">Cookies</a></p>'
 }
 
 # oneDAL project directory is needed for `dalapi` extension


### PR DESCRIPTION
# Description

To collect usage data for GitHub Pages, we need to link to the Intel cookies notice.

Plus other minor updates to align with the oneAPI content strategy.