### PR TITLE
Replacing Intel clang with dpcpp in makefiles

### DIFF
--- a/dev/make/cmplr.icx.mk
+++ b/dev/make/cmplr.icx.mk
@@ -1,0 +1,48 @@
+#===============================================================================
+# Copyright 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#===============================================================================
+
+#++
+#  Intel compiler defenitions for makefile
+#--
+
+PLATs.icx = lnx32e mac32e fbsd32e
+
+CMPLRDIRSUFF.icx = _icx
+
+CORE.SERV.COMPILER.icx = generic
+
+-Zl.icx =  -no-intel-lib=libirc
+-DEBC.icx = -g
+
+COMPILER.lnx.icx = icpx $(if $(IA_is_ia32),-m32,-m64) \
+                     -Werror -Wreturn-type
+
+
+link.dynamic.lnx.icx = icpx $(if $(IA_is_ia32),-m32,-m64)
+
+pedantic.opts.icx = -pedantic \
+                      -Wall \
+                      -Wextra \
+                      -Wno-unused-parameter
+
+pedantic.opts.lnx.icx = $(pedantic.opts.icx)
+
+p4_OPT.icx   = $(-Q)march=nocona
+mc_OPT.icx   = $(-Q)march=core2
+mc3_OPT.icx  = $(-Q)march=nehalem
+avx_OPT.icx  = $(-Q)march=sandybridge
+avx2_OPT.icx = $(-Q)march=haswell
+skx_OPT.icx  = $(-Q)march=skx

