### PR TITLE
Fix for oneAPI C++ Mac examples list

### DIFF
--- a/examples/oneapi/cpp/onedal_mac.lst
+++ b/examples/oneapi/cpp/onedal_mac.lst
@@ -19,7 +19,7 @@
 ##     oneAPI Data Analytics Library examples list
 ##******************************************************************************
 
-ONEDAL = basic_statistics_dense_batch        \ 
+ONEDAL = basic_statistics_dense_batch        \
          column_accessor_homogen             \
          connected_components_batch          \
          cor_dense_batch                     \


### PR DESCRIPTION
# Description
Remove extra space from first line of list to fix examples running.