### PR TITLE
Graph examples: delete allocator usage in example

### DIFF
--- a/cpp/oneapi/dal/algo/subgraph_isomorphism/common.hpp
+++ b/cpp/oneapi/dal/algo/subgraph_isomorphism/common.hpp
@@ -98,7 +98,7 @@ public:
     using task_t = Task;
     using allocator_t = Allocator;
 
-    explicit descriptor(Allocator allocator) {
+    explicit descriptor(Allocator allocator = std::allocator<char>()) {
         _alloc = allocator;
     }
 

--- a/cpp/oneapi/dal/algo/triangle_counting/common.hpp
+++ b/cpp/oneapi/dal/algo/triangle_counting/common.hpp
@@ -107,7 +107,7 @@ public:
     using task_t = Task;
     using allocator_t = Allocator;
 
-    explicit descriptor(Allocator allocator) {
+    explicit descriptor(Allocator allocator = std::allocator<char>()) {
         _alloc = allocator;
     }
 

--- a/examples/oneapi/cpp/source/connected_components/connected_components_batch.cpp
+++ b/examples/oneapi/cpp/source/connected_components/connected_components_batch.cpp
@@ -30,16 +30,13 @@ int main(int argc, char** argv) {
     // read the graph
     const dal::preview::graph_csv_data_source ds(filename);
     const dal::preview::load_graph::descriptor<> d;
-    const auto my_graph = dal::preview::load_graph::load(d, ds);
-    std::allocator<char> alloc;
-
-    // set algorithm parameters
-    const auto cc_desc = dal::preview::connected_components::descriptor<>(alloc);
+    const auto graph = dal::preview::load_graph::load(d, ds);
 
     try {
         // compute connected_components
         const auto result_connected_components =
-            dal::preview::vertex_partitioning(cc_desc, my_graph);
+            dal::preview::vertex_partitioning(dal::preview::connected_components::descriptor<>{},
+                                              graph);
 
         // extract the result
         std::cout << "Components' labels:\n"

--- a/examples/oneapi/cpp/source/example_util/output_helpers.hpp
+++ b/examples/oneapi/cpp/source/example_util/output_helpers.hpp
@@ -26,12 +26,14 @@
 std::ostream &operator<<(std::ostream &stream, const oneapi::dal::table &table) {
     auto arr = oneapi::dal::row_accessor<const float>(table).pull();
     const auto x = arr.get_data();
+    const std::int32_t precision =
+        oneapi::dal::detail::is_floating_point(table.get_metadata().get_data_type(0)) ? 3 : 0;
 
     if (table.get_row_count() <= 10) {
         for (std::int64_t i = 0; i < table.get_row_count(); i++) {
             for (std::int64_t j = 0; j < table.get_column_count(); j++) {
                 std::cout << std::setw(10) << std::setiosflags(std::ios::fixed)
-                          << std::setprecision(3) << x[i * table.get_column_count() + j];
+                          << std::setprecision(precision) << x[i * table.get_column_count() + j];
             }
             std::cout << std::endl;
         }
@@ -40,7 +42,7 @@ std::ostream &operator<<(std::ostream &stream, const oneapi::dal::table &table) 
         for (std::int64_t i = 0; i < 5; i++) {
             for (std::int64_t j = 0; j < table.get_column_count(); j++) {
                 std::cout << std::setw(10) << std::setiosflags(std::ios::fixed)
-                          << std::setprecision(3) << x[i * table.get_column_count() + j];
+                          << std::setprecision(precision) << x[i * table.get_column_count() + j];
             }
             std::cout << std::endl;
         }
@@ -48,7 +50,7 @@ std::ostream &operator<<(std::ostream &stream, const oneapi::dal::table &table) 
         for (std::int64_t i = table.get_row_count() - 5; i < table.get_row_count(); i++) {
             for (std::int64_t j = 0; j < table.get_column_count(); j++) {
                 std::cout << std::setw(10) << std::setiosflags(std::ios::fixed)
-                          << std::setprecision(3) << x[i * table.get_column_count() + j];
+                          << std::setprecision(precision) << x[i * table.get_column_count() + j];
             }
             std::cout << std::endl;
         }

--- a/examples/oneapi/cpp/source/example_util/output_helpers.hpp
+++ b/examples/oneapi/cpp/source/example_util/output_helpers.hpp
@@ -24,6 +24,9 @@
 #include "oneapi/dal/table/homogen.hpp"
 
 std::ostream &operator<<(std::ostream &stream, const oneapi::dal::table &table) {
+    if (!table.has_data())
+        return stream;
+
     auto arr = oneapi::dal::row_accessor<const float>(table).pull();
     const auto x = arr.get_data();
     const std::int32_t precision =

--- a/examples/oneapi/cpp/source/graph/directed_graph.cpp
+++ b/examples/oneapi/cpp/source/graph/directed_graph.cpp
@@ -37,22 +37,22 @@ int main(int argc, char** argv) {
     const dal::preview::load_graph::
         descriptor<dal::preview::weighted_edge_list<vertex_type, weight_type>, my_graph_type>
             d;
-    const auto my_graph = dal::preview::load_graph::load(d, ds);
+    const auto graph = dal::preview::load_graph::load(d, ds);
 
-    std::cout << "Number of vertices: " << dal::preview::get_vertex_count(my_graph) << std::endl;
-    std::cout << "Number of edges: " << dal::preview::get_edge_count(my_graph) << std::endl;
+    std::cout << "Number of vertices: " << dal::preview::get_vertex_count(graph) << std::endl;
+    std::cout << "Number of edges: " << dal::preview::get_edge_count(graph) << std::endl;
 
     dal::preview::vertex_outward_edge_size_type<my_graph_type> vertex_id = 0;
     std::cout << "Degree of " << vertex_id << ": "
-              << dal::preview::get_vertex_outward_degree(my_graph, vertex_id) << std::endl;
+              << dal::preview::get_vertex_outward_degree(graph, vertex_id) << std::endl;
 
     for (dal::preview::vertex_outward_edge_size_type<my_graph_type> j = 0;
-         j < dal::preview::get_vertex_count(my_graph);
+         j < dal::preview::get_vertex_count(graph);
          ++j) {
         std::cout << "Neighbors of " << j << ": ";
-        const auto neigh = dal::preview::get_vertex_outward_neighbors(my_graph, j);
+        const auto neigh = dal::preview::get_vertex_outward_neighbors(graph, j);
         for (auto i = neigh.first; i != neigh.second; ++i) {
-            std::cout << *i << "-" << dal::preview::get_edge_value(my_graph, j, *i) << " ";
+            std::cout << *i << "-" << dal::preview::get_edge_value(graph, j, *i) << " ";
         }
         std::cout << std::endl;
     }

--- a/examples/oneapi/cpp/source/graph/graph_service_functions.cpp
+++ b/examples/oneapi/cpp/source/graph/graph_service_functions.cpp
@@ -31,19 +31,19 @@ int main(int argc, char **argv) {
     using my_graph_type = dal::preview::undirected_adjacency_vector_graph<>;
     const dal::preview::load_graph::descriptor<dal::preview::edge_list<int32_t>, my_graph_type>
         desc;
-    const auto my_graph = dal::preview::load_graph::load(desc, ds);
-    std::cout << "Number of vertices: " << dal::preview::get_vertex_count(my_graph) << std::endl;
-    std::cout << "Number of edges: " << dal::preview::get_edge_count(my_graph) << std::endl;
+    const auto graph = dal::preview::load_graph::load(desc, ds);
+    std::cout << "Number of vertices: " << dal::preview::get_vertex_count(graph) << std::endl;
+    std::cout << "Number of edges: " << dal::preview::get_edge_count(graph) << std::endl;
 
     dal::preview::vertex_edge_size_type<my_graph_type> vertex_id = 0;
     std::cout << "Degree of " << vertex_id << ": "
-              << dal::preview::get_vertex_degree(my_graph, vertex_id) << std::endl;
+              << dal::preview::get_vertex_degree(graph, vertex_id) << std::endl;
 
     for (dal::preview::vertex_edge_size_type<my_graph_type> j = 0;
-         j < dal::preview::get_vertex_count(my_graph);
+         j < dal::preview::get_vertex_count(graph);
          ++j) {
         std::cout << "Neighbors of " << j << ": ";
-        const auto neigh = dal::preview::get_vertex_neighbors(my_graph, j);
+        const auto neigh = dal::preview::get_vertex_neighbors(graph, j);
         for (auto i = neigh.first; i != neigh.second; ++i) {
             std::cout << *i << " ";
         }

--- a/examples/oneapi/cpp/source/graph/load_graph.cpp
+++ b/examples/oneapi/cpp/source/graph/load_graph.cpp
@@ -29,10 +29,10 @@ int main(int argc, char **argv) {
 
     const dal::preview::graph_csv_data_source ds(filename);
     const dal::preview::load_graph::descriptor<> d;
-    const auto my_graph = dal::preview::load_graph::load(d, ds);
+    const auto graph = dal::preview::load_graph::load(d, ds);
 
     std::cout << "Graph is read from file: " << filename << std::endl;
-    std::cout << "Number of vertices: " << dal::preview::get_vertex_count(my_graph) << std::endl;
-    std::cout << "Number of edges: " << dal::preview::get_edge_count(my_graph) << std::endl;
+    std::cout << "Number of vertices: " << dal::preview::get_vertex_count(graph) << std::endl;
+    std::cout << "Number of edges: " << dal::preview::get_edge_count(graph) << std::endl;
     return 0;
 }

--- a/examples/oneapi/cpp/source/jaccard/jaccard_batch.cpp
+++ b/examples/oneapi/cpp/source/jaccard/jaccard_batch.cpp
@@ -32,7 +32,7 @@ int main(int argc, char **argv) {
     // read the graph
     const dal::preview::graph_csv_data_source ds(filename);
     const dal::preview::load_graph::descriptor<> d;
-    const auto my_graph = dal::preview::load_graph::load(d, ds);
+    const auto graph = dal::preview::load_graph::load(d, ds);
 
     // set blocks ranges
     const std::int64_t row_range_begin = 0;
@@ -50,7 +50,7 @@ int main(int argc, char **argv) {
 
     // compute Jaccard similarity coefficients
     const auto result_vertex_similarity =
-        dal::preview::vertex_similarity(jaccard_desc, my_graph, builder);
+        dal::preview::vertex_similarity(jaccard_desc, graph, builder);
 
     // extract the result
     const auto jaccard_coeffs = result_vertex_similarity.get_coeffs();

--- a/examples/oneapi/cpp/source/shortest_paths/shortest_paths_batch.cpp
+++ b/examples/oneapi/cpp/source/shortest_paths/shortest_paths_batch.cpp
@@ -38,22 +38,21 @@ int main(int argc, char** argv) {
     const dal::preview::load_graph::
         descriptor<dal::preview::weighted_edge_list<vertex_type, weight_type>, my_graph_type>
             d;
-    const auto my_graph = dal::preview::load_graph::load(d, ds);
+    const auto graph = dal::preview::load_graph::load(d, ds);
 
-    std::allocator<char> alloc;
     // set algorithm parameters
-    const auto shortest_paths_desc =
-        descriptor<float, method::delta_stepping, task::one_to_all, std::allocator<char>>(
-            0,
-            0.85,
-            optional_results::distances | optional_results::predecessors,
-            alloc);
+    const auto shortest_paths_desc = descriptor<float, method::delta_stepping, task::one_to_all>(
+        0,
+        0.85,
+        optional_results::distances | optional_results::predecessors);
     // compute shortest paths
-    const auto result_shortest_paths = dal::preview::traverse(shortest_paths_desc, my_graph);
+    const auto result_shortest_paths = dal::preview::traverse(shortest_paths_desc, graph);
 
     // extract the result
-    std::cout << "Distances: " << result_shortest_paths.get_distances() << std::endl;
-    std::cout << "Predecessors: " << result_shortest_paths.get_predecessors() << std::endl;
+    std::cout << "Distances: " << std::endl;
+    std::cout << result_shortest_paths.get_distances() << std::endl;
+    std::cout << "Predecessors: " << std::endl;
+    std::cout << result_shortest_paths.get_predecessors() << std::endl;
 
     return 0;
 }

--- a/examples/oneapi/cpp/source/subgraph_isomorphism/subgraph_isomorphism_batch.cpp
+++ b/examples/oneapi/cpp/source/subgraph_isomorphism/subgraph_isomorphism_batch.cpp
@@ -40,11 +40,9 @@ int main(int argc, char **argv) {
     const dal::preview::load_graph::descriptor<> d_pattern;
     const auto pattern_graph = dal::preview::load_graph::load(d_pattern, ds_pattern);
 
-    std::allocator<char> alloc;
-
     // set algorithm parameters
     const auto subgraph_isomorphism_desc =
-        dal::preview::subgraph_isomorphism::descriptor<>(alloc)
+        dal::preview::subgraph_isomorphism::descriptor<>()
             .set_kind(dal::preview::subgraph_isomorphism::kind::non_induced)
             .set_semantic_match(false)
             .set_max_match_count(10);

--- a/examples/oneapi/cpp/source/triangle_counting/triangle_counting_batch.cpp
+++ b/examples/oneapi/cpp/source/triangle_counting/triangle_counting_batch.cpp
@@ -31,15 +31,12 @@ int main(int argc, char** argv) {
     // read the graph
     const dal::preview::graph_csv_data_source ds(filename);
     const dal::preview::load_graph::descriptor<> d;
-    const auto my_graph = dal::preview::load_graph::load(d, ds);
-    std::allocator<char> alloc;
+    const auto graph = dal::preview::load_graph::load(d, ds);
     // set algorithm parameters
-    const auto tc_desc =
-        descriptor<float, method::ordered_count, task::local_and_global, std::allocator<char>>(
-            alloc);
+    const auto tc_desc = descriptor<float, method::ordered_count, task::local_and_global>();
 
     // compute local and global triangles
-    const auto result_vertex_ranking = dal::preview::vertex_ranking(tc_desc, my_graph);
+    const auto result_vertex_ranking = dal::preview::vertex_ranking(tc_desc, graph);
 
     // extract the result
     std::cout << "Global triangles: " << result_vertex_ranking.get_global_rank() << std::endl;


### PR DESCRIPTION
deleting allocator usage in examples, beautifying example output