### PR TITLE
Prioritize wget while downloading dependencies

### DIFF
--- a/dev/download_micromkl.sh
+++ b/dev/download_micromkl.sh
@@ -48,15 +48,15 @@ function download_fpk()
   DST=$(cd "${DST}" || exit 1;pwd)
 
   if [ ! -e "${CONDITION}/${MKLFPK_OS}/lib/" ]; then
-    if [ -x "$(command -v curl)" ]; then
-      echo curl -L -o "${DST}/${FILENAME}" "${SRC}"
-      if curl -L -o "${DST}/${FILENAME}" "${SRC}";
+    if [ -x "$(command -v wget)" ]; then
+      echo wget -O "${DST}/${FILENAME}" "${SRC}"
+      if wget -O "${DST}/${FILENAME}" "${SRC}";
       then
         DOWNLOAD_CODE=0
       fi
-    elif [ -x "$(command -v wget)" ]; then
-      echo wget -O "${DST}/${FILENAME}" "${SRC}"
-      if wget -O "${DST}/${FILENAME}" "${SRC}";
+    elif [ -x "$(command -v curl)" ]; then
+      echo curl -L -o "${DST}/${FILENAME}" "${SRC}"
+      if curl -L -o "${DST}/${FILENAME}" "${SRC}";
       then
         DOWNLOAD_CODE=0
       fi

--- a/dev/download_tbb.sh
+++ b/dev/download_tbb.sh
@@ -39,15 +39,15 @@ DST=$(cd "${DST}" || exit 1;pwd)
 DOWNLOAD_CODE=1
 
 if [ ! -d "${DST}/${OS}/bin" ]; then
-  if [ -x "$(command -v curl)" ]; then
-    echo curl -L -o "${DST}/${TBB_PACKAGE}.tgz" "${TBB_URL}"
-    if curl -L -o "${DST}/${TBB_PACKAGE}.tgz" "${TBB_URL}";
+  if [ -x "$(command -v wget)" ]; then
+    echo wget -O "${DST}/${TBB_PACKAGE}.tgz" "${TBB_URL}"
+    if wget -O "${DST}/${TBB_PACKAGE}.tgz" "${TBB_URL}";
     then
       DOWNLOAD_CODE=0
     fi
-  elif [ -x "$(command -v wget)" ]; then
-    echo wget -O "${DST}/${TBB_PACKAGE}.tgz" "${TBB_URL}"
-    if wget -O "${DST}/${TBB_PACKAGE}.tgz" "${TBB_URL}";
+  elif [ -x "$(command -v curl)" ]; then
+    echo curl -L -o "${DST}/${TBB_PACKAGE}.tgz" "${TBB_URL}"
+    if curl -L -o "${DST}/${TBB_PACKAGE}.tgz" "${TBB_URL}";
     then
       DOWNLOAD_CODE=0
     fi


### PR DESCRIPTION
# Description
Moving of wget to 1st place in dependencies downloading options. Curl might fell while downloading because of network libraries conflict in some environments.