### PR TITLE
Add L0-based tools for GPU monitoring

### DIFF
--- a/dev/bazel/cc.bzl
+++ b/dev/bazel/cc.bzl
@@ -214,7 +214,7 @@ cc_dynamic_lib = rule(
 )
 
 
-def _cc_test_impl(ctx):
+def _cc_exec_impl(ctx):
     if not ctx.attr.deps:
         return
     toolchain, feature_config = _init_cc_rule(ctx)
@@ -228,6 +228,7 @@ def _cc_test_impl(ctx):
         cc_toolchain = toolchain,
         feature_configuration = feature_config,
         linking_contexts = linking_contexts,
+        user_link_flags = ctx.attr.user_link_flags,
     )
     default_info = DefaultInfo(
         files = depset([ executable ]),
@@ -239,13 +240,27 @@ def _cc_test_impl(ctx):
     return [default_info]
 
 cc_test = rule(
-    implementation = _cc_test_impl,
+    implementation = _cc_exec_impl,
     attrs = {
         "lib_tags": attr.string_list(),
         "deps": attr.label_list(),
         "data": attr.label_list(allow_files=True),
+        "user_link_flags": attr.string_list(),
     },
     toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
     fragments = ["cpp"],
     test = True,
+)
+
+cc_executable = rule(
+    implementation = _cc_exec_impl,
+    attrs = {
+        "lib_tags": attr.string_list(),
+        "deps": attr.label_list(),
+        "data": attr.label_list(allow_files=True),
+        "user_link_flags": attr.string_list(),
+    },
+    toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
+    fragments = ["cpp"],
+    executable = True,
 )

--- a/dev/l0_tools/.clang-format
+++ b/dev/l0_tools/.clang-format
@@ -1,0 +1,145 @@
+---
+Language: Cpp
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignConsecutiveMacros: true
+AlignEscapedNewlines: Left
+AlignOperands: true
+AlignTrailingComments: false
+AllowAllArgumentsOnNextLine: false
+AllowAllConstructorInitializersOnNextLine: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: Empty
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: false
+BinPackParameters: false
+BraceWrapping:
+  AfterCaseLabel: false
+  AfterClass: false
+  AfterControlStatement: false
+  AfterEnum: false
+  AfterFunction: false
+  AfterNamespace: false
+  AfterObjCDeclaration: false
+  AfterStruct: false
+  AfterUnion: false
+  AfterExternBlock: false
+  BeforeCatch: true
+  BeforeElse: true
+  IndentBraces: false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeColon
+BreakInheritanceList: BeforeColon
+BreakStringLiterals: false
+ColumnLimit: 100
+CommentPragmas: '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 8
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: false
+DerivePointerAlignment: true
+DisableFormat: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks: Preserve
+IncludeCategories:
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+  - Regex:           '^<.*'
+    Priority:        2
+  - Regex:           '.*'
+    Priority:        3
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IndentCaseLabels: true
+IndentPPDirectives: None
+IndentWidth: 4
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+RawStringFormats:
+  - Language: Cpp
+    Delimiters:
+      - cc
+      - CC
+      - cpp
+      - Cpp
+      - CPP
+      - 'c++'
+      - 'C++'
+    CanonicalDelimiter: ''
+    BasedOnStyle: google
+  - Language: TextProto
+    Delimiters:
+      - pb
+      - PB
+      - proto
+      - PROTO
+    EnclosingFunctions:
+      - EqualsProto
+      - EquivToProto
+      - PARSE_PARTIAL_TEXT_PROTO
+      - PARSE_TEST_PROTO
+      - PARSE_TEXT_PROTO
+      - ParseTextOrDie
+      - ParseTextProtoOrDie
+    CanonicalDelimiter: ''
+    BasedOnStyle: google
+ReflowComments: false
+SortIncludes: false
+SortUsingDeclarations: false
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: false
+SpacesInContainerLiterals: false
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard: Cpp11
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth: 1
+UseTab: Never
+...

--- a/dev/l0_tools/BUILD
+++ b/dev/l0_tools/BUILD
@@ -1,0 +1,35 @@
+load("@onedal//dev/bazel:cc.bzl",
+    "cc_module",
+    "cc_executable",
+)
+
+_FEATURES = ["dpc++", "pedantic"]
+
+cc_module(
+    name = "common",
+    hdrs = glob(["*.hpp"]),
+    deps = [
+        "@fmt//:fmt",
+    ],
+    features = _FEATURES,
+)
+
+cc_module(
+    name = "_zeinfo",
+    srcs = [
+        "zeinfo.cpp",
+    ],
+    deps = [
+        ":common",
+    ],
+    features = _FEATURES,
+)
+
+cc_executable(
+    name = "zeinfo",
+    deps = [
+        ":_zeinfo",
+    ],
+    user_link_flags = [ "-lze_loader" ],
+    features = _FEATURES,
+)

--- a/dev/l0_tools/utils.hpp
+++ b/dev/l0_tools/utils.hpp
@@ -1,0 +1,87 @@
+/*******************************************************************************
+* Copyright 2021 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#pragma once
+
+template <typename Container>
+class enumerate_iterator {
+public:
+    using container_const_iterator_t = typename Container::const_iterator;
+    using value_t = typename Container::value_type;
+
+    explicit enumerate_iterator(std::size_t position, const container_const_iterator_t& iterator)
+            : position_(position),
+              iterator_(iterator) {}
+
+    bool is_equal(const enumerate_iterator& other) const {
+        return iterator_ == other.iterator_;
+    }
+
+    enumerate_iterator& operator++() {
+        ++position_;
+        ++iterator_;
+        return *this;
+    }
+
+    enumerate_iterator operator++(int) {
+        const auto copy = *this;
+        ++position_;
+        ++iterator_;
+        return copy;
+    }
+
+    std::tuple<std::size_t, value_t> operator*() const {
+        return std::make_tuple(position_, *iterator_);
+    }
+
+    std::tuple<std::size_t, value_t> operator->() const {
+        return std::make_tuple(position_, *iterator_);
+    }
+
+private:
+    std::size_t position_;
+    container_const_iterator_t iterator_;
+};
+
+template <typename Container>
+inline bool operator==(const enumerate_iterator<Container>& lhs,
+                       const enumerate_iterator<Container>& rhs) {
+    return lhs.is_equal(rhs);
+}
+
+template <typename Container>
+inline bool operator!=(const enumerate_iterator<Container>& lhs,
+                       const enumerate_iterator<Container>& rhs) {
+    return !lhs.is_equal(rhs);
+}
+
+template <typename Container>
+class enumerate {
+public:
+    explicit enumerate(const Container& container) : container_(container) {}
+    explicit enumerate(Container&& container) : container_(std::move(container)) {}
+
+    enumerate_iterator<Container> begin() const {
+        return enumerate_iterator<Container>{ 0, container_.begin() };
+    }
+
+    enumerate_iterator<Container> end() const {
+        return enumerate_iterator<Container>{ container_.size(), container_.end() };
+    }
+
+private:
+    Container container_;
+};

--- a/dev/l0_tools/zeinfo.cpp
+++ b/dev/l0_tools/zeinfo.cpp
@@ -1,0 +1,166 @@
+/*******************************************************************************
+* Copyright 2021 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include <chrono>
+#include <thread>
+#include <iostream>
+#include <optional>
+#include <fmt/core.h>
+
+#include "zexx.hpp"
+#include "utils.hpp"
+
+void display_frequency(std::uint32_t index, const zexx::frequency_domain& domain) {
+    const auto properties = domain.get_properties();
+    fmt::print("   Min frequency ({}): {}MHz\n", properties.get_type_name(), properties.get_min());
+    fmt::print("   Max frequency ({}): {}MHz\n", properties.get_type_name(), properties.get_max());
+}
+
+void display_devices_info(std::uint32_t index, const zexx::device& device) {
+    const auto properties = device.get_properties();
+    fmt::print("[{}:{}] {} {}\n",
+               properties.get_type_name(),
+               index,
+               properties.get_name(),
+               properties.is_integrated() ? "(integrated)" : "");
+    fmt::print("   Threads per EU: {}\n", properties.get_thread_count_per_unit());
+    fmt::print("   EU SIMD width (32-bit lane): {}\n", properties.get_simd_width());
+    fmt::print("   EUs layout (EUs x sub-slices x slices): {} x {} x {} = {}\n",
+               properties.get_unit_count_per_subslice(),
+               properties.get_subslices_count_per_slice(),
+               properties.get_slice_count(),
+               properties.get_total_unit_count());
+    fmt::print("   Peak f32_mad/clock: {}\n", properties.get_float_mads_per_clock());
+
+    const auto freq_domains = device.get_frequency_domains();
+    for (auto [i, domain] : enumerate{ freq_domains }) {
+        display_frequency(i, domain);
+        if (i + 1 < freq_domains.size()) {
+            fmt::print("\n");
+        }
+    }
+}
+
+void display_devices_info(std::uint32_t index, const zexx::driver& driver) {
+    const auto devices = driver.get_devices();
+    if (devices.empty()) {
+        throw std::runtime_error{ "Cannot find any device" };
+    }
+
+    for (auto [i, device] : enumerate{ devices }) {
+        display_devices_info(i, device);
+        if (i + 1 < devices.size()) {
+            fmt::print("\n");
+        }
+    }
+}
+
+void display_devices_info() {
+    zexx::system_manager sysman;
+
+    const auto drivers = sysman.get_drivers();
+    if (drivers.empty()) {
+        throw std::runtime_error{ "Cannot find any driver" };
+    }
+
+    for (auto [i, driver] : enumerate{ drivers }) {
+        display_devices_info(i, driver);
+        if (i + 1 < drivers.size()) {
+            fmt::print("\n");
+        }
+    }
+}
+
+class frequency_monitor {
+public:
+    explicit frequency_monitor(std::uint32_t index, const zexx::device& device) {
+        name_ = fmt::format("{}:{}", device.get_properties().get_type_name(), index);
+        for (auto domain : device.get_frequency_domains()) {
+            if (domain.get_properties().get_type_name() == "core") {
+                core_ = domain;
+            }
+        }
+        if (!core_) {
+            throw std::runtime_error{ "Cannot query GPU frequency" };
+        }
+    }
+
+    double get_core_frequency() const {
+        return core_->get_state().get_actual();
+    }
+
+    const std::string& get_name() const {
+        return name_;
+    }
+
+private:
+    std::optional<zexx::frequency_domain> core_;
+    std::string name_;
+};
+
+std::vector<frequency_monitor> create_frequency_monitors() {
+    zexx::system_manager sysman;
+    const auto devices = sysman.get_devices();
+
+    std::vector<frequency_monitor> monitors;
+    monitors.reserve(devices.size());
+
+    for (auto [i, device] : enumerate{ devices }) {
+        monitors.emplace_back(i, device);
+    }
+
+    return monitors;
+}
+
+void display_frequency_monitors() {
+    constexpr char move_cursor_up[] = "\033[A\033[K";
+
+    const auto monitors = create_frequency_monitors();
+    while (true) {
+        for (auto& monitor : monitors) {
+            fmt::print("[{}]: {}MHz\n", monitor.get_name(), monitor.get_core_frequency());
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        std::cout << move_cursor_up << move_cursor_up << std::flush;
+    }
+}
+
+void dispatch(int argc, char const* argv[]) {
+    if (argc <= 1) {
+        return display_devices_info();
+    }
+
+    const std::string command = argv[1];
+
+    if (command == "info") {
+        display_devices_info();
+    }
+    else if (command == "freq") {
+        display_frequency_monitors();
+    }
+    else {
+        throw std::runtime_error{ "Unknown command: `" + command + "`" };
+    }
+}
+
+int main(int argc, char const* argv[]) {
+    try {
+        dispatch(argc, argv);
+    }
+    catch (const std::exception& ex) {
+        std::cerr << "Error: " << ex.what() << std::endl;
+    }
+}

--- a/dev/l0_tools/zexx.hpp
+++ b/dev/l0_tools/zexx.hpp
@@ -1,0 +1,346 @@
+/*******************************************************************************
+* Copyright 2021 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#pragma once
+
+#include <cassert>
+#include <stdexcept>
+#include <vector>
+#include <optional>
+
+#include <fmt/core.h>
+#include <level_zero/ze_api.h>
+#include <level_zero/zes_api.h>
+
+namespace zexx {
+
+inline std::string get_ze_error_message(ze_result_t status) {
+    switch (status) {
+        case ZE_RESULT_SUCCESS: return "success";
+        case ZE_RESULT_NOT_READY: return "synchronization primitive not signaled";
+        case ZE_RESULT_ERROR_DEVICE_LOST:
+            return "device hung, reset, was removed, or driver update occurred";
+        case ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY: return "insufficient host memory to satisfy call";
+        case ZE_RESULT_ERROR_OUT_OF_DEVICE_MEMORY:
+            return "insufficient device memory to satisfy call";
+        case ZE_RESULT_ERROR_MODULE_BUILD_FAILURE:
+            return "error occurred when building module, see build log for details";
+        case ZE_RESULT_ERROR_MODULE_LINK_FAILURE:
+            return "error occurred when linking modules, see build log for details";
+        case ZE_RESULT_ERROR_INSUFFICIENT_PERMISSIONS:
+            return "access denied due to permission level";
+        case ZE_RESULT_ERROR_NOT_AVAILABLE:
+            return "resource already in use and simultaneous access not allowed or resource was removed";
+        case ZE_RESULT_ERROR_DEPENDENCY_UNAVAILABLE:
+            return "external required dependency is unavailable or missing";
+        case ZE_RESULT_ERROR_UNINITIALIZED: return "driver is not initialized";
+        case ZE_RESULT_ERROR_UNSUPPORTED_VERSION:
+            return "generic error code for unsupported versions";
+        case ZE_RESULT_ERROR_UNSUPPORTED_FEATURE:
+            return "generic error code for unsupported features";
+        case ZE_RESULT_ERROR_INVALID_ARGUMENT: return "generic error code for invalid arguments";
+        case ZE_RESULT_ERROR_INVALID_NULL_HANDLE: return "handle argument is not valid";
+        case ZE_RESULT_ERROR_HANDLE_OBJECT_IN_USE:
+            return "object pointed to by handle still in-use by device";
+        case ZE_RESULT_ERROR_INVALID_NULL_POINTER: return "pointer argument may not be nullptr";
+        case ZE_RESULT_ERROR_INVALID_SIZE:
+            return "size argument is invalid (e.g., must not be zero)";
+        case ZE_RESULT_ERROR_UNSUPPORTED_SIZE:
+            return "size argument is not supported by the device (e.g., too large)";
+        case ZE_RESULT_ERROR_UNSUPPORTED_ALIGNMENT:
+            return "alignment argument is not supported by the device (e.g.,";
+        case ZE_RESULT_ERROR_INVALID_SYNCHRONIZATION_OBJECT:
+            return "synchronization object in invalid state";
+        case ZE_RESULT_ERROR_INVALID_ENUMERATION: return "enumerator argument is not valid";
+        case ZE_RESULT_ERROR_UNSUPPORTED_ENUMERATION:
+            return "enumerator argument is not supported by the device";
+        case ZE_RESULT_ERROR_UNSUPPORTED_IMAGE_FORMAT:
+            return "image format is not supported by the device";
+        case ZE_RESULT_ERROR_INVALID_NATIVE_BINARY:
+            return "native binary is not supported by the device";
+        case ZE_RESULT_ERROR_INVALID_GLOBAL_NAME:
+            return "global variable is not found in the module";
+        case ZE_RESULT_ERROR_INVALID_KERNEL_NAME: return "kernel name is not found in the module";
+        case ZE_RESULT_ERROR_INVALID_FUNCTION_NAME:
+            return "function name is not found in the module";
+        case ZE_RESULT_ERROR_INVALID_GROUP_SIZE_DIMENSION:
+            return "group size dimension is not valid for the kernel or";
+        case ZE_RESULT_ERROR_INVALID_GLOBAL_WIDTH_DIMENSION:
+            return "global width dimension is not valid for the kernel or";
+        case ZE_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_INDEX:
+            return "kernel argument index is not valid for kernel";
+        case ZE_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE:
+            return "kernel argument size does not match kernel";
+        case ZE_RESULT_ERROR_INVALID_KERNEL_ATTRIBUTE_VALUE:
+            return "value of kernel attribute is not valid for the kernel or";
+        case ZE_RESULT_ERROR_INVALID_MODULE_UNLINKED:
+            return "module with imports needs to be linked before kernels can";
+        case ZE_RESULT_ERROR_INVALID_COMMAND_LIST_TYPE:
+            return "command list type does not match command queue type";
+        case ZE_RESULT_ERROR_OVERLAPPING_REGIONS:
+            return "copy operations do not support overlapping regions of";
+        default: return "unknown or internal error";
+    }
+}
+
+inline void check_ze(ze_result_t status) {
+    if (status != ZE_RESULT_SUCCESS) {
+        throw std::runtime_error{ fmt::format("L0 returned error: {}",
+                                              get_ze_error_message(status)) };
+    }
+}
+
+template <typename T, typename Init>
+inline T get_or_init(std::optional<T>& optional_value, Init&& init) {
+    if (!optional_value) {
+        optional_value = T{ init() };
+    }
+    return *optional_value;
+}
+
+template <typename Handle>
+class handled {
+public:
+    explicit handled(const Handle& handle) : handle_(handle) {
+        if constexpr (std::is_pointer_v<Handle>) {
+            assert(handle != nullptr);
+        }
+    }
+
+protected:
+    const Handle& get_handle() const {
+        return handle_;
+    }
+
+private:
+    Handle handle_;
+};
+
+class frequency_domain_properties : public handled<zes_freq_properties_t> {
+public:
+    using handled<zes_freq_properties_t>::handled;
+
+    std::string get_type_name() const {
+        return get_or_init(type_name_, [&]() {
+            switch (get_handle().type) {
+                case ZES_FREQ_DOMAIN_GPU: return "core";
+                case ZES_FREQ_DOMAIN_MEMORY: return "memory";
+                default: return "Unknown";
+            }
+        });
+    }
+
+    double get_min() const {
+        return get_handle().min;
+    }
+
+    double get_max() const {
+        return get_handle().max;
+    }
+
+private:
+    mutable std::optional<std::string> type_name_;
+};
+
+class frequency_domain_state : public handled<zes_freq_state_t> {
+public:
+    using handled<zes_freq_state_t>::handled;
+
+    double get_actual() const {
+        return get_handle().actual;
+    }
+};
+
+class frequency_domain : public handled<zes_freq_handle_t> {
+public:
+    using handled<zes_freq_handle_t>::handled;
+
+    frequency_domain_properties get_properties() const {
+        return get_or_init(properties_, [&]() {
+            zes_freq_properties_t properties;
+            check_ze(zesFrequencyGetProperties(get_handle(), &properties));
+            return properties;
+        });
+    }
+
+    frequency_domain_state get_state() const {
+        zes_freq_state_t state;
+        check_ze(zesFrequencyGetState(get_handle(), &state));
+        return frequency_domain_state{ state };
+    }
+
+private:
+    mutable std::optional<frequency_domain_properties> properties_;
+};
+
+class device_properties : public handled<ze_device_properties_t> {
+public:
+    using handled<ze_device_properties_t>::handled;
+
+    std::string get_name() const {
+        return get_or_init(name_, [&]() {
+            return get_handle().name;
+        });
+    }
+
+    std::string get_type_name() const {
+        return get_or_init(type_name_, [&]() {
+            switch (get_handle().type) {
+                case ZE_DEVICE_TYPE_CPU: return "CPU";
+                case ZE_DEVICE_TYPE_GPU: return "GPU";
+                case ZE_DEVICE_TYPE_FPGA: return "FPGA";
+                default: return "Unknown";
+            }
+        });
+    }
+
+    std::uint32_t get_id() const {
+        return get_handle().deviceId;
+    }
+
+    std::uint32_t get_thread_count_per_unit() const {
+        return get_handle().numThreadsPerEU;
+    }
+
+    std::uint32_t get_simd_width() const {
+        return get_handle().physicalEUSimdWidth;
+    }
+
+    std::uint32_t get_unit_count_per_subslice() const {
+        return get_handle().numEUsPerSubslice;
+    }
+
+    std::uint32_t get_subslices_count_per_slice() const {
+        return get_handle().numSubslicesPerSlice;
+    }
+
+    std::uint32_t get_slice_count() const {
+        return get_handle().numSlices;
+    }
+
+    std::uint32_t get_total_unit_count() const {
+        return get_unit_count_per_subslice() * //
+               get_subslices_count_per_slice() * //
+               get_slice_count();
+    }
+
+    std::uint32_t get_float_mads_per_clock() const {
+        return get_simd_width() * get_total_unit_count();
+    }
+
+    bool is_integrated() const {
+        return bool(get_handle().flags & ZE_DEVICE_PROPERTY_FLAG_INTEGRATED);
+    }
+
+private:
+    mutable std::optional<std::string> name_;
+    mutable std::optional<std::string> type_name_;
+};
+
+class device : public handled<ze_device_handle_t> {
+public:
+    using handled<ze_device_handle_t>::handled;
+
+    device_properties get_properties() const {
+        return get_or_init(properties_, [&]() {
+            ze_device_properties_t handle;
+            check_ze(zeDeviceGetProperties(get_handle(), &handle));
+            return handle;
+        });
+    }
+
+    std::vector<frequency_domain> get_frequency_domains() const {
+        std::uint32_t domain_count = 0;
+        check_ze(zesDeviceEnumFrequencyDomains(get_zes_handle(), &domain_count, nullptr));
+
+        std::vector<zes_freq_handle_t> domain_handles(domain_count);
+        check_ze(
+            zesDeviceEnumFrequencyDomains(get_zes_handle(), &domain_count, domain_handles.data()));
+
+        std::vector<frequency_domain> domains;
+        domains.reserve(domain_handles.size());
+        for (auto handle : domain_handles) {
+            domains.emplace_back(handle);
+        }
+        return domains;
+    }
+
+    void query_frequency() const {
+        // zesDeviceEnumFrequencyDomains()
+    }
+
+private:
+    zes_device_handle_t get_zes_handle() const {
+        return static_cast<zes_device_handle_t>(get_handle());
+    }
+
+    mutable std::optional<device_properties> properties_;
+};
+
+class driver : public handled<ze_driver_handle_t> {
+public:
+    using handled<ze_driver_handle_t>::handled;
+
+    std::vector<device> get_devices() const {
+        std::uint32_t device_count = 0;
+        check_ze(zeDeviceGet(get_handle(), &device_count, nullptr));
+
+        std::vector<ze_device_handle_t> device_handles(device_count);
+        check_ze(zeDeviceGet(get_handle(), &device_count, device_handles.data()));
+
+        std::vector<device> devices;
+        devices.reserve(device_handles.size());
+        for (auto handle : device_handles) {
+            devices.emplace_back(handle);
+        }
+        return devices;
+    }
+};
+
+class system_manager {
+public:
+    explicit system_manager() {
+        setenv("ZES_ENABLE_SYSMAN", "1", true);
+        check_ze(zeInit(0));
+    }
+
+    std::vector<driver> get_drivers() const {
+        std::uint32_t driver_count = 0;
+        check_ze(zeDriverGet(&driver_count, nullptr));
+
+        std::vector<ze_driver_handle_t> driver_handles(driver_count);
+        check_ze(zeDriverGet(&driver_count, driver_handles.data()));
+
+        std::vector<driver> drivers;
+        drivers.reserve(driver_handles.size());
+        for (auto handle : driver_handles) {
+            drivers.emplace_back(handle);
+        }
+        return drivers;
+    }
+
+    std::vector<device> get_devices() const {
+        std::vector<device> devices;
+        for (auto driver : get_drivers()) {
+            for (auto device : driver.get_devices()) {
+                devices.push_back(device);
+            }
+        }
+        return devices;
+    }
+};
+
+} // namespace zexx

--- a/dev/l0_tools/zexx.hpp
+++ b/dev/l0_tools/zexx.hpp
@@ -278,10 +278,6 @@ public:
         return domains;
     }
 
-    void query_frequency() const {
-        // zesDeviceEnumFrequencyDomains()
-    }
-
 private:
     zes_device_handle_t get_zes_handle() const {
         return static_cast<zes_device_handle_t>(get_handle());


### PR DESCRIPTION
Introduce L0-based tool to get information about GPU :fire:

**Build:**
```sh
bazel build //dev/l0_tools:zeinfo
```

**Usage:**
```sh
# Info about GPUs
./bazel-bin/dev/l0_tools/zeinfo
# or 
./bazel-bin/dev/l0_tools/zeinfo info

# Dynamically monitor frequency
./bazel-bin/dev/l0_tools/zeinfo freq
```

In general, you may find out LevelZero API usage examples useful in the future.

Example of tool output:
```sh
[GPU:0] XXXXXXXXXXXXXXXXXXX [xxxxxx] 
   Threads per EU: X
   EU SIMD width (32-bit lane): X
   EUs layout (EUs x sub-slices x slices): X x X x X = XX
   Peak f32_mad/clock: XXX
   Min frequency (core): XXXMHz
   Max frequency (core): XXXXMHz
```