### PR TITLE
removal of unnecessary windows examples linking

### DIFF
--- a/examples/daal/cpp/makefile_win
+++ b/examples/daal/cpp/makefile_win
@@ -117,10 +117,13 @@ COPTS=-Wall -w -m64 $(COPTS)
 COPTS=-W3 -EHsc $(COPTS)
 !ENDIF
 
-DAAL_LIB = "$(DAAL_PATH)\onedal_core$(EXT)" "$(DAAL_PATH)\onedal_thread.lib"
+!IF ("$(RES_EXT)"=="lib")
+LOPTS = "$(DAAL_PATH)\onedal_core$(EXT)" "$(DAAL_PATH)\onedal_thread.lib" tbb12.lib tbbmalloc.lib
+!ELSE
+LOPTS = "$(DAAL_PATH)\onedal_core$(EXT)"
+!ENDIF
 
 COPTS = -MD -Isource\utils $(COPTS) $(OUT_OPTS)
-LOPTS = $(DAAL_LIB) tbb12.lib tbbmalloc.lib
 RES_DIR  =_results\$(compiler)_intel64_$(RES_EXT)
 
 lib libintel64:

--- a/examples/daal/cpp_sycl/makefile_win
+++ b/examples/daal/cpp_sycl/makefile_win
@@ -103,10 +103,13 @@ COPTS=-Wall -w $(COPTS)
 COPTS=-m64 $(COPTS)
 !ENDIF
 
-DAAL_LIB = "$(DAAL_PATH)\onedal_core$(EXT)" "$(DAAL_PATH)\onedal_thread.lib"
+!IF ("$(RES_EXT)"=="lib")
+LOPTS = "$(DAAL_PATH)\onedal_core$(EXT)" "$(DAAL_PATH)\onedal_thread.lib" tbb12.lib tbbmalloc.lib $(RT_LIB)
+!ELSE
+LOPTS = "$(DAAL_PATH)\onedal_core$(EXT)" $(RT_LIB)
+!ENDIF
 
 COPTS = -MD -Isource\utils $(COPTS) $(OUT_OPTS)
-LOPTS = $(DAAL_LIB) tbb12.lib tbbmalloc.lib $(RT_LIB)
 RES_DIR  =_results\$(compiler)_$(_IA)_$(RES_EXT)
 
 lib libintel64:

--- a/examples/oneapi/cpp/makefile_win
+++ b/examples/oneapi/cpp/makefile_win
@@ -115,7 +115,11 @@ EXT_LIB = tbb12.lib tbbmalloc.lib
 EXT_LIB = /link /DEFAULTLIB:tbb12.lib /DEFAULTLIB:tbbmalloc.lib
 !ENDIF
 
+!IF ("$(RES_EXT)"=="lib")
 DAAL_LIB = "$(DAAL_PATH)\onedal$(EXT)" "$(DAAL_PATH)\onedal_core$(EXT)" "$(DAAL_PATH)\onedal_thread.lib"
+!ELSE
+DAAL_LIB = "$(DAAL_PATH)\onedal$(EXT)" "$(DAAL_PATH)\onedal_core$(EXT)"
+!ENDIF
 
 RES_DIR = _results\$(compiler)_$(_IA)_$(RES_EXT)
 COPTS = -MD /Isource /I"$(DAALROOT)\include" $(COPTS) /Fe$(RES_DIR)\\

--- a/examples/oneapi/dpc/makefile_win
+++ b/examples/oneapi/dpc/makefile_win
@@ -86,16 +86,16 @@ CLEAN=
 !ENDIF
 
 !IF ("$(RES_EXT)"=="lib")
-DAAL_LIB="$(DAAL_PATH)\onedal_core.lib" "$(DAAL_PATH)\onedal_dpc.lib" "$(DAAL_PATH)\onedal_sycl.lib"
+DAAL_LIB="$(DAAL_PATH)\onedal_core.lib" "$(DAAL_PATH)\onedal_dpc.lib" "$(DAAL_PATH)\onedal_sycl.lib" "$(DAAL_PATH)\onedal_thread.lib"
 RT_LIB=/link /ignore:4078 OpenCL.lib
-
+LOPTS = $(DAAL_LIB) tbb12.lib tbbmalloc.lib $(RT_LIB)
 !ELSE
 DAAL_LIB="$(DAAL_PATH)\onedal_dpc_dll.lib"
 RT_LIB=/link /ignore:4078
+LOPTS = $(DAAL_LIB) $(RT_LIB)
 !ENDIF
 
 COPTS = -MD /Isource /I"$(DAALROOT)\include" $(COPTS) $(OUT_OPTS)
-LOPTS = $(DAAL_LIB) "$(DAAL_PATH)\onedal_thread.lib" tbb12.lib tbbmalloc.lib $(RT_LIB)
 RES_DIR  =_results\$(compiler)_$(_IA)_$(RES_EXT)
 
 lib libintel64:


### PR DESCRIPTION
# Description
Removes unneeded linking on windows and resolves multiply linked symbols error with daal cpp_sycl dynamically linked examples. This error occurred as a result of a previous [pull request](https://github.com/oneapi-src/oneDAL/commit/ad9103a711d8d6ea704b74323bffe68bd0b63d08#diff-db189495ec2d3afed2d74de2deffdcbe325519345bfcf0a2cfda66417a848027) removing the condition to only link the threading library if static linking is indicated. The addition of the thread linking in dynamic mode produces a multiply defined symbols error on windows. Additional unneeded linking is also removed.

Changes proposed in this pull request:
-Each windows makefile in oneDAL examples has been modified to remove unnecessary linking for dynamic builds

Each makefile's updates have been tested with both dynamic and static linking