### PR TITLE
replaced vector_class with std::vector

### DIFF
--- a/cpp/oneapi/dal/array.hpp
+++ b/cpp/oneapi/dal/array.hpp
@@ -172,7 +172,7 @@ public:
     template <typename Y>
     [[deprecated]] static array<T> wrap(Y* data,
                                         std::int64_t count,
-                                        const sycl::vector_class<sycl::event>& dependencies) {
+                                        const std::vector<sycl::event>& dependencies) {
         sycl::event::wait_and_throw(dependencies);
         return array<T>{ data, count, dal::detail::empty_delete<const T>{} };
     }
@@ -193,7 +193,7 @@ public:
     static array<T> wrap(const sycl::queue& queue,
                          Y* data,
                          std::int64_t count,
-                         const sycl::vector_class<sycl::event>& dependencies = {}) {
+                         const std::vector<sycl::event>& dependencies = {}) {
         return array<T>{ queue, data, count, dal::detail::empty_delete<const T>{}, dependencies };
     }
 #endif
@@ -253,7 +253,7 @@ public:
                    T* data,
                    std::int64_t count,
                    Deleter&& deleter,
-                   const sycl::vector_class<sycl::event>& dependencies = {})
+                   const std::vector<sycl::event>& dependencies = {})
             : impl_(new impl_t(detail::data_parallel_policy{ queue },
                                data,
                                count,
@@ -302,7 +302,7 @@ public:
                    const T* data,
                    std::int64_t count,
                    ConstDeleter&& deleter,
-                   const sycl::vector_class<sycl::event>& dependencies = {})
+                   const std::vector<sycl::event>& dependencies = {})
             : impl_(new impl_t(detail::data_parallel_policy{ queue },
                                data,
                                count,
@@ -333,7 +333,7 @@ public:
     explicit array(const sycl::queue& queue,
                    const std::shared_ptr<T>& data,
                    std::int64_t count,
-                   const sycl::vector_class<sycl::event>& dependencies = {})
+                   const std::vector<sycl::event>& dependencies = {})
             : impl_(new impl_t(detail::data_parallel_policy{ queue }, data, count)) {
         ONEDAL_ASSERT(sycl::get_pointer_type(data.get(), queue.get_context()) !=
                       sycl::usm::alloc::unknown);
@@ -362,7 +362,7 @@ public:
     explicit array(const sycl::queue& queue,
                    const std::shared_ptr<const T>& data,
                    std::int64_t count,
-                   const sycl::vector_class<sycl::event>& dependencies = {})
+                   const std::vector<sycl::event>& dependencies = {})
             : impl_(new impl_t(detail::data_parallel_policy{ queue }, data, count)) {
         ONEDAL_ASSERT(sycl::get_pointer_type(data.get(), queue.get_context()) !=
                       sycl::usm::alloc::unknown);
@@ -545,7 +545,7 @@ public:
                T* data,
                std::int64_t count,
                Deleter&& deleter,
-               const sycl::vector_class<sycl::event>& dependencies = {}) {
+               const std::vector<sycl::event>& dependencies = {}) {
         ONEDAL_ASSERT(sycl::get_pointer_type(data, queue.get_context()) !=
                       sycl::usm::alloc::unknown);
         impl_->reset(detail::data_parallel_policy{ queue },
@@ -594,7 +594,7 @@ public:
                const T* data,
                std::int64_t count,
                ConstDeleter&& deleter,
-               const sycl::vector_class<sycl::event>& dependencies = {}) {
+               const std::vector<sycl::event>& dependencies = {}) {
         ONEDAL_ASSERT(sycl::get_pointer_type(data, queue.get_context()) !=
                       sycl::usm::alloc::unknown);
         impl_->reset(detail::data_parallel_policy{ queue },

--- a/cpp/oneapi/dal/detail/array_compat.hpp
+++ b/cpp/oneapi/dal/detail/array_compat.hpp
@@ -99,7 +99,7 @@ public:
     template <typename Y>
     static array<T> wrap(Y* data,
                          std::int64_t count,
-                         const sycl::vector_class<sycl::event>& dependencies) {
+                         const std::vector<sycl::event>& dependencies) {
         return array<T>{ data, count, dal::detail::empty_delete<const T>{}, dependencies };
     }
 #endif
@@ -145,7 +145,7 @@ public:
                    T* data,
                    std::int64_t count,
                    Deleter&& deleter,
-                   const sycl::vector_class<sycl::event>& dependencies = {})
+                   const std::vector<sycl::event>& dependencies = {})
             : impl_(new impl_t(data, count, std::forward<Deleter>(deleter))) {
         update_data(impl_.get());
         sycl::event::wait_and_throw(dependencies);
@@ -156,7 +156,7 @@ public:
                    const T* data,
                    std::int64_t count,
                    ConstDeleter&& deleter,
-                   const sycl::vector_class<sycl::event>& dependencies = {})
+                   const std::vector<sycl::event>& dependencies = {})
             : impl_(new impl_t(data, count, std::forward<ConstDeleter>(deleter))) {
         update_data(impl_.get());
         sycl::event::wait_and_throw(dependencies);
@@ -257,7 +257,7 @@ public:
     void reset(Y* data,
                std::int64_t count,
                YDeleter&& deleter,
-               const sycl::vector_class<sycl::event>& dependencies) {
+               const std::vector<sycl::event>& dependencies) {
         sycl::event::wait_and_throw(dependencies);
         reset(data, count, std::forward<YDeleter>(deleter));
     }

--- a/cpp/oneapi/dal/table/detail/table_builder.hpp
+++ b/cpp/oneapi/dal/table/detail/table_builder.hpp
@@ -113,7 +113,7 @@ public:
                     const Data* data,
                     std::int64_t row_count,
                     std::int64_t column_count,
-                    const sycl::vector_class<sycl::event>& dependencies = {}) {
+                    const std::vector<sycl::event>& dependencies = {}) {
         sycl::event::wait_and_throw(dependencies);
         get_impl().copy_data(detail::data_parallel_policy{ queue }, data, row_count, column_count);
         return *this;

--- a/cpp/oneapi/dal/table/homogen.hpp
+++ b/cpp/oneapi/dal/table/homogen.hpp
@@ -81,7 +81,7 @@ public:
                               const Data* data_pointer,
                               std::int64_t row_count,
                               std::int64_t column_count,
-                              const sycl::vector_class<sycl::event>& dependencies = {},
+                              const std::vector<sycl::event>& dependencies = {},
                               data_layout layout = data_layout::row_major) {
         return homogen_table{ queue,
                               data_pointer,
@@ -179,7 +179,7 @@ public:
                   std::int64_t row_count,
                   std::int64_t column_count,
                   ConstDeleter&& data_deleter,
-                  const sycl::vector_class<sycl::event>& dependencies = {},
+                  const std::vector<sycl::event>& dependencies = {},
                   data_layout layout = data_layout::row_major) {
         init_impl(detail::data_parallel_policy{ queue },
                   row_count,


### PR DESCRIPTION
replaced vector_class with std::vector because of compiler deprecated "using vector_class"