### PR TITLE
Initialize ze_device_properties_t before calling zeDeviceGetProperties

### DIFF
--- a/dev/l0_tools/zexx.hpp
+++ b/dev/l0_tools/zexx.hpp
@@ -256,7 +256,9 @@ public:
 
     device_properties get_properties() const {
         return get_or_init(properties_, [&]() {
-            ze_device_properties_t handle;
+            ze_device_properties_t handle{};
+            handle.stype = ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES;
+            handle.pNext = nullptr;
             check_ze(zeDeviceGetProperties(get_handle(), &handle));
             return handle;
         });


### PR DESCRIPTION
# Description

`stype` and `pNext` members of `ze_device_properties_t` are input parameters and should be initialized before calling  `zeDeviceGetProperties` 

Signed-off-by: Mateusz Jablonski <mateusz.jablonski@intel.com>