### PR TITLE
FIX: kmeans bad alloc issue

### DIFF
--- a/cpp/oneapi/dal/algo/kmeans/backend/gpu/kernels_fp_impl.hpp
+++ b/cpp/oneapi/dal/algo/kmeans/backend/gpu/kernels_fp_impl.hpp
@@ -85,7 +85,7 @@ template <typename Float>
 std::int64_t kernels_fp<Float>::get_block_size_in_rows(sycl::queue& queue,
                                                        std::int64_t column_count,
                                                        std::int64_t cluster_count) {
-    std::int64_t block_size_in_bytes = bk::device_global_mem_cache_size(queue);
+    std::int64_t block_size_in_bytes = bk::device_global_mem_size(queue);
     bool use_cache = can_use_cache_for_distance_matrix(queue, block_size_in_bytes, column_count);
     if (!use_cache) {
         const auto max_block_size_in_bytes = get_max_block_size_in_bytes(queue);


### PR DESCRIPTION
# Description
Using `device_global_mem_size` instead of `device_global_mem_cache_size`