### PR TITLE
Introducing automerge for doc requerements

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,16 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    ":preserveSemverRanges"
+  ],
+  "pip_doc_requirements": [
+    {
+    "fileMatch": [
+      "(^|/)docs/requirements.txt$"
+    ],
+    "matchUpdateTypes": ["minor", "patch"],
+    "matchCurrentVersion": "!/^0/",
+    "automerge": true
+    }
   ]
 }

--- a/.github/workflows/renovate-validation.yml
+++ b/.github/workflows/renovate-validation.yml
@@ -1,0 +1,21 @@
+name: renovate-validation
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
+jobs:
+  validate:
+    name: Renovate validation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Validate
+        uses: rinchsan/renovate-config-validator@v0.0.10
+        with:
+          pattern: '*.json' # Regular expression for filename to validate, default to *.json


### PR DESCRIPTION
# Description
This change is intended for enabling automerge for doc dependencies generated by renovate

Changes proposed in this pull request:
- enable automerge for renovate jobs on docs
- add github action validation for renovate config