### PR TITLE
fixed issue with calculating sqrt for classification

### DIFF
--- a/cpp/daal/src/algorithms/dtrees/forest/classification/oneapi/df_classification_train_hist_oneapi_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/classification/oneapi/df_classification_train_hist_oneapi_impl.i
@@ -789,7 +789,7 @@ services::Status ClassificationTrainBatchKernelOneAPI<algorithmFPType, hist>::co
         return services::Status(services::ErrorIncorrectNumberOfColumnsInInputNumericTable);
     }
 
-    const size_t nSelectedFeatures = par.featuresPerNode ? par.featuresPerNode : daal::internal::Math<algorithmFPType, sse2>::sSqrt(_nFeatures);
+    const size_t nSelectedFeatures = par.featuresPerNode ? par.featuresPerNode : daal::internal::Math<double, sse2>::sSqrt(_nFeatures);
 
     _nSelectedRows = par.observationsPerTreeFraction * _nRows;
     DAAL_CHECK_EX((_nSelectedRows > 0), ErrorIncorrectParameter, ParameterName, observationsPerTreeFractionStr());


### PR DESCRIPTION
fix for the issue with 0 selected features, the root cause is that under icx daal::internal::Math<float, sse2>::sSqrt(1) returns 0.9999. 