--- a/dev/make/deps.mk
+++ b/dev/make/deps.mk
@@ -79,6 +79,7 @@ $1 = $$(if $$(or $$(.sources-changed),$$(and $$(.mkfiles-changed),$$(call .trigg
 dep-gen-enhanced-common   = $(call $(SELF),$1 $(.copt-gen-deps)) && $(.keep-raw-deps) sed -n $(sed.-i) $(sed.fix-deps) $(sed.rm-abs-paths) -e '/./{ p; $(sed.mk-phony-targets)}' $(.dep-file-tmp)
 dep-gen-enhanced.icc   = $(dep-gen-enhanced-common)
 dep-gen-enhanced.icl   = $(dep-gen-enhanced-common)
+dep-gen-enhanced.icx   = $(dep-gen-enhanced-common)
 dep-gen-enhanced.g++   = $(dep-gen-enhanced-common)
 dep-gen-enhanced.dpcpp = $(if $(OS_is_win),,$(dep-gen-enhanced-common))
 cmd-enhanced-with-dep-gen = $(or $(dep-gen-enhanced.$(call get-command-name,$($(SELF)))),$($(SELF)))

--- a/examples/daal/cpp_sycl/makefile_lnx
+++ b/examples/daal/cpp_sycl/makefile_lnx
@@ -24,8 +24,8 @@ help:
 	@echo
 	@echo "name              - example name. Please see daal.lst file."
 	@echo
-	@echo "compiler_name     - the only supported compiler is clang (default value)"
-	@echo "                    Intel(R) oneAPI DPC++ compiler"
+	@echo "compiler_name     - the only supported compiler is dpcpp (default value)"
+	@echo "                    Intel(R) oneAPI DPC++/C++ Compiler"
 	@echo "mode_name         - can be build or run. Default is run"
 
 ##------------------------------------------------------------------------------
@@ -35,15 +35,15 @@ help:
 ##                                 and run pca example for 64-bit
 ##                                 applications, static linking
 ##
-## make sointel64 compiler=clang   - build by Intel(R) oneAPI Compiler and run all examples
+## make sointel64 compiler=dpcpp   - build by Intel(R) oneAPI Compiler and run all examples
 ##                                 of Intel(R) oneDAL for
 ##                                 64-bit applications, dynamic linking
 ##
-## make sointel64                - build by Intel(R) oneAPI Compiler (as default)
+## make sointel64                - build by Intel(R) oneAPI DPC++/C++ Compiler (as default)
 ##                                 and run all examples for Intel(R)64 processor
 ##                                 family  applications, dynamic linking
 ##
-## make sointel64 mode=build     - build only (not run) by Intel(R) oneAPI Compiler
+## make sointel64 mode=build     - build only (not run) by Intel(R) oneAPI DPC++/C++ Compiler
 ##                                 (as default) all examples for Intel(R)64
 ##                                 processor family  applications, dynamic linking
 ##
@@ -57,8 +57,17 @@ ifndef example
     example = $(DAAL)
 endif
 
+ifeq ($(compiler),clang)
+    $(warning warning: clang driver usage has been deprecated. Please user dpcpp)
+    override compiler = dpcpp
+endif
+
 ifndef compiler
-    compiler = clang
+    compiler = dpcpp
+endif
+
+ifneq ($(compiler),dpcpp)
+    override compiler = dpcpp
 endif
 
 ifneq ($(mode),build)
@@ -104,10 +113,10 @@ LOPTS := -Wl,--start-group -Wl,$(DAAL_LIB),$(EXT_LIB) $(DAAL_PATH)/libonedal_syc
 RES_DIR=_results/$(compiler)_$(_IA)_$(threading)_$(RES_EXT)
 RES = $(addprefix $(RES_DIR)/, $(if $(filter run, $(mode)), $(addsuffix .res ,$(example)), $(addsuffix .exe,$(example))))
 
-ifeq ($(compiler),clang)
-    gcc_toolchain := $(realpath $(dir $(shell which gcc))/..)
-    CC = dpcpp --gcc-toolchain=$(gcc_toolchain)
-endif
+
+gcc_toolchain := $(realpath $(dir $(shell which gcc))/..)
+CC = dpcpp --gcc-toolchain=$(gcc_toolchain)
+
 
 CC := $(if $(COVFILE), cov01 -1; covc -i  $(CC),$(CC))
 

--- a/examples/daal/cpp_sycl/makefile_win
+++ b/examples/daal/cpp_sycl/makefile_win
@@ -24,8 +24,8 @@ help:
 	@echo
 	@echo "name              - example name."
 	@echo
-	@echo "compiler_name     - the only supported compiler is clang (default value)"
-	@echo "                    Intel(R) oneAPI DPC++ compiler"
+	@echo "compiler_name     - the only supported compiler is dpcpp (default value)"
+	@echo "                    Intel(R) oneAPI DPC++/C++ Compiler"
 	@echo
 	@echo "mode_name         - can be build or run. Default is run."
 
@@ -36,19 +36,19 @@ help:
 ##                                                 and run kmeans_dense_batch example for 64-bit
 ##                                                 applications, static linking
 ##
-## nmake dll example=kmeans_dense_batch+         - build by Intel(R) oneAPI Compiler (as default)
+## nmake dll example=kmeans_dense_batch+         - build by Intel(R) oneAPI DPC++/C++ Compiler (as default)
 ##                                                 and run kmeans_dense_batch example for 64-bit
 ##                                                 applications, dynamic linking
 ##
-## nmake dll compiler=clang                      - build by Intel(R) oneAPI Compiler (as default)
+## nmake dll compiler=dpcpp                      - build by Intel(R) oneAPI DPC++/C++ Compiler (as default)
 ##                                                 and run all examples of Intel(R) oneDAL for
 ##                                                 64-bit applications, dynamic linking
 ##
-## nmake dll                                     - build by Intel(R) oneAPI Compiler (as default)
+## nmake dll                                     - build by Intel(R) oneAPI DPC++/C++ Compiler (as default)
 ##                                                 and run all examples for Intel(R) 64 processor
 ##                                                 family applications, dynamic linking
 ##
-## nmake dll mode=build                          - build only (not run) by Intel(R) oneAPI Compiler
+## nmake dll mode=build                          - build only (not run) by Intel(R) oneAPI DPC++/C++ Compiler
 ##                                                 (as default) all examples for Intel(R) 64
 ##                                                 processor family applications, dynamic linking
 ##
@@ -62,8 +62,13 @@ help:
 example = $(EXAMPLES_LIST)
 !ENDIF
 
+!IF ("$(compiler)"=="clang")
+WARNING  clang driver usage has been deprecated. Please use dpcpp
+compiler = dpcpp
+!ENDIF
+
 !IFNDEF compiler
-compiler = clang
+compiler = dpcpp
 !ENDIF
 
 !IFNDEF mode
@@ -88,8 +93,8 @@ RES = $(example:+=.exe)
 RES = $(example:+=.res)
 !ENDIF
 
-!IF ("$(compiler)"=="clang")
-CC=dpcpp
+!IF ("$(compiler)"=="dpcpp")
+CC=dpcpp-cl
 COPTS= /EHs -fsycl-device-code-split=per_kernel
 OUT_OPTS=/Fe$(RES_DIR)
 RT_LIB=/link /ignore:4078 OpenCL.lib "$(DAAL_PATH)\onedal_sycl.lib"

--- a/examples/oneapi/cpp/makefile_lnx
+++ b/examples/oneapi/cpp/makefile_lnx
@@ -25,7 +25,7 @@ help:
 	@echo
 	@echo "name              - example name. Please see onedal.lst file"
 	@echo
-	@echo "compiler_name     - can be intel, gnu, clang or icx. Default value is intel."
+	@echo "compiler_name     - can be intel, dpcpp, icx or gnu. Default value is intel."
 	@echo
 	@echo "threading_name    - can be parallel or sequential. Default value is parallel."
 	@echo
@@ -59,8 +59,12 @@ ifndef example
     example = $(ONEDAL)
 endif
 
+ifeq ($(compiler),clang)
+    override compiler = dpcpp
+endif
+
 ifneq ($(compiler),gnu)
-    ifneq ($(compiler),clang)
+    ifneq ($(compiler),dpcpp)
         ifneq ($(compiler),icx)
             override compiler = intel
         endif
@@ -136,9 +140,9 @@ ifeq ($(compiler),gnu)
     CC = g++
 endif
 
-ifeq ($(compiler),clang)
+ifeq ($(compiler),dpcpp)
     gcc_toolchain := $(realpath $(dir $(shell which gcc))/..)
-    CC = clang++ --gcc-toolchain=$(gcc_toolchain)
+    CC = dpcpp --gcc-toolchain=$(gcc_toolchain)
 endif
 
 ifeq ($(compiler),icx)

--- a/examples/oneapi/cpp/makefile_win
+++ b/examples/oneapi/cpp/makefile_win
@@ -24,7 +24,7 @@ help:
 	@echo
 	@echo "name              - example name."
 	@echo
-	@echo "compiler_name     - can be intel, msvs, clang or icx. Default value is intel."
+	@echo "compiler_name     - can be intel, msvs, dpcpp or icx. Default value is intel."
 	@echo "                    Intel(R) C++ Compiler as default."
 	@echo
 	@echo "threading_name    - can be parallel or sequential. Default value is parallel."
@@ -101,8 +101,8 @@ CC=icl
 COPTS=$(COMMON_COPTS) -Qstd:c++17 $(ARCH_OPT)
 !ENDIF
 
-!IF ("$(compiler)"=="clang")
-CC=clang-cl
+!IF ("$(compiler)"=="dpcpp" || "$(compiler)"=="clang")
+CC=dpcpp-cl
 COPTS=$(COMMON_COPTS) -Qstd:c++17 $(ARCH_OPT)
 !ENDIF
 
@@ -117,7 +117,7 @@ DAAL_LIB_T = $(DAAL_PATH)\onedal_sequential.lib
 threading = parallel
 DAAL_LIB_T = $(DAAL_PATH)\onedal_thread.lib
 
-!IF ("$(compiler)"!="clang"&&"$(compiler)"!="icx")
+!IF ("$(compiler)"!="icx"&&"$(compiler)"!="dpcpp"&&"$(compiler)"!="clang")
 EXT_LIB = tbb12.lib tbbmalloc.lib
 !ELSE
 EXT_LIB = /link /DEFAULTLIB:tbb12.lib /DEFAULTLIB:tbbmalloc.lib

--- a/examples/oneapi/dpc/makefile_lnx
+++ b/examples/oneapi/dpc/makefile_lnx
@@ -25,20 +25,20 @@ help:
 	@echo "name              - example name. Please see onedal.lst file"
 	@echo
 	@echo "compiler_name     - currently can be dpcpp only that stands
-	@echo "                    for Intel(R) oneAPI DPC++ Compiler."
+	@echo "                    for Intel(R) oneAPI DPC++/C++ Compiler."
 	@echo
 	@echo "mode_name         - can be build or run. Default is run"
 
 ##------------------------------------------------------------------------------
 ## examples of using:
 ##
-## make lib example=pca_cor_dense_batch   - build by Intel(R) oneAPI DPC++ Compiler (as default)
+## make lib example=pca_cor_dense_batch   - build by Intel(R) oneAPI DPC++/C++ Compiler (as default)
 ##                                          and run pca_cor_dense_batch example, static linking
 ##
-## make so                                - build by Intel(R) oneAPI DPC++ Compiler (as default)
+## make so                                - build by Intel(R) oneAPI DPC++/C++ Compiler (as default)
 ##                                          and run all examples, dynamic linking
 ##
-## make so mode=build                     - build only (not run) by Intel(R) oneAPI DPC++ Compiler
+## make so mode=build                     - build only (not run) by Intel(R) oneAPI DPC++/C++ Compiler
 ##                                          (as default) all examples, dynamic linking
 ##
 ## make help                              - show help

--- a/examples/oneapi/dpc/makefile_win
+++ b/examples/oneapi/dpc/makefile_win
@@ -25,7 +25,7 @@ help:
 	@echo "name              - example name."
 	@echo
 	@echo "compiler_name     - the only supported compiler is dpcpp (default value)"
-	@echo "                    Intel(R) oneAPI DPC++ Compiler"
+	@echo "                    Intel(R) oneAPI DPC++/C++ Compiler"
 	@echo
 	@echo "threading_name    - can be parallel or sequential. Default value is parallel."
 	@echo
@@ -38,10 +38,10 @@ help:
 ##                                          and run kmeans_dense_batch example for 64-bit
 ##                                          applications, static linking
 ##
-## make dll                               - build by Intel(R) oneAPI DPC++ Compiler (as default)
+## make dll                               - build by Intel(R) oneAPI DPC++/C++ Compiler (as default)
 ##                                          and run all examples, dynamic linking
 ##
-## make dll mode=build                    - build only (not run) by Intel(R) oneAPI DPC++ Compiler
+## make dll mode=build                    - build only (not run) by Intel(R) oneAPI DPC++/C++ Compiler
 ##                                          (as default) all examples, dynamic linking
 ##
 ## make help                              - show help
@@ -81,7 +81,7 @@ RES = $(example:+=.res)
 !ENDIF
 
 !IF ("$(compiler)"=="dpcpp" || "$(compiler)"=="clang")
-CC=dpcpp
+CC=dpcpp-cl
 COPTS=/W3 /EHsc /std:c++17 -fsycl-device-code-split=per_kernel
 OUT_OPTS=/Fe$(RES_DIR)
 CLEAN=

--- a/makefile
+++ b/makefile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #===============================================================================
 
-COMPILERs = icc gnu clang vc
+COMPILERs = icc icx gnu clang vc
 COMPILER ?= icc
 
 $(if $(filter $(COMPILERs),$(COMPILER)),,$(error COMPILER must be one of $(COMPILERs)))

--- a/samples/daal/cpp/oneccl/makefile_lnx
+++ b/samples/daal/cpp/oneccl/makefile_lnx
@@ -24,7 +24,7 @@ help:
 	@echo
 	@echo "name              - example name. Please see daal.lst file."
 	@echo
-	@echo "compiler_name     - the only supported compiler is clang (default value)"
+	@echo "compiler_name     - the only supported compiler is dpcpp (default value)"
 	@echo "                    Intel(R) oneAPI DPC++ compiler"
 	@echo
 	@echo "threading_name    - can be parallel or sequential. Default value is parallel."
@@ -38,7 +38,7 @@ help:
 ##                                 and run pca example for 64-bit
 ##                                 applications, static linking
 ##
-## make sointel64 compiler=clang   - build by Intel(R) oneAPI Compiler and run all examples
+## make sointel64 compiler=dpcpp   - build by Intel(R) oneAPI Compiler and run all examples
 ##                                 of oneDAL for
 ##                                 64-bit applications, dynamic linking
 ##
@@ -61,7 +61,12 @@ ifndef example
 endif
 
 ifndef compiler
-    compiler = clang
+    compiler = dpcpp
+endif
+
+ifeq ($(compiler),clang)
+    $(warning warning: clang driver usage has been deprecated. Please user dpcpp)
+    override compiler = dpcpp
 endif
 
 ifneq ($(mode),build)
@@ -99,8 +104,8 @@ DAAL_LIB := -L$(DAAL_PATH),$(DAAL_LIB_EXT),-lonedal_core,-Bdynamic -Wl,$(DAAL_LI
 
 COPTS := -Wall -w -I./source/utils
 
-ifeq ($(compiler),clang)
-    CC = clang++
+ifeq ($(compiler),dpcpp)
+    CC = dpcpp
     COPTS += -fsycl -fsycl-device-code-split=per_kernel
 endif
 

--- a/samples/oneapi/dpc/ccl/makefile_lnx
+++ b/samples/oneapi/dpc/ccl/makefile_lnx
@@ -25,20 +25,20 @@ help:
 	@echo "name              - sample name. Please see onedal.lst file"
 	@echo
 	@echo "compiler_name     - currently can be dpcpp only that stands
-	@echo "                    for Intel(R) oneAPI DPC++ Compiler."
+	@echo "                    for Intel(R) oneAPI DPC++/C++ Compiler."
 	@echo
 	@echo "mode_name         - can be build or run. Default is run"
 
 ##------------------------------------------------------------------------------
 ## examples of using:
 ##
-## make lib sample=kmeans_distr_oneccl   - build by Intel(R) oneAPI DPC++ Compiler (as default)
+## make lib sample=kmeans_distr_oneccl   - build by Intel(R) oneAPI DPC++/C++ Compiler (as default)
 ##                                          and run kmeans_distr_oneccl sample, static linking
 ##
-## make so                                - build by Intel(R) oneAPI DPC++ Compiler (as default)
+## make so                                - build by Intel(R) oneAPI DPC++/C++ Compiler (as default)
 ##                                          and run all samples, dynamic linking
 ##
-## make so mode=build                     - build only (not run) by Intel(R) oneAPI DPC++ Compiler
+## make so mode=build                     - build only (not run) by Intel(R) oneAPI DPC++/C++ Compiler
 ##                                          (as default) all samples, dynamic linking
 ##
 ## make help                              - show help


### PR DESCRIPTION
This PR contains: 

- Replacing clang (Intel clang) driver with dpcpp in the makefiles
- Enabling library building with icx