### PR TITLE
Changed PKG_CONFIG_PATH variable separator for Windows

### DIFF
--- a/deploy/local/vars_win.bat
+++ b/deploy/local/vars_win.bat
@@ -46,7 +46,7 @@ set "INCLUDE=%DAAL%\include;%INCLUDE%"
 set "CPATH=%DAAL%\include;%CPATH%"
 set "LIB=%DAAL%\lib\%DAAL_IA%;%LIB%"
 set "CMAKE_PREFIX_PATH=%DAAL%;%CMAKE_PREFIX_PATH%"
-set "PKG_CONFIG_PATH=%DAAL%\lib\pkgconfig;%PKG_CONFIG_PATH%"
+set "PKG_CONFIG_PATH=%DAAL%\lib\pkgconfig:%PKG_CONFIG_PATH%"
 if exist "%DAAL_UP_OLD%\redist" (
     set "PATH=%DAAL_UP_OLD%\redist\%DAAL_IA%_win\daal;%PATH%"
 ) else (


### PR DESCRIPTION
Since PKG_CONFIG_PATH is a POSIX variable, the (;) it is perceived by the Windows system as part of the path, so the .pc files are not found. Colon (:) separation solves this problem.