### PR TITLE
Fix of Decision Forest model serialization

### DIFF
--- a/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_model.cpp
+++ b/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_model.cpp
@@ -238,7 +238,7 @@ bool ModelImpl::add(const TreeType & tree, size_t nClasses, size_t iTree)
     auto pTbl           = new DecisionTreeTable(nNode);
     auto impTbl         = new HomogenNumericTable<double>(1, nNode, NumericTable::doAllocate);
     auto nodeSamplesTbl = new HomogenNumericTable<int>(1, nNode, NumericTable::doAllocate);
-    auto probTbl        = new HomogenNumericTable<double>(nNode, nClasses, NumericTable::doAllocate);
+    auto probTbl        = new HomogenNumericTable<double>(DictionaryIface::equal, nNode, nClasses, NumericTable::doAllocate);
 
     if (!pTbl || !impTbl || !nodeSamplesTbl || !probTbl)
     {


### PR DESCRIPTION
# Description
Since 2020.0 release decision forest serialized model grew 10x times because of probabilities tables addition. Collection of these tables has nTrees items of shape nClasses rows x nNodes columns, each item is Homogen table with dictionary property `featuresEqual = notEqual`. On serialization, numeric table dictionary saves every Feature (i.e. nNodes Features), which has 5 properties (each stored in 64 bytes block because of DataArchive implementation). In result, rough memory usage of serialized prob. tables collection: `nTrees x nNodes x 5 x 64 bytes +  nTrees x nClasses x nNodes x sizeof(double)`. 
Fix: set `featuresEqual = equal` to serialize Feature once for each table
Deserialization from previous releases is saved and checked.