### PR TITLE
doc: Update build-application.rst

### DIFF
--- a/docs/source/onedal/build_app/build-application.rst
+++ b/docs/source/onedal/build_app/build-application.rst
@@ -186,12 +186,14 @@ Examples
 Dynamic linking, Multi-threaded |short_name|:
 
    * Linux* OS:
+   
    .. code-block:: text
 
      icpx -fsycl my_first_dal_program.cpp -Wl,
      --start-group -L<install dir>/dal/latest/lib/intel64 -lonedal_core -lonedal_dpc -lonedal_thread -lpthread -ldl -lOpenCL -L<install dir>/tbb/latest/lib/intel64/gcc4.8 -ltbb -ltbbmalloc <install dir>/dal/latest/lib/intel64/libonedal_sycl.a -Wl,--end-group
 
    * Windows* OS:
+   
    .. code-block:: text
 
      icx-cl -fsycl my_first_dal_program.cpp -Wl,
@@ -200,12 +202,14 @@ Dynamic linking, Multi-threaded |short_name|:
 Static linking, Single-threaded |short_name|:
 
    * Linux* OS:
+   
    .. code-block:: text
 
      icpx -fsycl my_first_dal_program.cpp -Wl,
      --start-group <install dir>/dal/latest/lib/intel64/libonedal_core.a <install dir>/dal/latest/lib/intel64/libonedal_dpc.a <install dir>/dal/latest/lib/intel64/libonedal_sequential.a -lpthread -ldl -lOpenCL <install dir>/dal/latest/lib/intel64/libonedal_sycl.a -Wl,--end-group
      
    * Windows* OS:
+   
    .. code-block:: text
 
      icx-cl -fsycl my_first_dal_program.cpp -Wl,

--- a/docs/source/onedal/build_app/build-application.rst
+++ b/docs/source/onedal/build_app/build-application.rst
@@ -31,7 +31,7 @@ Applications on Linux* OS
 
 #. Set environment variables by calling ``<install dir>/setvars.sh``.
 
-#. Use the C++ driver with the -fsycl option to build the application:
+#. Build the application using ``icpx`` (Linux* OS) and ``icx-cl`` (Windows* OS) commands:
 
    - Add |short_name| ``includes`` folder:
 

--- a/docs/source/onedal/build_app/build-application.rst
+++ b/docs/source/onedal/build_app/build-application.rst
@@ -31,7 +31,7 @@ Applications on Linux* OS
 
 #. Set environment variables by calling ``<install dir>/setvars.sh``.
 
-#. Build your application with dpcpp:
+#. Use the C++ driver with the -fsycl option to build the application:
 
    - Add |short_name| ``includes`` folder:
 
@@ -185,14 +185,28 @@ Examples
 
 Dynamic linking, Multi-threaded |short_name|:
 
-.. code-block:: text
+   * Linux* OS:
+   .. code-block:: text
 
-     dpcpp my_first_dal_program.cpp -Wl,
+     icpx -fsycl my_first_dal_program.cpp -Wl,
+     --start-group -L<install dir>/dal/latest/lib/intel64 -lonedal_core -lonedal_dpc -lonedal_thread -lpthread -ldl -lOpenCL -L<install dir>/tbb/latest/lib/intel64/gcc4.8 -ltbb -ltbbmalloc <install dir>/dal/latest/lib/intel64/libonedal_sycl.a -Wl,--end-group
+
+   * Windows* OS:
+   .. code-block:: text
+
+     icx-cl -fsycl my_first_dal_program.cpp -Wl,
      --start-group -L<install dir>/dal/latest/lib/intel64 -lonedal_core -lonedal_dpc -lonedal_thread -lpthread -ldl -lOpenCL -L<install dir>/tbb/latest/lib/intel64/gcc4.8 -ltbb -ltbbmalloc <install dir>/dal/latest/lib/intel64/libonedal_sycl.a -Wl,--end-group
 
 Static linking, Single-threaded |short_name|:
 
-.. code-block:: text
+   * Linux* OS:
+   .. code-block:: text
 
-     dpcpp my_first_dal_program.cpp -Wl,
+     icpx -fsycl my_first_dal_program.cpp -Wl,
+     --start-group <install dir>/dal/latest/lib/intel64/libonedal_core.a <install dir>/dal/latest/lib/intel64/libonedal_dpc.a <install dir>/dal/latest/lib/intel64/libonedal_sequential.a -lpthread -ldl -lOpenCL <install dir>/dal/latest/lib/intel64/libonedal_sycl.a -Wl,--end-group
+     
+   * Windows* OS:
+   .. code-block:: text
+
+     icx-cl -fsycl my_first_dal_program.cpp -Wl,
      --start-group <install dir>/dal/latest/lib/intel64/libonedal_core.a <install dir>/dal/latest/lib/intel64/libonedal_dpc.a <install dir>/dal/latest/lib/intel64/libonedal_sequential.a -lpthread -ldl -lOpenCL <install dir>/dal/latest/lib/intel64/libonedal_sycl.a -Wl,--end-group


### PR DESCRIPTION
# Description
Update build-application.rst since dpcpp driver is deprecated in the 2023.0 release. 
