### PR TITLE
Renamed send_receive_replace communicator method to sendrecv_replace

### DIFF
--- a/cpp/oneapi/dal/backend/communicator.cpp
+++ b/cpp/oneapi/dal/backend/communicator.cpp
@@ -118,11 +118,11 @@ public:
         copy_if_different_pointers(recv_buf, send_buf, count, dtype);
         return nullptr;
     }
-    request_t* send_receive_replace(byte_t* buf,
-                                    std::int64_t count,
-                                    const data_type& dtype,
-                                    std::int64_t destination_rank,
-                                    std::int64_t source_rank) override {
+    request_t* sendrecv_replace(byte_t* buf,
+                                std::int64_t count,
+                                const data_type& dtype,
+                                std::int64_t destination_rank,
+                                std::int64_t source_rank) override {
         return nullptr;
     }
 };
@@ -221,20 +221,20 @@ public:
         copy_if_different_pointers(recv_buf, send_buf, count, dtype);
         return nullptr;
     }
-    request_t* send_receive_replace(byte_t* buf,
-                                    std::int64_t count,
-                                    const data_type& dtype,
-                                    std::int64_t destination_rank,
-                                    std::int64_t source_rank) override {
+    request_t* sendrecv_replace(byte_t* buf,
+                                std::int64_t count,
+                                const data_type& dtype,
+                                std::int64_t destination_rank,
+                                std::int64_t source_rank) override {
         return nullptr;
     }
-    request_t* send_receive_replace(sycl::queue& q,
-                                    byte_t* buf,
-                                    std::int64_t count,
-                                    const data_type& dtype,
-                                    std::int64_t destination_rank,
-                                    std::int64_t source_rank,
-                                    const event_vector& deps) override {
+    request_t* sendrecv_replace(sycl::queue& q,
+                                byte_t* buf,
+                                std::int64_t count,
+                                const data_type& dtype,
+                                std::int64_t destination_rank,
+                                std::int64_t source_rank,
+                                const event_vector& deps) override {
         sycl::event::wait_and_throw(deps);
         return nullptr;
     }

--- a/cpp/oneapi/dal/backend/communicator.hpp
+++ b/cpp/oneapi/dal/backend/communicator.hpp
@@ -112,8 +112,8 @@ public:
         return public_comm_.allreduce(std::forward<Args>(args)...);
     }
     template <typename... Args>
-    communicator_event send_receive_replace(Args&&... args) const {
-        return public_comm_.send_receive_replace(std::forward<Args>(args)...);
+    communicator_event sendrecv_replace(Args&&... args) const {
+        return public_comm_.sendrecv_replace(std::forward<Args>(args)...);
     }
 
     void set_active_exception(const std::exception_ptr& ex_ptr) const {

--- a/cpp/oneapi/dal/detail/ccl/communicator.hpp
+++ b/cpp/oneapi/dal/detail/ccl/communicator.hpp
@@ -114,7 +114,7 @@ public:
     using spmd::communicator_iface::bcast;
     using spmd::communicator_iface::allgatherv;
     using spmd::communicator_iface::allreduce;
-    using spmd::communicator_iface::send_receive_replace;
+    using spmd::communicator_iface::sendrecv_replace;
 
     template <typename Kvs>
     explicit ccl_device_communicator_impl(const sycl::queue& queue,
@@ -223,13 +223,13 @@ public:
                                     stream_->get_ref());
         return new ccl_request_impl{ std::move(event) };
     }
-    spmd::request_iface* send_receive_replace(sycl::queue& q,
-                                              byte_t* buf,
-                                              std::int64_t count,
-                                              const data_type& dtype,
-                                              std::int64_t destination_rank,
-                                              std::int64_t source_rank,
-                                              const std::vector<sycl::event>& deps) override {
+    spmd::request_iface* sendrecv_replace(sycl::queue& q,
+                                          byte_t* buf,
+                                          std::int64_t count,
+                                          const data_type& dtype,
+                                          std::int64_t destination_rank,
+                                          std::int64_t source_rank,
+                                          const std::vector<sycl::event>& deps) override {
         ONEDAL_ASSERT(destination_rank >= 0);
         ONEDAL_ASSERT(source_rank >= 0);
         ONEDAL_ASSERT(destination_rank < rank_count_);
@@ -288,7 +288,7 @@ public:
     using base_t::bcast;
     using base_t::allgatherv;
     using base_t::allreduce;
-    using base_t::send_receive_replace;
+    using base_t::sendrecv_replace;
 
     explicit ccl_communicator_impl(ccl::shared_ptr_class<ccl::kvs> kvs,
                                    std::int64_t rank,
@@ -360,7 +360,6 @@ public:
             internal_recv_counts[i] = integral_cast<size_t>(recv_counts[i]);
         }
 
-        ONEDAL_ASSERT(send_buf);
         ONEDAL_ASSERT(recv_buf);
 
         auto event = ccl::allgatherv(send_buf,
@@ -392,11 +391,11 @@ public:
                                     host_comm_->get_ref());
         return new ccl_request_impl{ std::move(event) };
     }
-    spmd::request_iface* send_receive_replace(byte_t* buf,
-                                              std::int64_t count,
-                                              const data_type& dtype,
-                                              std::int64_t destination_rank,
-                                              std::int64_t source_rank) override {
+    spmd::request_iface* sendrecv_replace(byte_t* buf,
+                                          std::int64_t count,
+                                          const data_type& dtype,
+                                          std::int64_t destination_rank,
+                                          std::int64_t source_rank) override {
         ONEDAL_ASSERT(destination_rank >= 0);
         ONEDAL_ASSERT(source_rank >= 0);
         ONEDAL_ASSERT(destination_rank < rank_count_);

--- a/cpp/oneapi/dal/detail/ccl/communicator.hpp
+++ b/cpp/oneapi/dal/detail/ccl/communicator.hpp
@@ -223,6 +223,7 @@ public:
                                     stream_->get_ref());
         return new ccl_request_impl{ std::move(event) };
     }
+    /// `sendrecv_replace` that accepts USM pointers
     spmd::request_iface* sendrecv_replace(sycl::queue& q,
                                           byte_t* buf,
                                           std::int64_t count,

--- a/cpp/oneapi/dal/detail/communicator.cpp
+++ b/cpp/oneapi/dal/detail/communicator.cpp
@@ -174,7 +174,7 @@ spmd::request_iface* spmd_communicator_via_host_impl::allreduce(
 #endif
 
 #ifdef ONEDAL_DATA_PARALLEL
-spmd::request_iface* spmd_communicator_via_host_impl::send_receive_replace(
+spmd::request_iface* spmd_communicator_via_host_impl::sendrecv_replace(
     sycl::queue& q,
     byte_t* buf,
     std::int64_t count,
@@ -201,11 +201,11 @@ spmd::request_iface* spmd_communicator_via_host_impl::send_receive_replace(
     const auto buff_host = array<byte_t>::empty(size);
     memcpy_usm2host(q, buff_host.get_mutable_data(), buf, size);
 
-    wait_request(send_receive_replace(buff_host.get_mutable_data(),
-                                      count,
-                                      dtype,
-                                      destination_rank,
-                                      source_rank));
+    wait_request(sendrecv_replace(buff_host.get_mutable_data(),
+                                  count,
+                                  dtype,
+                                  destination_rank,
+                                  source_rank));
 
     memcpy_host2usm(q, buf, buff_host.get_mutable_data(), size);
 

--- a/cpp/oneapi/dal/detail/communicator.hpp
+++ b/cpp/oneapi/dal/detail/communicator.hpp
@@ -38,7 +38,7 @@ public:
     using base_t::bcast;
     using base_t::allgatherv;
     using base_t::allreduce;
-    using base_t::send_receive_replace;
+    using base_t::sendrecv_replace;
 
     explicit spmd_communicator_via_host_impl(sycl::queue& queue) : queue_(queue) {}
 
@@ -68,13 +68,13 @@ public:
                                    const data_type& dtype,
                                    const spmd::reduce_op& op,
                                    const std::vector<sycl::event>& deps) override;
-    spmd::request_iface* send_receive_replace(sycl::queue& q,
-                                              byte_t* buf,
-                                              std::int64_t count,
-                                              const data_type& dtype,
-                                              std::int64_t destination_rank,
-                                              std::int64_t source_rank,
-                                              const std::vector<sycl::event>& deps) override;
+    spmd::request_iface* sendrecv_replace(sycl::queue& q,
+                                          byte_t* buf,
+                                          std::int64_t count,
+                                          const data_type& dtype,
+                                          std::int64_t destination_rank,
+                                          std::int64_t source_rank,
+                                          const std::vector<sycl::event>& deps) override;
 
 private:
     sycl::queue queue_;

--- a/cpp/oneapi/dal/detail/error_messages.cpp
+++ b/cpp/oneapi/dal/detail/error_messages.cpp
@@ -319,8 +319,8 @@ MSG(invalid_count, "SPMD: invalid data count")
 MSG(invalid_mpi_comm, "SPMD: invalid mpi communicator")
 MSG(invalid_root, "SPMD: invalid root")
 MSG(unknown_mpi_error, "SPMD: unknown MPI error")
-MSG(send_receive_replace_is_not_implemented_for_threaded_communicator,
-    "SPMD: send_recieve_replace communicator method is implemented only for MPI and CCL backend")
+MSG(sendrecv_replace_is_not_implemented_for_threaded_communicator,
+    "SPMD: sendrecv_replace communicator method is implemented only for MPI and CCL backend")
 
 } // namespace v1
 } // namespace oneapi::dal::detail

--- a/cpp/oneapi/dal/detail/error_messages.hpp
+++ b/cpp/oneapi/dal/detail/error_messages.hpp
@@ -293,7 +293,7 @@ public:
     MSG(invalid_mpi_comm);
     MSG(invalid_root);
     MSG(unknown_mpi_error);
-    MSG(send_receive_replace_is_not_implemented_for_threaded_communicator);
+    MSG(sendrecv_replace_is_not_implemented_for_threaded_communicator);
 };
 
 #undef MSG

--- a/cpp/oneapi/dal/detail/mpi/communicator.hpp
+++ b/cpp/oneapi/dal/detail/mpi/communicator.hpp
@@ -110,7 +110,7 @@ public:
     using base_t::bcast;
     using base_t::allgatherv;
     using base_t::allreduce;
-    using base_t::send_receive_replace;
+    using base_t::sendrecv_replace;
 
     explicit mpi_communicator_impl(std::int64_t default_root = 0)
             : mpi_comm_(MPI_COMM_WORLD),
@@ -178,8 +178,6 @@ public:
                                     const std::int64_t* recv_counts,
                                     const std::int64_t* displs,
                                     const data_type& dtype) override {
-        ONEDAL_ASSERT(root >= 0);
-
         ONEDAL_ASSERT(send_buf);
         ONEDAL_ASSERT(recv_counts);
         ONEDAL_ASSERT(displs);
@@ -267,11 +265,11 @@ public:
         }
     }
 
-    spmd::request_iface* send_receive_replace(byte_t* buf,
-                                              std::int64_t count,
-                                              const data_type& dtype,
-                                              std::int64_t destination_rank,
-                                              std::int64_t source_rank) override {
+    spmd::request_iface* sendrecv_replace(byte_t* buf,
+                                          std::int64_t count,
+                                          const data_type& dtype,
+                                          std::int64_t destination_rank,
+                                          std::int64_t source_rank) override {
         ONEDAL_ASSERT(destination_rank >= 0);
         ONEDAL_ASSERT(source_rank >= 0);
 

--- a/cpp/oneapi/dal/spmd/communicator.cpp
+++ b/cpp/oneapi/dal/spmd/communicator.cpp
@@ -45,10 +45,10 @@ request communicator<MemoryAccessKind>::allgatherv(const array<D>& send,
 
 template <typename MemoryAccessKind>
 template <typename D>
-request communicator<MemoryAccessKind>::send_receive_replace(array<D>& buf,
-                                                             std::int64_t destination_rank,
-                                                             std::int64_t source_rank) const {
-    return de::send_receive_replace(*this, buf, destination_rank, source_rank);
+request communicator<MemoryAccessKind>::sendrecv_replace(array<D>& buf,
+                                                         std::int64_t destination_rank,
+                                                         std::int64_t source_rank) const {
+    return de::sendrecv_replace(*this, buf, destination_rank, source_rank);
 }
 
 template <typename MemoryAccessKind>
@@ -113,9 +113,9 @@ void communicator<MemoryAccessKind>::reset_error_flag() const {
                                                     const std::int64_t* displs) const;         \
     template request communicator<M>::allreduce<D>(const array<D>& ary, const reduce_op& op)   \
         const;                                                                                 \
-    template request communicator<M>::send_receive_replace<D>(array<D> & ary,                  \
-                                                              std::int64_t destination_rank,   \
-                                                              std::int64_t) const;
+    template request communicator<M>::sendrecv_replace<D>(array<D> & ary,                      \
+                                                          std::int64_t destination_rank,       \
+                                                          std::int64_t) const;
 
 #define INSTANTIATE_MEMORY_ACCESS(M)                                                             \
     template void communicator<M>::set_active_exception(const std::exception_ptr& ex_ptr) const; \

--- a/cpp/oneapi/dal/spmd/communicator.cpp
+++ b/cpp/oneapi/dal/spmd/communicator.cpp
@@ -45,7 +45,7 @@ request communicator<MemoryAccessKind>::allgatherv(const array<D>& send,
 
 template <typename MemoryAccessKind>
 template <typename D>
-request communicator<MemoryAccessKind>::sendrecv_replace(array<D>& buf,
+request communicator<MemoryAccessKind>::sendrecv_replace(const array<D>& buf,
                                                          std::int64_t destination_rank,
                                                          std::int64_t source_rank) const {
     return de::sendrecv_replace(*this, buf, destination_rank, source_rank);
@@ -113,7 +113,7 @@ void communicator<MemoryAccessKind>::reset_error_flag() const {
                                                     const std::int64_t* displs) const;         \
     template request communicator<M>::allreduce<D>(const array<D>& ary, const reduce_op& op)   \
         const;                                                                                 \
-    template request communicator<M>::sendrecv_replace<D>(array<D> & ary,                      \
+    template request communicator<M>::sendrecv_replace<D>(const array<D>& ary,                 \
                                                           std::int64_t destination_rank,       \
                                                           std::int64_t) const;
 

--- a/cpp/oneapi/dal/spmd/communicator.hpp
+++ b/cpp/oneapi/dal/spmd/communicator.hpp
@@ -84,11 +84,11 @@ public:
                                      std::int64_t count,
                                      const data_type& dtype,
                                      const reduce_op& op) = 0;
-    virtual request_iface* send_receive_replace(byte_t* buf,
-                                                std::int64_t count,
-                                                const data_type& dtype,
-                                                std::int64_t destination_rank,
-                                                std::int64_t source_rank) = 0;
+    virtual request_iface* sendrecv_replace(byte_t* buf,
+                                            std::int64_t count,
+                                            const data_type& dtype,
+                                            std::int64_t destination_rank,
+                                            std::int64_t source_rank) = 0;
 };
 
 template <typename MemoryAccessKind>
@@ -107,7 +107,7 @@ public:
     using base_t::bcast;
     using base_t::allgatherv;
     using base_t::allreduce;
-    using base_t::send_receive_replace;
+    using base_t::sendrecv_replace;
 
     virtual request_iface* bcast(sycl::queue& q,
                                  byte_t* send_buf,
@@ -130,13 +130,13 @@ public:
                                      const data_type& dtype,
                                      const reduce_op& op,
                                      const std::vector<sycl::event>& deps) = 0;
-    virtual request_iface* send_receive_replace(sycl::queue& q,
-                                                byte_t* buf,
-                                                std::int64_t count,
-                                                const data_type& dtype,
-                                                std::int64_t destination_rank,
-                                                std::int64_t source_rank,
-                                                const std::vector<sycl::event>& deps) = 0;
+    virtual request_iface* sendrecv_replace(sycl::queue& q,
+                                            byte_t* buf,
+                                            std::int64_t count,
+                                            const data_type& dtype,
+                                            std::int64_t destination_rank,
+                                            std::int64_t source_rank,
+                                            const std::vector<sycl::event>& deps) = 0;
     virtual sycl::queue get_queue() = 0;
 };
 
@@ -436,64 +436,64 @@ public:
     /// @param source_rank          The rank to receive data from.
     ///
     /// @return The object to track the progress of the operation
-    request send_receive_replace(byte_t* buf,
-                                 std::int64_t count,
-                                 const data_type& dtype,
-                                 std::int64_t destination_rank,
-                                 std::int64_t source_rank) const {
+    request sendrecv_replace(byte_t* buf,
+                             std::int64_t count,
+                             const data_type& dtype,
+                             std::int64_t destination_rank,
+                             std::int64_t source_rank) const {
         wait_for_exception_handling();
         return dal::detail::make_private<request>(
-            impl_->send_receive_replace(buf, count, dtype, destination_rank, source_rank));
+            impl_->sendrecv_replace(buf, count, dtype, destination_rank, source_rank));
     }
 #ifdef ONEDAL_DATA_PARALLEL
-    /// `send_receive_replace` that accepts USM pointers
-    request send_receive_replace(sycl::queue& q,
-                                 byte_t* buf,
-                                 std::int64_t count,
-                                 const data_type& dtype,
-                                 std::int64_t destination_rank,
-                                 std::int64_t source_rank,
-                                 const std::vector<sycl::event>& deps = {}) const {
+    /// `sendrecv_replace` that accepts USM pointers
+    request sendrecv_replace(sycl::queue& q,
+                             byte_t* buf,
+                             std::int64_t count,
+                             const data_type& dtype,
+                             std::int64_t destination_rank,
+                             std::int64_t source_rank,
+                             const std::vector<sycl::event>& deps = {}) const {
         wait_for_exception_handling();
         return dal::detail::make_private<request>(
-            impl_->send_receive_replace(q, buf, count, dtype, destination_rank, source_rank, deps));
+            impl_->sendrecv_replace(q, buf, count, dtype, destination_rank, source_rank, deps));
     }
 #endif
     template <typename D, enable_if_primitive_t<D>* = nullptr>
-    request send_receive_replace(D* buf,
-                                 std::int64_t count,
-                                 std::int64_t destination_rank,
-                                 std::int64_t source_rank) const {
-        return send_receive_replace(reinterpret_cast<byte_t*>(buf),
-                                    count,
-                                    dal::detail::make_data_type<D>(),
-                                    destination_rank,
-                                    source_rank);
+    request sendrecv_replace(D* buf,
+                             std::int64_t count,
+                             std::int64_t destination_rank,
+                             std::int64_t source_rank) const {
+        return sendrecv_replace(reinterpret_cast<byte_t*>(buf),
+                                count,
+                                dal::detail::make_data_type<D>(),
+                                destination_rank,
+                                source_rank);
     }
 #ifdef ONEDAL_DATA_PARALLEL
     template <typename D,
               typename T = MemoryAccessKind,
               typename = std::enable_if_t<dal::detail::is_one_of_v<T, device_memory_access::usm> &&
                                           is_primitive_v<D>>>
-    request send_receive_replace(sycl::queue& queue,
-                                 D* buf,
-                                 std::int64_t count,
-                                 std::int64_t destination_rank,
-                                 std::int64_t source_rank,
-                                 const std::vector<sycl::event>& deps = {}) const {
-        return send_receive_replace(queue,
-                                    reinterpret_cast<byte_t*>(buf),
-                                    count,
-                                    dal::detail::make_data_type<D>(),
-                                    destination_rank,
-                                    source_rank,
-                                    deps);
+    request sendrecv_replace(sycl::queue& queue,
+                             D* buf,
+                             std::int64_t count,
+                             std::int64_t destination_rank,
+                             std::int64_t source_rank,
+                             const std::vector<sycl::event>& deps = {}) const {
+        return sendrecv_replace(queue,
+                                reinterpret_cast<byte_t*>(buf),
+                                count,
+                                dal::detail::make_data_type<D>(),
+                                destination_rank,
+                                source_rank,
+                                deps);
     }
 #endif
     template <typename D>
-    request send_receive_replace(array<D>& buf,
-                                 std::int64_t destination_rank,
-                                 std::int64_t source_rank) const;
+    request sendrecv_replace(array<D>& buf,
+                             std::int64_t destination_rank,
+                             std::int64_t source_rank) const;
 #ifdef ONEDAL_DATA_PARALLEL
     template <typename T = MemoryAccessKind, typename = enable_if_device_memory_accessible_t<T>>
     sycl::queue get_queue() const {

--- a/cpp/oneapi/dal/spmd/communicator.hpp
+++ b/cpp/oneapi/dal/spmd/communicator.hpp
@@ -426,7 +426,7 @@ public:
     }
     template <typename D>
     request allreduce(const array<D>& ary, const reduce_op& op = reduce_op::sum) const;
-    /// Shuffle data reusing the same buffer for send and receive operations
+    /// Shuffles data reusing the same buffer for send and receive operations
     ///
     /// @param buf                  The buffer
     /// @param count                The number of elements of `dtype` sent to and
@@ -491,7 +491,7 @@ public:
     }
 #endif
     template <typename D>
-    request sendrecv_replace(array<D>& buf,
+    request sendrecv_replace(const array<D>& buf,
                              std::int64_t destination_rank,
                              std::int64_t source_rank) const;
 #ifdef ONEDAL_DATA_PARALLEL

--- a/cpp/oneapi/dal/spmd/detail/communicator_utils.hpp
+++ b/cpp/oneapi/dal/spmd/detail/communicator_utils.hpp
@@ -183,10 +183,10 @@ spmd::request allgather(const spmd::communicator<MemoryAccessKind>& comm,
 }
 
 template <typename MemoryAccessKind, typename T, enable_if_primitive_t<T>* = nullptr>
-spmd::request send_receive_replace(const spmd::communicator<MemoryAccessKind>& comm,
-                                   const array<T>& buf,
-                                   std::int64_t destination_rank,
-                                   std::int64_t source_rank) {
+spmd::request sendrecv_replace(const spmd::communicator<MemoryAccessKind>& comm,
+                               const array<T>& buf,
+                               std::int64_t destination_rank,
+                               std::int64_t source_rank) {
     ONEDAL_ASSERT(buf.has_mutable_data());
     ONEDAL_ASSERT(destination_rank >= 0);
     ONEDAL_ASSERT(source_rank >= 0);
@@ -197,19 +197,19 @@ spmd::request send_receive_replace(const spmd::communicator<MemoryAccessKind>& c
         __ONEDAL_IF_QUEUE__(buf.get_queue(), {
             ONEDAL_ASSERT(buf.get_queue().has_value());
             auto q = buf.get_queue().value();
-            request = comm.send_receive_replace(q,
-                                                buf.get_mutable_data(),
-                                                buf.get_count(),
-                                                destination_rank,
-                                                source_rank);
+            request = comm.sendrecv_replace(q,
+                                            buf.get_mutable_data(),
+                                            buf.get_count(),
+                                            destination_rank,
+                                            source_rank);
         });
     }
 
     __ONEDAL_IF_NO_QUEUE__(buf.get_queue(), {
-        request = comm.send_receive_replace(buf.get_mutable_data(),
-                                            buf.get_count(),
-                                            destination_rank,
-                                            source_rank);
+        request = comm.sendrecv_replace(buf.get_mutable_data(),
+                                        buf.get_count(),
+                                        destination_rank,
+                                        source_rank);
     });
 
     return request;

--- a/cpp/oneapi/dal/test/ccl_communicator.cpp
+++ b/cpp/oneapi/dal/test/ccl_communicator.cpp
@@ -97,25 +97,25 @@ public:
     }
 
     template <typename T>
-    void test_send_receive_replace(T* buffer,
-                                   std::int64_t count,
-                                   std::int64_t destination_rank,
-                                   std::int64_t source_rank) {
-        get_new_comm().send_receive_replace(buffer, count, destination_rank, source_rank).wait();
+    void test_sendrecv_replace(T* buffer,
+                               std::int64_t count,
+                               std::int64_t destination_rank,
+                               std::int64_t source_rank) {
+        get_new_comm().sendrecv_replace(buffer, count, destination_rank, source_rank).wait();
     }
 
     template <typename T>
-    void test_send_receive_replace_on_device(T* buffer,
-                                             std::int64_t count,
-                                             std::int64_t destination_rank,
-                                             std::int64_t source_rank) {
+    void test_sendrecv_replace_on_device(T* buffer,
+                                         std::int64_t count,
+                                         std::int64_t destination_rank,
+                                         std::int64_t source_rank) {
         auto comm = get_new_comm();
         auto buffer_device = copy_to_device(buffer, count);
-        comm.send_receive_replace(get_queue(),
-                                  buffer_device.get_mutable_data(),
-                                  count,
-                                  destination_rank,
-                                  source_rank)
+        comm.sendrecv_replace(get_queue(),
+                              buffer_device.get_mutable_data(),
+                              count,
+                              destination_rank,
+                              source_rank)
             .wait();
         copy_to_host(buffer, buffer_device.get_data(), count);
     }
@@ -297,7 +297,7 @@ TEST_M(ccl_comm_test, "allgatherv_empty_rank") {
     }
 }
 
-TEST_M(ccl_comm_test, "send_receive_replace") {
+TEST_M(ccl_comm_test, "sendrecv_replace") {
     auto comm = get_new_comm();
     const std::int64_t count = 2;
     const std::int64_t rank_count = comm.get_rank_count();
@@ -311,12 +311,12 @@ TEST_M(ccl_comm_test, "send_receive_replace") {
     }
 
     SECTION("host") {
-        test_send_receive_replace(buffer.data(), count, destination_rank, source_rank);
+        test_sendrecv_replace(buffer.data(), count, destination_rank, source_rank);
     }
 
 #ifdef ONEDAL_DATA_PARALLEL
     SECTION("device") {
-        test_send_receive_replace_on_device(buffer.data(), count, destination_rank, source_rank);
+        test_sendrecv_replace_on_device(buffer.data(), count, destination_rank, source_rank);
     }
 #endif
 

--- a/cpp/oneapi/dal/test/communicator.cpp
+++ b/cpp/oneapi/dal/test/communicator.cpp
@@ -490,7 +490,7 @@ TEST_M(communicator_test, "empty USM allreduce is allowed", "[allreduce][usm][em
 }
 #endif
 
-TEST_M(communicator_test, "send_receive_replace", "[send_receive_replace][single value]") {
+TEST_M(communicator_test, "sendrecv_replace", "[sendrecv_replace][single value]") {
     constexpr std::int64_t count_per_rank = 1;
     auto comm = create_communicator();
     execute([&](std::int64_t rank) {
@@ -498,7 +498,7 @@ TEST_M(communicator_test, "send_receive_replace", "[send_receive_replace][single
         const std::int64_t source_rank = rank == rank_count - 1 ? 0 : rank + 1;
         const std::int64_t destination_rank = rank == 0 ? rank_count - 1 : rank - 1;
         auto ary = this->array_full(count_per_rank, float(rank));
-        comm.send_receive_replace(ary, destination_rank, source_rank).wait();
+        comm.sendrecv_replace(ary, destination_rank, source_rank).wait();
         exclusive([&]() {
             const auto expected = this->array_full(count_per_rank, float(source_rank));
             check_if_arrays_equal(ary, expected);
@@ -507,7 +507,7 @@ TEST_M(communicator_test, "send_receive_replace", "[send_receive_replace][single
 }
 
 #ifdef ONEDAL_DATA_PARALLEL
-TEST_M(communicator_test, "send_receive_replace USM", "[send_receive_replace][usm][single value]") {
+TEST_M(communicator_test, "sendrecv_replace USM", "[sendrecv_replace][usm][single value]") {
     constexpr std::int64_t count_per_rank = 1;
     auto comm = create_communicator();
     execute([&](std::int64_t rank) {
@@ -515,7 +515,7 @@ TEST_M(communicator_test, "send_receive_replace USM", "[send_receive_replace][us
         const std::int64_t source_rank = rank == rank_count - 1 ? 0 : rank + 1;
         const std::int64_t destination_rank = rank == 0 ? rank_count - 1 : rank - 1;
         auto ary = this->to_device(this->array_full(count_per_rank, float(rank)));
-        comm.send_receive_replace(ary, destination_rank, source_rank).wait();
+        comm.sendrecv_replace(ary, destination_rank, source_rank).wait();
         exclusive([&]() {
             const auto expected = this->array_full(count_per_rank, float(source_rank));
             check_if_arrays_equal(this->to_host(ary), expected);

--- a/cpp/oneapi/dal/test/engine/thread_communicator.cpp
+++ b/cpp/oneapi/dal/test/engine/thread_communicator.cpp
@@ -155,13 +155,12 @@ void thread_communicator_allgatherv::operator()(const byte_t* send_buf,
     });
 }
 
-void thread_communicator_send_receive_replace::operator()(byte_t* buf,
-                                                          std::int64_t count,
-                                                          const data_type& dtype,
-                                                          std::int64_t destination_rank,
-                                                          std::int64_t source_rank) {
-    ONEDAL_ASSERT(send_buf);
-    ONEDAL_ASSERT(recv_buf);
+void thread_communicator_sendrecv_replace::operator()(byte_t* buf,
+                                                      std::int64_t count,
+                                                      const data_type& dtype,
+                                                      std::int64_t destination_rank,
+                                                      std::int64_t source_rank) {
+    ONEDAL_ASSERT(buf);
 
     const std::int64_t rank = ctx_.get_this_thread_rank();
     const std::int64_t dtype_size = dal::detail::get_data_type_size(dtype);
@@ -497,14 +496,14 @@ auto thread_communicator_impl<MemoryAccessKind>::allreduce(const byte_t* send_bu
 }
 
 template <typename MemoryAccessKind>
-auto thread_communicator_impl<MemoryAccessKind>::send_receive_replace(byte_t* buf,
-                                                                      std::int64_t count,
-                                                                      const data_type& dtype,
-                                                                      std::int64_t destination_rank,
-                                                                      std::int64_t source_rank)
+auto thread_communicator_impl<MemoryAccessKind>::sendrecv_replace(byte_t* buf,
+                                                                  std::int64_t count,
+                                                                  const data_type& dtype,
+                                                                  std::int64_t destination_rank,
+                                                                  std::int64_t source_rank)
     -> request_t* {
     collective_operation_guard guard{ ctx_ };
-    send_receive_replace_(buf, count, dtype, destination_rank, source_rank);
+    sendrecv_replace_(buf, count, dtype, destination_rank, source_rank);
     return nullptr;
 }
 

--- a/cpp/oneapi/dal/test/engine/thread_communicator.hpp
+++ b/cpp/oneapi/dal/test/engine/thread_communicator.hpp
@@ -207,14 +207,14 @@ private:
     std::vector<buffer_info> send_buffers_;
 };
 
-class thread_communicator_send_receive_replace {
+class thread_communicator_sendrecv_replace {
 public:
     struct buffer_info {
         byte_t* buf = nullptr;
         std::int64_t count = 0;
     };
 
-    explicit thread_communicator_send_receive_replace(thread_communicator_context& ctx)
+    explicit thread_communicator_sendrecv_replace(thread_communicator_context& ctx)
             : ctx_(ctx),
               barrier_(ctx),
               send_buffers_(ctx_.get_thread_count()) {}
@@ -325,7 +325,7 @@ public:
     using base_t::bcast;
     using base_t::allgatherv;
     using base_t::allreduce;
-    using base_t::send_receive_replace;
+    using base_t::sendrecv_replace;
 
     class collective_operation_guard {
     public:
@@ -347,7 +347,7 @@ public:
               bcast_(ctx_),
               gather_(ctx_),
               allgatherv_(ctx_),
-              send_receive_replace_(ctx_),
+              sendrecv_replace_(ctx_),
               allreduce_(ctx_),
               allgather_(ctx_) {}
 #endif
@@ -361,7 +361,7 @@ public:
               bcast_(ctx_),
               gather_(ctx_),
               allgatherv_(ctx_),
-              send_receive_replace_(ctx_),
+              sendrecv_replace_(ctx_),
               allreduce_(ctx_),
               allgather_(ctx_) {}
 #endif
@@ -402,11 +402,11 @@ public:
                          const data_type& dtype,
                          const spmd::reduce_op& op) override;
 
-    request_t* send_receive_replace(byte_t* buf,
-                                    std::int64_t count,
-                                    const data_type& dtype,
-                                    std::int64_t destination_rank,
-                                    std::int64_t source_rank) override;
+    request_t* sendrecv_replace(byte_t* buf,
+                                std::int64_t count,
+                                const data_type& dtype,
+                                std::int64_t destination_rank,
+                                std::int64_t source_rank) override;
 
 private:
     thread_communicator_context ctx_;
@@ -414,7 +414,7 @@ private:
     thread_communicator_bcast bcast_;
     thread_communicator_gather gather_;
     thread_communicator_allgatherv allgatherv_;
-    thread_communicator_send_receive_replace send_receive_replace_;
+    thread_communicator_sendrecv_replace sendrecv_replace_;
     thread_communicator_allreduce allreduce_;
     thread_communicator_allgather allgather_;
 };

--- a/cpp/oneapi/dal/test/mpi_communicator.cpp
+++ b/cpp/oneapi/dal/test/mpi_communicator.cpp
@@ -111,26 +111,26 @@ public:
 #endif
 
     template <typename T>
-    void test_send_receive_replace(T* buffer,
-                                   std::int64_t count,
-                                   std::int64_t destination_rank,
-                                   std::int64_t source_rank) {
-        get_new_comm().send_receive_replace(buffer, count, destination_rank, source_rank).wait();
+    void test_sendrecv_replace(T* buffer,
+                               std::int64_t count,
+                               std::int64_t destination_rank,
+                               std::int64_t source_rank) {
+        get_new_comm().sendrecv_replace(buffer, count, destination_rank, source_rank).wait();
     }
 
 #ifdef ONEDAL_DATA_PARALLEL
     template <typename T>
-    void test_send_receive_replace_on_device(T* buffer,
-                                             std::int64_t count,
-                                             std::int64_t destination_rank,
-                                             std::int64_t source_rank) {
+    void test_sendrecv_replace_on_device(T* buffer,
+                                         std::int64_t count,
+                                         std::int64_t destination_rank,
+                                         std::int64_t source_rank) {
         auto comm = get_new_comm();
         auto buffer_device = copy_to_device(buffer, count);
-        comm.send_receive_replace(get_queue(),
-                                  buffer_device.get_mutable_data(),
-                                  count,
-                                  destination_rank,
-                                  source_rank)
+        comm.sendrecv_replace(get_queue(),
+                              buffer_device.get_mutable_data(),
+                              count,
+                              destination_rank,
+                              source_rank)
             .wait();
         copy_to_host(buffer, buffer_device.get_data(), count);
     }
@@ -258,7 +258,7 @@ TEST_M(mpi_comm_test, "allgatherv") {
     }
 }
 */
-TEST_M(mpi_comm_test, "send_receive_replace") {
+TEST_M(mpi_comm_test, "sendrecv_replace") {
     auto comm = get_new_comm();
     const std::int64_t count = 2;
     const std::int64_t rank_count = comm.get_rank_count();
@@ -272,12 +272,12 @@ TEST_M(mpi_comm_test, "send_receive_replace") {
     }
 
     SECTION("host") {
-        test_send_receive_replace(buffer.data(), count, destination_rank, source_rank);
+        test_sendrecv_replace(buffer.data(), count, destination_rank, source_rank);
     }
 
 #ifdef ONEDAL_DATA_PARALLEL
     SECTION("device") {
-        test_send_receive_replace_on_device(buffer.data(), count, destination_rank, source_rank);
+        test_sendrecv_replace_on_device(buffer.data(), count, destination_rank, source_rank);
     }
 #endif
 


### PR DESCRIPTION
# Description
- Renamed send_receive_replace communicator method to sendrecv_replace
- Fixed incorrect assertions in communicator methods