### PR TITLE
Enabling clang-format for samples

### DIFF
--- a/.ci/scripts/clang-format.sh
+++ b/.ci/scripts/clang-format.sh
@@ -20,7 +20,7 @@ echo "Starting format check..."
 
 RETURN_CODE=0
 
-for sources_path in cpp/daal cpp/oneapi examples/oneapi examples/daal ; do
+for sources_path in cpp/daal cpp/oneapi examples/oneapi examples/daal samples/oneapi samples/daal; do
     pushd ${sources_path} || exit 1
     for filename in $(find . -type f | grep -P ".*\.(c|cpp|h|hpp|cl|i)$"); do clang-format -style=file -i "${filename}"; done
 

--- a/samples/daal/.clang-format
+++ b/samples/daal/.clang-format
@@ -1,0 +1,145 @@
+---
+Language: Cpp
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignConsecutiveMacros: true
+AlignEscapedNewlines: Left
+AlignOperands: true
+AlignTrailingComments: false
+AllowAllArgumentsOnNextLine: false
+AllowAllConstructorInitializersOnNextLine: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: Empty
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: false
+BinPackParameters: false
+BraceWrapping:
+  AfterCaseLabel: false
+  AfterClass: false
+  AfterControlStatement: false
+  AfterEnum: false
+  AfterFunction: false
+  AfterNamespace: false
+  AfterObjCDeclaration: false
+  AfterStruct: false
+  AfterUnion: false
+  AfterExternBlock: false
+  BeforeCatch: true
+  BeforeElse: true
+  IndentBraces: false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeColon
+BreakInheritanceList: BeforeColon
+BreakStringLiterals: false
+ColumnLimit: 100
+CommentPragmas: '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 8
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: false
+DerivePointerAlignment: true
+DisableFormat: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks: Preserve
+IncludeCategories:
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+  - Regex:           '^<.*'
+    Priority:        2
+  - Regex:           '.*'
+    Priority:        3
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IndentCaseLabels: true
+IndentPPDirectives: None
+IndentWidth: 4
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+RawStringFormats:
+  - Language: Cpp
+    Delimiters:
+      - cc
+      - CC
+      - cpp
+      - Cpp
+      - CPP
+      - 'c++'
+      - 'C++'
+    CanonicalDelimiter: ''
+    BasedOnStyle: google
+  - Language: TextProto
+    Delimiters:
+      - pb
+      - PB
+      - proto
+      - PROTO
+    EnclosingFunctions:
+      - EqualsProto
+      - EquivToProto
+      - PARSE_PARTIAL_TEXT_PROTO
+      - PARSE_TEST_PROTO
+      - PARSE_TEXT_PROTO
+      - ParseTextOrDie
+      - ParseTextProtoOrDie
+    CanonicalDelimiter: ''
+    BasedOnStyle: google
+ReflowComments: false
+SortIncludes: false
+SortUsingDeclarations: false
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: false
+SpacesInContainerLiterals: false
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard: Cpp03
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth: 1
+UseTab: Never
+...

--- a/samples/daal/cpp/arrow/sources/datastructures_arrow.cpp
+++ b/samples/daal/cpp/arrow/sources/datastructures_arrow.cpp
@@ -27,8 +27,8 @@
 !******************************************************************************/
 
 #if defined(_WIN32) || defined(_WIN64)
-    #define NOMINMAX
-    #include <windows.h>
+#define NOMINMAX
+#include <windows.h>
 #endif
 
 #include <iostream>
@@ -51,23 +51,24 @@ using namespace arrow::csv;
 
 const string csvFileName = "./data/datastructures_arrow.csv";
 
-int main(int argc, char * argv[])
-{
+int main(int argc, char* argv[]) {
     /* Open CSV file */
     shared_ptr<ReadableFile> file;
     const arrow::Status openStatus = ReadableFile::Open(csvFileName, &file);
-    if (!openStatus.ok())
-    {
+    if (!openStatus.ok()) {
         cout << "Cannot open CSV file: " << openStatus.message() << endl;
         exit(-1);
     }
 
     /* Make the table reader */
     shared_ptr<TableReader> tableReader;
-    const arrow::Status makeReaderStatus =
-        TableReader::Make(default_memory_pool(), file, ReadOptions::Defaults(), ParseOptions::Defaults(), ConvertOptions::Defaults(), &tableReader);
-    if (!makeReaderStatus.ok())
-    {
+    const arrow::Status makeReaderStatus = TableReader::Make(default_memory_pool(),
+                                                             file,
+                                                             ReadOptions::Defaults(),
+                                                             ParseOptions::Defaults(),
+                                                             ConvertOptions::Defaults(),
+                                                             &tableReader);
+    if (!makeReaderStatus.ok()) {
         cout << "Cannot make table reader: " << makeReaderStatus.message() << endl;
         exit(-1);
     }
@@ -75,8 +76,7 @@ int main(int argc, char * argv[])
     /* Read the table */
     shared_ptr<Table> table;
     const arrow::Status readTableStatus = tableReader->Read(&table);
-    if (!readTableStatus.ok())
-    {
+    if (!readTableStatus.ok()) {
         cout << "Cannot read table: " << readTableStatus.message() << endl;
         exit(-1);
     }

--- a/samples/daal/cpp/arrow/sources/error_handling.h
+++ b/samples/daal/cpp/arrow/sources/error_handling.h
@@ -25,29 +25,24 @@
 
 const int fileError = -1001;
 
-void checkAllocation(void * ptr)
-{
-    if (!ptr)
-    {
+void checkAllocation(void* ptr) {
+    if (!ptr) {
         std::cout << "Error: Memory allocation failed" << std::endl;
         exit(-1);
     }
 }
 
-void fileOpenError(const char * filename)
-{
+void fileOpenError(const char* filename) {
     std::cout << "Unable to open file '" << filename << "'" << std::endl;
     exit(fileError);
 }
 
-void fileReadError()
-{
+void fileReadError() {
     std::cout << "Unable to read next line" << std::endl;
     exit(fileError);
 }
 
-void sparceFileReadError()
-{
+void sparceFileReadError() {
     std::cout << "Incorrect format of file" << std::endl;
     exit(fileError);
 }

--- a/samples/daal/cpp/arrow/sources/service.h
+++ b/samples/daal/cpp/arrow/sources/service.h
@@ -39,11 +39,9 @@ using namespace daal::data_management;
 
 #include "error_handling.h"
 
-size_t readTextFile(const std::string & datasetFileName, daal::byte ** data)
-{
+size_t readTextFile(const std::string &datasetFileName, daal::byte **data) {
     std::ifstream file(datasetFileName.c_str(), std::ios::binary | std::ios::ate);
-    if (!file.is_open())
-    {
+    if (!file.is_open()) {
         fileOpenError(datasetFileName.c_str());
     }
 
@@ -55,8 +53,7 @@ size_t readTextFile(const std::string & datasetFileName, daal::byte ** data)
     (*data) = new daal::byte[fileSize];
     checkAllocation(data);
 
-    if (!file.read((char *)(*data), fileSize))
-    {
+    if (!file.read((char *)(*data), fileSize)) {
         delete[] data;
         fileReadError();
     }
@@ -65,36 +62,32 @@ size_t readTextFile(const std::string & datasetFileName, daal::byte ** data)
 }
 
 template <typename item_type>
-void readRowUnknownLength(char * line, std::vector<item_type> & data)
-{
-    size_t n               = 0;
-    const char * prevDelim = line - 1;
-    char * ptr             = line;
-    for (; *ptr; ++ptr)
-    {
-        if (*ptr == ',' || *ptr == '\r')
-        {
-            if (prevDelim != ptr - 1) ++n;
-            *ptr      = ' ';
+void readRowUnknownLength(char *line, std::vector<item_type> &data) {
+    size_t n = 0;
+    const char *prevDelim = line - 1;
+    char *ptr = line;
+    for (; *ptr; ++ptr) {
+        if (*ptr == ',' || *ptr == '\r') {
+            if (prevDelim != ptr - 1)
+                ++n;
+            *ptr = ' ';
             prevDelim = ptr;
         }
     }
-    if (prevDelim != ptr - 1) ++n;
+    if (prevDelim != ptr - 1)
+        ++n;
     data.resize(n);
     std::stringstream iss(line);
-    for (size_t i = 0; i < n; ++i)
-    {
+    for (size_t i = 0; i < n; ++i) {
         iss >> data[i];
     }
 }
 
 template <typename item_type>
-CSRNumericTable * createSparseTable(const std::string & datasetFileName)
-{
+CSRNumericTable *createSparseTable(const std::string &datasetFileName) {
     std::ifstream file(datasetFileName.c_str());
 
-    if (!file.is_open())
-    {
+    if (!file.is_open()) {
         fileOpenError(datasetFileName.c_str());
     }
 
@@ -104,7 +97,8 @@ CSRNumericTable * createSparseTable(const std::string & datasetFileName)
     std::getline(file, str);
     std::vector<size_t> rowOffsets;
     readRowUnknownLength<size_t>(&str[0], rowOffsets);
-    if (!rowOffsets.size()) return NULL;
+    if (!rowOffsets.size())
+        return NULL;
     const size_t nVectors = rowOffsets.size() - 1;
 
     //read cols indices
@@ -119,61 +113,59 @@ CSRNumericTable * createSparseTable(const std::string & datasetFileName)
     const size_t nNonZeros = data.size();
 
     size_t maxCol = 0;
-    for (size_t i = 0; i < colIndices.size(); ++i)
-    {
-        if (colIndices[i] > maxCol) maxCol = colIndices[i];
+    for (size_t i = 0; i < colIndices.size(); ++i) {
+        if (colIndices[i] > maxCol)
+            maxCol = colIndices[i];
     }
     const size_t nFeatures = maxCol;
 
-    if (!nFeatures || !nVectors || colIndices.size() != nNonZeros || nNonZeros != (rowOffsets[nVectors] - 1))
-    {
+    if (!nFeatures || !nVectors || colIndices.size() != nNonZeros ||
+        nNonZeros != (rowOffsets[nVectors] - 1)) {
         sparceFileReadError();
     }
 
-    size_t * resultRowOffsets      = NULL;
-    size_t * resultColIndices      = NULL;
-    item_type * resultData         = NULL;
-    CSRNumericTable * numericTable = new CSRNumericTable(resultData, resultColIndices, resultRowOffsets, nFeatures, nVectors);
+    size_t *resultRowOffsets = NULL;
+    size_t *resultColIndices = NULL;
+    item_type *resultData = NULL;
+    CSRNumericTable *numericTable =
+        new CSRNumericTable(resultData, resultColIndices, resultRowOffsets, nFeatures, nVectors);
     numericTable->allocateDataMemory(nNonZeros);
     numericTable->getArrays<item_type>(&resultData, &resultColIndices, &resultRowOffsets);
-    for (size_t i = 0; i < nNonZeros; ++i)
-    {
-        resultData[i]       = data[i];
+    for (size_t i = 0; i < nNonZeros; ++i) {
+        resultData[i] = data[i];
         resultColIndices[i] = colIndices[i];
     }
-    for (size_t i = 0; i < nVectors + 1; ++i)
-    {
+    for (size_t i = 0; i < nVectors + 1; ++i) {
         resultRowOffsets[i] = rowOffsets[i];
     }
     return numericTable;
 }
 
-void printAprioriItemsets(NumericTablePtr largeItemsetsTable, NumericTablePtr largeItemsetsSupportTable, size_t nItemsetToPrint = 20)
-{
-    size_t largeItemsetCount     = largeItemsetsSupportTable->getNumberOfRows();
+void printAprioriItemsets(NumericTablePtr largeItemsetsTable,
+                          NumericTablePtr largeItemsetsSupportTable,
+                          size_t nItemsetToPrint = 20) {
+    size_t largeItemsetCount = largeItemsetsSupportTable->getNumberOfRows();
     size_t nItemsInLargeItemsets = largeItemsetsTable->getNumberOfRows();
 
     BlockDescriptor<int> block1;
     largeItemsetsTable->getBlockOfRows(0, nItemsInLargeItemsets, readOnly, block1);
-    int * largeItemsets = block1.getBlockPtr();
+    int *largeItemsets = block1.getBlockPtr();
 
     BlockDescriptor<int> block2;
     largeItemsetsSupportTable->getBlockOfRows(0, largeItemsetCount, readOnly, block2);
-    int * largeItemsetsSupportData = block2.getBlockPtr();
+    int *largeItemsetsSupportData = block2.getBlockPtr();
 
     std::vector<std::vector<size_t> > largeItemsetsVector;
     largeItemsetsVector.resize(largeItemsetCount);
 
-    for (size_t i = 0; i < nItemsInLargeItemsets; i++)
-    {
+    for (size_t i = 0; i < nItemsInLargeItemsets; i++) {
         largeItemsetsVector[largeItemsets[2 * i]].push_back(largeItemsets[2 * i + 1]);
     }
 
     std::vector<size_t> supportVector;
     supportVector.resize(largeItemsetCount);
 
-    for (size_t i = 0; i < largeItemsetCount; i++)
-    {
+    for (size_t i = 0; i < largeItemsetCount; i++) {
         supportVector[largeItemsetsSupportData[2 * i]] = largeItemsetsSupportData[2 * i + 1];
     }
 
@@ -184,12 +176,12 @@ void printAprioriItemsets(NumericTablePtr largeItemsetsTable, NumericTablePtr la
               << "Itemset"
               << "\t\t\tSupport" << std::endl;
 
-    size_t iMin = (((largeItemsetCount > nItemsetToPrint) && (nItemsetToPrint != 0)) ? largeItemsetCount - nItemsetToPrint : 0);
-    for (size_t i = iMin; i < largeItemsetCount; i++)
-    {
+    size_t iMin = (((largeItemsetCount > nItemsetToPrint) && (nItemsetToPrint != 0))
+                       ? largeItemsetCount - nItemsetToPrint
+                       : 0);
+    for (size_t i = iMin; i < largeItemsetCount; i++) {
         std::cout << "{";
-        for (size_t l = 0; l < largeItemsetsVector[i].size() - 1; l++)
-        {
+        for (size_t l = 0; l < largeItemsetsVector[i].size() - 1; l++) {
             std::cout << largeItemsetsVector[i][l] << ", ";
         }
         std::cout << largeItemsetsVector[i][largeItemsetsVector[i].size() - 1] << "}\t\t";
@@ -201,51 +193,49 @@ void printAprioriItemsets(NumericTablePtr largeItemsetsTable, NumericTablePtr la
     largeItemsetsSupportTable->releaseBlockOfRows(block2);
 }
 
-void printAprioriRules(NumericTablePtr leftItemsTable, NumericTablePtr rightItemsTable, NumericTablePtr confidenceTable, size_t nRulesToPrint = 20)
-{
-    size_t nRules      = confidenceTable->getNumberOfRows();
-    size_t nLeftItems  = leftItemsTable->getNumberOfRows();
+void printAprioriRules(NumericTablePtr leftItemsTable,
+                       NumericTablePtr rightItemsTable,
+                       NumericTablePtr confidenceTable,
+                       size_t nRulesToPrint = 20) {
+    size_t nRules = confidenceTable->getNumberOfRows();
+    size_t nLeftItems = leftItemsTable->getNumberOfRows();
     size_t nRightItems = rightItemsTable->getNumberOfRows();
 
     BlockDescriptor<int> block1;
     leftItemsTable->getBlockOfRows(0, nLeftItems, readOnly, block1);
-    int * leftItems = block1.getBlockPtr();
+    int *leftItems = block1.getBlockPtr();
 
     BlockDescriptor<int> block2;
     rightItemsTable->getBlockOfRows(0, nRightItems, readOnly, block2);
-    int * rightItems = block2.getBlockPtr();
+    int *rightItems = block2.getBlockPtr();
 
     BlockDescriptor<DAAL_DATA_TYPE> block3;
     confidenceTable->getBlockOfRows(0, nRules, readOnly, block3);
-    DAAL_DATA_TYPE * confidence = block3.getBlockPtr();
+    DAAL_DATA_TYPE *confidence = block3.getBlockPtr();
 
     std::vector<std::vector<size_t> > leftItemsVector;
     leftItemsVector.resize(nRules);
 
-    if (nRules == 0)
-    {
+    if (nRules == 0) {
         std::cout << std::endl << "No association rules were found " << std::endl;
         return;
     }
 
-    for (size_t i = 0; i < nLeftItems; i++)
-    {
+    for (size_t i = 0; i < nLeftItems; i++) {
         leftItemsVector[leftItems[2 * i]].push_back(leftItems[2 * i + 1]);
     }
 
     std::vector<std::vector<size_t> > rightItemsVector;
     rightItemsVector.resize(nRules);
 
-    for (size_t i = 0; i < nRightItems; i++)
-    {
+    for (size_t i = 0; i < nRightItems; i++) {
         rightItemsVector[rightItems[2 * i]].push_back(rightItems[2 * i + 1]);
     }
 
     std::vector<DAAL_DATA_TYPE> confidenceVector;
     confidenceVector.resize(nRules);
 
-    for (size_t i = 0; i < nRules; i++)
-    {
+    for (size_t i = 0; i < nRules; i++) {
         confidenceVector[i] = confidence[i];
     }
 
@@ -253,19 +243,17 @@ void printAprioriRules(NumericTablePtr leftItemsTable, NumericTablePtr rightItem
     std::cout << std::endl
               << "Rule"
               << "\t\t\t\tConfidence" << std::endl;
-    size_t iMin = (((nRules > nRulesToPrint) && (nRulesToPrint != 0)) ? (nRules - nRulesToPrint) : 0);
+    size_t iMin =
+        (((nRules > nRulesToPrint) && (nRulesToPrint != 0)) ? (nRules - nRulesToPrint) : 0);
 
-    for (size_t i = iMin; i < nRules; i++)
-    {
+    for (size_t i = iMin; i < nRules; i++) {
         std::cout << "{";
-        for (size_t l = 0; l < leftItemsVector[i].size() - 1; l++)
-        {
+        for (size_t l = 0; l < leftItemsVector[i].size() - 1; l++) {
             std::cout << leftItemsVector[i][l] << ", ";
         }
         std::cout << leftItemsVector[i][leftItemsVector[i].size() - 1] << "} => {";
 
-        for (size_t l = 0; l < rightItemsVector[i].size() - 1; l++)
-        {
+        for (size_t l = 0; l < rightItemsVector[i].size() - 1; l++) {
             std::cout << rightItemsVector[i][l] << ", ";
         }
         std::cout << rightItemsVector[i][rightItemsVector[i].size() - 1] << "}\t\t";
@@ -278,45 +266,43 @@ void printAprioriRules(NumericTablePtr leftItemsTable, NumericTablePtr rightItem
     confidenceTable->releaseBlockOfRows(block3);
 }
 
-bool isFull(NumericTableIface::StorageLayout layout)
-{
+bool isFull(NumericTableIface::StorageLayout layout) {
     int layoutInt = (int)layout;
-    if (packed_mask & layoutInt)
-    {
+    if (packed_mask & layoutInt) {
         return false;
     }
     return true;
 }
 
-bool isUpper(NumericTableIface::StorageLayout layout)
-{
-    if (layout == NumericTableIface::upperPackedSymmetricMatrix || layout == NumericTableIface::upperPackedTriangularMatrix)
-    {
+bool isUpper(NumericTableIface::StorageLayout layout) {
+    if (layout == NumericTableIface::upperPackedSymmetricMatrix ||
+        layout == NumericTableIface::upperPackedTriangularMatrix) {
         return true;
     }
     return false;
 }
 
-bool isLower(NumericTableIface::StorageLayout layout)
-{
-    if (layout == NumericTableIface::lowerPackedSymmetricMatrix || layout == NumericTableIface::lowerPackedTriangularMatrix)
-    {
+bool isLower(NumericTableIface::StorageLayout layout) {
+    if (layout == NumericTableIface::lowerPackedSymmetricMatrix ||
+        layout == NumericTableIface::lowerPackedTriangularMatrix) {
         return true;
     }
     return false;
 }
 
 template <typename T>
-void printArray(T * array, const size_t nPrintedCols, const size_t nPrintedRows, const size_t nCols, const std::string & message,
-                size_t interval = 10)
-{
+void printArray(T *array,
+                const size_t nPrintedCols,
+                const size_t nPrintedRows,
+                const size_t nCols,
+                const std::string &message,
+                size_t interval = 10) {
     std::cout << std::setiosflags(std::ios::left);
     std::cout << message << std::endl;
-    for (size_t i = 0; i < nPrintedRows; i++)
-    {
-        for (size_t j = 0; j < nPrintedCols; j++)
-        {
-            std::cout << std::setw(interval) << std::setiosflags(std::ios::fixed) << std::setprecision(3);
+    for (size_t i = 0; i < nPrintedRows; i++) {
+        for (size_t j = 0; j < nPrintedCols; j++) {
+            std::cout << std::setw(interval) << std::setiosflags(std::ios::fixed)
+                      << std::setprecision(3);
             std::cout << array[i * nCols + j];
         }
         std::cout << std::endl;
@@ -325,22 +311,26 @@ void printArray(T * array, const size_t nPrintedCols, const size_t nPrintedRows,
 }
 
 template <typename T>
-void printArray(T * array, const size_t nCols, const size_t nRows, const std::string & message, size_t interval = 10)
-{
+void printArray(T *array,
+                const size_t nCols,
+                const size_t nRows,
+                const std::string &message,
+                size_t interval = 10) {
     printArray(array, nCols, nRows, nCols, message, interval);
 }
 
 template <typename T>
-void printLowerArray(T * array, const size_t nPrintedRows, const std::string & message, size_t interval = 10)
-{
+void printLowerArray(T *array,
+                     const size_t nPrintedRows,
+                     const std::string &message,
+                     size_t interval = 10) {
     std::cout << std::setiosflags(std::ios::left);
     std::cout << message << std::endl;
     int ind = 0;
-    for (size_t i = 0; i < nPrintedRows; i++)
-    {
-        for (size_t j = 0; j <= i; j++)
-        {
-            std::cout << std::setw(interval) << std::setiosflags(std::ios::fixed) << std::setprecision(3);
+    for (size_t i = 0; i < nPrintedRows; i++) {
+        for (size_t j = 0; j <= i; j++) {
+            std::cout << std::setw(interval) << std::setiosflags(std::ios::fixed)
+                      << std::setprecision(3);
             std::cout << array[ind++];
         }
         std::cout << std::endl;
@@ -349,25 +339,25 @@ void printLowerArray(T * array, const size_t nPrintedRows, const std::string & m
 }
 
 template <typename T>
-void printUpperArray(T * array, const size_t nPrintedCols, const size_t nPrintedRows, const size_t nCols, const std::string & message,
-                     size_t interval = 10)
-{
+void printUpperArray(T *array,
+                     const size_t nPrintedCols,
+                     const size_t nPrintedRows,
+                     const size_t nCols,
+                     const std::string &message,
+                     size_t interval = 10) {
     std::cout << std::setiosflags(std::ios::left);
     std::cout << message << std::endl;
     int ind = 0;
-    for (size_t i = 0; i < nPrintedRows; i++)
-    {
-        for (size_t j = 0; j < i; j++)
-        {
+    for (size_t i = 0; i < nPrintedRows; i++) {
+        for (size_t j = 0; j < i; j++) {
             std::cout << "          ";
         }
-        for (size_t j = i; j < nPrintedCols; j++)
-        {
-            std::cout << std::setw(interval) << std::setiosflags(std::ios::fixed) << std::setprecision(3);
+        for (size_t j = i; j < nPrintedCols; j++) {
+            std::cout << std::setw(interval) << std::setiosflags(std::ios::fixed)
+                      << std::setprecision(3);
             std::cout << array[ind++];
         }
-        for (size_t j = nPrintedCols; j < nCols; j++)
-        {
+        for (size_t j = nPrintedCols; j < nCols; j++) {
             ind++;
         }
         std::cout << std::endl;
@@ -375,80 +365,92 @@ void printUpperArray(T * array, const size_t nPrintedCols, const size_t nPrinted
     std::cout << std::endl;
 }
 
-void printNumericTable(NumericTable * dataTable, const char * message = "", size_t nPrintedRows = 0, size_t nPrintedCols = 0, size_t interval = 10)
-{
-    size_t nRows                            = dataTable->getNumberOfRows();
-    size_t nCols                            = dataTable->getNumberOfColumns();
+void printNumericTable(NumericTable *dataTable,
+                       const char *message = "",
+                       size_t nPrintedRows = 0,
+                       size_t nPrintedCols = 0,
+                       size_t interval = 10) {
+    size_t nRows = dataTable->getNumberOfRows();
+    size_t nCols = dataTable->getNumberOfColumns();
     NumericTableIface::StorageLayout layout = dataTable->getDataLayout();
 
-    if (nPrintedRows != 0)
-    {
+    if (nPrintedRows != 0) {
         nPrintedRows = std::min(nRows, nPrintedRows);
     }
-    else
-    {
+    else {
         nPrintedRows = nRows;
     }
 
-    if (nPrintedCols != 0)
-    {
+    if (nPrintedCols != 0) {
         nPrintedCols = std::min(nCols, nPrintedCols);
     }
-    else
-    {
+    else {
         nPrintedCols = nCols;
     }
 
     BlockDescriptor<DAAL_DATA_TYPE> block;
-    if (isFull(layout) || layout == NumericTableIface::csrArray)
-    {
+    if (isFull(layout) || layout == NumericTableIface::csrArray) {
         dataTable->getBlockOfRows(0, nRows, readOnly, block);
-        printArray<DAAL_DATA_TYPE>(block.getBlockPtr(), nPrintedCols, nPrintedRows, nCols, message, interval);
+        printArray<DAAL_DATA_TYPE>(block.getBlockPtr(),
+                                   nPrintedCols,
+                                   nPrintedRows,
+                                   nCols,
+                                   message,
+                                   interval);
         dataTable->releaseBlockOfRows(block);
     }
-    else
-    {
-        PackedArrayNumericTableIface * packedTable = dynamic_cast<PackedArrayNumericTableIface *>(dataTable);
+    else {
+        PackedArrayNumericTableIface *packedTable =
+            dynamic_cast<PackedArrayNumericTableIface *>(dataTable);
         packedTable->getPackedArray(readOnly, block);
-        if (isLower(layout))
-        {
+        if (isLower(layout)) {
             printLowerArray<DAAL_DATA_TYPE>(block.getBlockPtr(), nPrintedRows, message, interval);
         }
-        else if (isUpper(layout))
-        {
-            printUpperArray<DAAL_DATA_TYPE>(block.getBlockPtr(), nPrintedCols, nPrintedRows, nCols, message, interval);
+        else if (isUpper(layout)) {
+            printUpperArray<DAAL_DATA_TYPE>(block.getBlockPtr(),
+                                            nPrintedCols,
+                                            nPrintedRows,
+                                            nCols,
+                                            message,
+                                            interval);
         }
         packedTable->releasePackedArray(block);
     }
 }
 
-void printNumericTable(NumericTable & dataTable, const char * message = "", size_t nPrintedRows = 0, size_t nPrintedCols = 0, size_t interval = 10)
-{
+void printNumericTable(NumericTable &dataTable,
+                       const char *message = "",
+                       size_t nPrintedRows = 0,
+                       size_t nPrintedCols = 0,
+                       size_t interval = 10) {
     printNumericTable(&dataTable, message, nPrintedRows, nPrintedCols, interval);
 }
 
-void printNumericTable(const NumericTablePtr & dataTable, const char * message = "", size_t nPrintedRows = 0, size_t nPrintedCols = 0,
-                       size_t interval = 10)
-{
+void printNumericTable(const NumericTablePtr &dataTable,
+                       const char *message = "",
+                       size_t nPrintedRows = 0,
+                       size_t nPrintedCols = 0,
+                       size_t interval = 10) {
     printNumericTable(dataTable.get(), message, nPrintedRows, nPrintedCols, interval);
 }
 
-void printPackedNumericTable(NumericTable * dataTable, size_t nFeatures, const char * message = "", size_t interval = 10)
-{
+void printPackedNumericTable(NumericTable *dataTable,
+                             size_t nFeatures,
+                             const char *message = "",
+                             size_t interval = 10) {
     BlockDescriptor<DAAL_DATA_TYPE> block;
 
     dataTable->getBlockOfRows(0, 1, readOnly, block);
 
-    DAAL_DATA_TYPE * data = block.getBlockPtr();
+    DAAL_DATA_TYPE *data = block.getBlockPtr();
 
     std::cout << std::setiosflags(std::ios::left);
     std::cout << message << std::endl;
     size_t index = 0;
-    for (size_t i = 0; i < nFeatures; i++)
-    {
-        for (size_t j = 0; j <= i; j++, index++)
-        {
-            std::cout << std::setw(interval) << std::setiosflags(std::ios::fixed) << std::setprecision(3);
+    for (size_t i = 0; i < nFeatures; i++) {
+        for (size_t j = 0; j <= i; j++, index++) {
+            std::cout << std::setw(interval) << std::setiosflags(std::ios::fixed)
+                      << std::setprecision(3);
             std::cout << data[index];
         }
         std::cout << std::endl;
@@ -458,15 +460,21 @@ void printPackedNumericTable(NumericTable * dataTable, size_t nFeatures, const c
     dataTable->releaseBlockOfRows(block);
 }
 
-void printPackedNumericTable(NumericTable & dataTable, size_t nFeatures, const char * message = "", size_t interval = 10)
-{
+void printPackedNumericTable(NumericTable &dataTable,
+                             size_t nFeatures,
+                             const char *message = "",
+                             size_t interval = 10) {
     printPackedNumericTable(&dataTable, nFeatures, message);
 }
 
 template <typename type1, typename type2>
-void printNumericTables(NumericTable * dataTable1, NumericTable * dataTable2, const char * title1 = "", const char * title2 = "",
-                        const char * message = "", size_t nPrintedRows = 0, size_t interval = 15)
-{
+void printNumericTables(NumericTable *dataTable1,
+                        NumericTable *dataTable2,
+                        const char *title1 = "",
+                        const char *title2 = "",
+                        const char *message = "",
+                        size_t nPrintedRows = 0,
+                        size_t interval = 15) {
     size_t nRows1 = dataTable1->getNumberOfRows();
     size_t nRows2 = dataTable2->getNumberOfRows();
     size_t nCols1 = dataTable1->getNumberOfColumns();
@@ -476,30 +484,27 @@ void printNumericTables(NumericTable * dataTable1, NumericTable * dataTable2, co
     BlockDescriptor<type2> block2;
 
     size_t nRows = std::min(nRows1, nRows2);
-    if (nPrintedRows != 0)
-    {
+    if (nPrintedRows != 0) {
         nRows = std::min(std::min(nRows1, nRows2), nPrintedRows);
     }
 
     dataTable1->getBlockOfRows(0, nRows, readOnly, block1);
     dataTable2->getBlockOfRows(0, nRows, readOnly, block2);
 
-    type1 * data1 = block1.getBlockPtr();
-    type2 * data2 = block2.getBlockPtr();
+    type1 *data1 = block1.getBlockPtr();
+    type2 *data2 = block2.getBlockPtr();
 
     std::cout << std::setiosflags(std::ios::left);
     std::cout << message << std::endl;
     std::cout << std::setw(interval * nCols1) << title1;
     std::cout << std::setw(interval * nCols2) << title2 << std::endl;
-    for (size_t i = 0; i < nRows; i++)
-    {
-        for (size_t j = 0; j < nCols1; j++)
-        {
-            std::cout << std::setw(interval) << std::setiosflags(std::ios::fixed) << std::setprecision(3);
+    for (size_t i = 0; i < nRows; i++) {
+        for (size_t j = 0; j < nCols1; j++) {
+            std::cout << std::setw(interval) << std::setiosflags(std::ios::fixed)
+                      << std::setprecision(3);
             std::cout << data1[i * nCols1 + j];
         }
-        for (size_t j = 0; j < nCols2; j++)
-        {
+        for (size_t j = 0; j < nCols2; j++) {
             std::cout << std::setprecision(0) << std::setw(interval) << data2[i * nCols2 + j];
         }
         std::cout << std::endl;
@@ -511,15 +516,29 @@ void printNumericTables(NumericTable * dataTable1, NumericTable * dataTable2, co
 }
 
 template <typename type1, typename type2>
-void printNumericTables(NumericTable * dataTable1, NumericTable & dataTable2, const char * title1 = "", const char * title2 = "",
-                        const char * message = "", size_t nPrintedRows = 0, size_t interval = 10)
-{
-    printNumericTables<type1, type2>(dataTable1, &dataTable2, title1, title2, message, nPrintedRows, interval);
+void printNumericTables(NumericTable *dataTable1,
+                        NumericTable &dataTable2,
+                        const char *title1 = "",
+                        const char *title2 = "",
+                        const char *message = "",
+                        size_t nPrintedRows = 0,
+                        size_t interval = 10) {
+    printNumericTables<type1, type2>(dataTable1,
+                                     &dataTable2,
+                                     title1,
+                                     title2,
+                                     message,
+                                     nPrintedRows,
+                                     interval);
 }
 
-void printNumericTables(NumericTable * dataTable1, NumericTable * dataTable2, const char * title1 = "", const char * title2 = "",
-                        const char * message = "", size_t nPrintedRows = 0, size_t interval = 10)
-{
+void printNumericTables(NumericTable *dataTable1,
+                        NumericTable *dataTable2,
+                        const char *title1 = "",
+                        const char *title2 = "",
+                        const char *message = "",
+                        size_t nPrintedRows = 0,
+                        size_t interval = 10) {
     size_t nRows1 = dataTable1->getNumberOfRows();
     size_t nRows2 = dataTable2->getNumberOfRows();
     size_t nCols1 = dataTable1->getNumberOfColumns();
@@ -529,30 +548,27 @@ void printNumericTables(NumericTable * dataTable1, NumericTable * dataTable2, co
     BlockDescriptor<DAAL_DATA_TYPE> block2;
 
     size_t nRows = std::min(nRows1, nRows2);
-    if (nPrintedRows != 0)
-    {
+    if (nPrintedRows != 0) {
         nRows = std::min(std::min(nRows1, nRows2), nPrintedRows);
     }
 
     dataTable1->getBlockOfRows(0, nRows, readOnly, block1);
     dataTable2->getBlockOfRows(0, nRows, readOnly, block2);
 
-    DAAL_DATA_TYPE * data1 = block1.getBlockPtr();
-    DAAL_DATA_TYPE * data2 = block2.getBlockPtr();
+    DAAL_DATA_TYPE *data1 = block1.getBlockPtr();
+    DAAL_DATA_TYPE *data2 = block2.getBlockPtr();
 
     std::cout << std::setiosflags(std::ios::left);
     std::cout << message << std::endl;
     std::cout << std::setw(interval * nCols1) << title1;
     std::cout << std::setw(interval * nCols2) << title2 << std::endl;
-    for (size_t i = 0; i < nRows; i++)
-    {
-        for (size_t j = 0; j < nCols1; j++)
-        {
-            std::cout << std::setw(interval) << std::setiosflags(std::ios::fixed) << std::setprecision(3);
+    for (size_t i = 0; i < nRows; i++) {
+        for (size_t j = 0; j < nCols1; j++) {
+            std::cout << std::setw(interval) << std::setiosflags(std::ios::fixed)
+                      << std::setprecision(3);
             std::cout << data1[i * nCols1 + j];
         }
-        for (size_t j = 0; j < nCols2; j++)
-        {
+        for (size_t j = 0; j < nCols2; j++) {
             std::cout << std::setprecision(0) << std::setw(interval) << data2[i * nCols2 + j];
         }
         std::cout << std::endl;
@@ -563,112 +579,103 @@ void printNumericTables(NumericTable * dataTable1, NumericTable * dataTable2, co
     dataTable2->releaseBlockOfRows(block2);
 }
 
-void printNumericTables(NumericTable * dataTable1, NumericTable & dataTable2, const char * title1 = "", const char * title2 = "",
-                        const char * message = "", size_t nPrintedRows = 0, size_t interval = 10)
-{
+void printNumericTables(NumericTable *dataTable1,
+                        NumericTable &dataTable2,
+                        const char *title1 = "",
+                        const char *title2 = "",
+                        const char *message = "",
+                        size_t nPrintedRows = 0,
+                        size_t interval = 10) {
     printNumericTables(dataTable1, &dataTable2, title1, title2, message, nPrintedRows, interval);
 }
 
 template <typename type1, typename type2>
-void printNumericTables(NumericTablePtr dataTable1, NumericTablePtr dataTable2, const char * title1 = "", const char * title2 = "",
-                        const char * message = "", size_t nPrintedRows = 0, size_t interval = 10)
-{
-    printNumericTables<type1, type2>(dataTable1.get(), dataTable2.get(), title1, title2, message, nPrintedRows, interval);
+void printNumericTables(NumericTablePtr dataTable1,
+                        NumericTablePtr dataTable2,
+                        const char *title1 = "",
+                        const char *title2 = "",
+                        const char *message = "",
+                        size_t nPrintedRows = 0,
+                        size_t interval = 10) {
+    printNumericTables<type1, type2>(dataTable1.get(),
+                                     dataTable2.get(),
+                                     title1,
+                                     title2,
+                                     message,
+                                     nPrintedRows,
+                                     interval);
 }
 
-bool checkFileIsAvailable(std::string filename, bool needExit = false)
-{
+bool checkFileIsAvailable(std::string filename, bool needExit = false) {
     std::ifstream file(filename.c_str());
-    if (file.good())
-    {
+    if (file.good()) {
         return true;
     }
-    else
-    {
+    else {
         std::cout << "Can't open file " << filename << std::endl;
-        if (needExit)
-        {
+        if (needExit) {
             exit(fileError);
         }
         return false;
     }
 }
 
-void checkArguments(int argc, char * argv[], int count, ...)
-{
-    std::string ** filelist = new std::string *[count];
+void checkArguments(int argc, char *argv[], int count, ...) {
+    std::string **filelist = new std::string *[count];
     va_list ap;
     va_start(ap, count);
-    for (int i = 0; i < count; i++)
-    {
+    for (int i = 0; i < count; i++) {
         filelist[i] = va_arg(ap, std::string *);
     }
     va_end(ap);
-    if (argc == 1)
-    {
-        for (int i = 0; i < count; i++)
-        {
+    if (argc == 1) {
+        for (int i = 0; i < count; i++) {
             checkFileIsAvailable(*(filelist[i]), true);
         }
     }
-    else if (argc == (count + 1))
-    {
+    else if (argc == (count + 1)) {
         bool isAllCorrect = true;
-        for (int i = 0; i < count; i++)
-        {
-            if (!checkFileIsAvailable(argv[i + 1]))
-            {
+        for (int i = 0; i < count; i++) {
+            if (!checkFileIsAvailable(argv[i + 1])) {
                 isAllCorrect = false;
                 break;
             }
         }
-        if (isAllCorrect == true)
-        {
-            for (int i = 0; i < count; i++)
-            {
+        if (isAllCorrect == true) {
+            for (int i = 0; i < count; i++) {
                 (*filelist[i]) = argv[i + 1];
             }
         }
-        else
-        {
+        else {
             std::cout << "Warning: Try to open default datasetFileNames" << std::endl;
-            for (int i = 0; i < count; i++)
-            {
+            for (int i = 0; i < count; i++) {
                 checkFileIsAvailable(*(filelist[i]), true);
             }
         }
     }
-    else
-    {
+    else {
         std::cout << "Usage: " << argv[0] << " [ ";
-        for (int i = 0; i < count; i++)
-        {
+        for (int i = 0; i < count; i++) {
             std::cout << "<filename_" << i << "> ";
         }
         std::cout << "]" << std::endl;
         std::cout << "Warning: Try to open default datasetFileNames" << std::endl;
-        for (int i = 0; i < count; i++)
-        {
+        for (int i = 0; i < count; i++) {
             checkFileIsAvailable(*(filelist[i]), true);
         }
     }
     delete[] filelist;
 }
 
-void copyBytes(daal::byte * dst, daal::byte * src, size_t size)
-{
-    for (size_t i = 0; i < size; i++)
-    {
+void copyBytes(daal::byte *dst, daal::byte *src, size_t size) {
+    for (size_t i = 0; i < size; i++) {
         dst[i] = src[i];
     }
 }
 
-size_t checkBytes(daal::byte * dst, daal::byte * src, size_t size)
-{
-    for (size_t i = 0; i < size; i++)
-    {
-        if (dst[i] != src[i])
-        {
+size_t checkBytes(daal::byte *dst, daal::byte *src, size_t size) {
+    for (size_t i = 0; i < size; i++) {
+        if (dst[i] != src[i]) {
             return i + 1;
         }
     }

--- a/samples/daal/cpp/kdb/sources/datasource_kdb.cpp
+++ b/samples/daal/cpp/kdb/sources/datasource_kdb.cpp
@@ -29,8 +29,8 @@
 !******************************************************************************/
 
 #if defined(_WIN32) || defined(_WIN64)
-    #define NOMINMAX
-    #include <windows.h>
+#define NOMINMAX
+#include <windows.h>
 #endif
 
 #define KXVER 3
@@ -45,35 +45,43 @@ using namespace daal::algorithms;
 using namespace daal;
 using namespace std;
 
-string dataSourceName     = "kdb-examples.intel.com";
-size_t dataSourcePort     = 9999;
+string dataSourceName = "kdb-examples.intel.com";
+size_t dataSourcePort = 9999;
 string dataSourceUsername = "";
 string dataSourcePassword = "";
 
 string tableName = "test_table";
 
-int main(int argc, char * argv[])
-{
-    I handle =
-        khpu(const_cast<char *>(dataSourceName.c_str()), dataSourcePort, const_cast<char *>((dataSourceUsername + ":" + dataSourcePassword).c_str()));
+int main(int argc, char *argv[]) {
+    I handle = khpu(const_cast<char *>(dataSourceName.c_str()),
+                    dataSourcePort,
+                    const_cast<char *>((dataSourceUsername + ":" + dataSourcePassword).c_str()));
 
-    if (handle < 0)
-    {
+    if (handle < 0) {
         std::cout << "Cannot connect" << std::endl;
         exit(-1);
     }
 
-    if (handle == 0)
-    {
+    if (handle == 0) {
         std::cout << "Wrong credentials" << std::endl;
         exit(-1);
     }
 
-    K result = k(
-        handle, const_cast<char *>((tableName + ":([]x:1 2 3 4 5 6; y:2.1 3.45 -2.1 4.2 2.1 0.05; z:6 1 5 2 4 3; class:0 1 1 0 1 0)").c_str()), (K)0);
+    K result =
+        k(handle,
+          const_cast<char *>(
+              (tableName +
+               ":([]x:1 2 3 4 5 6; y:2.1 3.45 -2.1 4.2 2.1 0.05; z:6 1 5 2 4 3; class:0 1 1 0 1 0)")
+                  .c_str()),
+          (K)0);
 
-    KDBDataSource<KDBFeatureManager> dataSource(dataSourceName, dataSourcePort, tableName, dataSourceUsername, dataSourcePassword,
-                                                DataSource::doAllocateNumericTable, DataSource::doDictionaryFromContext);
+    KDBDataSource<KDBFeatureManager> dataSource(dataSourceName,
+                                                dataSourcePort,
+                                                tableName,
+                                                dataSourceUsername,
+                                                dataSourcePassword,
+                                                DataSource::doAllocateNumericTable,
+                                                DataSource::doDictionaryFromContext);
 
     /* Get the number of rows in the data table */
     size_t nRows = dataSource.getNumberOfAvailableRows();

--- a/samples/daal/cpp/kdb/sources/error_handling.h
+++ b/samples/daal/cpp/kdb/sources/error_handling.h
@@ -25,29 +25,24 @@
 
 const int fileError = -1001;
 
-void checkAllocation(void * ptr)
-{
-    if (!ptr)
-    {
+void checkAllocation(void* ptr) {
+    if (!ptr) {
         std::cout << "Error: Memory allocation failed" << std::endl;
         exit(-1);
     }
 }
 
-void fileOpenError(const char * filename)
-{
+void fileOpenError(const char* filename) {
     std::cout << "Unable to open file '" << filename << "'" << std::endl;
     exit(fileError);
 }
 
-void fileReadError()
-{
+void fileReadError() {
     std::cout << "Unable to read next line" << std::endl;
     exit(fileError);
 }
 
-void sparceFileReadError()
-{
+void sparceFileReadError() {
     std::cout << "Incorrect format of file" << std::endl;
     exit(fileError);
 }

--- a/samples/daal/cpp/kdb/sources/service.h
+++ b/samples/daal/cpp/kdb/sources/service.h
@@ -39,11 +39,9 @@ using namespace daal::data_management;
 
 #include "error_handling.h"
 
-size_t readTextFile(const std::string & datasetFileName, daal::byte ** data)
-{
+size_t readTextFile(const std::string &datasetFileName, daal::byte **data) {
     std::ifstream file(datasetFileName.c_str(), std::ios::binary | std::ios::ate);
-    if (!file.is_open())
-    {
+    if (!file.is_open()) {
         fileOpenError(datasetFileName.c_str());
     }
 
@@ -55,8 +53,7 @@ size_t readTextFile(const std::string & datasetFileName, daal::byte ** data)
     (*data) = new daal::byte[fileSize];
     checkAllocation(data);
 
-    if (!file.read((char *)(*data), fileSize))
-    {
+    if (!file.read((char *)(*data), fileSize)) {
         delete[] data;
         fileReadError();
     }
@@ -65,36 +62,32 @@ size_t readTextFile(const std::string & datasetFileName, daal::byte ** data)
 }
 
 template <typename item_type>
-void readRowUnknownLength(char * line, std::vector<item_type> & data)
-{
-    size_t n               = 0;
-    const char * prevDelim = line - 1;
-    char * ptr             = line;
-    for (; *ptr; ++ptr)
-    {
-        if (*ptr == ',' || *ptr == '\r')
-        {
-            if (prevDelim != ptr - 1) ++n;
-            *ptr      = ' ';
+void readRowUnknownLength(char *line, std::vector<item_type> &data) {
+    size_t n = 0;
+    const char *prevDelim = line - 1;
+    char *ptr = line;
+    for (; *ptr; ++ptr) {
+        if (*ptr == ',' || *ptr == '\r') {
+            if (prevDelim != ptr - 1)
+                ++n;
+            *ptr = ' ';
             prevDelim = ptr;
         }
     }
-    if (prevDelim != ptr - 1) ++n;
+    if (prevDelim != ptr - 1)
+        ++n;
     data.resize(n);
     std::stringstream iss(line);
-    for (size_t i = 0; i < n; ++i)
-    {
+    for (size_t i = 0; i < n; ++i) {
         iss >> data[i];
     }
 }
 
 template <typename item_type>
-CSRNumericTable * createSparseTable(const std::string & datasetFileName)
-{
+CSRNumericTable *createSparseTable(const std::string &datasetFileName) {
     std::ifstream file(datasetFileName.c_str());
 
-    if (!file.is_open())
-    {
+    if (!file.is_open()) {
         fileOpenError(datasetFileName.c_str());
     }
 
@@ -104,7 +97,8 @@ CSRNumericTable * createSparseTable(const std::string & datasetFileName)
     std::getline(file, str);
     std::vector<size_t> rowOffsets;
     readRowUnknownLength<size_t>(&str[0], rowOffsets);
-    if (!rowOffsets.size()) return NULL;
+    if (!rowOffsets.size())
+        return NULL;
     const size_t nVectors = rowOffsets.size() - 1;
 
     //read cols indices
@@ -119,61 +113,59 @@ CSRNumericTable * createSparseTable(const std::string & datasetFileName)
     const size_t nNonZeros = data.size();
 
     size_t maxCol = 0;
-    for (size_t i = 0; i < colIndices.size(); ++i)
-    {
-        if (colIndices[i] > maxCol) maxCol = colIndices[i];
+    for (size_t i = 0; i < colIndices.size(); ++i) {
+        if (colIndices[i] > maxCol)
+            maxCol = colIndices[i];
     }
     const size_t nFeatures = maxCol;
 
-    if (!nFeatures || !nVectors || colIndices.size() != nNonZeros || nNonZeros != (rowOffsets[nVectors] - 1))
-    {
+    if (!nFeatures || !nVectors || colIndices.size() != nNonZeros ||
+        nNonZeros != (rowOffsets[nVectors] - 1)) {
         sparceFileReadError();
     }
 
-    size_t * resultRowOffsets      = NULL;
-    size_t * resultColIndices      = NULL;
-    item_type * resultData         = NULL;
-    CSRNumericTable * numericTable = new CSRNumericTable(resultData, resultColIndices, resultRowOffsets, nFeatures, nVectors);
+    size_t *resultRowOffsets = NULL;
+    size_t *resultColIndices = NULL;
+    item_type *resultData = NULL;
+    CSRNumericTable *numericTable =
+        new CSRNumericTable(resultData, resultColIndices, resultRowOffsets, nFeatures, nVectors);
     numericTable->allocateDataMemory(nNonZeros);
     numericTable->getArrays<item_type>(&resultData, &resultColIndices, &resultRowOffsets);
-    for (size_t i = 0; i < nNonZeros; ++i)
-    {
-        resultData[i]       = data[i];
+    for (size_t i = 0; i < nNonZeros; ++i) {
+        resultData[i] = data[i];
         resultColIndices[i] = colIndices[i];
     }
-    for (size_t i = 0; i < nVectors + 1; ++i)
-    {
+    for (size_t i = 0; i < nVectors + 1; ++i) {
         resultRowOffsets[i] = rowOffsets[i];
     }
     return numericTable;
 }
 
-void printAprioriItemsets(NumericTablePtr largeItemsetsTable, NumericTablePtr largeItemsetsSupportTable, size_t nItemsetToPrint = 20)
-{
-    size_t largeItemsetCount     = largeItemsetsSupportTable->getNumberOfRows();
+void printAprioriItemsets(NumericTablePtr largeItemsetsTable,
+                          NumericTablePtr largeItemsetsSupportTable,
+                          size_t nItemsetToPrint = 20) {
+    size_t largeItemsetCount = largeItemsetsSupportTable->getNumberOfRows();
     size_t nItemsInLargeItemsets = largeItemsetsTable->getNumberOfRows();
 
     BlockDescriptor<int> block1;
     largeItemsetsTable->getBlockOfRows(0, nItemsInLargeItemsets, readOnly, block1);
-    int * largeItemsets = block1.getBlockPtr();
+    int *largeItemsets = block1.getBlockPtr();
 
     BlockDescriptor<int> block2;
     largeItemsetsSupportTable->getBlockOfRows(0, largeItemsetCount, readOnly, block2);
-    int * largeItemsetsSupportData = block2.getBlockPtr();
+    int *largeItemsetsSupportData = block2.getBlockPtr();
 
     std::vector<std::vector<size_t> > largeItemsetsVector;
     largeItemsetsVector.resize(largeItemsetCount);
 
-    for (size_t i = 0; i < nItemsInLargeItemsets; i++)
-    {
+    for (size_t i = 0; i < nItemsInLargeItemsets; i++) {
         largeItemsetsVector[largeItemsets[2 * i]].push_back(largeItemsets[2 * i + 1]);
     }
 
     std::vector<size_t> supportVector;
     supportVector.resize(largeItemsetCount);
 
-    for (size_t i = 0; i < largeItemsetCount; i++)
-    {
+    for (size_t i = 0; i < largeItemsetCount; i++) {
         supportVector[largeItemsetsSupportData[2 * i]] = largeItemsetsSupportData[2 * i + 1];
     }
 
@@ -184,12 +176,12 @@ void printAprioriItemsets(NumericTablePtr largeItemsetsTable, NumericTablePtr la
               << "Itemset"
               << "\t\t\tSupport" << std::endl;
 
-    size_t iMin = (((largeItemsetCount > nItemsetToPrint) && (nItemsetToPrint != 0)) ? largeItemsetCount - nItemsetToPrint : 0);
-    for (size_t i = iMin; i < largeItemsetCount; i++)
-    {
+    size_t iMin = (((largeItemsetCount > nItemsetToPrint) && (nItemsetToPrint != 0))
+                       ? largeItemsetCount - nItemsetToPrint
+                       : 0);
+    for (size_t i = iMin; i < largeItemsetCount; i++) {
         std::cout << "{";
-        for (size_t l = 0; l < largeItemsetsVector[i].size() - 1; l++)
-        {
+        for (size_t l = 0; l < largeItemsetsVector[i].size() - 1; l++) {
             std::cout << largeItemsetsVector[i][l] << ", ";
         }
         std::cout << largeItemsetsVector[i][largeItemsetsVector[i].size() - 1] << "}\t\t";
@@ -201,51 +193,49 @@ void printAprioriItemsets(NumericTablePtr largeItemsetsTable, NumericTablePtr la
     largeItemsetsSupportTable->releaseBlockOfRows(block2);
 }
 
-void printAprioriRules(NumericTablePtr leftItemsTable, NumericTablePtr rightItemsTable, NumericTablePtr confidenceTable, size_t nRulesToPrint = 20)
-{
-    size_t nRules      = confidenceTable->getNumberOfRows();
-    size_t nLeftItems  = leftItemsTable->getNumberOfRows();
+void printAprioriRules(NumericTablePtr leftItemsTable,
+                       NumericTablePtr rightItemsTable,
+                       NumericTablePtr confidenceTable,
+                       size_t nRulesToPrint = 20) {
+    size_t nRules = confidenceTable->getNumberOfRows();
+    size_t nLeftItems = leftItemsTable->getNumberOfRows();
     size_t nRightItems = rightItemsTable->getNumberOfRows();
 
     BlockDescriptor<int> block1;
     leftItemsTable->getBlockOfRows(0, nLeftItems, readOnly, block1);
-    int * leftItems = block1.getBlockPtr();
+    int *leftItems = block1.getBlockPtr();
 
     BlockDescriptor<int> block2;
     rightItemsTable->getBlockOfRows(0, nRightItems, readOnly, block2);
-    int * rightItems = block2.getBlockPtr();
+    int *rightItems = block2.getBlockPtr();
 
     BlockDescriptor<DAAL_DATA_TYPE> block3;
     confidenceTable->getBlockOfRows(0, nRules, readOnly, block3);
-    DAAL_DATA_TYPE * confidence = block3.getBlockPtr();
+    DAAL_DATA_TYPE *confidence = block3.getBlockPtr();
 
     std::vector<std::vector<size_t> > leftItemsVector;
     leftItemsVector.resize(nRules);
 
-    if (nRules == 0)
-    {
+    if (nRules == 0) {
         std::cout << std::endl << "No association rules were found " << std::endl;
         return;
     }
 
-    for (size_t i = 0; i < nLeftItems; i++)
-    {
+    for (size_t i = 0; i < nLeftItems; i++) {
         leftItemsVector[leftItems[2 * i]].push_back(leftItems[2 * i + 1]);
     }
 
     std::vector<std::vector<size_t> > rightItemsVector;
     rightItemsVector.resize(nRules);
 
-    for (size_t i = 0; i < nRightItems; i++)
-    {
+    for (size_t i = 0; i < nRightItems; i++) {
         rightItemsVector[rightItems[2 * i]].push_back(rightItems[2 * i + 1]);
     }
 
     std::vector<DAAL_DATA_TYPE> confidenceVector;
     confidenceVector.resize(nRules);
 
-    for (size_t i = 0; i < nRules; i++)
-    {
+    for (size_t i = 0; i < nRules; i++) {
         confidenceVector[i] = confidence[i];
     }
 
@@ -253,19 +243,17 @@ void printAprioriRules(NumericTablePtr leftItemsTable, NumericTablePtr rightItem
     std::cout << std::endl
               << "Rule"
               << "\t\t\t\tConfidence" << std::endl;
-    size_t iMin = (((nRules > nRulesToPrint) && (nRulesToPrint != 0)) ? (nRules - nRulesToPrint) : 0);
+    size_t iMin =
+        (((nRules > nRulesToPrint) && (nRulesToPrint != 0)) ? (nRules - nRulesToPrint) : 0);
 
-    for (size_t i = iMin; i < nRules; i++)
-    {
+    for (size_t i = iMin; i < nRules; i++) {
         std::cout << "{";
-        for (size_t l = 0; l < leftItemsVector[i].size() - 1; l++)
-        {
+        for (size_t l = 0; l < leftItemsVector[i].size() - 1; l++) {
             std::cout << leftItemsVector[i][l] << ", ";
         }
         std::cout << leftItemsVector[i][leftItemsVector[i].size() - 1] << "} => {";
 
-        for (size_t l = 0; l < rightItemsVector[i].size() - 1; l++)
-        {
+        for (size_t l = 0; l < rightItemsVector[i].size() - 1; l++) {
             std::cout << rightItemsVector[i][l] << ", ";
         }
         std::cout << rightItemsVector[i][rightItemsVector[i].size() - 1] << "}\t\t";
@@ -278,45 +266,43 @@ void printAprioriRules(NumericTablePtr leftItemsTable, NumericTablePtr rightItem
     confidenceTable->releaseBlockOfRows(block3);
 }
 
-bool isFull(NumericTableIface::StorageLayout layout)
-{
+bool isFull(NumericTableIface::StorageLayout layout) {
     int layoutInt = (int)layout;
-    if (packed_mask & layoutInt)
-    {
+    if (packed_mask & layoutInt) {
         return false;
     }
     return true;
 }
 
-bool isUpper(NumericTableIface::StorageLayout layout)
-{
-    if (layout == NumericTableIface::upperPackedSymmetricMatrix || layout == NumericTableIface::upperPackedTriangularMatrix)
-    {
+bool isUpper(NumericTableIface::StorageLayout layout) {
+    if (layout == NumericTableIface::upperPackedSymmetricMatrix ||
+        layout == NumericTableIface::upperPackedTriangularMatrix) {
         return true;
     }
     return false;
 }
 
-bool isLower(NumericTableIface::StorageLayout layout)
-{
-    if (layout == NumericTableIface::lowerPackedSymmetricMatrix || layout == NumericTableIface::lowerPackedTriangularMatrix)
-    {
+bool isLower(NumericTableIface::StorageLayout layout) {
+    if (layout == NumericTableIface::lowerPackedSymmetricMatrix ||
+        layout == NumericTableIface::lowerPackedTriangularMatrix) {
         return true;
     }
     return false;
 }
 
 template <typename T>
-void printArray(T * array, const size_t nPrintedCols, const size_t nPrintedRows, const size_t nCols, const std::string & message,
-                size_t interval = 10)
-{
+void printArray(T *array,
+                const size_t nPrintedCols,
+                const size_t nPrintedRows,
+                const size_t nCols,
+                const std::string &message,
+                size_t interval = 10) {
     std::cout << std::setiosflags(std::ios::left);
     std::cout << message << std::endl;
-    for (size_t i = 0; i < nPrintedRows; i++)
-    {
-        for (size_t j = 0; j < nPrintedCols; j++)
-        {
-            std::cout << std::setw(interval) << std::setiosflags(std::ios::fixed) << std::setprecision(3);
+    for (size_t i = 0; i < nPrintedRows; i++) {
+        for (size_t j = 0; j < nPrintedCols; j++) {
+            std::cout << std::setw(interval) << std::setiosflags(std::ios::fixed)
+                      << std::setprecision(3);
             std::cout << array[i * nCols + j];
         }
         std::cout << std::endl;
@@ -325,22 +311,26 @@ void printArray(T * array, const size_t nPrintedCols, const size_t nPrintedRows,
 }
 
 template <typename T>
-void printArray(T * array, const size_t nCols, const size_t nRows, const std::string & message, size_t interval = 10)
-{
+void printArray(T *array,
+                const size_t nCols,
+                const size_t nRows,
+                const std::string &message,
+                size_t interval = 10) {
     printArray(array, nCols, nRows, nCols, message, interval);
 }
 
 template <typename T>
-void printLowerArray(T * array, const size_t nPrintedRows, const std::string & message, size_t interval = 10)
-{
+void printLowerArray(T *array,
+                     const size_t nPrintedRows,
+                     const std::string &message,
+                     size_t interval = 10) {
     std::cout << std::setiosflags(std::ios::left);
     std::cout << message << std::endl;
     int ind = 0;
-    for (size_t i = 0; i < nPrintedRows; i++)
-    {
-        for (size_t j = 0; j <= i; j++)
-        {
-            std::cout << std::setw(interval) << std::setiosflags(std::ios::fixed) << std::setprecision(3);
+    for (size_t i = 0; i < nPrintedRows; i++) {
+        for (size_t j = 0; j <= i; j++) {
+            std::cout << std::setw(interval) << std::setiosflags(std::ios::fixed)
+                      << std::setprecision(3);
             std::cout << array[ind++];
         }
         std::cout << std::endl;
@@ -349,25 +339,25 @@ void printLowerArray(T * array, const size_t nPrintedRows, const std::string & m
 }
 
 template <typename T>
-void printUpperArray(T * array, const size_t nPrintedCols, const size_t nPrintedRows, const size_t nCols, const std::string & message,
-                     size_t interval = 10)
-{
+void printUpperArray(T *array,
+                     const size_t nPrintedCols,
+                     const size_t nPrintedRows,
+                     const size_t nCols,
+                     const std::string &message,
+                     size_t interval = 10) {
     std::cout << std::setiosflags(std::ios::left);
     std::cout << message << std::endl;
     int ind = 0;
-    for (size_t i = 0; i < nPrintedRows; i++)
-    {
-        for (size_t j = 0; j < i; j++)
-        {
+    for (size_t i = 0; i < nPrintedRows; i++) {
+        for (size_t j = 0; j < i; j++) {
             std::cout << "          ";
         }
-        for (size_t j = i; j < nPrintedCols; j++)
-        {
-            std::cout << std::setw(interval) << std::setiosflags(std::ios::fixed) << std::setprecision(3);
+        for (size_t j = i; j < nPrintedCols; j++) {
+            std::cout << std::setw(interval) << std::setiosflags(std::ios::fixed)
+                      << std::setprecision(3);
             std::cout << array[ind++];
         }
-        for (size_t j = nPrintedCols; j < nCols; j++)
-        {
+        for (size_t j = nPrintedCols; j < nCols; j++) {
             ind++;
         }
         std::cout << std::endl;
@@ -375,80 +365,92 @@ void printUpperArray(T * array, const size_t nPrintedCols, const size_t nPrinted
     std::cout << std::endl;
 }
 
-void printNumericTable(NumericTable * dataTable, const char * message = "", size_t nPrintedRows = 0, size_t nPrintedCols = 0, size_t interval = 10)
-{
-    size_t nRows                            = dataTable->getNumberOfRows();
-    size_t nCols                            = dataTable->getNumberOfColumns();
+void printNumericTable(NumericTable *dataTable,
+                       const char *message = "",
+                       size_t nPrintedRows = 0,
+                       size_t nPrintedCols = 0,
+                       size_t interval = 10) {
+    size_t nRows = dataTable->getNumberOfRows();
+    size_t nCols = dataTable->getNumberOfColumns();
     NumericTableIface::StorageLayout layout = dataTable->getDataLayout();
 
-    if (nPrintedRows != 0)
-    {
+    if (nPrintedRows != 0) {
         nPrintedRows = std::min(nRows, nPrintedRows);
     }
-    else
-    {
+    else {
         nPrintedRows = nRows;
     }
 
-    if (nPrintedCols != 0)
-    {
+    if (nPrintedCols != 0) {
         nPrintedCols = std::min(nCols, nPrintedCols);
     }
-    else
-    {
+    else {
         nPrintedCols = nCols;
     }
 
     BlockDescriptor<DAAL_DATA_TYPE> block;
-    if (isFull(layout) || layout == NumericTableIface::csrArray)
-    {
+    if (isFull(layout) || layout == NumericTableIface::csrArray) {
         dataTable->getBlockOfRows(0, nRows, readOnly, block);
-        printArray<DAAL_DATA_TYPE>(block.getBlockPtr(), nPrintedCols, nPrintedRows, nCols, message, interval);
+        printArray<DAAL_DATA_TYPE>(block.getBlockPtr(),
+                                   nPrintedCols,
+                                   nPrintedRows,
+                                   nCols,
+                                   message,
+                                   interval);
         dataTable->releaseBlockOfRows(block);
     }
-    else
-    {
-        PackedArrayNumericTableIface * packedTable = dynamic_cast<PackedArrayNumericTableIface *>(dataTable);
+    else {
+        PackedArrayNumericTableIface *packedTable =
+            dynamic_cast<PackedArrayNumericTableIface *>(dataTable);
         packedTable->getPackedArray(readOnly, block);
-        if (isLower(layout))
-        {
+        if (isLower(layout)) {
             printLowerArray<DAAL_DATA_TYPE>(block.getBlockPtr(), nPrintedRows, message, interval);
         }
-        else if (isUpper(layout))
-        {
-            printUpperArray<DAAL_DATA_TYPE>(block.getBlockPtr(), nPrintedCols, nPrintedRows, nCols, message, interval);
+        else if (isUpper(layout)) {
+            printUpperArray<DAAL_DATA_TYPE>(block.getBlockPtr(),
+                                            nPrintedCols,
+                                            nPrintedRows,
+                                            nCols,
+                                            message,
+                                            interval);
         }
         packedTable->releasePackedArray(block);
     }
 }
 
-void printNumericTable(NumericTable & dataTable, const char * message = "", size_t nPrintedRows = 0, size_t nPrintedCols = 0, size_t interval = 10)
-{
+void printNumericTable(NumericTable &dataTable,
+                       const char *message = "",
+                       size_t nPrintedRows = 0,
+                       size_t nPrintedCols = 0,
+                       size_t interval = 10) {
     printNumericTable(&dataTable, message, nPrintedRows, nPrintedCols, interval);
 }
 
-void printNumericTable(const NumericTablePtr & dataTable, const char * message = "", size_t nPrintedRows = 0, size_t nPrintedCols = 0,
-                       size_t interval = 10)
-{
+void printNumericTable(const NumericTablePtr &dataTable,
+                       const char *message = "",
+                       size_t nPrintedRows = 0,
+                       size_t nPrintedCols = 0,
+                       size_t interval = 10) {
     printNumericTable(dataTable.get(), message, nPrintedRows, nPrintedCols, interval);
 }
 
-void printPackedNumericTable(NumericTable * dataTable, size_t nFeatures, const char * message = "", size_t interval = 10)
-{
+void printPackedNumericTable(NumericTable *dataTable,
+                             size_t nFeatures,
+                             const char *message = "",
+                             size_t interval = 10) {
     BlockDescriptor<DAAL_DATA_TYPE> block;
 
     dataTable->getBlockOfRows(0, 1, readOnly, block);
 
-    DAAL_DATA_TYPE * data = block.getBlockPtr();
+    DAAL_DATA_TYPE *data = block.getBlockPtr();
 
     std::cout << std::setiosflags(std::ios::left);
     std::cout << message << std::endl;
     size_t index = 0;
-    for (size_t i = 0; i < nFeatures; i++)
-    {
-        for (size_t j = 0; j <= i; j++, index++)
-        {
-            std::cout << std::setw(interval) << std::setiosflags(std::ios::fixed) << std::setprecision(3);
+    for (size_t i = 0; i < nFeatures; i++) {
+        for (size_t j = 0; j <= i; j++, index++) {
+            std::cout << std::setw(interval) << std::setiosflags(std::ios::fixed)
+                      << std::setprecision(3);
             std::cout << data[index];
         }
         std::cout << std::endl;
@@ -458,15 +460,21 @@ void printPackedNumericTable(NumericTable * dataTable, size_t nFeatures, const c
     dataTable->releaseBlockOfRows(block);
 }
 
-void printPackedNumericTable(NumericTable & dataTable, size_t nFeatures, const char * message = "", size_t interval = 10)
-{
+void printPackedNumericTable(NumericTable &dataTable,
+                             size_t nFeatures,
+                             const char *message = "",
+                             size_t interval = 10) {
     printPackedNumericTable(&dataTable, nFeatures, message);
 }
 
 template <typename type1, typename type2>
-void printNumericTables(NumericTable * dataTable1, NumericTable * dataTable2, const char * title1 = "", const char * title2 = "",
-                        const char * message = "", size_t nPrintedRows = 0, size_t interval = 15)
-{
+void printNumericTables(NumericTable *dataTable1,
+                        NumericTable *dataTable2,
+                        const char *title1 = "",
+                        const char *title2 = "",
+                        const char *message = "",
+                        size_t nPrintedRows = 0,
+                        size_t interval = 15) {
     size_t nRows1 = dataTable1->getNumberOfRows();
     size_t nRows2 = dataTable2->getNumberOfRows();
     size_t nCols1 = dataTable1->getNumberOfColumns();
@@ -476,30 +484,27 @@ void printNumericTables(NumericTable * dataTable1, NumericTable * dataTable2, co
     BlockDescriptor<type2> block2;
 
     size_t nRows = std::min(nRows1, nRows2);
-    if (nPrintedRows != 0)
-    {
+    if (nPrintedRows != 0) {
         nRows = std::min(std::min(nRows1, nRows2), nPrintedRows);
     }
 
     dataTable1->getBlockOfRows(0, nRows, readOnly, block1);
     dataTable2->getBlockOfRows(0, nRows, readOnly, block2);
 
-    type1 * data1 = block1.getBlockPtr();
-    type2 * data2 = block2.getBlockPtr();
+    type1 *data1 = block1.getBlockPtr();
+    type2 *data2 = block2.getBlockPtr();
 
     std::cout << std::setiosflags(std::ios::left);
     std::cout << message << std::endl;
     std::cout << std::setw(interval * nCols1) << title1;
     std::cout << std::setw(interval * nCols2) << title2 << std::endl;
-    for (size_t i = 0; i < nRows; i++)
-    {
-        for (size_t j = 0; j < nCols1; j++)
-        {
-            std::cout << std::setw(interval) << std::setiosflags(std::ios::fixed) << std::setprecision(3);
+    for (size_t i = 0; i < nRows; i++) {
+        for (size_t j = 0; j < nCols1; j++) {
+            std::cout << std::setw(interval) << std::setiosflags(std::ios::fixed)
+                      << std::setprecision(3);
             std::cout << data1[i * nCols1 + j];
         }
-        for (size_t j = 0; j < nCols2; j++)
-        {
+        for (size_t j = 0; j < nCols2; j++) {
             std::cout << std::setprecision(0) << std::setw(interval) << data2[i * nCols2 + j];
         }
         std::cout << std::endl;
@@ -511,15 +516,29 @@ void printNumericTables(NumericTable * dataTable1, NumericTable * dataTable2, co
 }
 
 template <typename type1, typename type2>
-void printNumericTables(NumericTable * dataTable1, NumericTable & dataTable2, const char * title1 = "", const char * title2 = "",
-                        const char * message = "", size_t nPrintedRows = 0, size_t interval = 10)
-{
-    printNumericTables<type1, type2>(dataTable1, &dataTable2, title1, title2, message, nPrintedRows, interval);
+void printNumericTables(NumericTable *dataTable1,
+                        NumericTable &dataTable2,
+                        const char *title1 = "",
+                        const char *title2 = "",
+                        const char *message = "",
+                        size_t nPrintedRows = 0,
+                        size_t interval = 10) {
+    printNumericTables<type1, type2>(dataTable1,
+                                     &dataTable2,
+                                     title1,
+                                     title2,
+                                     message,
+                                     nPrintedRows,
+                                     interval);
 }
 
-void printNumericTables(NumericTable * dataTable1, NumericTable * dataTable2, const char * title1 = "", const char * title2 = "",
-                        const char * message = "", size_t nPrintedRows = 0, size_t interval = 10)
-{
+void printNumericTables(NumericTable *dataTable1,
+                        NumericTable *dataTable2,
+                        const char *title1 = "",
+                        const char *title2 = "",
+                        const char *message = "",
+                        size_t nPrintedRows = 0,
+                        size_t interval = 10) {
     size_t nRows1 = dataTable1->getNumberOfRows();
     size_t nRows2 = dataTable2->getNumberOfRows();
     size_t nCols1 = dataTable1->getNumberOfColumns();
@@ -529,30 +548,27 @@ void printNumericTables(NumericTable * dataTable1, NumericTable * dataTable2, co
     BlockDescriptor<DAAL_DATA_TYPE> block2;
 
     size_t nRows = std::min(nRows1, nRows2);
-    if (nPrintedRows != 0)
-    {
+    if (nPrintedRows != 0) {
         nRows = std::min(std::min(nRows1, nRows2), nPrintedRows);
     }
 
     dataTable1->getBlockOfRows(0, nRows, readOnly, block1);
     dataTable2->getBlockOfRows(0, nRows, readOnly, block2);
 
-    DAAL_DATA_TYPE * data1 = block1.getBlockPtr();
-    DAAL_DATA_TYPE * data2 = block2.getBlockPtr();
+    DAAL_DATA_TYPE *data1 = block1.getBlockPtr();
+    DAAL_DATA_TYPE *data2 = block2.getBlockPtr();
 
     std::cout << std::setiosflags(std::ios::left);
     std::cout << message << std::endl;
     std::cout << std::setw(interval * nCols1) << title1;
     std::cout << std::setw(interval * nCols2) << title2 << std::endl;
-    for (size_t i = 0; i < nRows; i++)
-    {
-        for (size_t j = 0; j < nCols1; j++)
-        {
-            std::cout << std::setw(interval) << std::setiosflags(std::ios::fixed) << std::setprecision(3);
+    for (size_t i = 0; i < nRows; i++) {
+        for (size_t j = 0; j < nCols1; j++) {
+            std::cout << std::setw(interval) << std::setiosflags(std::ios::fixed)
+                      << std::setprecision(3);
             std::cout << data1[i * nCols1 + j];
         }
-        for (size_t j = 0; j < nCols2; j++)
-        {
+        for (size_t j = 0; j < nCols2; j++) {
             std::cout << std::setprecision(0) << std::setw(interval) << data2[i * nCols2 + j];
         }
         std::cout << std::endl;
@@ -563,112 +579,103 @@ void printNumericTables(NumericTable * dataTable1, NumericTable * dataTable2, co
     dataTable2->releaseBlockOfRows(block2);
 }
 
-void printNumericTables(NumericTable * dataTable1, NumericTable & dataTable2, const char * title1 = "", const char * title2 = "",
-                        const char * message = "", size_t nPrintedRows = 0, size_t interval = 10)
-{
+void printNumericTables(NumericTable *dataTable1,
+                        NumericTable &dataTable2,
+                        const char *title1 = "",
+                        const char *title2 = "",
+                        const char *message = "",
+                        size_t nPrintedRows = 0,
+                        size_t interval = 10) {
     printNumericTables(dataTable1, &dataTable2, title1, title2, message, nPrintedRows, interval);
 }
 
 template <typename type1, typename type2>
-void printNumericTables(NumericTablePtr dataTable1, NumericTablePtr dataTable2, const char * title1 = "", const char * title2 = "",
-                        const char * message = "", size_t nPrintedRows = 0, size_t interval = 10)
-{
-    printNumericTables<type1, type2>(dataTable1.get(), dataTable2.get(), title1, title2, message, nPrintedRows, interval);
+void printNumericTables(NumericTablePtr dataTable1,
+                        NumericTablePtr dataTable2,
+                        const char *title1 = "",
+                        const char *title2 = "",
+                        const char *message = "",
+                        size_t nPrintedRows = 0,
+                        size_t interval = 10) {
+    printNumericTables<type1, type2>(dataTable1.get(),
+                                     dataTable2.get(),
+                                     title1,
+                                     title2,
+                                     message,
+                                     nPrintedRows,
+                                     interval);
 }
 
-bool checkFileIsAvailable(std::string filename, bool needExit = false)
-{
+bool checkFileIsAvailable(std::string filename, bool needExit = false) {
     std::ifstream file(filename.c_str());
-    if (file.good())
-    {
+    if (file.good()) {
         return true;
     }
-    else
-    {
+    else {
         std::cout << "Can't open file " << filename << std::endl;
-        if (needExit)
-        {
+        if (needExit) {
             exit(fileError);
         }
         return false;
     }
 }
 
-void checkArguments(int argc, char * argv[], int count, ...)
-{
-    std::string ** filelist = new std::string *[count];
+void checkArguments(int argc, char *argv[], int count, ...) {
+    std::string **filelist = new std::string *[count];
     va_list ap;
     va_start(ap, count);
-    for (int i = 0; i < count; i++)
-    {
+    for (int i = 0; i < count; i++) {
         filelist[i] = va_arg(ap, std::string *);
     }
     va_end(ap);
-    if (argc == 1)
-    {
-        for (int i = 0; i < count; i++)
-        {
+    if (argc == 1) {
+        for (int i = 0; i < count; i++) {
             checkFileIsAvailable(*(filelist[i]), true);
         }
     }
-    else if (argc == (count + 1))
-    {
+    else if (argc == (count + 1)) {
         bool isAllCorrect = true;
-        for (int i = 0; i < count; i++)
-        {
-            if (!checkFileIsAvailable(argv[i + 1]))
-            {
+        for (int i = 0; i < count; i++) {
+            if (!checkFileIsAvailable(argv[i + 1])) {
                 isAllCorrect = false;
                 break;
             }
         }
-        if (isAllCorrect == true)
-        {
-            for (int i = 0; i < count; i++)
-            {
+        if (isAllCorrect == true) {
+            for (int i = 0; i < count; i++) {
                 (*filelist[i]) = argv[i + 1];
             }
         }
-        else
-        {
+        else {
             std::cout << "Warning: Try to open default datasetFileNames" << std::endl;
-            for (int i = 0; i < count; i++)
-            {
+            for (int i = 0; i < count; i++) {
                 checkFileIsAvailable(*(filelist[i]), true);
             }
         }
     }
-    else
-    {
+    else {
         std::cout << "Usage: " << argv[0] << " [ ";
-        for (int i = 0; i < count; i++)
-        {
+        for (int i = 0; i < count; i++) {
             std::cout << "<filename_" << i << "> ";
         }
         std::cout << "]" << std::endl;
         std::cout << "Warning: Try to open default datasetFileNames" << std::endl;
-        for (int i = 0; i < count; i++)
-        {
+        for (int i = 0; i < count; i++) {
             checkFileIsAvailable(*(filelist[i]), true);
         }
     }
     delete[] filelist;
 }
 
-void copyBytes(daal::byte * dst, daal::byte * src, size_t size)
-{
-    for (size_t i = 0; i < size; i++)
-    {
+void copyBytes(daal::byte *dst, daal::byte *src, size_t size) {
+    for (size_t i = 0; i < size; i++) {
         dst[i] = src[i];
     }
 }
 
-size_t checkBytes(daal::byte * dst, daal::byte * src, size_t size)
-{
-    for (size_t i = 0; i < size; i++)
-    {
-        if (dst[i] != src[i])
-        {
+size_t checkBytes(daal::byte *dst, daal::byte *src, size_t size) {
+    for (size_t i = 0; i < size; i++) {
+        if (dst[i] != src[i]) {
             return i + 1;
         }
     }

--- a/samples/daal/cpp/mpi/sources/covariance_dense_distributed_mpi.cpp
+++ b/samples/daal/cpp/mpi/sources/covariance_dense_distributed_mpi.cpp
@@ -41,19 +41,28 @@ const size_t nBlocks = 4;
 int rankId, comm_size;
 #define mpi_root 0
 
-const string datasetFileNames[] = { "./data/distributed/covcormoments_dense_1.csv", "./data/distributed/covcormoments_dense_2.csv",
-                                    "./data/distributed/covcormoments_dense_3.csv", "./data/distributed/covcormoments_dense_4.csv" };
+const string datasetFileNames[] = { "./data/distributed/covcormoments_dense_1.csv",
+                                    "./data/distributed/covcormoments_dense_2.csv",
+                                    "./data/distributed/covcormoments_dense_3.csv",
+                                    "./data/distributed/covcormoments_dense_4.csv" };
 
-int main(int argc, char * argv[])
-{
-    checkArguments(argc, argv, 4, &datasetFileNames[0], &datasetFileNames[1], &datasetFileNames[2], &datasetFileNames[3]);
+int main(int argc, char* argv[]) {
+    checkArguments(argc,
+                   argv,
+                   4,
+                   &datasetFileNames[0],
+                   &datasetFileNames[1],
+                   &datasetFileNames[2],
+                   &datasetFileNames[3]);
 
     MPI_Init(&argc, &argv);
     MPI_Comm_size(MPI_COMM_WORLD, &comm_size);
     MPI_Comm_rank(MPI_COMM_WORLD, &rankId);
 
     /* Initialize FileDataSource<CSVFeatureManager> to retrieve the input data from a .csv file */
-    FileDataSource<CSVFeatureManager> dataSource(datasetFileNames[rankId], DataSource::doAllocateNumericTable, DataSource::doDictionaryFromContext);
+    FileDataSource<CSVFeatureManager> dataSource(datasetFileNames[rankId],
+                                                 DataSource::doAllocateNumericTable,
+                                                 DataSource::doDictionaryFromContext);
 
     /* Retrieve the input data */
     dataSource.loadDataBlock();
@@ -74,30 +83,36 @@ int main(int argc, char * argv[])
     size_t perNodeArchLength = dataArch.getSizeOfArchive();
 
     /* Serialized data is of equal size on each node if each node called compute() equal number of times */
-    if (rankId == mpi_root)
-    {
+    if (rankId == mpi_root) {
         serializedData = services::SharedPtr<byte>(new byte[perNodeArchLength * nBlocks]);
     }
 
-    byte * nodeResults = new byte[perNodeArchLength];
+    byte* nodeResults = new byte[perNodeArchLength];
     dataArch.copyArchiveToArray(nodeResults, perNodeArchLength);
 
     /* Transfer partial results to step 2 on the root node */
-    MPI_Gather(nodeResults, perNodeArchLength, MPI_CHAR, serializedData.get(), perNodeArchLength, MPI_CHAR, mpi_root, MPI_COMM_WORLD);
+    MPI_Gather(nodeResults,
+               perNodeArchLength,
+               MPI_CHAR,
+               serializedData.get(),
+               perNodeArchLength,
+               MPI_CHAR,
+               mpi_root,
+               MPI_COMM_WORLD);
 
     delete[] nodeResults;
 
-    if (rankId == mpi_root)
-    {
+    if (rankId == mpi_root) {
         /* Create an algorithm to compute a variance-covariance matrix on the master node */
         covariance::Distributed<step2Master> masterAlgorithm;
 
-        for (size_t i = 0; i < nBlocks; i++)
-        {
+        for (size_t i = 0; i < nBlocks; i++) {
             /* Deserialize partial results from step 1 */
-            OutputDataArchive dataArch(serializedData.get() + perNodeArchLength * i, perNodeArchLength);
+            OutputDataArchive dataArch(serializedData.get() + perNodeArchLength * i,
+                                       perNodeArchLength);
 
-            covariance::PartialResultPtr dataForStep2FromStep1 = covariance::PartialResultPtr(new covariance::PartialResult());
+            covariance::PartialResultPtr dataForStep2FromStep1 =
+                covariance::PartialResultPtr(new covariance::PartialResult());
 
             dataForStep2FromStep1->deserialize(dataArch);
 

--- a/samples/daal/cpp/mpi/sources/dbscan_dense_distributed_mpi.cpp
+++ b/samples/daal/cpp/mpi/sources/dbscan_dense_distributed_mpi.cpp
@@ -36,13 +36,15 @@ using namespace daal::algorithms;
 /* Input data set parameters */
 const size_t nBlocks = 4;
 
-const string datasetFileNames[nBlocks] = { "./data/distributed/dbscan_dense_1.csv", "./data/distributed/dbscan_dense_2.csv",
-                                           "./data/distributed/dbscan_dense_3.csv", "./data/distributed/dbscan_dense_4.csv" };
+const string datasetFileNames[nBlocks] = { "./data/distributed/dbscan_dense_1.csv",
+                                           "./data/distributed/dbscan_dense_2.csv",
+                                           "./data/distributed/dbscan_dense_3.csv",
+                                           "./data/distributed/dbscan_dense_4.csv" };
 
 typedef float algorithmFPType; /* Algorithm floating-point type */
 
 /* Algorithm parameters */
-const float epsilon          = 0.02f;
+const float epsilon = 0.02f;
 const size_t minObservations = 180;
 
 NumericTablePtr dataTable;
@@ -71,14 +73,39 @@ NumericTablePtr totalNClusters;
 NumericTablePtr readData(size_t rankId);
 void geometricPartitioning();
 void clustering();
-void sendCollectionAllToAll(size_t beginId, size_t endId, size_t curId, int tag, DataCollectionPtr & collection, DataCollectionPtr & destCollection);
-void sendTableAllToAll(size_t beginId, size_t endId, size_t curId, int tag, NumericTablePtr & table, DataCollectionPtr & destCollection,
+void sendCollectionAllToAll(size_t beginId,
+                            size_t endId,
+                            size_t curId,
+                            int tag,
+                            DataCollectionPtr& collection,
+                            DataCollectionPtr& destCollection);
+void sendTableAllToAll(size_t beginId,
+                       size_t endId,
+                       size_t curId,
+                       int tag,
+                       NumericTablePtr& table,
+                       DataCollectionPtr& destCollection,
                        bool preserveOrder = false);
-void sendTableAllToMaster(size_t beginId, size_t endId, size_t rankId, int tag, NumericTablePtr & table, DataCollectionPtr & destCollection);
-void sendCollectionMasterToAll(size_t beginId, size_t endId, size_t rankId, int tag, DataCollectionPtr & collection, NumericTablePtr & destTable);
-void sendTableMasterToAll(size_t beginId, size_t endId, size_t rankId, int tag, NumericTablePtr & table, NumericTablePtr & destTable);
-void sendTable(NumericTablePtr & table, int recpnt, int tag);
-void recvTable(NumericTablePtr & table, int sender, int tag);
+void sendTableAllToMaster(size_t beginId,
+                          size_t endId,
+                          size_t rankId,
+                          int tag,
+                          NumericTablePtr& table,
+                          DataCollectionPtr& destCollection);
+void sendCollectionMasterToAll(size_t beginId,
+                               size_t endId,
+                               size_t rankId,
+                               int tag,
+                               DataCollectionPtr& collection,
+                               NumericTablePtr& destTable);
+void sendTableMasterToAll(size_t beginId,
+                          size_t endId,
+                          size_t rankId,
+                          int tag,
+                          NumericTablePtr& table,
+                          NumericTablePtr& destTable);
+void sendTable(NumericTablePtr& table, int recpnt, int tag);
+void recvTable(NumericTablePtr& table, int sender, int tag);
 void printResults();
 
 int computeFinishedFlag();
@@ -86,27 +113,32 @@ int computeFinishedFlag();
 int rankId, comm_size;
 #define mpi_root 0
 
-const int step2ResultBoundingBoxTag                = 1;
-const int step3ResultSplitTag                      = 2;
-const int step4ResultPartitionedDataTag            = 3;
-const int step4ResultPartitionedPartialOrdersTag   = 4;
-const int step5ResultPartitionedHaloDataTag        = 5;
+const int step2ResultBoundingBoxTag = 1;
+const int step3ResultSplitTag = 2;
+const int step4ResultPartitionedDataTag = 3;
+const int step4ResultPartitionedPartialOrdersTag = 4;
+const int step5ResultPartitionedHaloDataTag = 5;
 const int step5ResultPartitionedHaloDataIndicesTag = 6;
-const int step5ResultPartitionedHaloBlocksTag      = 7;
-const int step6ResultQueriesTag                    = 8;
-const int step8ResultQueriesTag                    = 9;
-const int step8ResultNClustersTag                  = 10;
-const int resultFinishedFlagTag                    = 11;
-const int step7ResultFinishedFlagTag               = 12;
-const int step9ResultNClustersTag                  = 13;
-const int step9ResultClusterOffsetsTag             = 14;
-const int step10ResultQueriesTag                   = 15;
-const int step11ResultQueriesTag                   = 16;
-const int step12ResultAssignmentQueriesTag         = 17;
+const int step5ResultPartitionedHaloBlocksTag = 7;
+const int step6ResultQueriesTag = 8;
+const int step8ResultQueriesTag = 9;
+const int step8ResultNClustersTag = 10;
+const int resultFinishedFlagTag = 11;
+const int step7ResultFinishedFlagTag = 12;
+const int step9ResultNClustersTag = 13;
+const int step9ResultClusterOffsetsTag = 14;
+const int step10ResultQueriesTag = 15;
+const int step11ResultQueriesTag = 16;
+const int step12ResultAssignmentQueriesTag = 17;
 
-int main(int argc, char * argv[])
-{
-    checkArguments(argc, argv, 4, &datasetFileNames[0], &datasetFileNames[1], &datasetFileNames[2], &datasetFileNames[3]);
+int main(int argc, char* argv[]) {
+    checkArguments(argc,
+                   argv,
+                   4,
+                   &datasetFileNames[0],
+                   &datasetFileNames[1],
+                   &datasetFileNames[2],
+                   &datasetFileNames[3]);
 
     MPI_Init(&argc, &argv);
     MPI_Comm_size(MPI_COMM_WORLD, &comm_size);
@@ -125,43 +157,49 @@ int main(int argc, char * argv[])
     return 0;
 }
 
-void geometricPartitioning()
-{
+void geometricPartitioning() {
     dbscan::Distributed<step1Local, algorithmFPType, dbscan::defaultDense> step1(rankId, comm_size);
     step1.input.set(dbscan::step1Data, dataTable);
     step1.compute();
 
-    partitionedData          = DataCollectionPtr(new DataCollection());
+    partitionedData = DataCollectionPtr(new DataCollection());
     partitionedPartialOrders = DataCollectionPtr(new DataCollection());
 
     partitionedData->push_back(dataTable);
     partitionedPartialOrders->push_back(step1.getPartialResult()->get(dbscan::partialOrder));
 
     size_t beginId = 0;
-    size_t endId   = comm_size;
+    size_t endId = comm_size;
 
-    while (true)
-    {
+    while (true) {
         const size_t curNPartitions = endId - beginId;
-        if (curNPartitions == 1)
-        {
+        if (curNPartitions == 1) {
             break;
         }
 
-        partialSplits        = DataCollectionPtr(new DataCollection());
+        partialSplits = DataCollectionPtr(new DataCollection());
         partialBoundingBoxes = DataCollectionPtr(new DataCollection());
 
-        dbscan::Distributed<step2Local, algorithmFPType, dbscan::defaultDense> step2(rankId - beginId, curNPartitions);
+        dbscan::Distributed<step2Local, algorithmFPType, dbscan::defaultDense> step2(
+            rankId - beginId,
+            curNPartitions);
         step2.input.set(dbscan::partialData, partitionedData);
         step2.compute();
         NumericTablePtr curBoundingBox = step2.getPartialResult()->get(dbscan::boundingBox);
 
-        sendTableAllToAll(beginId, endId, rankId, step2ResultBoundingBoxTag, curBoundingBox, partialBoundingBoxes);
+        sendTableAllToAll(beginId,
+                          endId,
+                          rankId,
+                          step2ResultBoundingBoxTag,
+                          curBoundingBox,
+                          partialBoundingBoxes);
 
-        const size_t leftPartitions  = curNPartitions / 2;
+        const size_t leftPartitions = curNPartitions / 2;
         const size_t rightPartitions = curNPartitions - leftPartitions;
 
-        dbscan::Distributed<step3Local, algorithmFPType, dbscan::defaultDense> step3(leftPartitions, rightPartitions);
+        dbscan::Distributed<step3Local, algorithmFPType, dbscan::defaultDense> step3(
+            leftPartitions,
+            rightPartitions);
         step3.input.set(dbscan::partialData, partitionedData);
         step3.input.set(dbscan::step3PartialBoundingBoxes, partialBoundingBoxes);
         step3.compute();
@@ -169,74 +207,111 @@ void geometricPartitioning()
 
         sendTableAllToAll(beginId, endId, rankId, step3ResultSplitTag, curSplit, partialSplits);
 
-        dbscan::Distributed<step4Local, algorithmFPType, dbscan::defaultDense> step4(leftPartitions, rightPartitions);
+        dbscan::Distributed<step4Local, algorithmFPType, dbscan::defaultDense> step4(
+            leftPartitions,
+            rightPartitions);
         step4.input.set(dbscan::partialData, partitionedData);
         step4.input.set(dbscan::step4PartialOrders, partitionedPartialOrders);
         step4.input.set(dbscan::step4PartialSplits, partialSplits);
         step4.compute();
 
-        DataCollectionPtr curPartitionedData          = step4.getPartialResult()->get(dbscan::partitionedData);
-        DataCollectionPtr curPartitionedPartialOrders = step4.getPartialResult()->get(dbscan::partitionedPartialOrders);
+        DataCollectionPtr curPartitionedData =
+            step4.getPartialResult()->get(dbscan::partitionedData);
+        DataCollectionPtr curPartitionedPartialOrders =
+            step4.getPartialResult()->get(dbscan::partitionedPartialOrders);
 
-        partitionedData          = DataCollectionPtr(new DataCollection());
+        partitionedData = DataCollectionPtr(new DataCollection());
         partitionedPartialOrders = DataCollectionPtr(new DataCollection());
 
-        sendCollectionAllToAll(beginId, endId, rankId, step4ResultPartitionedDataTag, curPartitionedData, partitionedData);
-        sendCollectionAllToAll(beginId, endId, rankId, step4ResultPartitionedPartialOrdersTag, curPartitionedPartialOrders, partitionedPartialOrders);
+        sendCollectionAllToAll(beginId,
+                               endId,
+                               rankId,
+                               step4ResultPartitionedDataTag,
+                               curPartitionedData,
+                               partitionedData);
+        sendCollectionAllToAll(beginId,
+                               endId,
+                               rankId,
+                               step4ResultPartitionedPartialOrdersTag,
+                               curPartitionedPartialOrders,
+                               partitionedPartialOrders);
 
-        if (rankId < beginId + leftPartitions)
-        {
+        if (rankId < beginId + leftPartitions) {
             endId = beginId + leftPartitions;
         }
-        else
-        {
+        else {
             beginId = beginId + leftPartitions;
         }
     }
 }
 
-void clustering()
-{
+void clustering() {
     partialBoundingBoxes = DataCollectionPtr(new DataCollection());
-    haloData             = DataCollectionPtr(new DataCollection());
-    haloDataIndices      = DataCollectionPtr(new DataCollection());
-    haloBlocks           = DataCollectionPtr(new DataCollection());
+    haloData = DataCollectionPtr(new DataCollection());
+    haloDataIndices = DataCollectionPtr(new DataCollection());
+    haloBlocks = DataCollectionPtr(new DataCollection());
 
     dbscan::Distributed<step2Local, algorithmFPType, dbscan::defaultDense> step2(rankId, comm_size);
     step2.input.set(dbscan::partialData, partitionedData);
     step2.compute();
     NumericTablePtr curBoundingBox = step2.getPartialResult()->get(dbscan::boundingBox);
 
-    sendTableAllToAll(0, comm_size, rankId, step2ResultBoundingBoxTag, curBoundingBox, partialBoundingBoxes, true /* preserveOrder */);
+    sendTableAllToAll(0,
+                      comm_size,
+                      rankId,
+                      step2ResultBoundingBoxTag,
+                      curBoundingBox,
+                      partialBoundingBoxes,
+                      true /* preserveOrder */);
 
-    dbscan::Distributed<step5Local, algorithmFPType, dbscan::defaultDense> step5(rankId, comm_size, epsilon);
+    dbscan::Distributed<step5Local, algorithmFPType, dbscan::defaultDense> step5(rankId,
+                                                                                 comm_size,
+                                                                                 epsilon);
     step5.input.set(dbscan::partialData, partitionedData);
     step5.input.set(dbscan::step5PartialBoundingBoxes, partialBoundingBoxes);
     step5.compute();
-    DataCollectionPtr curHaloData        = step5.getPartialResult()->get(dbscan::partitionedHaloData);
-    DataCollectionPtr curHaloDataIndices = step5.getPartialResult()->get(dbscan::partitionedHaloDataIndices);
+    DataCollectionPtr curHaloData = step5.getPartialResult()->get(dbscan::partitionedHaloData);
+    DataCollectionPtr curHaloDataIndices =
+        step5.getPartialResult()->get(dbscan::partitionedHaloDataIndices);
     DataCollectionPtr curHaloBlocks(new DataCollection());
 
-    for (size_t destId = 0; destId < curHaloData->size(); destId++)
-    {
-        NumericTablePtr dataTable = services::staticPointerCast<NumericTable, SerializationIface>((*curHaloData)[destId]);
-        if (dataTable->getNumberOfRows() > 0)
-        {
-            curHaloBlocks->push_back(HomogenNumericTable<int>::create(1, 1, NumericTableIface::doAllocate, (int)rankId));
+    for (size_t destId = 0; destId < curHaloData->size(); destId++) {
+        NumericTablePtr dataTable =
+            services::staticPointerCast<NumericTable, SerializationIface>((*curHaloData)[destId]);
+        if (dataTable->getNumberOfRows() > 0) {
+            curHaloBlocks->push_back(
+                HomogenNumericTable<int>::create(1, 1, NumericTableIface::doAllocate, (int)rankId));
         }
-        else
-        {
+        else {
             curHaloBlocks->push_back(NumericTablePtr());
         }
     }
 
-    sendCollectionAllToAll(0, comm_size, rankId, step5ResultPartitionedHaloDataTag, curHaloData, haloData);
-    sendCollectionAllToAll(0, comm_size, rankId, step5ResultPartitionedHaloDataIndicesTag, curHaloDataIndices, haloDataIndices);
-    sendCollectionAllToAll(0, comm_size, rankId, step5ResultPartitionedHaloBlocksTag, curHaloBlocks, haloBlocks);
+    sendCollectionAllToAll(0,
+                           comm_size,
+                           rankId,
+                           step5ResultPartitionedHaloDataTag,
+                           curHaloData,
+                           haloData);
+    sendCollectionAllToAll(0,
+                           comm_size,
+                           rankId,
+                           step5ResultPartitionedHaloDataIndicesTag,
+                           curHaloDataIndices,
+                           haloDataIndices);
+    sendCollectionAllToAll(0,
+                           comm_size,
+                           rankId,
+                           step5ResultPartitionedHaloBlocksTag,
+                           curHaloBlocks,
+                           haloBlocks);
 
     queries = DataCollectionPtr(new DataCollection());
 
-    dbscan::Distributed<step6Local, algorithmFPType, dbscan::defaultDense> step6(rankId, comm_size, epsilon, minObservations);
+    dbscan::Distributed<step6Local, algorithmFPType, dbscan::defaultDense> step6(rankId,
+                                                                                 comm_size,
+                                                                                 epsilon,
+                                                                                 minObservations);
 
     step6.input.set(dbscan::partialData, partitionedData);
     step6.input.set(dbscan::haloData, haloData);
@@ -244,24 +319,24 @@ void clustering()
     step6.input.set(dbscan::haloBlocks, haloBlocks);
     step6.compute();
     clusterStructure = step6.getPartialResult()->get(dbscan::step6ClusterStructure);
-    finishedFlag     = step6.getPartialResult()->get(dbscan::step6FinishedFlag);
-    nClusters        = step6.getPartialResult()->get(dbscan::step6NClusters);
+    finishedFlag = step6.getPartialResult()->get(dbscan::step6FinishedFlag);
+    nClusters = step6.getPartialResult()->get(dbscan::step6NClusters);
 
     DataCollectionPtr curQueries = step6.getPartialResult()->get(dbscan::step6Queries);
 
     sendCollectionAllToAll(0, comm_size, rankId, step6ResultQueriesTag, curQueries, queries);
 
-    while (computeFinishedFlag() == 0)
-    {
-        dbscan::Distributed<step8Local, algorithmFPType, dbscan::defaultDense> step8(rankId, comm_size);
+    while (computeFinishedFlag() == 0) {
+        dbscan::Distributed<step8Local, algorithmFPType, dbscan::defaultDense> step8(rankId,
+                                                                                     comm_size);
         step8.input.set(dbscan::step8InputClusterStructure, clusterStructure);
         step8.input.set(dbscan::step8InputNClusters, nClusters);
         step8.input.set(dbscan::step8PartialQueries, queries);
         step8.compute();
 
         clusterStructure = step8.getPartialResult()->get(dbscan::step8ClusterStructure);
-        finishedFlag     = step8.getPartialResult()->get(dbscan::step8FinishedFlag);
-        nClusters        = step8.getPartialResult()->get(dbscan::step8NClusters);
+        finishedFlag = step8.getPartialResult()->get(dbscan::step8FinishedFlag);
+        nClusters = step8.getPartialResult()->get(dbscan::step8NClusters);
 
         DataCollectionPtr curQueries = step8.getPartialResult()->get(dbscan::step8Queries);
 
@@ -270,10 +345,14 @@ void clustering()
         sendCollectionAllToAll(0, comm_size, rankId, step8ResultQueriesTag, curQueries, queries);
     }
 
-    if (rankId == 0)
-    {
+    if (rankId == 0) {
         DataCollectionPtr partialNClusters(new DataCollection());
-        sendTableAllToMaster(0, comm_size, rankId, step8ResultNClustersTag, nClusters, partialNClusters);
+        sendTableAllToMaster(0,
+                             comm_size,
+                             rankId,
+                             step8ResultNClustersTag,
+                             nClusters,
+                             partialNClusters);
 
         dbscan::Distributed<step9Master, algorithmFPType, dbscan::defaultDense> step9;
         step9.input.set(dbscan::partialNClusters, partialNClusters);
@@ -281,45 +360,70 @@ void clustering()
         step9.finalizeCompute();
 
         totalNClusters = step9.getResult()->get(dbscan::step9NClusters);
-        sendTableMasterToAll(0, comm_size, rankId, step9ResultNClustersTag, totalNClusters, totalNClusters);
+        sendTableMasterToAll(0,
+                             comm_size,
+                             rankId,
+                             step9ResultNClustersTag,
+                             totalNClusters,
+                             totalNClusters);
 
         DataCollectionPtr curClusterOffsets = step9.getPartialResult()->get(dbscan::clusterOffsets);
-        sendCollectionMasterToAll(0, comm_size, rankId, step9ResultClusterOffsetsTag, curClusterOffsets, clusterOffset);
+        sendCollectionMasterToAll(0,
+                                  comm_size,
+                                  rankId,
+                                  step9ResultClusterOffsetsTag,
+                                  curClusterOffsets,
+                                  clusterOffset);
     }
-    else
-    {
+    else {
         DataCollectionPtr partialNClusters;
-        sendTableAllToMaster(0, comm_size, rankId, step8ResultNClustersTag, nClusters, partialNClusters);
+        sendTableAllToMaster(0,
+                             comm_size,
+                             rankId,
+                             step8ResultNClustersTag,
+                             nClusters,
+                             partialNClusters);
 
-        sendTableMasterToAll(0, comm_size, rankId, step9ResultNClustersTag, totalNClusters, totalNClusters);
+        sendTableMasterToAll(0,
+                             comm_size,
+                             rankId,
+                             step9ResultNClustersTag,
+                             totalNClusters,
+                             totalNClusters);
 
         DataCollectionPtr curClusterOffsets;
-        sendCollectionMasterToAll(0, comm_size, rankId, step9ResultClusterOffsetsTag, curClusterOffsets, clusterOffset);
+        sendCollectionMasterToAll(0,
+                                  comm_size,
+                                  rankId,
+                                  step9ResultClusterOffsetsTag,
+                                  curClusterOffsets,
+                                  clusterOffset);
     }
 
     queries = DataCollectionPtr(new DataCollection());
 
-    dbscan::Distributed<step10Local, algorithmFPType, dbscan::defaultDense> step10(rankId, comm_size);
+    dbscan::Distributed<step10Local, algorithmFPType, dbscan::defaultDense> step10(rankId,
+                                                                                   comm_size);
     step10.input.set(dbscan::step10InputClusterStructure, clusterStructure);
     step10.input.set(dbscan::step10ClusterOffset, clusterOffset);
     step10.compute();
 
     clusterStructure = step10.getPartialResult()->get(dbscan::step10ClusterStructure);
-    finishedFlag     = step10.getPartialResult()->get(dbscan::step10FinishedFlag);
+    finishedFlag = step10.getPartialResult()->get(dbscan::step10FinishedFlag);
 
     curQueries = step10.getPartialResult()->get(dbscan::step10Queries);
 
     sendCollectionAllToAll(0, comm_size, rankId, step10ResultQueriesTag, curQueries, queries);
 
-    while (computeFinishedFlag() == 0)
-    {
-        dbscan::Distributed<step11Local, algorithmFPType, dbscan::defaultDense> step11(rankId, comm_size);
+    while (computeFinishedFlag() == 0) {
+        dbscan::Distributed<step11Local, algorithmFPType, dbscan::defaultDense> step11(rankId,
+                                                                                       comm_size);
         step11.input.set(dbscan::step11InputClusterStructure, clusterStructure);
         step11.input.set(dbscan::step11PartialQueries, queries);
         step11.compute();
 
         clusterStructure = step11.getPartialResult()->get(dbscan::step11ClusterStructure);
-        finishedFlag     = step11.getPartialResult()->get(dbscan::step11FinishedFlag);
+        finishedFlag = step11.getPartialResult()->get(dbscan::step11FinishedFlag);
 
         DataCollectionPtr curQueries = step11.getPartialResult()->get(dbscan::step11Queries);
 
@@ -329,14 +433,21 @@ void clustering()
 
     assignmentQueries = DataCollectionPtr(new DataCollection());
 
-    dbscan::Distributed<step12Local, algorithmFPType, dbscan::defaultDense> step12(rankId, comm_size);
+    dbscan::Distributed<step12Local, algorithmFPType, dbscan::defaultDense> step12(rankId,
+                                                                                   comm_size);
     step12.input.set(dbscan::step12InputClusterStructure, clusterStructure);
     step12.input.set(dbscan::step12PartialOrders, partitionedPartialOrders);
     step12.compute();
 
-    DataCollectionPtr curAssignmentQueries = step12.getPartialResult()->get(dbscan::assignmentQueries);
+    DataCollectionPtr curAssignmentQueries =
+        step12.getPartialResult()->get(dbscan::assignmentQueries);
 
-    sendCollectionAllToAll(0, comm_size, rankId, step12ResultAssignmentQueriesTag, curAssignmentQueries, assignmentQueries);
+    sendCollectionAllToAll(0,
+                           comm_size,
+                           rankId,
+                           step12ResultAssignmentQueriesTag,
+                           curAssignmentQueries,
+                           assignmentQueries);
 
     dbscan::Distributed<step13Local, algorithmFPType, dbscan::defaultDense> step13;
     step13.input.set(dbscan::partialAssignmentQueries, assignmentQueries);
@@ -346,245 +457,246 @@ void clustering()
     assignments = step13.getResult()->get(dbscan::step13Assignments);
 }
 
-int computeFinishedFlag()
-{
-    if (rankId == 0)
-    {
+int computeFinishedFlag() {
+    if (rankId == 0) {
         DataCollectionPtr partialFinishedFlags(new DataCollection());
-        sendTableAllToMaster(0, comm_size, rankId, resultFinishedFlagTag, finishedFlag, partialFinishedFlags);
+        sendTableAllToMaster(0,
+                             comm_size,
+                             rankId,
+                             resultFinishedFlagTag,
+                             finishedFlag,
+                             partialFinishedFlags);
 
         dbscan::Distributed<step7Master, algorithmFPType, dbscan::defaultDense> step7;
         step7.input.set(dbscan::partialFinishedFlags, partialFinishedFlags);
         step7.compute();
         finishedFlag = step7.getPartialResult()->get(dbscan::finishedFlag);
 
-        sendTableMasterToAll(0, comm_size, rankId, step7ResultFinishedFlagTag, finishedFlag, finishedFlag);
+        sendTableMasterToAll(0,
+                             comm_size,
+                             rankId,
+                             step7ResultFinishedFlagTag,
+                             finishedFlag,
+                             finishedFlag);
 
         int finishedFlagValue = finishedFlag->getValue<int>(0, 0);
         return finishedFlagValue;
     }
-    else
-    {
+    else {
         DataCollectionPtr partialFinishedFlags;
-        sendTableAllToMaster(0, comm_size, rankId, resultFinishedFlagTag, finishedFlag, partialFinishedFlags);
+        sendTableAllToMaster(0,
+                             comm_size,
+                             rankId,
+                             resultFinishedFlagTag,
+                             finishedFlag,
+                             partialFinishedFlags);
 
-        sendTableMasterToAll(0, comm_size, rankId, step7ResultFinishedFlagTag, finishedFlag, finishedFlag);
+        sendTableMasterToAll(0,
+                             comm_size,
+                             rankId,
+                             step7ResultFinishedFlagTag,
+                             finishedFlag,
+                             finishedFlag);
 
         int finishedFlagValue = finishedFlag->getValue<int>(0, 0);
         return finishedFlagValue;
     }
 }
 
-NumericTablePtr readData(size_t rankId)
-{
+NumericTablePtr readData(size_t rankId) {
     /* Read trainDatasetFileName from a file and create a numeric table to store the input data */
     /* Initialize FileDataSource<CSVFeatureManager> to retrieve the input data from a .csv file */
-    FileDataSource<CSVFeatureManager> dataSource(datasetFileNames[rankId], DataSource::doAllocateNumericTable, DataSource::doDictionaryFromContext);
+    FileDataSource<CSVFeatureManager> dataSource(datasetFileNames[rankId],
+                                                 DataSource::doAllocateNumericTable,
+                                                 DataSource::doDictionaryFromContext);
 
     /* Retrieve the data from the input file */
     dataSource.loadDataBlock();
     return dataSource.getNumericTable();
 }
 
-void sendCollectionAllToAll(size_t beginId, size_t endId, size_t curId, int tag, DataCollectionPtr & collection, DataCollectionPtr & destCollection)
-{
-    size_t nIds    = endId - beginId;
+void sendCollectionAllToAll(size_t beginId,
+                            size_t endId,
+                            size_t curId,
+                            int tag,
+                            DataCollectionPtr& collection,
+                            DataCollectionPtr& destCollection) {
+    size_t nIds = endId - beginId;
     size_t nShifts = 1;
-    while (nShifts < nIds) nShifts <<= 1;
+    while (nShifts < nIds)
+        nShifts <<= 1;
 
-    for (size_t shift = 0; shift < nShifts; shift++)
-    {
+    for (size_t shift = 0; shift < nShifts; shift++) {
         size_t partnerId = ((curId - beginId) ^ shift) + beginId;
-        if (partnerId < beginId || partnerId >= endId)
-        {
+        if (partnerId < beginId || partnerId >= endId) {
             continue;
         }
 
         NumericTablePtr table = NumericTable::cast((*collection)[partnerId - beginId]);
         NumericTablePtr partnerTable;
 
-        if (partnerId == curId)
-        {
+        if (partnerId == curId) {
             partnerTable = table;
         }
-        else
-        {
-            if (curId < partnerId)
-            {
+        else {
+            if (curId < partnerId) {
                 sendTable(table, partnerId, tag);
                 recvTable(partnerTable, partnerId, tag);
             }
-            else
-            {
+            else {
                 recvTable(partnerTable, partnerId, tag);
                 sendTable(table, partnerId, tag);
             }
         }
 
-        if (partnerTable.get() && partnerTable->getNumberOfRows() > 0)
-        {
+        if (partnerTable.get() && partnerTable->getNumberOfRows() > 0) {
             destCollection->push_back(partnerTable);
         }
     }
 }
 
-void sendTableAllToAll(size_t beginId, size_t endId, size_t curId, int tag, NumericTablePtr & table, DataCollectionPtr & destCollection,
-                       bool preserveOrder)
-{
-    size_t nIds    = endId - beginId;
+void sendTableAllToAll(size_t beginId,
+                       size_t endId,
+                       size_t curId,
+                       int tag,
+                       NumericTablePtr& table,
+                       DataCollectionPtr& destCollection,
+                       bool preserveOrder) {
+    size_t nIds = endId - beginId;
     size_t nShifts = 1;
-    while (nShifts < nIds) nShifts <<= 1;
+    while (nShifts < nIds)
+        nShifts <<= 1;
 
-    if (preserveOrder)
-    {
+    if (preserveOrder) {
         destCollection = DataCollectionPtr(new DataCollection(nIds));
     }
 
-    for (size_t shift = 0; shift < nShifts; shift++)
-    {
+    for (size_t shift = 0; shift < nShifts; shift++) {
         size_t partnerId = ((curId - beginId) ^ shift) + beginId;
-        if (partnerId < beginId || partnerId >= endId)
-        {
+        if (partnerId < beginId || partnerId >= endId) {
             continue;
         }
 
         NumericTablePtr partnerTable;
 
-        if (partnerId == curId)
-        {
+        if (partnerId == curId) {
             partnerTable = table;
         }
-        else
-        {
-            if (curId < partnerId)
-            {
+        else {
+            if (curId < partnerId) {
                 sendTable(table, partnerId, tag);
                 recvTable(partnerTable, partnerId, tag);
             }
-            else
-            {
+            else {
                 recvTable(partnerTable, partnerId, tag);
                 sendTable(table, partnerId, tag);
             }
         }
 
-        if (partnerTable.get() && partnerTable->getNumberOfRows() > 0)
-        {
-            if (preserveOrder)
-            {
+        if (partnerTable.get() && partnerTable->getNumberOfRows() > 0) {
+            if (preserveOrder) {
                 (*destCollection)[partnerId - beginId] = partnerTable;
             }
-            else
-            {
+            else {
                 destCollection->push_back(partnerTable);
             }
         }
     }
 }
 
-void sendTableAllToMaster(size_t beginId, size_t endId, size_t rankId, int tag, NumericTablePtr & table, DataCollectionPtr & destCollection)
-{
-    if (rankId == beginId)
-    {
-        for (size_t partnerId = beginId; partnerId < endId; partnerId++)
-        {
+void sendTableAllToMaster(size_t beginId,
+                          size_t endId,
+                          size_t rankId,
+                          int tag,
+                          NumericTablePtr& table,
+                          DataCollectionPtr& destCollection) {
+    if (rankId == beginId) {
+        for (size_t partnerId = beginId; partnerId < endId; partnerId++) {
             NumericTablePtr partnerTable;
-            if (partnerId == rankId)
-            {
+            if (partnerId == rankId) {
                 partnerTable = table;
             }
-            else
-            {
+            else {
                 recvTable(partnerTable, partnerId, tag);
             }
 
-            if (partnerTable.get() && partnerTable->getNumberOfRows() > 0)
-            {
+            if (partnerTable.get() && partnerTable->getNumberOfRows() > 0) {
                 destCollection->push_back(partnerTable);
             }
         }
     }
-    else
-    {
+    else {
         sendTable(table, beginId, tag);
     }
 }
 
-void sendCollectionMasterToAll(size_t beginId, size_t endId, size_t rankId, int tag, DataCollectionPtr & collection, NumericTablePtr & destTable)
-{
-    if (rankId == beginId)
-    {
-        for (size_t partnerId = beginId; partnerId < endId; partnerId++)
-        {
+void sendCollectionMasterToAll(size_t beginId,
+                               size_t endId,
+                               size_t rankId,
+                               int tag,
+                               DataCollectionPtr& collection,
+                               NumericTablePtr& destTable) {
+    if (rankId == beginId) {
+        for (size_t partnerId = beginId; partnerId < endId; partnerId++) {
             NumericTablePtr table = NumericTable::cast((*collection)[partnerId - beginId]);
-            if (partnerId == rankId)
-            {
+            if (partnerId == rankId) {
                 destTable = table;
             }
-            else
-            {
+            else {
                 sendTable(table, partnerId, tag);
             }
         }
     }
-    else
-    {
+    else {
         recvTable(destTable, beginId, tag);
     }
 }
 
-void sendTableMasterToAll(size_t beginId, size_t endId, size_t rankId, int tag, NumericTablePtr & table, NumericTablePtr & destTable)
-{
-    if (rankId == beginId)
-    {
-        for (size_t partnerId = beginId; partnerId < endId; partnerId++)
-        {
-            if (partnerId == rankId)
-            {
+void sendTableMasterToAll(size_t beginId,
+                          size_t endId,
+                          size_t rankId,
+                          int tag,
+                          NumericTablePtr& table,
+                          NumericTablePtr& destTable) {
+    if (rankId == beginId) {
+        for (size_t partnerId = beginId; partnerId < endId; partnerId++) {
+            if (partnerId == rankId) {
                 destTable = table;
             }
-            else
-            {
+            else {
                 sendTable(table, partnerId, tag);
             }
         }
     }
-    else
-    {
+    else {
         recvTable(destTable, beginId, tag);
     }
 }
 
-void sendTable(NumericTablePtr & table, int recpnt, int tag)
-{
+void sendTable(NumericTablePtr& table, int recpnt, int tag) {
     ByteBuffer buff;
-    size_t size = (table.get() && table->getNumberOfRows() > 0) ? serializeDAALObject(table.get(), buff) : 0;
+    size_t size =
+        (table.get() && table->getNumberOfRows() > 0) ? serializeDAALObject(table.get(), buff) : 0;
     MPI_Send(&size, sizeof(size_t), MPI_BYTE, recpnt, tag * 2 + 0, MPI_COMM_WORLD);
-    if (size)
-    {
+    if (size) {
         MPI_Send(&buff[0], size, MPI_BYTE, recpnt, tag * 2 + 1, MPI_COMM_WORLD);
     }
 }
 
-void recvTable(NumericTablePtr & table, int sender, int tag)
-{
+void recvTable(NumericTablePtr& table, int sender, int tag) {
     size_t size = 0;
     MPI_Status status;
     MPI_Recv(&size, sizeof(size_t), MPI_BYTE, sender, tag * 2 + 0, MPI_COMM_WORLD, &status);
-    if (size)
-    {
+    if (size) {
         ByteBuffer buff(size);
         MPI_Recv(&buff[0], size, MPI_BYTE, sender, tag * 2 + 1, MPI_COMM_WORLD, &status);
         table = NumericTable::cast(deserializeDAALObject(&buff[0], size));
     }
 }
 
-void printResults()
-{
-    for (size_t id = 0; id < comm_size; id++)
-    {
-        if (id == rankId)
-        {
+void printResults() {
+    for (size_t id = 0; id < comm_size; id++) {
+        if (id == rankId) {
             std::cout << "Results on node with id = " << id << " :" << std::endl;
             printNumericTable(totalNClusters, "Number of clusters:");
             printNumericTable(assignments, "Assignments of first 20 observations from block:", 20);

--- a/samples/daal/cpp/mpi/sources/error_handling.h
+++ b/samples/daal/cpp/mpi/sources/error_handling.h
@@ -25,38 +25,31 @@
 
 const int fileError = -1001;
 
-void checkAllocation(void * ptr)
-{
-    if (!ptr)
-    {
+void checkAllocation(void* ptr) {
+    if (!ptr) {
         std::cout << "Error: Memory allocation failed" << std::endl;
         exit(-1);
     }
 }
 
-void checkPtr(void * ptr)
-{
-    if (!ptr)
-    {
+void checkPtr(void* ptr) {
+    if (!ptr) {
         std::cout << "Error: NULL pointer" << std::endl;
         exit(-2);
     }
 }
 
-void fileOpenError(const char * filename)
-{
+void fileOpenError(const char* filename) {
     std::cout << "Unable to open file '" << filename << "'" << std::endl;
     exit(fileError);
 }
 
-void fileReadError()
-{
+void fileReadError() {
     std::cout << "Unable to read next line" << std::endl;
     exit(fileError);
 }
 
-void sparceFileReadError()
-{
+void sparceFileReadError() {
     std::cout << "Incorrect format of file" << std::endl;
     exit(fileError);
 }

--- a/samples/daal/cpp/mpi/sources/implicit_als_csr_distributed_mpi.cpp
+++ b/samples/daal/cpp/mpi/sources/implicit_als_csr_distributed_mpi.cpp
@@ -43,7 +43,8 @@ int rankId, comm_size;
 #define mpi_root 0
 
 /* Number of observations in transposed training data set blocks */
-const string trainDatasetFileNames[nBlocks] = { "./data/distributed/implicit_als_trans_csr_1.csv", "./data/distributed/implicit_als_trans_csr_2.csv",
+const string trainDatasetFileNames[nBlocks] = { "./data/distributed/implicit_als_trans_csr_1.csv",
+                                                "./data/distributed/implicit_als_trans_csr_2.csv",
                                                 "./data/distributed/implicit_als_trans_csr_3.csv",
                                                 "./data/distributed/implicit_als_trans_csr_4.csv" };
 
@@ -60,7 +61,7 @@ typedef float algorithmFPType; /* Algorithm floating-point type */
 /* Algorithm parameters */
 const size_t nUsers = 46; /* Full number of users */
 
-const size_t nFactors      = 2; /* Number of factors */
+const size_t nFactors = 2; /* Number of factors */
 const size_t maxIterations = 5; /* Number of iterations in the implicit ALS training algorithm */
 
 int displs[nBlocks];
@@ -93,13 +94,12 @@ void testModel();
 void predictRatings();
 
 template <typename T>
-void gather(const ByteBuffer & nodeResults, T * result);
-void gatherItems(const ByteBuffer & nodeResults);
+void gather(const ByteBuffer &nodeResults, T *result);
+void gatherItems(const ByteBuffer &nodeResults);
 template <typename T>
-void all2all(ByteBuffer * nodeResults, KeyValueDataCollectionPtr result);
+void all2all(ByteBuffer *nodeResults, KeyValueDataCollectionPtr result);
 
-int main(int argc, char * argv[])
-{
+int main(int argc, char *argv[]) {
     MPI_Init(&argc, &argv);
     MPI_Comm_size(MPI_COMM_WORLD, &comm_size);
     MPI_Comm_rank(MPI_COMM_WORLD, &rankId);
@@ -112,14 +112,12 @@ int main(int argc, char * argv[])
 
     testModel();
 
-    if (rankId == mpi_root)
-    {
-        for (size_t i = 0; i < nBlocks; i++)
-        {
-            for (size_t j = 0; j < nBlocks; j++)
-            {
+    if (rankId == mpi_root) {
+        for (size_t i = 0; i < nBlocks; i++) {
+            for (size_t j = 0; j < nBlocks; j++) {
                 cout << "Ratings for users block " << i << ", items block " << j << " :" << endl;
-                printALSRatings(NumericTable::cast((*userOffsetsOnMaster)[i]), NumericTable::cast((*itemOffsetsOnMaster)[j]),
+                printALSRatings(NumericTable::cast((*userOffsetsOnMaster)[i]),
+                                NumericTable::cast((*itemOffsetsOnMaster)[j]),
                                 predictedRatingsMaster[i][j]);
             }
         }
@@ -129,20 +127,19 @@ int main(int argc, char * argv[])
     return 0;
 }
 
-void readData()
-{
+void readData() {
     /* Read trainDatasetFileName from a file and create a numeric table to store the input data */
     dataTable.reset(createSparseTable<float>(trainDatasetFileNames[rankId]));
 }
 
-KeyValueDataCollectionPtr initializeStep1Local()
-{
+KeyValueDataCollectionPtr initializeStep1Local() {
     /* Create an algorithm object to initialize the implicit ALS model with the default method */
     training::init::Distributed<step1Local, algorithmFPType, training::init::fastCSR> initAlgorithm;
     initAlgorithm.parameter.fullNUsers = nUsers;
-    initAlgorithm.parameter.nFactors   = nFactors;
+    initAlgorithm.parameter.nFactors = nFactors;
     initAlgorithm.parameter.seed += rankId;
-    initAlgorithm.parameter.partition.reset(new HomogenNumericTable<int>((int *)usersPartition, 1, 1));
+    initAlgorithm.parameter.partition.reset(
+        new HomogenNumericTable<int>((int *)usersPartition, 1, 1));
     /* Pass a training data set and dependent values to the algorithm */
     initAlgorithm.input.set(training::init::data, dataTable);
 
@@ -150,10 +147,9 @@ KeyValueDataCollectionPtr initializeStep1Local()
     initAlgorithm.compute();
 
     training::init::PartialResultPtr partialResult = initAlgorithm.getPartialResult();
-    itemStep3LocalInput                            = partialResult->get(training::init::outputOfInitForComputeStep3);
-    userOffset                                     = partialResult->get(training::init::offsets, (size_t)rankId);
-    if (rankId == mpi_root)
-    {
+    itemStep3LocalInput = partialResult->get(training::init::outputOfInitForComputeStep3);
+    userOffset = partialResult->get(training::init::offsets, (size_t)rankId);
+    if (rankId == mpi_root) {
         userOffsetsOnMaster = partialResult->get(training::init::offsets);
     }
     PartialModelPtr partialModelLocal = partialResult->get(training::init::partialModel);
@@ -164,8 +160,7 @@ KeyValueDataCollectionPtr initializeStep1Local()
     return partialResult->get(training::init::outputOfStep1ForStep2);
 }
 
-void initializeStep2Local(const KeyValueDataCollectionPtr & initStep2LocalInput)
-{
+void initializeStep2Local(const KeyValueDataCollectionPtr &initStep2LocalInput) {
     /* Create an algorithm object to perform the second step of the implicit ALS initialization algorithm */
     training::init::Distributed<step2Local, algorithmFPType, training::init::fastCSR> initAlgorithm;
 
@@ -174,24 +169,22 @@ void initializeStep2Local(const KeyValueDataCollectionPtr & initStep2LocalInput)
     /* Compute partial results of the second step on local nodes */
     initAlgorithm.compute();
 
-    training::init::DistributedPartialResultStep2Ptr partialResult = initAlgorithm.getPartialResult();
-    transposedDataTable                                            = CSRNumericTable::cast(partialResult->get(training::init::transposedData));
-    userStep3LocalInput                                            = partialResult->get(training::init::outputOfInitForComputeStep3);
-    itemOffset                                                     = partialResult->get(training::init::offsets, (size_t)rankId);
-    if (rankId == mpi_root)
-    {
+    training::init::DistributedPartialResultStep2Ptr partialResult =
+        initAlgorithm.getPartialResult();
+    transposedDataTable = CSRNumericTable::cast(partialResult->get(training::init::transposedData));
+    userStep3LocalInput = partialResult->get(training::init::outputOfInitForComputeStep3);
+    itemOffset = partialResult->get(training::init::offsets, (size_t)rankId);
+    if (rankId == mpi_root) {
         itemOffsetsOnMaster = partialResult->get(training::init::offsets);
     }
 }
 
-void initializeModel()
-{
+void initializeModel() {
     KeyValueDataCollectionPtr initStep1LocalResult = initializeStep1Local();
 
     /* MPI_Alltoallv to populate initStep2LocalInput */
     ByteBuffer nodeCPs[nBlocks];
-    for (size_t i = 0; i < nBlocks; i++)
-    {
+    for (size_t i = 0; i < nBlocks; i++) {
         serializeDAALObject((*initStep1LocalResult)[i].get(), nodeCPs[i]);
     }
     KeyValueDataCollectionPtr initStep2LocalInput(new KeyValueDataCollection());
@@ -200,14 +193,15 @@ void initializeModel()
     initializeStep2Local(initStep2LocalInput);
 }
 
-training::DistributedPartialResultStep1Ptr computeStep1Local(const training::DistributedPartialResultStep4Ptr & partialResultLocal)
-{
+training::DistributedPartialResultStep1Ptr computeStep1Local(
+    const training::DistributedPartialResultStep4Ptr &partialResultLocal) {
     /* Create algorithm objects to compute implicit ALS algorithm in the distributed processing mode on the local node using the default method */
     training::Distributed<step1Local> algorithm;
     algorithm.parameter.nFactors = nFactors;
 
     /* Set input objects for the algorithm */
-    algorithm.input.set(training::partialModel, partialResultLocal->get(training::outputOfStep4ForStep1));
+    algorithm.input.set(training::partialModel,
+                        partialResultLocal->get(training::outputOfStep4ForStep1));
 
     /* Compute partial estimates on local nodes */
     algorithm.compute();
@@ -216,15 +210,14 @@ training::DistributedPartialResultStep1Ptr computeStep1Local(const training::Dis
     return algorithm.getPartialResult();
 }
 
-NumericTablePtr computeStep2Master(const training::DistributedPartialResultStep1Ptr * step1LocalResultsOnMaster)
-{
+NumericTablePtr computeStep2Master(
+    const training::DistributedPartialResultStep1Ptr *step1LocalResultsOnMaster) {
     /* Create algorithm objects to compute implicit ALS algorithm in the distributed processing mode on the master node using the default method */
     training::Distributed<step2Master> algorithm;
     algorithm.parameter.nFactors = nFactors;
 
     /* Set input objects for the algorithm */
-    for (size_t i = 0; i < nBlocks; i++)
-    {
+    for (size_t i = 0; i < nBlocks; i++) {
         algorithm.input.add(training::inputOfStep2FromStep1, step1LocalResultsOnMaster[i]);
     }
 
@@ -234,13 +227,15 @@ NumericTablePtr computeStep2Master(const training::DistributedPartialResultStep1
     return algorithm.getPartialResult()->get(training::outputOfStep2ForStep4);
 }
 
-KeyValueDataCollectionPtr computeStep3Local(const NumericTablePtr & offset, const training::DistributedPartialResultStep4Ptr & partialResultLocal,
-                                            const KeyValueDataCollectionPtr & step3LocalInput)
-{
+KeyValueDataCollectionPtr computeStep3Local(
+    const NumericTablePtr &offset,
+    const training::DistributedPartialResultStep4Ptr &partialResultLocal,
+    const KeyValueDataCollectionPtr &step3LocalInput) {
     training::Distributed<step3Local> algorithm;
     algorithm.parameter.nFactors = nFactors;
 
-    algorithm.input.set(training::partialModel, partialResultLocal->get(training::outputOfStep4ForStep3));
+    algorithm.input.set(training::partialModel,
+                        partialResultLocal->get(training::outputOfStep4ForStep3));
     algorithm.input.set(training::inputOfStep3FromInit, step3LocalInput);
     algorithm.input.set(training::offset, offset);
 
@@ -249,9 +244,10 @@ KeyValueDataCollectionPtr computeStep3Local(const NumericTablePtr & offset, cons
     return algorithm.getPartialResult()->get(training::outputOfStep3ForStep4);
 }
 
-training::DistributedPartialResultStep4Ptr computeStep4Local(const CSRNumericTablePtr & dataTable, const NumericTablePtr & step2MasterResult,
-                                                             const KeyValueDataCollectionPtr & step4LocalInput)
-{
+training::DistributedPartialResultStep4Ptr computeStep4Local(
+    const CSRNumericTablePtr &dataTable,
+    const NumericTablePtr &step2MasterResult,
+    const KeyValueDataCollectionPtr &step4LocalInput) {
     training::Distributed<step4Local> algorithm;
     algorithm.parameter.nFactors = nFactors;
 
@@ -264,8 +260,7 @@ training::DistributedPartialResultStep4Ptr computeStep4Local(const CSRNumericTab
     return algorithm.getPartialResult();
 }
 
-void trainModel()
-{
+void trainModel() {
     training::DistributedPartialResultStep1Ptr step1LocalResultsOnMaster[nBlocks];
     training::DistributedPartialResultStep1Ptr step1LocalResult;
     NumericTablePtr step2MasterResult;
@@ -277,8 +272,7 @@ void trainModel()
     ByteBuffer crossProductBuf;
     int crossProductLen;
 
-    for (size_t iteration = 0; iteration < maxIterations; iteration++)
-    {
+    for (size_t iteration = 0; iteration < maxIterations; iteration++) {
         step1LocalResult = computeStep1Local(itemsPartialResultLocal);
 
         serializeDAALObject(step1LocalResult.get(), nodeResults);
@@ -286,31 +280,31 @@ void trainModel()
         /* Gathering step1LocalResult on the master */
         gather(nodeResults, step1LocalResultsOnMaster);
 
-        if (rankId == mpi_root)
-        {
+        if (rankId == mpi_root) {
             step2MasterResult = computeStep2Master(step1LocalResultsOnMaster);
             serializeDAALObject(step2MasterResult.get(), crossProductBuf);
             crossProductLen = crossProductBuf.size();
         }
 
         MPI_Bcast(&crossProductLen, sizeof(int), MPI_CHAR, mpi_root, MPI_COMM_WORLD);
-        if (rankId != mpi_root)
-        {
+        if (rankId != mpi_root) {
             crossProductBuf.resize(crossProductLen);
         }
         MPI_Bcast(&crossProductBuf[0], crossProductLen, MPI_CHAR, mpi_root, MPI_COMM_WORLD);
-        step2MasterResult = NumericTable::cast(deserializeDAALObject(&crossProductBuf[0], crossProductLen));
+        step2MasterResult =
+            NumericTable::cast(deserializeDAALObject(&crossProductBuf[0], crossProductLen));
 
-        step3LocalResult = computeStep3Local(itemOffset, itemsPartialResultLocal, itemStep3LocalInput);
+        step3LocalResult =
+            computeStep3Local(itemOffset, itemsPartialResultLocal, itemStep3LocalInput);
 
         /* MPI_Alltoallv to populate step4LocalInput */
-        for (size_t i = 0; i < nBlocks; i++)
-        {
+        for (size_t i = 0; i < nBlocks; i++) {
             serializeDAALObject((*step3LocalResult)[i].get(), nodeCPs[i]);
         }
         all2all<PartialModel>(nodeCPs, step4LocalInput);
 
-        usersPartialResultLocal = computeStep4Local(transposedDataTable, step2MasterResult, step4LocalInput);
+        usersPartialResultLocal =
+            computeStep4Local(transposedDataTable, step2MasterResult, step4LocalInput);
 
         step1LocalResult = computeStep1Local(usersPartialResultLocal);
 
@@ -319,26 +313,25 @@ void trainModel()
         /*Gathering step1LocalResult on the master*/
         gather(nodeResults, step1LocalResultsOnMaster);
 
-        if (rankId == mpi_root)
-        {
+        if (rankId == mpi_root) {
             step2MasterResult = computeStep2Master(step1LocalResultsOnMaster);
             serializeDAALObject(step2MasterResult.get(), crossProductBuf);
             crossProductLen = crossProductBuf.size();
         }
 
         MPI_Bcast(&crossProductLen, sizeof(int), MPI_CHAR, mpi_root, MPI_COMM_WORLD);
-        if (rankId != mpi_root)
-        {
+        if (rankId != mpi_root) {
             crossProductBuf.resize(crossProductLen);
         }
         MPI_Bcast(&crossProductBuf[0], crossProductLen, MPI_CHAR, mpi_root, MPI_COMM_WORLD);
-        step2MasterResult = NumericTable::cast(deserializeDAALObject(&crossProductBuf[0], crossProductLen));
+        step2MasterResult =
+            NumericTable::cast(deserializeDAALObject(&crossProductBuf[0], crossProductLen));
 
-        step3LocalResult = computeStep3Local(userOffset, usersPartialResultLocal, userStep3LocalInput);
+        step3LocalResult =
+            computeStep3Local(userOffset, usersPartialResultLocal, userStep3LocalInput);
 
         /* MPI_Alltoallv to populate step4LocalInput */
-        for (size_t i = 0; i < nBlocks; i++)
-        {
+        for (size_t i = 0; i < nBlocks; i++) {
             serializeDAALObject((*step3LocalResult)[i].get(), nodeCPs[i]);
         }
         all2all<PartialModel>(nodeCPs, step4LocalInput);
@@ -351,17 +344,17 @@ void trainModel()
     gatherItems(nodeResults);
 }
 
-void testModel()
-{
+void testModel() {
     ByteBuffer nodeResults;
     /* Create an algorithm object to predict recommendations of the implicit ALS model */
-    for (size_t i = 0; i < nBlocks; i++)
-    {
+    for (size_t i = 0; i < nBlocks; i++) {
         prediction::ratings::Distributed<step1Local> algorithm;
         algorithm.parameter.nFactors = nFactors;
 
-        algorithm.input.set(prediction::ratings::usersPartialModel, usersPartialResultLocal->get(training::outputOfStep4ForStep1));
-        algorithm.input.set(prediction::ratings::itemsPartialModel, itemsPartialResultsMaster[i]->get(training::outputOfStep4ForStep1));
+        algorithm.input.set(prediction::ratings::usersPartialModel,
+                            usersPartialResultLocal->get(training::outputOfStep4ForStep1));
+        algorithm.input.set(prediction::ratings::itemsPartialModel,
+                            itemsPartialResultsMaster[i]->get(training::outputOfStep4ForStep1));
 
         algorithm.compute();
 
@@ -373,83 +366,99 @@ void testModel()
 }
 
 template <typename T>
-void gather(const ByteBuffer & nodeResults, T * result)
-{
+void gather(const ByteBuffer &nodeResults, T *result) {
     int perNodeArchLengthMaster[nBlocks];
     int perNodeArchLength = nodeResults.size();
-    MPI_Gather(&perNodeArchLength, sizeof(int), MPI_CHAR, perNodeArchLengthMaster, sizeof(int), MPI_CHAR, mpi_root, MPI_COMM_WORLD);
+    MPI_Gather(&perNodeArchLength,
+               sizeof(int),
+               MPI_CHAR,
+               perNodeArchLengthMaster,
+               sizeof(int),
+               MPI_CHAR,
+               mpi_root,
+               MPI_COMM_WORLD);
 
-    if (rankId == mpi_root)
-    {
+    if (rankId == mpi_root) {
         int memoryBuf = 0;
-        for (size_t i = 0; i < nBlocks; i++)
-        {
+        for (size_t i = 0; i < nBlocks; i++) {
             memoryBuf += perNodeArchLengthMaster[i];
         }
         serializedData.resize(memoryBuf);
 
         size_t shift = 0;
-        for (size_t i = 0; i < nBlocks; i++)
-        {
+        for (size_t i = 0; i < nBlocks; i++) {
             displs[i] = shift;
             shift += perNodeArchLengthMaster[i];
         }
     }
 
     /* Transfer partial results to step 2 on the root node */
-    MPI_Gatherv(&nodeResults[0], perNodeArchLength, MPI_CHAR, &serializedData[0], perNodeArchLengthMaster, displs, MPI_CHAR, mpi_root,
+    MPI_Gatherv(&nodeResults[0],
+                perNodeArchLength,
+                MPI_CHAR,
+                &serializedData[0],
+                perNodeArchLengthMaster,
+                displs,
+                MPI_CHAR,
+                mpi_root,
                 MPI_COMM_WORLD);
 
-    if (rankId == mpi_root)
-    {
-        for (size_t i = 0; i < nBlocks; i++)
-        {
+    if (rankId == mpi_root) {
+        for (size_t i = 0; i < nBlocks; i++) {
             /* Deserialize partial results from step 1 */
-            result[i] = result[i]->cast(deserializeDAALObject(&serializedData[0] + displs[i], perNodeArchLengthMaster[i]));
+            result[i] = result[i]->cast(
+                deserializeDAALObject(&serializedData[0] + displs[i], perNodeArchLengthMaster[i]));
         }
     }
 }
 
-void gatherItems(const ByteBuffer & nodeResults)
-{
+void gatherItems(const ByteBuffer &nodeResults) {
     int perNodeArchLengthMaster[nBlocks];
     int perNodeArchLength = nodeResults.size();
-    MPI_Allgather(&perNodeArchLength, sizeof(int), MPI_CHAR, perNodeArchLengthMaster, sizeof(int), MPI_CHAR, MPI_COMM_WORLD);
+    MPI_Allgather(&perNodeArchLength,
+                  sizeof(int),
+                  MPI_CHAR,
+                  perNodeArchLengthMaster,
+                  sizeof(int),
+                  MPI_CHAR,
+                  MPI_COMM_WORLD);
 
     int memoryBuf = 0;
-    for (int i = 0; i < nBlocks; i++)
-    {
+    for (int i = 0; i < nBlocks; i++) {
         memoryBuf += perNodeArchLengthMaster[i];
     }
     serializedData.resize(memoryBuf);
 
     size_t shift = 0;
-    for (size_t i = 0; i < nBlocks; i++)
-    {
+    for (size_t i = 0; i < nBlocks; i++) {
         displs[i] = shift;
         shift += perNodeArchLengthMaster[i];
     }
 
     /* Transfer partial results to step 2 on the root node */
-    MPI_Allgatherv(&nodeResults[0], perNodeArchLength, MPI_CHAR, &serializedData[0], perNodeArchLengthMaster, displs, MPI_CHAR, MPI_COMM_WORLD);
+    MPI_Allgatherv(&nodeResults[0],
+                   perNodeArchLength,
+                   MPI_CHAR,
+                   &serializedData[0],
+                   perNodeArchLengthMaster,
+                   displs,
+                   MPI_CHAR,
+                   MPI_COMM_WORLD);
 
-    for (size_t i = 0; i < nBlocks; i++)
-    {
+    for (size_t i = 0; i < nBlocks; i++) {
         /* Deserialize partial results from step 4 */
-        itemsPartialResultsMaster[i] =
-            training::DistributedPartialResultStep4::cast(deserializeDAALObject(&serializedData[0] + displs[i], perNodeArchLengthMaster[i]));
+        itemsPartialResultsMaster[i] = training::DistributedPartialResultStep4::cast(
+            deserializeDAALObject(&serializedData[0] + displs[i], perNodeArchLengthMaster[i]));
     }
 }
 
 template <typename T>
-void all2all(ByteBuffer * nodeResults, KeyValueDataCollectionPtr result)
-{
+void all2all(ByteBuffer *nodeResults, KeyValueDataCollectionPtr result) {
     int memoryBuf = 0;
-    size_t shift  = 0;
+    size_t shift = 0;
     int perNodeArchLengths[nBlocks];
     int perNodeArchLengthsRecv[nBlocks];
-    for (int i = 0; i < nBlocks; i++)
-    {
+    for (int i = 0; i < nBlocks; i++) {
         perNodeArchLengths[i] = nodeResults[i].size();
         memoryBuf += perNodeArchLengths[i];
         sdispls[i] = shift;
@@ -459,18 +468,23 @@ void all2all(ByteBuffer * nodeResults, KeyValueDataCollectionPtr result)
 
     /* memcpy to avoid double compute */
     memoryBuf = 0;
-    for (int i = 0; i < nBlocks; i++)
-    {
-        for (int j = 0; j < perNodeArchLengths[i]; j++) serializedSendData[memoryBuf + j] = nodeResults[i][j];
+    for (int i = 0; i < nBlocks; i++) {
+        for (int j = 0; j < perNodeArchLengths[i]; j++)
+            serializedSendData[memoryBuf + j] = nodeResults[i][j];
         memoryBuf += perNodeArchLengths[i];
     }
 
-    MPI_Alltoall(perNodeArchLengths, sizeof(int), MPI_CHAR, perNodeArchLengthsRecv, sizeof(int), MPI_CHAR, MPI_COMM_WORLD);
+    MPI_Alltoall(perNodeArchLengths,
+                 sizeof(int),
+                 MPI_CHAR,
+                 perNodeArchLengthsRecv,
+                 sizeof(int),
+                 MPI_CHAR,
+                 MPI_COMM_WORLD);
 
     memoryBuf = 0;
-    shift     = 0;
-    for (int i = 0; i < nBlocks; i++)
-    {
+    shift = 0;
+    for (int i = 0; i < nBlocks; i++) {
         memoryBuf += perNodeArchLengthsRecv[i];
         rdispls[i] = shift;
         shift += perNodeArchLengthsRecv[i];
@@ -478,11 +492,18 @@ void all2all(ByteBuffer * nodeResults, KeyValueDataCollectionPtr result)
     serializedRecvData.resize(memoryBuf);
 
     /* Transfer partial results to step 2 on the root node */
-    MPI_Alltoallv(&serializedSendData[0], perNodeArchLengths, sdispls, MPI_CHAR, &serializedRecvData[0], perNodeArchLengthsRecv, rdispls, MPI_CHAR,
+    MPI_Alltoallv(&serializedSendData[0],
+                  perNodeArchLengths,
+                  sdispls,
+                  MPI_CHAR,
+                  &serializedRecvData[0],
+                  perNodeArchLengthsRecv,
+                  rdispls,
+                  MPI_CHAR,
                   MPI_COMM_WORLD);
 
-    for (size_t i = 0; i < nBlocks; i++)
-    {
-        (*result)[i] = T::cast(deserializeDAALObject(&serializedRecvData[rdispls[i]], perNodeArchLengthsRecv[i]));
+    for (size_t i = 0; i < nBlocks; i++) {
+        (*result)[i] = T::cast(
+            deserializeDAALObject(&serializedRecvData[rdispls[i]], perNodeArchLengthsRecv[i]));
     }
 }

--- a/samples/daal/cpp/mpi/sources/kmeans_csr_distributed_mpi.cpp
+++ b/samples/daal/cpp/mpi/sources/kmeans_csr_distributed_mpi.cpp
@@ -39,53 +39,58 @@ typedef float algorithmFPType; /* Algorithm floating-point type */
 typedef std::vector<byte> ByteBuffer;
 
 /* K-Means algorithm parameters */
-const size_t nClusters   = 20;
+const size_t nClusters = 20;
 const size_t nIterations = 5;
-const size_t nBlocks     = 4;
+const size_t nBlocks = 4;
 
 /* Input data set parameters */
-const string dataFileNames[4] = { "./data/distributed/kmeans_csr.csv", "./data/distributed/kmeans_csr.csv", "./data/distributed/kmeans_csr.csv",
+const string dataFileNames[4] = { "./data/distributed/kmeans_csr.csv",
+                                  "./data/distributed/kmeans_csr.csv",
+                                  "./data/distributed/kmeans_csr.csv",
                                   "./data/distributed/kmeans_csr.csv" };
 
 int rankId, comm_size;
 #define mpi_root 0
 
-NumericTablePtr loadData(int rankId)
-{
+NumericTablePtr loadData(int rankId) {
     return NumericTablePtr(createSparseTable<float>(dataFileNames[rankId]));
 }
 
-NumericTablePtr init(int rankId, const NumericTablePtr & pData);
-NumericTablePtr compute(int rankId, const NumericTablePtr & pData, const NumericTablePtr & initialCentroids);
+NumericTablePtr init(int rankId, const NumericTablePtr& pData);
+NumericTablePtr compute(int rankId,
+                        const NumericTablePtr& pData,
+                        const NumericTablePtr& initialCentroids);
 
-int main(int argc, char * argv[])
-{
+int main(int argc, char* argv[]) {
     int rankId, comm_size;
     MPI_Init(&argc, &argv);
     MPI_Comm_size(MPI_COMM_WORLD, &comm_size);
     MPI_Comm_rank(MPI_COMM_WORLD, &rankId);
 
-    NumericTablePtr pData     = loadData(rankId);
+    NumericTablePtr pData = loadData(rankId);
     NumericTablePtr centroids = init(rankId, pData);
 
-    for (size_t it = 0; it < nIterations; it++) centroids = compute(rankId, pData, centroids);
+    for (size_t it = 0; it < nIterations; it++)
+        centroids = compute(rankId, pData, centroids);
 
     /* Print the clusterization results */
-    if (rankId == mpi_root) printNumericTable(centroids, "First 10 dimensions of centroids:", 20, 10);
+    if (rankId == mpi_root)
+        printNumericTable(centroids, "First 10 dimensions of centroids:", 20, 10);
 
     MPI_Finalize();
     return 0;
 }
 
-NumericTablePtr init(int rankId, const NumericTablePtr & pData)
-{
+NumericTablePtr init(int rankId, const NumericTablePtr& pData) {
     const bool isRoot = (rankId == mpi_root);
 
     const size_t nVectorsInBlock = pData->getNumberOfRows();
 
     /* Create an algorithm to compute k-means on local nodes */
-    kmeans::init::Distributed<step1Local, algorithmFPType, kmeans::init::randomCSR> localInit(nClusters, nBlocks * nVectorsInBlock,
-                                                                                              rankId * nVectorsInBlock);
+    kmeans::init::Distributed<step1Local, algorithmFPType, kmeans::init::randomCSR> localInit(
+        nClusters,
+        nBlocks * nVectorsInBlock,
+        rankId * nVectorsInBlock);
 
     /* Set the input data set to the algorithm */
     localInit.input.set(kmeans::init::data, pData);
@@ -100,16 +105,21 @@ NumericTablePtr init(int rankId, const NumericTablePtr & pData)
 
     int aPerNodeArchLength[nBlocks];
     /* Transfer archive length to the step 2 on the root node */
-    MPI_Gather(&perNodeArchLength, sizeof(int), MPI_CHAR, isRoot ? &aPerNodeArchLength[0] : NULL, sizeof(int), MPI_CHAR, mpi_root, MPI_COMM_WORLD);
+    MPI_Gather(&perNodeArchLength,
+               sizeof(int),
+               MPI_CHAR,
+               isRoot ? &aPerNodeArchLength[0] : NULL,
+               sizeof(int),
+               MPI_CHAR,
+               mpi_root,
+               MPI_COMM_WORLD);
 
     ByteBuffer serializedData;
     /* Calculate total archive length */
     int totalArchLength = 0;
     int displs[nBlocks];
-    if (isRoot)
-    {
-        for (size_t i = 0; i < nBlocks; ++i)
-        {
+    if (isRoot) {
+        for (size_t i = 0; i < nBlocks; ++i) {
             displs[i] = totalArchLength;
             totalArchLength += aPerNodeArchLength[i];
         }
@@ -120,15 +130,21 @@ NumericTablePtr init(int rankId, const NumericTablePtr & pData)
     dataArch.copyArchiveToArray(&nodeResults[0], perNodeArchLength);
 
     /* Transfer partial results to step 2 on the root node */
-    MPI_Gatherv(&nodeResults[0], perNodeArchLength, MPI_CHAR, serializedData.size() ? &serializedData[0] : NULL, aPerNodeArchLength, displs, MPI_CHAR,
-                mpi_root, MPI_COMM_WORLD);
+    MPI_Gatherv(&nodeResults[0],
+                perNodeArchLength,
+                MPI_CHAR,
+                serializedData.size() ? &serializedData[0] : NULL,
+                aPerNodeArchLength,
+                displs,
+                MPI_CHAR,
+                mpi_root,
+                MPI_COMM_WORLD);
 
-    if (isRoot)
-    {
+    if (isRoot) {
         /* Create an algorithm to compute k-means on the master node */
-        kmeans::init::Distributed<step2Master, algorithmFPType, kmeans::init::randomCSR> masterInit(nClusters);
-        for (size_t i = 0, shift = 0; i < nBlocks; shift += aPerNodeArchLength[i], ++i)
-        {
+        kmeans::init::Distributed<step2Master, algorithmFPType, kmeans::init::randomCSR> masterInit(
+            nClusters);
+        for (size_t i = 0, shift = 0; i < nBlocks; shift += aPerNodeArchLength[i], ++i) {
             /* Deserialize partial results from step 1 */
             OutputDataArchive dataArch(&serializedData[shift], aPerNodeArchLength[i]);
 
@@ -148,13 +164,13 @@ NumericTablePtr init(int rankId, const NumericTablePtr & pData)
     return NumericTablePtr();
 }
 
-NumericTablePtr compute(int rankId, const NumericTablePtr & pData, const NumericTablePtr & initialCentroids)
-{
-    const bool isRoot          = (rankId == mpi_root);
+NumericTablePtr compute(int rankId,
+                        const NumericTablePtr& pData,
+                        const NumericTablePtr& initialCentroids) {
+    const bool isRoot = (rankId == mpi_root);
     size_t CentroidsArchLength = 0;
     InputDataArchive inputArch;
-    if (isRoot)
-    {
+    if (isRoot) {
         /*Retrieve the algorithm results and serialize them */
         initialCentroids->serialize(inputArch);
         CentroidsArchLength = inputArch.getSizeOfArchive();
@@ -164,7 +180,8 @@ NumericTablePtr compute(int rankId, const NumericTablePtr & pData, const Numeric
     MPI_Bcast(&CentroidsArchLength, sizeof(size_t), MPI_CHAR, mpi_root, MPI_COMM_WORLD);
 
     ByteBuffer nodeCentroids(CentroidsArchLength);
-    if (isRoot) inputArch.copyArchiveToArray(&nodeCentroids[0], CentroidsArchLength);
+    if (isRoot)
+        inputArch.copyArchiveToArray(&nodeCentroids[0], CentroidsArchLength);
 
     MPI_Bcast(&nodeCentroids[0], CentroidsArchLength, MPI_CHAR, mpi_root, MPI_COMM_WORLD);
 
@@ -192,22 +209,28 @@ NumericTablePtr compute(int rankId, const NumericTablePtr & pData, const Numeric
     ByteBuffer serializedData;
 
     /* Serialized data is of equal size on each node if each node called compute() equal number of times */
-    if (isRoot) serializedData.resize(perNodeArchLength * nBlocks);
+    if (isRoot)
+        serializedData.resize(perNodeArchLength * nBlocks);
 
     ByteBuffer nodeResults(perNodeArchLength);
     dataArch.copyArchiveToArray(&nodeResults[0], perNodeArchLength);
 
     /* Transfer partial results to step 2 on the root node */
-    MPI_Gather(&nodeResults[0], perNodeArchLength, MPI_CHAR, serializedData.size() ? &serializedData[0] : NULL, perNodeArchLength, MPI_CHAR, mpi_root,
+    MPI_Gather(&nodeResults[0],
+               perNodeArchLength,
+               MPI_CHAR,
+               serializedData.size() ? &serializedData[0] : NULL,
+               perNodeArchLength,
+               MPI_CHAR,
+               mpi_root,
                MPI_COMM_WORLD);
 
-    if (isRoot)
-    {
+    if (isRoot) {
         /* Create an algorithm to compute k-means on the master node */
-        kmeans::Distributed<step2Master, algorithmFPType, kmeans::lloydCSR> masterAlgorithm(nClusters);
+        kmeans::Distributed<step2Master, algorithmFPType, kmeans::lloydCSR> masterAlgorithm(
+            nClusters);
 
-        for (size_t i = 0; i < nBlocks; i++)
-        {
+        for (size_t i = 0; i < nBlocks; i++) {
             /* Deserialize partial results from step 1 */
             OutputDataArchive dataArch(&serializedData[perNodeArchLength * i], perNodeArchLength);
 

--- a/samples/daal/cpp/mpi/sources/kmeans_dense_distributed_mpi.cpp
+++ b/samples/daal/cpp/mpi/sources/kmeans_dense_distributed_mpi.cpp
@@ -38,57 +38,64 @@ typedef std::vector<byte> ByteBuffer;
 typedef float algorithmFPType; /* Algorithm floating-point type */
 
 /* K-Means algorithm parameters */
-const size_t nClusters   = 20;
+const size_t nClusters = 20;
 const size_t nIterations = 5;
-const size_t nBlocks     = 4;
+const size_t nBlocks = 4;
 
 /* Input data set parameters */
-const string dataFileNames[4] = { "./data/distributed/kmeans_dense.csv", "./data/distributed/kmeans_dense.csv", "./data/distributed/kmeans_dense.csv",
+const string dataFileNames[4] = { "./data/distributed/kmeans_dense.csv",
+                                  "./data/distributed/kmeans_dense.csv",
+                                  "./data/distributed/kmeans_dense.csv",
                                   "./data/distributed/kmeans_dense.csv" };
 
 #define mpi_root 0
 
-NumericTablePtr loadData(int rankId)
-{
+NumericTablePtr loadData(int rankId) {
     /* Initialize FileDataSource<CSVFeatureManager> to retrieve the input data from a .csv file */
-    FileDataSource<CSVFeatureManager> dataSource(dataFileNames[rankId], DataSource::doAllocateNumericTable, DataSource::doDictionaryFromContext);
+    FileDataSource<CSVFeatureManager> dataSource(dataFileNames[rankId],
+                                                 DataSource::doAllocateNumericTable,
+                                                 DataSource::doDictionaryFromContext);
 
     /* Retrieve the data from the input file */
     dataSource.loadDataBlock();
     return dataSource.getNumericTable();
 }
 
-NumericTablePtr init(int rankId, const NumericTablePtr & pData);
-NumericTablePtr compute(int rankId, const NumericTablePtr & pData, const NumericTablePtr & initialCentroids);
+NumericTablePtr init(int rankId, const NumericTablePtr& pData);
+NumericTablePtr compute(int rankId,
+                        const NumericTablePtr& pData,
+                        const NumericTablePtr& initialCentroids);
 
-int main(int argc, char * argv[])
-{
+int main(int argc, char* argv[]) {
     int rankId, comm_size;
     MPI_Init(&argc, &argv);
     MPI_Comm_size(MPI_COMM_WORLD, &comm_size);
     MPI_Comm_rank(MPI_COMM_WORLD, &rankId);
 
-    NumericTablePtr pData     = loadData(rankId);
+    NumericTablePtr pData = loadData(rankId);
     NumericTablePtr centroids = init(rankId, pData);
 
-    for (size_t it = 0; it < nIterations; it++) centroids = compute(rankId, pData, centroids);
+    for (size_t it = 0; it < nIterations; it++)
+        centroids = compute(rankId, pData, centroids);
 
     /* Print the clusterization results */
-    if (rankId == mpi_root) printNumericTable(centroids, "First 10 dimensions of centroids:", 20, 10);
+    if (rankId == mpi_root)
+        printNumericTable(centroids, "First 10 dimensions of centroids:", 20, 10);
 
     MPI_Finalize();
     return 0;
 }
 
-NumericTablePtr init(int rankId, const NumericTablePtr & pData)
-{
+NumericTablePtr init(int rankId, const NumericTablePtr& pData) {
     const bool isRoot = (rankId == mpi_root);
 
     const size_t nVectorsInBlock = pData->getNumberOfRows();
 
     /* Create an algorithm to compute k-means on local nodes */
-    kmeans::init::Distributed<step1Local, algorithmFPType, kmeans::init::randomDense> localInit(nClusters, nBlocks * nVectorsInBlock,
-                                                                                                rankId * nVectorsInBlock);
+    kmeans::init::Distributed<step1Local, algorithmFPType, kmeans::init::randomDense> localInit(
+        nClusters,
+        nBlocks * nVectorsInBlock,
+        rankId * nVectorsInBlock);
 
     /* Set the input data set to the algorithm */
     localInit.input.set(kmeans::init::data, pData);
@@ -103,16 +110,21 @@ NumericTablePtr init(int rankId, const NumericTablePtr & pData)
 
     int aPerNodeArchLength[nBlocks];
     /* Transfer archive length to the step 2 on the root node */
-    MPI_Gather(&perNodeArchLength, sizeof(int), MPI_CHAR, isRoot ? &aPerNodeArchLength[0] : NULL, sizeof(int), MPI_CHAR, mpi_root, MPI_COMM_WORLD);
+    MPI_Gather(&perNodeArchLength,
+               sizeof(int),
+               MPI_CHAR,
+               isRoot ? &aPerNodeArchLength[0] : NULL,
+               sizeof(int),
+               MPI_CHAR,
+               mpi_root,
+               MPI_COMM_WORLD);
 
     ByteBuffer serializedData;
     /* Calculate total archive length */
     int totalArchLength = 0;
     int displs[nBlocks];
-    if (isRoot)
-    {
-        for (size_t i = 0; i < nBlocks; ++i)
-        {
+    if (isRoot) {
+        for (size_t i = 0; i < nBlocks; ++i) {
             displs[i] = totalArchLength;
             totalArchLength += aPerNodeArchLength[i];
         }
@@ -123,15 +135,21 @@ NumericTablePtr init(int rankId, const NumericTablePtr & pData)
     dataArch.copyArchiveToArray(&nodeResults[0], perNodeArchLength);
 
     /* Transfer partial results to step 2 on the root node */
-    MPI_Gatherv(&nodeResults[0], perNodeArchLength, MPI_CHAR, serializedData.size() ? &serializedData[0] : NULL, aPerNodeArchLength, displs, MPI_CHAR,
-                mpi_root, MPI_COMM_WORLD);
+    MPI_Gatherv(&nodeResults[0],
+                perNodeArchLength,
+                MPI_CHAR,
+                serializedData.size() ? &serializedData[0] : NULL,
+                aPerNodeArchLength,
+                displs,
+                MPI_CHAR,
+                mpi_root,
+                MPI_COMM_WORLD);
 
-    if (isRoot)
-    {
+    if (isRoot) {
         /* Create an algorithm to compute k-means on the master node */
-        kmeans::init::Distributed<step2Master, algorithmFPType, kmeans::init::randomDense> masterInit(nClusters);
-        for (size_t i = 0, shift = 0; i < nBlocks; shift += aPerNodeArchLength[i], ++i)
-        {
+        kmeans::init::Distributed<step2Master, algorithmFPType, kmeans::init::randomDense>
+            masterInit(nClusters);
+        for (size_t i = 0, shift = 0; i < nBlocks; shift += aPerNodeArchLength[i], ++i) {
             /* Deserialize partial results from step 1 */
             OutputDataArchive dataArch(&serializedData[shift], aPerNodeArchLength[i]);
 
@@ -151,13 +169,13 @@ NumericTablePtr init(int rankId, const NumericTablePtr & pData)
     return NumericTablePtr();
 }
 
-NumericTablePtr compute(int rankId, const NumericTablePtr & pData, const NumericTablePtr & initialCentroids)
-{
-    const bool isRoot          = (rankId == mpi_root);
+NumericTablePtr compute(int rankId,
+                        const NumericTablePtr& pData,
+                        const NumericTablePtr& initialCentroids) {
+    const bool isRoot = (rankId == mpi_root);
     size_t CentroidsArchLength = 0;
     InputDataArchive inputArch;
-    if (isRoot)
-    {
+    if (isRoot) {
         /*Retrieve the algorithm results and serialize them */
         initialCentroids->serialize(inputArch);
         CentroidsArchLength = inputArch.getSizeOfArchive();
@@ -167,7 +185,8 @@ NumericTablePtr compute(int rankId, const NumericTablePtr & pData, const Numeric
     MPI_Bcast(&CentroidsArchLength, sizeof(size_t), MPI_CHAR, mpi_root, MPI_COMM_WORLD);
 
     ByteBuffer nodeCentroids(CentroidsArchLength);
-    if (isRoot) inputArch.copyArchiveToArray(&nodeCentroids[0], CentroidsArchLength);
+    if (isRoot)
+        inputArch.copyArchiveToArray(&nodeCentroids[0], CentroidsArchLength);
 
     MPI_Bcast(&nodeCentroids[0], CentroidsArchLength, MPI_CHAR, mpi_root, MPI_COMM_WORLD);
 
@@ -195,22 +214,27 @@ NumericTablePtr compute(int rankId, const NumericTablePtr & pData, const Numeric
     ByteBuffer serializedData;
 
     /* Serialized data is of equal size on each node if each node called compute() equal number of times */
-    if (isRoot) serializedData.resize(perNodeArchLength * nBlocks);
+    if (isRoot)
+        serializedData.resize(perNodeArchLength * nBlocks);
 
     ByteBuffer nodeResults(perNodeArchLength);
     dataArch.copyArchiveToArray(&nodeResults[0], perNodeArchLength);
 
     /* Transfer partial results to step 2 on the root node */
-    MPI_Gather(&nodeResults[0], perNodeArchLength, MPI_CHAR, serializedData.size() ? &serializedData[0] : NULL, perNodeArchLength, MPI_CHAR, mpi_root,
+    MPI_Gather(&nodeResults[0],
+               perNodeArchLength,
+               MPI_CHAR,
+               serializedData.size() ? &serializedData[0] : NULL,
+               perNodeArchLength,
+               MPI_CHAR,
+               mpi_root,
                MPI_COMM_WORLD);
 
-    if (isRoot)
-    {
+    if (isRoot) {
         /* Create an algorithm to compute k-means on the master node */
         kmeans::Distributed<step2Master> masterAlgorithm(nClusters);
 
-        for (size_t i = 0; i < nBlocks; i++)
-        {
+        for (size_t i = 0; i < nBlocks; i++) {
             /* Deserialize partial results from step 1 */
             OutputDataArchive dataArch(&serializedData[perNodeArchLength * i], perNodeArchLength);
 

--- a/samples/daal/cpp/mpi/sources/kmeans_init_csr_distributed_mpi.cpp
+++ b/samples/daal/cpp/mpi/sources/kmeans_init_csr_distributed_mpi.cpp
@@ -40,39 +40,43 @@ typedef std::vector<byte> ByteBuffer;
 typedef float algorithmFPType; /* Algorithm floating-point type */
 
 /* K-Means algorithm parameters */
-const size_t nClusters   = 20;
+const size_t nClusters = 20;
 const size_t nIterations = 5;
-const size_t nBlocks     = 4;
+const size_t nBlocks = 4;
 
 /* Input data set parameters */
-const string dataFileNames[4] = { "./data/distributed/kmeans_csr.csv", "./data/distributed/kmeans_csr.csv", "./data/distributed/kmeans_csr.csv",
+const string dataFileNames[4] = { "./data/distributed/kmeans_csr.csv",
+                                  "./data/distributed/kmeans_csr.csv",
+                                  "./data/distributed/kmeans_csr.csv",
                                   "./data/distributed/kmeans_csr.csv" };
 
 #define mpi_root 0
 const int step3ResultSizeTag = 1;
-const int step3ResultTag     = 2;
+const int step3ResultTag = 2;
 
-NumericTablePtr loadData(int rankId)
-{
+NumericTablePtr loadData(int rankId) {
     return NumericTablePtr(createSparseTable<float>(dataFileNames[rankId]));
 }
 
 template <kmeans::init::Method method>
-NumericTablePtr initCentroids(int rankId, const NumericTablePtr & pData);
-NumericTablePtr computeCentroids(int rankId, const NumericTablePtr & pData, const NumericTablePtr & initialCentroids);
+NumericTablePtr initCentroids(int rankId, const NumericTablePtr& pData);
+NumericTablePtr computeCentroids(int rankId,
+                                 const NumericTablePtr& pData,
+                                 const NumericTablePtr& initialCentroids);
 
 template <kmeans::init::Method method>
-void runKMeans(int rankId, const NumericTablePtr & pData, const char * methodName)
-{
-    if (rankId == mpi_root) std::cout << "K-means init parameters: method = " << methodName << std::endl;
+void runKMeans(int rankId, const NumericTablePtr& pData, const char* methodName) {
+    if (rankId == mpi_root)
+        std::cout << "K-means init parameters: method = " << methodName << std::endl;
     NumericTablePtr centroids = initCentroids<method>(rankId, pData);
-    for (size_t it = 0; it < nIterations; it++) centroids = computeCentroids(rankId, pData, centroids);
+    for (size_t it = 0; it < nIterations; it++)
+        centroids = computeCentroids(rankId, pData, centroids);
     /* Print the clusterization results */
-    if (rankId == mpi_root) printNumericTable(centroids, "First 10 dimensions of centroids:", 20, 10);
+    if (rankId == mpi_root)
+        printNumericTable(centroids, "First 10 dimensions of centroids:", 20, 10);
 }
 
-int main(int argc, char * argv[])
-{
+int main(int argc, char* argv[]) {
     int rankId, comm_size;
     MPI_Init(&argc, &argv);
     MPI_Comm_size(MPI_COMM_WORLD, &comm_size);
@@ -87,136 +91,188 @@ int main(int argc, char * argv[])
     return 0;
 }
 
-static int lengthsToShifts(const int lengths[nBlocks], int shifts[nBlocks])
-{
+static int lengthsToShifts(const int lengths[nBlocks], int shifts[nBlocks]) {
     int shift = 0;
-    for (size_t i = 0; i < nBlocks; shift += lengths[i], ++i) shifts[i] = shift;
+    for (size_t i = 0; i < nBlocks; shift += lengths[i], ++i)
+        shifts[i] = shift;
     return shift;
 }
 
 /* Send the value to all processes in the group and collect received values into one table */
-static NumericTablePtr allToAll(const NumericTablePtr & value)
-{
+static NumericTablePtr allToAll(const NumericTablePtr& value) {
     std::vector<NumericTablePtr> aRes;
     ByteBuffer dataToSend;
-    if (value.get()) serializeDAALObject(value.get(), dataToSend);
+    if (value.get())
+        serializeDAALObject(value.get(), dataToSend);
     const int dataToSendLength = dataToSend.size();
     int perNodeArchLength[nBlocks];
-    for (size_t i = 0; i < nBlocks; i++) perNodeArchLength[i] = 0;
+    for (size_t i = 0; i < nBlocks; i++)
+        perNodeArchLength[i] = 0;
 
-    MPI_Allgather(&dataToSendLength, sizeof(int), MPI_CHAR, perNodeArchLength, sizeof(int), MPI_CHAR, MPI_COMM_WORLD);
+    MPI_Allgather(&dataToSendLength,
+                  sizeof(int),
+                  MPI_CHAR,
+                  perNodeArchLength,
+                  sizeof(int),
+                  MPI_CHAR,
+                  MPI_COMM_WORLD);
 
     int perNodeArchShift[nBlocks];
     const int totalToReceive = lengthsToShifts(perNodeArchLength, perNodeArchShift);
-    if (!totalToReceive) return NumericTablePtr();
+    if (!totalToReceive)
+        return NumericTablePtr();
 
     ByteBuffer dataToReceive(totalToReceive);
-    MPI_Allgatherv(&dataToSend[0], dataToSendLength, MPI_CHAR, &dataToReceive[0], perNodeArchLength, perNodeArchShift, MPI_CHAR, MPI_COMM_WORLD);
+    MPI_Allgatherv(&dataToSend[0],
+                   dataToSendLength,
+                   MPI_CHAR,
+                   &dataToReceive[0],
+                   perNodeArchLength,
+                   perNodeArchShift,
+                   MPI_CHAR,
+                   MPI_COMM_WORLD);
 
-    for (size_t i = 0, shift = 0; i < nBlocks; shift += perNodeArchLength[i], ++i)
-    {
-        if (!perNodeArchLength[i]) continue;
-        NumericTablePtr pTbl = NumericTable::cast(deserializeDAALObject(&dataToReceive[shift], perNodeArchLength[i]));
+    for (size_t i = 0, shift = 0; i < nBlocks; shift += perNodeArchLength[i], ++i) {
+        if (!perNodeArchLength[i])
+            continue;
+        NumericTablePtr pTbl =
+            NumericTable::cast(deserializeDAALObject(&dataToReceive[shift], perNodeArchLength[i]));
         aRes.push_back(pTbl);
     }
-    if (!aRes.size()) return NumericTablePtr();
-    if (aRes.size() == 1) return aRes[0];
+    if (!aRes.size())
+        return NumericTablePtr();
+    if (aRes.size() == 1)
+        return aRes[0];
 
     /* For parallelPlus algorithm */
     RowMergedNumericTablePtr pMerged(new RowMergedNumericTable());
-    for (size_t i = 0; i < aRes.size(); ++i) pMerged->addNumericTable(aRes[i]);
+    for (size_t i = 0; i < aRes.size(); ++i)
+        pMerged->addNumericTable(aRes[i]);
     return NumericTable::cast(pMerged);
 }
 
 /* Send the value to all processes in the group and collect received values into one table */
-static void allToMaster(int rankId, const NumericTablePtr & value, std::vector<NumericTablePtr> & aRes)
-{
+static void allToMaster(int rankId,
+                        const NumericTablePtr& value,
+                        std::vector<NumericTablePtr>& aRes) {
     const bool isRoot = (rankId == mpi_root);
     aRes.clear();
     ByteBuffer dataToSend;
-    if (value.get()) serializeDAALObject(value.get(), dataToSend);
+    if (value.get())
+        serializeDAALObject(value.get(), dataToSend);
     const int dataToSendLength = dataToSend.size();
     int perNodeArchLength[nBlocks];
-    for (size_t i = 0; i < nBlocks; i++) perNodeArchLength[i] = 0;
+    for (size_t i = 0; i < nBlocks; i++)
+        perNodeArchLength[i] = 0;
 
-    MPI_Gather(&dataToSendLength, sizeof(int), MPI_CHAR, isRoot ? perNodeArchLength : NULL, sizeof(int), MPI_CHAR, mpi_root, MPI_COMM_WORLD);
+    MPI_Gather(&dataToSendLength,
+               sizeof(int),
+               MPI_CHAR,
+               isRoot ? perNodeArchLength : NULL,
+               sizeof(int),
+               MPI_CHAR,
+               mpi_root,
+               MPI_COMM_WORLD);
 
     ByteBuffer dataToReceive;
     int perNodeArchShift[nBlocks];
-    if (isRoot)
-    {
+    if (isRoot) {
         const int totalToReceive = lengthsToShifts(perNodeArchLength, perNodeArchShift);
-        if (!totalToReceive) return;
+        if (!totalToReceive)
+            return;
         dataToReceive.resize(totalToReceive);
     }
-    MPI_Gatherv(&dataToSend[0], dataToSendLength, MPI_CHAR, isRoot ? &dataToReceive[0] : NULL, perNodeArchLength, perNodeArchShift, MPI_CHAR,
-                mpi_root, MPI_COMM_WORLD);
+    MPI_Gatherv(&dataToSend[0],
+                dataToSendLength,
+                MPI_CHAR,
+                isRoot ? &dataToReceive[0] : NULL,
+                perNodeArchLength,
+                perNodeArchShift,
+                MPI_CHAR,
+                mpi_root,
+                MPI_COMM_WORLD);
 
-    if (!isRoot) return;
+    if (!isRoot)
+        return;
     aRes.resize(nBlocks);
-    for (size_t i = 0, shift = 0; i < nBlocks; shift += perNodeArchLength[i], ++i)
-    {
-        if (perNodeArchLength[i]) aRes[i] = NumericTable::cast(deserializeDAALObject(&dataToReceive[shift], perNodeArchLength[i]));
+    for (size_t i = 0, shift = 0; i < nBlocks; shift += perNodeArchLength[i], ++i) {
+        if (perNodeArchLength[i])
+            aRes[i] = NumericTable::cast(
+                deserializeDAALObject(&dataToReceive[shift], perNodeArchLength[i]));
     }
 }
 
 template <kmeans::init::Method method>
-NumericTablePtr initStep1(int rankId, const NumericTablePtr & pData)
-{
+NumericTablePtr initStep1(int rankId, const NumericTablePtr& pData) {
     const size_t nVectorsInBlock = pData->getNumberOfRows();
     /* Create an algorithm object for the K-Means algorithm */
-    kmeans::init::Distributed<step1Local, algorithmFPType, method> local(nClusters, nBlocks * nVectorsInBlock, rankId * nVectorsInBlock);
+    kmeans::init::Distributed<step1Local, algorithmFPType, method> local(nClusters,
+                                                                         nBlocks * nVectorsInBlock,
+                                                                         rankId * nVectorsInBlock);
     local.input.set(kmeans::init::data, pData);
     local.compute();
     return allToAll(local.getPartialResult()->get(kmeans::init::partialCentroids));
 }
 
 template <kmeans::init::Method method>
-void initStep2(int rankId, const NumericTablePtr & pData, DataCollectionPtr & localNodeData, const NumericTablePtr & step2Input, bool bFirstIteration,
-               std::vector<NumericTablePtr> & step2Results, bool bOutputForStep5Required = false)
-{
-    kmeans::init::Distributed<step2Local, algorithmFPType, method> step2(nClusters, bFirstIteration);
+void initStep2(int rankId,
+               const NumericTablePtr& pData,
+               DataCollectionPtr& localNodeData,
+               const NumericTablePtr& step2Input,
+               bool bFirstIteration,
+               std::vector<NumericTablePtr>& step2Results,
+               bool bOutputForStep5Required = false) {
+    kmeans::init::Distributed<step2Local, algorithmFPType, method> step2(nClusters,
+                                                                         bFirstIteration);
     step2.parameter.outputForStep5Required = bOutputForStep5Required;
     step2.input.set(kmeans::init::data, pData);
     step2.input.set(kmeans::init::internalInput, localNodeData);
     step2.input.set(kmeans::init::inputOfStep2, step2Input);
     step2.compute();
-    if (bFirstIteration) localNodeData = step2.getPartialResult()->get(kmeans::init::internalResult);
+    if (bFirstIteration)
+        localNodeData = step2.getPartialResult()->get(kmeans::init::internalResult);
     allToMaster(rankId,
-                step2.getPartialResult()->get(bOutputForStep5Required ? kmeans::init::outputOfStep2ForStep5 : kmeans::init::outputOfStep2ForStep3),
+                step2.getPartialResult()->get(bOutputForStep5Required
+                                                  ? kmeans::init::outputOfStep2ForStep5
+                                                  : kmeans::init::outputOfStep2ForStep3),
                 step2Results);
 }
 
 template <kmeans::init::Method method>
-NumericTablePtr initStep3(kmeans::init::Distributed<step3Master, algorithmFPType, method> & step3, std::vector<NumericTablePtr> & step2Results)
-{
-    for (size_t i = 0; i < step2Results.size(); ++i) step3.input.add(kmeans::init::inputOfStep3FromStep2, i, step2Results[i]);
+NumericTablePtr initStep3(kmeans::init::Distributed<step3Master, algorithmFPType, method>& step3,
+                          std::vector<NumericTablePtr>& step2Results) {
+    for (size_t i = 0; i < step2Results.size(); ++i)
+        step3.input.add(kmeans::init::inputOfStep3FromStep2, i, step2Results[i]);
     step3.compute();
     ByteBuffer buff;
     NumericTablePtr step4InputOnRoot;
-    for (size_t i = 0; i < nBlocks; ++i)
-    {
-        NumericTablePtr pTbl = step3.getPartialResult()->get(kmeans::init::outputOfStep3ForStep4, i); /* can be null */
-        if (i == mpi_root)
-        {
+    for (size_t i = 0; i < nBlocks; ++i) {
+        NumericTablePtr pTbl =
+            step3.getPartialResult()->get(kmeans::init::outputOfStep3ForStep4, i); /* can be null */
+        if (i == mpi_root) {
             step4InputOnRoot = pTbl;
             continue;
         }
         buff.clear();
         size_t size = pTbl.get() ? serializeDAALObject(pTbl.get(), buff) : 0;
         MPI_Send(&size, sizeof(size_t), MPI_BYTE, int(i), step3ResultSizeTag, MPI_COMM_WORLD);
-        if (size) MPI_Send(&buff[0], size, MPI_BYTE, int(i), step3ResultTag, MPI_COMM_WORLD);
+        if (size)
+            MPI_Send(&buff[0], size, MPI_BYTE, int(i), step3ResultTag, MPI_COMM_WORLD);
     }
     return step4InputOnRoot;
 }
 
-NumericTablePtr receiveStep3Output(int rankId)
-{
+NumericTablePtr receiveStep3Output(int rankId) {
     size_t size = 0;
     MPI_Status status;
-    MPI_Recv(&size, sizeof(size_t), MPI_BYTE, mpi_root, step3ResultSizeTag, MPI_COMM_WORLD, &status);
-    if (size)
-    {
+    MPI_Recv(&size,
+             sizeof(size_t),
+             MPI_BYTE,
+             mpi_root,
+             step3ResultSizeTag,
+             MPI_COMM_WORLD,
+             &status);
+    if (size) {
         ByteBuffer buff(size);
         MPI_Recv(&buff[0], size, MPI_BYTE, mpi_root, step3ResultTag, MPI_COMM_WORLD, &status);
         return NumericTable::cast(deserializeDAALObject(&buff[0], size));
@@ -225,11 +281,12 @@ NumericTablePtr receiveStep3Output(int rankId)
 }
 
 template <kmeans::init::Method method>
-NumericTablePtr initStep4(int rankId, const NumericTablePtr & pData, const DataCollectionPtr & localNodeData, const NumericTablePtr & step4Input)
-{
+NumericTablePtr initStep4(int rankId,
+                          const NumericTablePtr& pData,
+                          const DataCollectionPtr& localNodeData,
+                          const NumericTablePtr& step4Input) {
     NumericTablePtr step4Result;
-    if (step4Input)
-    {
+    if (step4Input) {
         /* Create an algorithm object for the step 4 */
         kmeans::init::Distributed<step4Local, algorithmFPType, method> step4(nClusters);
         /* Set the input data to the algorithm */
@@ -244,9 +301,8 @@ NumericTablePtr initStep4(int rankId, const NumericTablePtr & pData, const DataC
 }
 
 template <>
-NumericTablePtr initCentroids<kmeans::init::plusPlusCSR>(int rankId, const NumericTablePtr & pData)
-{
-    const bool isRoot                 = (rankId == mpi_root);
+NumericTablePtr initCentroids<kmeans::init::plusPlusCSR>(int rankId, const NumericTablePtr& pData) {
+    const bool isRoot = (rankId == mpi_root);
     const kmeans::init::Method method = kmeans::init::plusPlusCSR;
     /* Internal data to be stored on the local nodes */
     DataCollectionPtr localNodeData;
@@ -258,21 +314,27 @@ NumericTablePtr initCentroids<kmeans::init::plusPlusCSR>(int rankId, const Numer
     /* Create an algorithm object for the step 3 */
     typedef kmeans::init::Distributed<step3Master, algorithmFPType, method> Step3Master;
     SharedPtr<Step3Master> step3(isRoot ? new Step3Master(nClusters) : NULL);
-    for (size_t iCenter = 1; iCenter < nClusters; ++iCenter)
-    {
+    for (size_t iCenter = 1; iCenter < nClusters; ++iCenter) {
         std::vector<NumericTablePtr> step2ResultsOnMaster;
-        initStep2<method>(rankId, pData, localNodeData, step2Input, iCenter == 1, step2ResultsOnMaster);
-        NumericTablePtr step4Input = (step3 ? initStep3<method>(*step3, step2ResultsOnMaster) : receiveStep3Output(rankId));
-        step2Input                 = initStep4<method>(rankId, pData, localNodeData, step4Input);
+        initStep2<method>(rankId,
+                          pData,
+                          localNodeData,
+                          step2Input,
+                          iCenter == 1,
+                          step2ResultsOnMaster);
+        NumericTablePtr step4Input =
+            (step3 ? initStep3<method>(*step3, step2ResultsOnMaster) : receiveStep3Output(rankId));
+        step2Input = initStep4<method>(rankId, pData, localNodeData, step4Input);
         pCentroids->addNumericTable(step2Input);
     }
-    return daal::data_management::convertToHomogen<float>(*pCentroids); /* can be returned as pCentroids as well */
+    return daal::data_management::convertToHomogen<float>(
+        *pCentroids); /* can be returned as pCentroids as well */
 }
 
 template <>
-NumericTablePtr initCentroids<kmeans::init::parallelPlusCSR>(int rankId, const NumericTablePtr & pData)
-{
-    const bool isRoot                 = (rankId == mpi_root);
+NumericTablePtr initCentroids<kmeans::init::parallelPlusCSR>(int rankId,
+                                                             const NumericTablePtr& pData) {
+    const bool isRoot = (rankId == mpi_root);
     const kmeans::init::Method method = kmeans::init::parallelPlusCSR;
     /* default value of nRounds used by all steps */
     const size_t nRounds = kmeans::init::Parameter(nClusters).nRounds;
@@ -286,21 +348,28 @@ NumericTablePtr initCentroids<kmeans::init::parallelPlusCSR>(int rankId, const N
 
     /* First step on the local nodes */
     NumericTablePtr step2Input = initStep1<method>(rankId, pData);
-    if (step5) step5->input.add(kmeans::init::inputCentroids, step2Input);
+    if (step5)
+        step5->input.add(kmeans::init::inputCentroids, step2Input);
 
     /* Create an algorithm object for the step 3 */
     typedef kmeans::init::Distributed<step3Master, algorithmFPType, method> Step3Master;
     SharedPtr<Step3Master> step3(isRoot ? new Step3Master(nClusters) : NULL);
-    for (size_t iRound = 0; iRound < nRounds; ++iRound)
-    {
+    for (size_t iRound = 0; iRound < nRounds; ++iRound) {
         /* Perform step 2 */
         std::vector<NumericTablePtr> step2ResultsOnMaster;
-        initStep2<method>(rankId, pData, localNodeData, step2Input, iRound == 0, step2ResultsOnMaster);
+        initStep2<method>(rankId,
+                          pData,
+                          localNodeData,
+                          step2Input,
+                          iRound == 0,
+                          step2ResultsOnMaster);
         /* Perform step 3 */
-        NumericTablePtr step4Input = (step3 ? initStep3<method>(*step3, step2ResultsOnMaster) : receiveStep3Output(rankId));
+        NumericTablePtr step4Input =
+            (step3 ? initStep3<method>(*step3, step2ResultsOnMaster) : receiveStep3Output(rankId));
         /* Perform step 4 */
         step2Input = initStep4<method>(rankId, pData, localNodeData, step4Input);
-        if (step5) step5->input.add(kmeans::init::inputCentroids, step2Input);
+        if (step5)
+            step5->input.add(kmeans::init::inputCentroids, step2Input);
     }
 
     /* One more step 2 */
@@ -308,8 +377,10 @@ NumericTablePtr initCentroids<kmeans::init::parallelPlusCSR>(int rankId, const N
     initStep2<method>(rankId, pData, localNodeData, step2Input, false, step2Results, true);
     if (step5) /* isRoot == true */
     {
-        for (size_t i = 0; i < step2Results.size(); ++i) step5->input.add(kmeans::init::inputOfStep5FromStep2, step2Results[i]);
-        step5->input.set(kmeans::init::inputOfStep5FromStep3, step3->getPartialResult()->get(kmeans::init::outputOfStep3ForStep5));
+        for (size_t i = 0; i < step2Results.size(); ++i)
+            step5->input.add(kmeans::init::inputOfStep5FromStep2, step2Results[i]);
+        step5->input.set(kmeans::init::inputOfStep5FromStep3,
+                         step3->getPartialResult()->get(kmeans::init::outputOfStep3ForStep5));
         step5->compute();
         step5->finalizeCompute();
         return step5->getResult()->get(kmeans::init::centroids);
@@ -317,19 +388,23 @@ NumericTablePtr initCentroids<kmeans::init::parallelPlusCSR>(int rankId, const N
     return NumericTablePtr();
 }
 
-NumericTablePtr computeCentroids(int rankId, const NumericTablePtr & pData, const NumericTablePtr & initialCentroids)
-{
+NumericTablePtr computeCentroids(int rankId,
+                                 const NumericTablePtr& pData,
+                                 const NumericTablePtr& initialCentroids) {
     const bool isRoot = (rankId == mpi_root);
     ByteBuffer nodeCentroids;
-    size_t CentroidsArchLength = (isRoot ? serializeDAALObject(initialCentroids.get(), nodeCentroids) : 0);
+    size_t CentroidsArchLength =
+        (isRoot ? serializeDAALObject(initialCentroids.get(), nodeCentroids) : 0);
 
     /* Get centroids from the root node */
     MPI_Bcast(&CentroidsArchLength, sizeof(size_t), MPI_CHAR, mpi_root, MPI_COMM_WORLD);
 
-    if (!isRoot) nodeCentroids.resize(CentroidsArchLength);
+    if (!isRoot)
+        nodeCentroids.resize(CentroidsArchLength);
     MPI_Bcast(&nodeCentroids[0], CentroidsArchLength, MPI_CHAR, mpi_root, MPI_COMM_WORLD);
 
-    NumericTablePtr centroids = NumericTable::cast(deserializeDAALObject(&nodeCentroids[0], CentroidsArchLength));
+    NumericTablePtr centroids =
+        NumericTable::cast(deserializeDAALObject(&nodeCentroids[0], CentroidsArchLength));
 
     /* Create an algorithm to compute k-means on local nodes */
     kmeans::Distributed<step1Local, algorithmFPType, kmeans::lloydCSR> localAlgorithm(nClusters);
@@ -343,26 +418,35 @@ NumericTablePtr computeCentroids(int rankId, const NumericTablePtr & pData, cons
 
     /* Serialize partial results required by step 2 */
     ByteBuffer nodeResults;
-    size_t perNodeArchLength = serializeDAALObject(localAlgorithm.getPartialResult().get(), nodeResults);
+    size_t perNodeArchLength =
+        serializeDAALObject(localAlgorithm.getPartialResult().get(), nodeResults);
 
     /* Serialized data is of equal size on each node if each node called compute() equal number of times */
     ByteBuffer serializedData;
-    if (isRoot) serializedData.resize(perNodeArchLength * nBlocks);
+    if (isRoot)
+        serializedData.resize(perNodeArchLength * nBlocks);
 
     /* Transfer partial results to step 2 on the root node */
-    MPI_Gather(&nodeResults[0], perNodeArchLength, MPI_CHAR, serializedData.size() ? &serializedData[0] : NULL, perNodeArchLength, MPI_CHAR, mpi_root,
+    MPI_Gather(&nodeResults[0],
+               perNodeArchLength,
+               MPI_CHAR,
+               serializedData.size() ? &serializedData[0] : NULL,
+               perNodeArchLength,
+               MPI_CHAR,
+               mpi_root,
                MPI_COMM_WORLD);
 
-    if (isRoot)
-    {
+    if (isRoot) {
         /* Create an algorithm to compute k-means on the master node */
-        kmeans::Distributed<step2Master, algorithmFPType, kmeans::lloydCSR> masterAlgorithm(nClusters);
+        kmeans::Distributed<step2Master, algorithmFPType, kmeans::lloydCSR> masterAlgorithm(
+            nClusters);
 
-        for (size_t i = 0; i < nBlocks; i++)
-        {
+        for (size_t i = 0; i < nBlocks; i++) {
             /* Deserialize partial results from step 1 */
-            SerializationIfacePtr ptr                      = deserializeDAALObject(&serializedData[perNodeArchLength * i], perNodeArchLength);
-            kmeans::PartialResultPtr dataForStep2FromStep1 = dynamicPointerCast<kmeans::PartialResult, SerializationIface>(ptr);
+            SerializationIfacePtr ptr =
+                deserializeDAALObject(&serializedData[perNodeArchLength * i], perNodeArchLength);
+            kmeans::PartialResultPtr dataForStep2FromStep1 =
+                dynamicPointerCast<kmeans::PartialResult, SerializationIface>(ptr);
 
             /* Set local partial results as input for the master-node algorithm */
             masterAlgorithm.input.add(kmeans::partialResults, dataForStep2FromStep1);

--- a/samples/daal/cpp/mpi/sources/kmeans_init_dense_distributed_mpi.cpp
+++ b/samples/daal/cpp/mpi/sources/kmeans_init_dense_distributed_mpi.cpp
@@ -40,22 +40,25 @@ typedef std::vector<byte> ByteBuffer;
 typedef float algorithmFPType; /* Algorithm floating-point type */
 
 /* K-Means algorithm parameters */
-const size_t nClusters   = 20;
+const size_t nClusters = 20;
 const size_t nIterations = 5;
-const size_t nBlocks     = 4;
+const size_t nBlocks = 4;
 
 /* Input data set parameters */
-const string dataFileNames[4] = { "./data/distributed/kmeans_dense.csv", "./data/distributed/kmeans_dense.csv", "./data/distributed/kmeans_dense.csv",
+const string dataFileNames[4] = { "./data/distributed/kmeans_dense.csv",
+                                  "./data/distributed/kmeans_dense.csv",
+                                  "./data/distributed/kmeans_dense.csv",
                                   "./data/distributed/kmeans_dense.csv" };
 
 #define mpi_root 0
 const int step3ResultSizeTag = 1;
-const int step3ResultTag     = 2;
+const int step3ResultTag = 2;
 
-NumericTablePtr loadData(int rankId)
-{
+NumericTablePtr loadData(int rankId) {
     /* Initialize FileDataSource<CSVFeatureManager> to retrieve the input data from a .csv file */
-    FileDataSource<CSVFeatureManager> dataSource(dataFileNames[rankId], DataSource::doAllocateNumericTable, DataSource::doDictionaryFromContext);
+    FileDataSource<CSVFeatureManager> dataSource(dataFileNames[rankId],
+                                                 DataSource::doAllocateNumericTable,
+                                                 DataSource::doDictionaryFromContext);
 
     /* Retrieve the data from the input file */
     dataSource.loadDataBlock();
@@ -63,21 +66,24 @@ NumericTablePtr loadData(int rankId)
 }
 
 template <kmeans::init::Method method>
-NumericTablePtr initCentroids(int rankId, const NumericTablePtr & pData);
-NumericTablePtr computeCentroids(int rankId, const NumericTablePtr & pData, const NumericTablePtr & initialCentroids);
+NumericTablePtr initCentroids(int rankId, const NumericTablePtr& pData);
+NumericTablePtr computeCentroids(int rankId,
+                                 const NumericTablePtr& pData,
+                                 const NumericTablePtr& initialCentroids);
 
 template <kmeans::init::Method method>
-void runKMeans(int rankId, const NumericTablePtr & pData, const char * methodName)
-{
-    if (rankId == mpi_root) std::cout << "K-means init parameters: method = " << methodName << std::endl;
+void runKMeans(int rankId, const NumericTablePtr& pData, const char* methodName) {
+    if (rankId == mpi_root)
+        std::cout << "K-means init parameters: method = " << methodName << std::endl;
     NumericTablePtr centroids = initCentroids<method>(rankId, pData);
-    for (size_t it = 0; it < nIterations; it++) centroids = computeCentroids(rankId, pData, centroids);
+    for (size_t it = 0; it < nIterations; it++)
+        centroids = computeCentroids(rankId, pData, centroids);
     /* Print the clusterization results */
-    if (rankId == mpi_root) printNumericTable(centroids, "First 10 dimensions of centroids:", 20, 10);
+    if (rankId == mpi_root)
+        printNumericTable(centroids, "First 10 dimensions of centroids:", 20, 10);
 }
 
-int main(int argc, char * argv[])
-{
+int main(int argc, char* argv[]) {
     int rankId, comm_size;
     MPI_Init(&argc, &argv);
     MPI_Comm_size(MPI_COMM_WORLD, &comm_size);
@@ -92,136 +98,188 @@ int main(int argc, char * argv[])
     return 0;
 }
 
-static int lengthsToShifts(const int lengths[nBlocks], int shifts[nBlocks])
-{
+static int lengthsToShifts(const int lengths[nBlocks], int shifts[nBlocks]) {
     int shift = 0;
-    for (size_t i = 0; i < nBlocks; shift += lengths[i], ++i) shifts[i] = shift;
+    for (size_t i = 0; i < nBlocks; shift += lengths[i], ++i)
+        shifts[i] = shift;
     return shift;
 }
 
 /* Send the value to all processes in the group and collect received values into one table */
-static NumericTablePtr allToAll(const NumericTablePtr & value)
-{
+static NumericTablePtr allToAll(const NumericTablePtr& value) {
     std::vector<NumericTablePtr> aRes;
     ByteBuffer dataToSend;
-    if (value.get()) serializeDAALObject(value.get(), dataToSend);
+    if (value.get())
+        serializeDAALObject(value.get(), dataToSend);
     const int dataToSendLength = dataToSend.size();
     int perNodeArchLength[nBlocks];
-    for (size_t i = 0; i < nBlocks; i++) perNodeArchLength[i] = 0;
+    for (size_t i = 0; i < nBlocks; i++)
+        perNodeArchLength[i] = 0;
 
-    MPI_Allgather(&dataToSendLength, sizeof(int), MPI_CHAR, perNodeArchLength, sizeof(int), MPI_CHAR, MPI_COMM_WORLD);
+    MPI_Allgather(&dataToSendLength,
+                  sizeof(int),
+                  MPI_CHAR,
+                  perNodeArchLength,
+                  sizeof(int),
+                  MPI_CHAR,
+                  MPI_COMM_WORLD);
 
     int perNodeArchShift[nBlocks];
     const int totalToReceive = lengthsToShifts(perNodeArchLength, perNodeArchShift);
-    if (!totalToReceive) return NumericTablePtr();
+    if (!totalToReceive)
+        return NumericTablePtr();
 
     ByteBuffer dataToReceive(totalToReceive);
-    MPI_Allgatherv(&dataToSend[0], dataToSendLength, MPI_CHAR, &dataToReceive[0], perNodeArchLength, perNodeArchShift, MPI_CHAR, MPI_COMM_WORLD);
+    MPI_Allgatherv(&dataToSend[0],
+                   dataToSendLength,
+                   MPI_CHAR,
+                   &dataToReceive[0],
+                   perNodeArchLength,
+                   perNodeArchShift,
+                   MPI_CHAR,
+                   MPI_COMM_WORLD);
 
-    for (size_t i = 0, shift = 0; i < nBlocks; shift += perNodeArchLength[i], ++i)
-    {
-        if (!perNodeArchLength[i]) continue;
-        NumericTablePtr pTbl = NumericTable::cast(deserializeDAALObject(&dataToReceive[shift], perNodeArchLength[i]));
+    for (size_t i = 0, shift = 0; i < nBlocks; shift += perNodeArchLength[i], ++i) {
+        if (!perNodeArchLength[i])
+            continue;
+        NumericTablePtr pTbl =
+            NumericTable::cast(deserializeDAALObject(&dataToReceive[shift], perNodeArchLength[i]));
         aRes.push_back(pTbl);
     }
-    if (!aRes.size()) return NumericTablePtr();
-    if (aRes.size() == 1) return aRes[0];
+    if (!aRes.size())
+        return NumericTablePtr();
+    if (aRes.size() == 1)
+        return aRes[0];
 
     /* For parallelPlus algorithm */
     RowMergedNumericTablePtr pMerged(new RowMergedNumericTable());
-    for (size_t i = 0; i < aRes.size(); ++i) pMerged->addNumericTable(aRes[i]);
+    for (size_t i = 0; i < aRes.size(); ++i)
+        pMerged->addNumericTable(aRes[i]);
     return NumericTable::cast(pMerged);
 }
 
 /* Send the value to all processes in the group and collect received values into one table */
-static void allToMaster(int rankId, const NumericTablePtr & value, std::vector<NumericTablePtr> & aRes)
-{
+static void allToMaster(int rankId,
+                        const NumericTablePtr& value,
+                        std::vector<NumericTablePtr>& aRes) {
     const bool isRoot = (rankId == mpi_root);
     aRes.clear();
     ByteBuffer dataToSend;
-    if (value.get()) serializeDAALObject(value.get(), dataToSend);
+    if (value.get())
+        serializeDAALObject(value.get(), dataToSend);
     const int dataToSendLength = dataToSend.size();
     int perNodeArchLength[nBlocks];
-    for (size_t i = 0; i < nBlocks; i++) perNodeArchLength[i] = 0;
+    for (size_t i = 0; i < nBlocks; i++)
+        perNodeArchLength[i] = 0;
 
-    MPI_Gather(&dataToSendLength, sizeof(int), MPI_CHAR, isRoot ? perNodeArchLength : NULL, sizeof(int), MPI_CHAR, mpi_root, MPI_COMM_WORLD);
+    MPI_Gather(&dataToSendLength,
+               sizeof(int),
+               MPI_CHAR,
+               isRoot ? perNodeArchLength : NULL,
+               sizeof(int),
+               MPI_CHAR,
+               mpi_root,
+               MPI_COMM_WORLD);
 
     ByteBuffer dataToReceive;
     int perNodeArchShift[nBlocks];
-    if (isRoot)
-    {
+    if (isRoot) {
         const int totalToReceive = lengthsToShifts(perNodeArchLength, perNodeArchShift);
-        if (!totalToReceive) return;
+        if (!totalToReceive)
+            return;
         dataToReceive.resize(totalToReceive);
     }
-    MPI_Gatherv(&dataToSend[0], dataToSendLength, MPI_CHAR, isRoot ? &dataToReceive[0] : NULL, perNodeArchLength, perNodeArchShift, MPI_CHAR,
-                mpi_root, MPI_COMM_WORLD);
+    MPI_Gatherv(&dataToSend[0],
+                dataToSendLength,
+                MPI_CHAR,
+                isRoot ? &dataToReceive[0] : NULL,
+                perNodeArchLength,
+                perNodeArchShift,
+                MPI_CHAR,
+                mpi_root,
+                MPI_COMM_WORLD);
 
-    if (!isRoot) return;
+    if (!isRoot)
+        return;
     aRes.resize(nBlocks);
-    for (size_t i = 0, shift = 0; i < nBlocks; shift += perNodeArchLength[i], ++i)
-    {
-        if (perNodeArchLength[i]) aRes[i] = NumericTable::cast(deserializeDAALObject(&dataToReceive[shift], perNodeArchLength[i]));
+    for (size_t i = 0, shift = 0; i < nBlocks; shift += perNodeArchLength[i], ++i) {
+        if (perNodeArchLength[i])
+            aRes[i] = NumericTable::cast(
+                deserializeDAALObject(&dataToReceive[shift], perNodeArchLength[i]));
     }
 }
 
 template <kmeans::init::Method method>
-NumericTablePtr initStep1(int rankId, const NumericTablePtr & pData)
-{
+NumericTablePtr initStep1(int rankId, const NumericTablePtr& pData) {
     const size_t nVectorsInBlock = pData->getNumberOfRows();
     /* Create an algorithm object for the K-Means algorithm */
-    kmeans::init::Distributed<step1Local, algorithmFPType, method> local(nClusters, nBlocks * nVectorsInBlock, rankId * nVectorsInBlock);
+    kmeans::init::Distributed<step1Local, algorithmFPType, method> local(nClusters,
+                                                                         nBlocks * nVectorsInBlock,
+                                                                         rankId * nVectorsInBlock);
     local.input.set(kmeans::init::data, pData);
     local.compute();
     return allToAll(local.getPartialResult()->get(kmeans::init::partialCentroids));
 }
 
 template <kmeans::init::Method method>
-void initStep2(int rankId, const NumericTablePtr & pData, DataCollectionPtr & localNodeData, const NumericTablePtr & step2Input, bool bFirstIteration,
-               std::vector<NumericTablePtr> & step2Results, bool bOutputForStep5Required = false)
-{
-    kmeans::init::Distributed<step2Local, algorithmFPType, method> step2(nClusters, bFirstIteration);
+void initStep2(int rankId,
+               const NumericTablePtr& pData,
+               DataCollectionPtr& localNodeData,
+               const NumericTablePtr& step2Input,
+               bool bFirstIteration,
+               std::vector<NumericTablePtr>& step2Results,
+               bool bOutputForStep5Required = false) {
+    kmeans::init::Distributed<step2Local, algorithmFPType, method> step2(nClusters,
+                                                                         bFirstIteration);
     step2.parameter.outputForStep5Required = bOutputForStep5Required;
     step2.input.set(kmeans::init::data, pData);
     step2.input.set(kmeans::init::internalInput, localNodeData);
     step2.input.set(kmeans::init::inputOfStep2, step2Input);
     step2.compute();
-    if (bFirstIteration) localNodeData = step2.getPartialResult()->get(kmeans::init::internalResult);
+    if (bFirstIteration)
+        localNodeData = step2.getPartialResult()->get(kmeans::init::internalResult);
     allToMaster(rankId,
-                step2.getPartialResult()->get(bOutputForStep5Required ? kmeans::init::outputOfStep2ForStep5 : kmeans::init::outputOfStep2ForStep3),
+                step2.getPartialResult()->get(bOutputForStep5Required
+                                                  ? kmeans::init::outputOfStep2ForStep5
+                                                  : kmeans::init::outputOfStep2ForStep3),
                 step2Results);
 }
 
 template <kmeans::init::Method method>
-NumericTablePtr initStep3(kmeans::init::Distributed<step3Master, algorithmFPType, method> & step3, std::vector<NumericTablePtr> & step2Results)
-{
-    for (size_t i = 0; i < step2Results.size(); ++i) step3.input.add(kmeans::init::inputOfStep3FromStep2, i, step2Results[i]);
+NumericTablePtr initStep3(kmeans::init::Distributed<step3Master, algorithmFPType, method>& step3,
+                          std::vector<NumericTablePtr>& step2Results) {
+    for (size_t i = 0; i < step2Results.size(); ++i)
+        step3.input.add(kmeans::init::inputOfStep3FromStep2, i, step2Results[i]);
     step3.compute();
     ByteBuffer buff;
     NumericTablePtr step4InputOnRoot;
-    for (size_t i = 0; i < nBlocks; ++i)
-    {
-        NumericTablePtr pTbl = step3.getPartialResult()->get(kmeans::init::outputOfStep3ForStep4, i); /* can be null */
-        if (i == mpi_root)
-        {
+    for (size_t i = 0; i < nBlocks; ++i) {
+        NumericTablePtr pTbl =
+            step3.getPartialResult()->get(kmeans::init::outputOfStep3ForStep4, i); /* can be null */
+        if (i == mpi_root) {
             step4InputOnRoot = pTbl;
             continue;
         }
         buff.clear();
         size_t size = pTbl.get() ? serializeDAALObject(pTbl.get(), buff) : 0;
         MPI_Send(&size, sizeof(size_t), MPI_BYTE, int(i), step3ResultSizeTag, MPI_COMM_WORLD);
-        if (size) MPI_Send(&buff[0], size, MPI_BYTE, int(i), step3ResultTag, MPI_COMM_WORLD);
+        if (size)
+            MPI_Send(&buff[0], size, MPI_BYTE, int(i), step3ResultTag, MPI_COMM_WORLD);
     }
     return step4InputOnRoot;
 }
 
-NumericTablePtr receiveStep3Output(int rankId)
-{
+NumericTablePtr receiveStep3Output(int rankId) {
     size_t size = 0;
     MPI_Status status;
-    MPI_Recv(&size, sizeof(size_t), MPI_BYTE, mpi_root, step3ResultSizeTag, MPI_COMM_WORLD, &status);
-    if (size)
-    {
+    MPI_Recv(&size,
+             sizeof(size_t),
+             MPI_BYTE,
+             mpi_root,
+             step3ResultSizeTag,
+             MPI_COMM_WORLD,
+             &status);
+    if (size) {
         ByteBuffer buff(size);
         MPI_Recv(&buff[0], size, MPI_BYTE, mpi_root, step3ResultTag, MPI_COMM_WORLD, &status);
         return NumericTable::cast(deserializeDAALObject(&buff[0], size));
@@ -230,11 +288,12 @@ NumericTablePtr receiveStep3Output(int rankId)
 }
 
 template <kmeans::init::Method method>
-NumericTablePtr initStep4(int rankId, const NumericTablePtr & pData, const DataCollectionPtr & localNodeData, const NumericTablePtr & step4Input)
-{
+NumericTablePtr initStep4(int rankId,
+                          const NumericTablePtr& pData,
+                          const DataCollectionPtr& localNodeData,
+                          const NumericTablePtr& step4Input) {
     NumericTablePtr step4Result;
-    if (step4Input)
-    {
+    if (step4Input) {
         /* Create an algorithm object for the step 4 */
         kmeans::init::Distributed<step4Local, algorithmFPType, method> step4(nClusters);
         /* Set the input data to the algorithm */
@@ -249,9 +308,9 @@ NumericTablePtr initStep4(int rankId, const NumericTablePtr & pData, const DataC
 }
 
 template <>
-NumericTablePtr initCentroids<kmeans::init::plusPlusDense>(int rankId, const NumericTablePtr & pData)
-{
-    const bool isRoot                 = (rankId == mpi_root);
+NumericTablePtr initCentroids<kmeans::init::plusPlusDense>(int rankId,
+                                                           const NumericTablePtr& pData) {
+    const bool isRoot = (rankId == mpi_root);
     const kmeans::init::Method method = kmeans::init::plusPlusDense;
     /* Internal data to be stored on the local nodes */
     DataCollectionPtr localNodeData;
@@ -263,21 +322,27 @@ NumericTablePtr initCentroids<kmeans::init::plusPlusDense>(int rankId, const Num
     /* Create an algorithm object for the step 3 */
     typedef kmeans::init::Distributed<step3Master, algorithmFPType, method> Step3Master;
     SharedPtr<Step3Master> step3(isRoot ? new Step3Master(nClusters) : NULL);
-    for (size_t iCenter = 1; iCenter < nClusters; ++iCenter)
-    {
+    for (size_t iCenter = 1; iCenter < nClusters; ++iCenter) {
         std::vector<NumericTablePtr> step2ResultsOnMaster;
-        initStep2<method>(rankId, pData, localNodeData, step2Input, iCenter == 1, step2ResultsOnMaster);
-        NumericTablePtr step4Input = (step3 ? initStep3<method>(*step3, step2ResultsOnMaster) : receiveStep3Output(rankId));
-        step2Input                 = initStep4<method>(rankId, pData, localNodeData, step4Input);
+        initStep2<method>(rankId,
+                          pData,
+                          localNodeData,
+                          step2Input,
+                          iCenter == 1,
+                          step2ResultsOnMaster);
+        NumericTablePtr step4Input =
+            (step3 ? initStep3<method>(*step3, step2ResultsOnMaster) : receiveStep3Output(rankId));
+        step2Input = initStep4<method>(rankId, pData, localNodeData, step4Input);
         pCentroids->addNumericTable(step2Input);
     }
-    return daal::data_management::convertToHomogen<float>(*pCentroids); /* can be returned as pCentroids as well */
+    return daal::data_management::convertToHomogen<float>(
+        *pCentroids); /* can be returned as pCentroids as well */
 }
 
 template <>
-NumericTablePtr initCentroids<kmeans::init::parallelPlusDense>(int rankId, const NumericTablePtr & pData)
-{
-    const bool isRoot                 = (rankId == mpi_root);
+NumericTablePtr initCentroids<kmeans::init::parallelPlusDense>(int rankId,
+                                                               const NumericTablePtr& pData) {
+    const bool isRoot = (rankId == mpi_root);
     const kmeans::init::Method method = kmeans::init::parallelPlusDense;
     /* default value of nRounds used by all steps */
     const size_t nRounds = kmeans::init::Parameter(nClusters).nRounds;
@@ -291,21 +356,28 @@ NumericTablePtr initCentroids<kmeans::init::parallelPlusDense>(int rankId, const
 
     /* First step on the local nodes */
     NumericTablePtr step2Input = initStep1<method>(rankId, pData);
-    if (step5) step5->input.add(kmeans::init::inputCentroids, step2Input);
+    if (step5)
+        step5->input.add(kmeans::init::inputCentroids, step2Input);
 
     /* Create an algorithm object for the step 3 */
     typedef kmeans::init::Distributed<step3Master, algorithmFPType, method> Step3Master;
     SharedPtr<Step3Master> step3(isRoot ? new Step3Master(nClusters) : NULL);
-    for (size_t iRound = 0; iRound < nRounds; ++iRound)
-    {
+    for (size_t iRound = 0; iRound < nRounds; ++iRound) {
         /* Perform step 2 */
         std::vector<NumericTablePtr> step2ResultsOnMaster;
-        initStep2<method>(rankId, pData, localNodeData, step2Input, iRound == 0, step2ResultsOnMaster);
+        initStep2<method>(rankId,
+                          pData,
+                          localNodeData,
+                          step2Input,
+                          iRound == 0,
+                          step2ResultsOnMaster);
         /* Perform step 3 */
-        NumericTablePtr step4Input = (step3 ? initStep3<method>(*step3, step2ResultsOnMaster) : receiveStep3Output(rankId));
+        NumericTablePtr step4Input =
+            (step3 ? initStep3<method>(*step3, step2ResultsOnMaster) : receiveStep3Output(rankId));
         /* Perform step 4 */
         step2Input = initStep4<method>(rankId, pData, localNodeData, step4Input);
-        if (step5) step5->input.add(kmeans::init::inputCentroids, step2Input);
+        if (step5)
+            step5->input.add(kmeans::init::inputCentroids, step2Input);
     }
 
     /* One more step 2 */
@@ -313,8 +385,10 @@ NumericTablePtr initCentroids<kmeans::init::parallelPlusDense>(int rankId, const
     initStep2<method>(rankId, pData, localNodeData, step2Input, false, step2Results, true);
     if (step5) /* isRoot == true */
     {
-        for (size_t i = 0; i < step2Results.size(); ++i) step5->input.add(kmeans::init::inputOfStep5FromStep2, step2Results[i]);
-        step5->input.set(kmeans::init::inputOfStep5FromStep3, step3->getPartialResult()->get(kmeans::init::outputOfStep3ForStep5));
+        for (size_t i = 0; i < step2Results.size(); ++i)
+            step5->input.add(kmeans::init::inputOfStep5FromStep2, step2Results[i]);
+        step5->input.set(kmeans::init::inputOfStep5FromStep3,
+                         step3->getPartialResult()->get(kmeans::init::outputOfStep3ForStep5));
         step5->compute();
         step5->finalizeCompute();
         return step5->getResult()->get(kmeans::init::centroids);
@@ -322,19 +396,23 @@ NumericTablePtr initCentroids<kmeans::init::parallelPlusDense>(int rankId, const
     return NumericTablePtr();
 }
 
-NumericTablePtr computeCentroids(int rankId, const NumericTablePtr & pData, const NumericTablePtr & initialCentroids)
-{
+NumericTablePtr computeCentroids(int rankId,
+                                 const NumericTablePtr& pData,
+                                 const NumericTablePtr& initialCentroids) {
     const bool isRoot = (rankId == mpi_root);
     ByteBuffer nodeCentroids;
-    size_t CentroidsArchLength = (isRoot ? serializeDAALObject(initialCentroids.get(), nodeCentroids) : 0);
+    size_t CentroidsArchLength =
+        (isRoot ? serializeDAALObject(initialCentroids.get(), nodeCentroids) : 0);
 
     /* Get centroids from the root node */
     MPI_Bcast(&CentroidsArchLength, sizeof(size_t), MPI_CHAR, mpi_root, MPI_COMM_WORLD);
 
-    if (!isRoot) nodeCentroids.resize(CentroidsArchLength);
+    if (!isRoot)
+        nodeCentroids.resize(CentroidsArchLength);
     MPI_Bcast(&nodeCentroids[0], CentroidsArchLength, MPI_CHAR, mpi_root, MPI_COMM_WORLD);
 
-    NumericTablePtr centroids = NumericTable::cast(deserializeDAALObject(&nodeCentroids[0], CentroidsArchLength));
+    NumericTablePtr centroids =
+        NumericTable::cast(deserializeDAALObject(&nodeCentroids[0], CentroidsArchLength));
 
     /* Create an algorithm to compute k-means on local nodes */
     kmeans::Distributed<step1Local, algorithmFPType, kmeans::lloydDense> localAlgorithm(nClusters);
@@ -348,26 +426,35 @@ NumericTablePtr computeCentroids(int rankId, const NumericTablePtr & pData, cons
 
     /* Serialize partial results required by step 2 */
     ByteBuffer nodeResults;
-    size_t perNodeArchLength = serializeDAALObject(localAlgorithm.getPartialResult().get(), nodeResults);
+    size_t perNodeArchLength =
+        serializeDAALObject(localAlgorithm.getPartialResult().get(), nodeResults);
 
     /* Serialized data is of equal size on each node if each node called compute() equal number of times */
     ByteBuffer serializedData;
-    if (isRoot) serializedData.resize(perNodeArchLength * nBlocks);
+    if (isRoot)
+        serializedData.resize(perNodeArchLength * nBlocks);
 
     /* Transfer partial results to step 2 on the root node */
-    MPI_Gather(&nodeResults[0], perNodeArchLength, MPI_CHAR, serializedData.size() ? &serializedData[0] : NULL, perNodeArchLength, MPI_CHAR, mpi_root,
+    MPI_Gather(&nodeResults[0],
+               perNodeArchLength,
+               MPI_CHAR,
+               serializedData.size() ? &serializedData[0] : NULL,
+               perNodeArchLength,
+               MPI_CHAR,
+               mpi_root,
                MPI_COMM_WORLD);
 
-    if (isRoot)
-    {
+    if (isRoot) {
         /* Create an algorithm to compute k-means on the master node */
-        kmeans::Distributed<step2Master, algorithmFPType, kmeans::lloydDense> masterAlgorithm(nClusters);
+        kmeans::Distributed<step2Master, algorithmFPType, kmeans::lloydDense> masterAlgorithm(
+            nClusters);
 
-        for (size_t i = 0; i < nBlocks; i++)
-        {
+        for (size_t i = 0; i < nBlocks; i++) {
             /* Deserialize partial results from step 1 */
-            SerializationIfacePtr ptr                      = deserializeDAALObject(&serializedData[perNodeArchLength * i], perNodeArchLength);
-            kmeans::PartialResultPtr dataForStep2FromStep1 = dynamicPointerCast<kmeans::PartialResult, SerializationIface>(ptr);
+            SerializationIfacePtr ptr =
+                deserializeDAALObject(&serializedData[perNodeArchLength * i], perNodeArchLength);
+            kmeans::PartialResultPtr dataForStep2FromStep1 =
+                dynamicPointerCast<kmeans::PartialResult, SerializationIface>(ptr);
 
             /* Set local partial results as input for the master-node algorithm */
             masterAlgorithm.input.add(kmeans::partialResults, dataForStep2FromStep1);

--- a/samples/daal/cpp/mpi/sources/linear_regression_norm_eq_distributed_mpi.cpp
+++ b/samples/daal/cpp/mpi/sources/linear_regression_norm_eq_distributed_mpi.cpp
@@ -38,14 +38,17 @@ using namespace std;
 using namespace daal;
 using namespace daal::algorithms::linear_regression;
 
-const string trainDatasetFileNames[] = { "./data/distributed/linear_regression_train_1.csv", "./data/distributed/linear_regression_train_2.csv",
-                                         "./data/distributed/linear_regression_train_3.csv", "./data/distributed/linear_regression_train_4.csv" };
-string testDatasetFileName           = "./data/distributed/linear_regression_test.csv";
+const string trainDatasetFileNames[] = { "./data/distributed/linear_regression_train_1.csv",
+                                         "./data/distributed/linear_regression_train_2.csv",
+                                         "./data/distributed/linear_regression_train_3.csv",
+                                         "./data/distributed/linear_regression_train_4.csv" };
+string testDatasetFileName = "./data/distributed/linear_regression_test.csv";
 
 const size_t nBlocks = 4;
 
-const size_t nFeatures           = 10; /* Number of features in training and testing data sets */
-const size_t nDependentVariables = 2;  /* Number of dependent variables that correspond to each observation */
+const size_t nFeatures = 10; /* Number of features in training and testing data sets */
+const size_t nDependentVariables =
+    2; /* Number of dependent variables that correspond to each observation */
 
 int rankId, comm_size;
 #define mpi_root 0
@@ -56,16 +59,14 @@ void testModel();
 training::ResultPtr trainingResult;
 prediction::ResultPtr predictionResult;
 
-int main(int argc, char * argv[])
-{
+int main(int argc, char* argv[]) {
     MPI_Init(&argc, &argv);
     MPI_Comm_size(MPI_COMM_WORLD, &comm_size);
     MPI_Comm_rank(MPI_COMM_WORLD, &rankId);
 
     trainModel();
 
-    if (rankId == mpi_root)
-    {
+    if (rankId == mpi_root) {
         testModel();
     }
 
@@ -74,15 +75,16 @@ int main(int argc, char * argv[])
     return 0;
 }
 
-void trainModel()
-{
+void trainModel() {
     /* Initialize FileDataSource<CSVFeatureManager> to retrieve the input data from a .csv file */
-    FileDataSource<CSVFeatureManager> trainDataSource(trainDatasetFileNames[rankId], DataSource::notAllocateNumericTable,
+    FileDataSource<CSVFeatureManager> trainDataSource(trainDatasetFileNames[rankId],
+                                                      DataSource::notAllocateNumericTable,
                                                       DataSource::doDictionaryFromContext);
 
     /* Create Numeric Tables for training data and labels */
     NumericTablePtr trainData(new HomogenNumericTable<>(nFeatures, 0, NumericTable::doNotAllocate));
-    NumericTablePtr trainDependentVariables(new HomogenNumericTable<>(nDependentVariables, 0, NumericTable::doNotAllocate));
+    NumericTablePtr trainDependentVariables(
+        new HomogenNumericTable<>(nDependentVariables, 0, NumericTable::doNotAllocate));
     NumericTablePtr mergedData(new MergedNumericTable(trainData, trainDependentVariables));
 
     /* Retrieve the data from the input file */
@@ -105,30 +107,36 @@ void trainModel()
     size_t perNodeArchLength = dataArch.getSizeOfArchive();
 
     /* Serialized data is of equal size on each node if each node called compute() equal number of times */
-    if (rankId == mpi_root)
-    {
+    if (rankId == mpi_root) {
         serializedData = services::SharedPtr<byte>(new byte[perNodeArchLength * nBlocks]);
     }
 
-    byte * nodeResults = new byte[perNodeArchLength];
+    byte* nodeResults = new byte[perNodeArchLength];
     dataArch.copyArchiveToArray(nodeResults, perNodeArchLength);
 
     /* Transfer partial results to step 2 on the root node */
-    MPI_Gather(nodeResults, perNodeArchLength, MPI_CHAR, serializedData.get(), perNodeArchLength, MPI_CHAR, mpi_root, MPI_COMM_WORLD);
+    MPI_Gather(nodeResults,
+               perNodeArchLength,
+               MPI_CHAR,
+               serializedData.get(),
+               perNodeArchLength,
+               MPI_CHAR,
+               mpi_root,
+               MPI_COMM_WORLD);
 
     delete[] nodeResults;
 
-    if (rankId == mpi_root)
-    {
+    if (rankId == mpi_root) {
         /* Create an algorithm object to build the final multiple linear regression model on the master node */
         training::Distributed<step2Master> masterAlgorithm;
 
-        for (size_t i = 0; i < nBlocks; i++)
-        {
+        for (size_t i = 0; i < nBlocks; i++) {
             /* Deserialize partial results from step 1 */
-            OutputDataArchive dataArch(serializedData.get() + perNodeArchLength * i, perNodeArchLength);
+            OutputDataArchive dataArch(serializedData.get() + perNodeArchLength * i,
+                                       perNodeArchLength);
 
-            training::PartialResultPtr dataForStep2FromStep1 = training::PartialResultPtr(new training::PartialResult());
+            training::PartialResultPtr dataForStep2FromStep1 =
+                training::PartialResultPtr(new training::PartialResult());
             dataForStep2FromStep1->deserialize(dataArch);
 
             /* Set the local multiple linear regression model as input for the master-node algorithm */
@@ -141,18 +149,21 @@ void trainModel()
 
         /* Retrieve the algorithm results */
         trainingResult = masterAlgorithm.getResult();
-        printNumericTable(trainingResult->get(training::model)->getBeta(), "Linear Regression coefficients:");
+        printNumericTable(trainingResult->get(training::model)->getBeta(),
+                          "Linear Regression coefficients:");
     }
 }
 
-void testModel()
-{
+void testModel() {
     /* Initialize FileDataSource<CSVFeatureManager> to retrieve the input data from a .csv file */
-    FileDataSource<CSVFeatureManager> testDataSource(testDatasetFileName, DataSource::doAllocateNumericTable, DataSource::doDictionaryFromContext);
+    FileDataSource<CSVFeatureManager> testDataSource(testDatasetFileName,
+                                                     DataSource::doAllocateNumericTable,
+                                                     DataSource::doDictionaryFromContext);
 
     /* Create Numeric Tables for testing data and ground truth values */
     NumericTablePtr testData(new HomogenNumericTable<>(nFeatures, 0, NumericTable::doNotAllocate));
-    NumericTablePtr testGroundTruth(new HomogenNumericTable<>(nDependentVariables, 0, NumericTable::doNotAllocate));
+    NumericTablePtr testGroundTruth(
+        new HomogenNumericTable<>(nDependentVariables, 0, NumericTable::doNotAllocate));
     NumericTablePtr mergedData(new MergedNumericTable(testData, testGroundTruth));
 
     /* Retrieve the data from an input file */
@@ -170,6 +181,8 @@ void testModel()
 
     /* Retrieve the algorithm results */
     predictionResult = algorithm.getResult();
-    printNumericTable(predictionResult->get(prediction::prediction), "Linear Regression prediction results: (first 10 rows):", 10);
+    printNumericTable(predictionResult->get(prediction::prediction),
+                      "Linear Regression prediction results: (first 10 rows):",
+                      10);
     printNumericTable(testGroundTruth, "Ground truth (first 10 rows):", 10);
 }

--- a/samples/daal/cpp/mpi/sources/linear_regression_qr_distributed_mpi.cpp
+++ b/samples/daal/cpp/mpi/sources/linear_regression_qr_distributed_mpi.cpp
@@ -40,14 +40,17 @@ using namespace daal::algorithms::linear_regression;
 
 typedef float algorithmFPType; /* Algorithm floating-point type */
 
-const string trainDatasetFileNames[] = { "./data/distributed/linear_regression_train_1.csv", "./data/distributed/linear_regression_train_2.csv",
-                                         "./data/distributed/linear_regression_train_3.csv", "./data/distributed/linear_regression_train_4.csv" };
-string testDatasetFileName           = "./data/distributed/linear_regression_test.csv";
+const string trainDatasetFileNames[] = { "./data/distributed/linear_regression_train_1.csv",
+                                         "./data/distributed/linear_regression_train_2.csv",
+                                         "./data/distributed/linear_regression_train_3.csv",
+                                         "./data/distributed/linear_regression_train_4.csv" };
+string testDatasetFileName = "./data/distributed/linear_regression_test.csv";
 
 const size_t nBlocks = 4;
 
-const size_t nFeatures           = 10; /* Number of features in training and testing data sets */
-const size_t nDependentVariables = 2;  /* Number of dependent variables that correspond to each observation */
+const size_t nFeatures = 10; /* Number of features in training and testing data sets */
+const size_t nDependentVariables =
+    2; /* Number of dependent variables that correspond to each observation */
 
 int rankId, comm_size;
 #define mpi_root 0
@@ -58,16 +61,14 @@ void testModel();
 training::ResultPtr trainingResult;
 prediction::ResultPtr predictionResult;
 
-int main(int argc, char * argv[])
-{
+int main(int argc, char* argv[]) {
     MPI_Init(&argc, &argv);
     MPI_Comm_size(MPI_COMM_WORLD, &comm_size);
     MPI_Comm_rank(MPI_COMM_WORLD, &rankId);
 
     trainModel();
 
-    if (rankId == mpi_root)
-    {
+    if (rankId == mpi_root) {
         testModel();
     }
 
@@ -76,15 +77,16 @@ int main(int argc, char * argv[])
     return 0;
 }
 
-void trainModel()
-{
+void trainModel() {
     /* Initialize FileDataSource<CSVFeatureManager> to retrieve the input data from a .csv file */
-    FileDataSource<CSVFeatureManager> trainDataSource(trainDatasetFileNames[rankId], DataSource::notAllocateNumericTable,
+    FileDataSource<CSVFeatureManager> trainDataSource(trainDatasetFileNames[rankId],
+                                                      DataSource::notAllocateNumericTable,
                                                       DataSource::doDictionaryFromContext);
 
     /* Create Numeric Tables for training data and labels */
     NumericTablePtr trainData(new HomogenNumericTable<>(nFeatures, 0, NumericTable::doNotAllocate));
-    NumericTablePtr trainDependentVariables(new HomogenNumericTable<>(nDependentVariables, 0, NumericTable::doNotAllocate));
+    NumericTablePtr trainDependentVariables(
+        new HomogenNumericTable<>(nDependentVariables, 0, NumericTable::doNotAllocate));
     NumericTablePtr mergedData(new MergedNumericTable(trainData, trainDependentVariables));
 
     /* Retrieve the data from the input file */
@@ -107,30 +109,36 @@ void trainModel()
     size_t perNodeArchLength = dataArch.getSizeOfArchive();
 
     /* Serialized data is of equal size on each node if each node called compute() equal number of times */
-    if (rankId == mpi_root)
-    {
+    if (rankId == mpi_root) {
         serializedData = services::SharedPtr<byte>(new byte[perNodeArchLength * nBlocks]);
     }
 
-    byte * nodeResults = new byte[perNodeArchLength];
+    byte* nodeResults = new byte[perNodeArchLength];
     dataArch.copyArchiveToArray(nodeResults, perNodeArchLength);
 
     /* Transfer partial results to step 2 on the root node */
-    MPI_Gather(nodeResults, perNodeArchLength, MPI_CHAR, serializedData.get(), perNodeArchLength, MPI_CHAR, mpi_root, MPI_COMM_WORLD);
+    MPI_Gather(nodeResults,
+               perNodeArchLength,
+               MPI_CHAR,
+               serializedData.get(),
+               perNodeArchLength,
+               MPI_CHAR,
+               mpi_root,
+               MPI_COMM_WORLD);
 
     delete[] nodeResults;
 
-    if (rankId == mpi_root)
-    {
+    if (rankId == mpi_root) {
         /* Create an algorithm object to build the final multiple linear regression model on the master node */
         training::Distributed<step2Master, algorithmFPType, training::qrDense> masterAlgorithm;
 
-        for (size_t i = 0; i < nBlocks; i++)
-        {
+        for (size_t i = 0; i < nBlocks; i++) {
             /* Deserialize partial results from step 1 */
-            OutputDataArchive dataArch(serializedData.get() + perNodeArchLength * i, perNodeArchLength);
+            OutputDataArchive dataArch(serializedData.get() + perNodeArchLength * i,
+                                       perNodeArchLength);
 
-            training::PartialResultPtr dataForStep2FromStep1 = training::PartialResultPtr(new training::PartialResult());
+            training::PartialResultPtr dataForStep2FromStep1 =
+                training::PartialResultPtr(new training::PartialResult());
             dataForStep2FromStep1->deserialize(dataArch);
 
             /* Set the local multiple linear regression model as input for the master-node algorithm */
@@ -143,18 +151,21 @@ void trainModel()
 
         /* Retrieve the algorithm results */
         trainingResult = masterAlgorithm.getResult();
-        printNumericTable(trainingResult->get(training::model)->getBeta(), "Linear Regression coefficients:");
+        printNumericTable(trainingResult->get(training::model)->getBeta(),
+                          "Linear Regression coefficients:");
     }
 }
 
-void testModel()
-{
+void testModel() {
     /* Initialize FileDataSource<CSVFeatureManager> to retrieve the input data from a .csv file */
-    FileDataSource<CSVFeatureManager> testDataSource(testDatasetFileName, DataSource::doAllocateNumericTable, DataSource::doDictionaryFromContext);
+    FileDataSource<CSVFeatureManager> testDataSource(testDatasetFileName,
+                                                     DataSource::doAllocateNumericTable,
+                                                     DataSource::doDictionaryFromContext);
 
     /* Create Numeric Tables for testing data and ground truth values */
     NumericTablePtr testData(new HomogenNumericTable<>(nFeatures, 0, NumericTable::doNotAllocate));
-    NumericTablePtr testGroundTruth(new HomogenNumericTable<>(nDependentVariables, 0, NumericTable::doNotAllocate));
+    NumericTablePtr testGroundTruth(
+        new HomogenNumericTable<>(nDependentVariables, 0, NumericTable::doNotAllocate));
     NumericTablePtr mergedData(new MergedNumericTable(testData, testGroundTruth));
 
     /* Retrieve the data from an input file */
@@ -172,6 +183,8 @@ void testModel()
 
     /* Retrieve the algorithm results */
     predictionResult = algorithm.getResult();
-    printNumericTable(predictionResult->get(prediction::prediction), "Linear Regression prediction results: (first 10 rows):", 10);
+    printNumericTable(predictionResult->get(prediction::prediction),
+                      "Linear Regression prediction results: (first 10 rows):",
+                      10);
     printNumericTable(testGroundTruth, "Ground truth (first 10 rows):", 10);
 }

--- a/samples/daal/cpp/mpi/sources/low_order_moments_csr_distributed_mpi.cpp
+++ b/samples/daal/cpp/mpi/sources/low_order_moments_csr_distributed_mpi.cpp
@@ -44,22 +44,30 @@ typedef float algorithmFPType; /* Algorithm floating-point type */
 int rankId, comm_size;
 #define mpi_root 0
 
-const string datasetFileNames[] = { "./data/distributed/covcormoments_csr_1.csv", "./data/distributed/covcormoments_csr_2.csv",
-                                    "./data/distributed/covcormoments_csr_3.csv", "./data/distributed/covcormoments_csr_4.csv" };
+const string datasetFileNames[] = { "./data/distributed/covcormoments_csr_1.csv",
+                                    "./data/distributed/covcormoments_csr_2.csv",
+                                    "./data/distributed/covcormoments_csr_3.csv",
+                                    "./data/distributed/covcormoments_csr_4.csv" };
 
-int main(int argc, char * argv[])
-{
-    checkArguments(argc, argv, 4, &datasetFileNames[0], &datasetFileNames[1], &datasetFileNames[2], &datasetFileNames[3]);
+int main(int argc, char* argv[]) {
+    checkArguments(argc,
+                   argv,
+                   4,
+                   &datasetFileNames[0],
+                   &datasetFileNames[1],
+                   &datasetFileNames[2],
+                   &datasetFileNames[3]);
 
     MPI_Init(&argc, &argv);
     MPI_Comm_size(MPI_COMM_WORLD, &comm_size);
     MPI_Comm_rank(MPI_COMM_WORLD, &rankId);
 
     /* Retrieve the input data from a file */
-    CSRNumericTable * dataTable = createSparseTable<float>(datasetFileNames[rankId]);
+    CSRNumericTable* dataTable = createSparseTable<float>(datasetFileNames[rankId]);
 
     /* Create an algorithm to compute low order moments on local nodes */
-    low_order_moments::Distributed<step1Local, algorithmFPType, low_order_moments::fastCSR> localAlgorithm;
+    low_order_moments::Distributed<step1Local, algorithmFPType, low_order_moments::fastCSR>
+        localAlgorithm;
 
     /* Set the input data set to the algorithm */
     localAlgorithm.input.set(low_order_moments::data, CSRNumericTablePtr(dataTable));
@@ -74,30 +82,37 @@ int main(int argc, char * argv[])
     size_t perNodeArchLength = dataArch.getSizeOfArchive();
 
     /* Serialized data is of equal size on each node if each node called compute() equal number of times */
-    if (rankId == mpi_root)
-    {
+    if (rankId == mpi_root) {
         serializedData = services::SharedPtr<byte>(new byte[perNodeArchLength * nBlocks]);
     }
 
-    byte * nodeResults = new byte[perNodeArchLength];
+    byte* nodeResults = new byte[perNodeArchLength];
     dataArch.copyArchiveToArray(nodeResults, perNodeArchLength);
 
     /* Transfer partial results to step 2 on the root node */
-    MPI_Gather(nodeResults, perNodeArchLength, MPI_CHAR, serializedData.get(), perNodeArchLength, MPI_CHAR, mpi_root, MPI_COMM_WORLD);
+    MPI_Gather(nodeResults,
+               perNodeArchLength,
+               MPI_CHAR,
+               serializedData.get(),
+               perNodeArchLength,
+               MPI_CHAR,
+               mpi_root,
+               MPI_COMM_WORLD);
 
     delete[] nodeResults;
 
-    if (rankId == mpi_root)
-    {
+    if (rankId == mpi_root) {
         /* Create an algorithm to compute low order moments on the master node */
-        low_order_moments::Distributed<step2Master, algorithmFPType, low_order_moments::fastCSR> masterAlgorithm;
+        low_order_moments::Distributed<step2Master, algorithmFPType, low_order_moments::fastCSR>
+            masterAlgorithm;
 
-        for (size_t i = 0; i < nBlocks; i++)
-        {
+        for (size_t i = 0; i < nBlocks; i++) {
             /* Deserialize partial results from step 1 */
-            OutputDataArchive dataArch(serializedData.get() + perNodeArchLength * i, perNodeArchLength);
+            OutputDataArchive dataArch(serializedData.get() + perNodeArchLength * i,
+                                       perNodeArchLength);
 
-            low_order_moments::PartialResultPtr dataForStep2FromStep1 = low_order_moments::PartialResultPtr(new low_order_moments::PartialResult());
+            low_order_moments::PartialResultPtr dataForStep2FromStep1 =
+                low_order_moments::PartialResultPtr(new low_order_moments::PartialResult());
 
             dataForStep2FromStep1->deserialize(dataArch);
 
@@ -117,9 +132,11 @@ int main(int argc, char * argv[])
         printNumericTable(res->get(low_order_moments::maximum), "Maximum:");
         printNumericTable(res->get(low_order_moments::sum), "Sum:");
         printNumericTable(res->get(low_order_moments::sumSquares), "Sum of squares:");
-        printNumericTable(res->get(low_order_moments::sumSquaresCentered), "Sum of squared difference from the means:");
+        printNumericTable(res->get(low_order_moments::sumSquaresCentered),
+                          "Sum of squared difference from the means:");
         printNumericTable(res->get(low_order_moments::mean), "Mean:");
-        printNumericTable(res->get(low_order_moments::secondOrderRawMoment), "Second order raw moment:");
+        printNumericTable(res->get(low_order_moments::secondOrderRawMoment),
+                          "Second order raw moment:");
         printNumericTable(res->get(low_order_moments::variance), "Variance:");
         printNumericTable(res->get(low_order_moments::standardDeviation), "Standard deviation:");
         printNumericTable(res->get(low_order_moments::variation), "Variation:");

--- a/samples/daal/cpp/mpi/sources/low_order_moments_dense_distributed_mpi.cpp
+++ b/samples/daal/cpp/mpi/sources/low_order_moments_dense_distributed_mpi.cpp
@@ -41,19 +41,28 @@ const size_t nBlocks = 4;
 int rankId, comm_size;
 #define mpi_root 0
 
-const string datasetFileNames[] = { "./data/distributed/covcormoments_dense_1.csv", "./data/distributed/covcormoments_dense_2.csv",
-                                    "./data/distributed/covcormoments_dense_3.csv", "./data/distributed/covcormoments_dense_4.csv" };
+const string datasetFileNames[] = { "./data/distributed/covcormoments_dense_1.csv",
+                                    "./data/distributed/covcormoments_dense_2.csv",
+                                    "./data/distributed/covcormoments_dense_3.csv",
+                                    "./data/distributed/covcormoments_dense_4.csv" };
 
-int main(int argc, char * argv[])
-{
-    checkArguments(argc, argv, 4, &datasetFileNames[0], &datasetFileNames[1], &datasetFileNames[2], &datasetFileNames[3]);
+int main(int argc, char* argv[]) {
+    checkArguments(argc,
+                   argv,
+                   4,
+                   &datasetFileNames[0],
+                   &datasetFileNames[1],
+                   &datasetFileNames[2],
+                   &datasetFileNames[3]);
 
     MPI_Init(&argc, &argv);
     MPI_Comm_size(MPI_COMM_WORLD, &comm_size);
     MPI_Comm_rank(MPI_COMM_WORLD, &rankId);
 
     /* Initialize FileDataSource<CSVFeatureManager> to retrieve the input data from a .csv file */
-    FileDataSource<CSVFeatureManager> dataSource(datasetFileNames[rankId], DataSource::doAllocateNumericTable, DataSource::doDictionaryFromContext);
+    FileDataSource<CSVFeatureManager> dataSource(datasetFileNames[rankId],
+                                                 DataSource::doAllocateNumericTable,
+                                                 DataSource::doDictionaryFromContext);
 
     /* Retrieve the input data */
     dataSource.loadDataBlock();
@@ -74,30 +83,36 @@ int main(int argc, char * argv[])
     size_t perNodeArchLength = dataArch.getSizeOfArchive();
 
     /* Serialized data is of equal size on each node if each node called compute() equal number of times */
-    if (rankId == mpi_root)
-    {
+    if (rankId == mpi_root) {
         serializedData = services::SharedPtr<byte>(new byte[perNodeArchLength * nBlocks]);
     }
 
-    byte * nodeResults = new byte[perNodeArchLength];
+    byte* nodeResults = new byte[perNodeArchLength];
     dataArch.copyArchiveToArray(nodeResults, perNodeArchLength);
 
     /* Transfer partial results to step 2 on the root node */
-    MPI_Gather(nodeResults, perNodeArchLength, MPI_CHAR, serializedData.get(), perNodeArchLength, MPI_CHAR, mpi_root, MPI_COMM_WORLD);
+    MPI_Gather(nodeResults,
+               perNodeArchLength,
+               MPI_CHAR,
+               serializedData.get(),
+               perNodeArchLength,
+               MPI_CHAR,
+               mpi_root,
+               MPI_COMM_WORLD);
 
     delete[] nodeResults;
 
-    if (rankId == mpi_root)
-    {
+    if (rankId == mpi_root) {
         /* Create an algorithm to compute low order moments on the master node */
         low_order_moments::Distributed<step2Master> masterAlgorithm;
 
-        for (size_t i = 0; i < nBlocks; i++)
-        {
+        for (size_t i = 0; i < nBlocks; i++) {
             /* Deserialize partial results from step 1 */
-            OutputDataArchive dataArch(serializedData.get() + perNodeArchLength * i, perNodeArchLength);
+            OutputDataArchive dataArch(serializedData.get() + perNodeArchLength * i,
+                                       perNodeArchLength);
 
-            low_order_moments::PartialResultPtr dataForStep2FromStep1 = low_order_moments::PartialResultPtr(new low_order_moments::PartialResult());
+            low_order_moments::PartialResultPtr dataForStep2FromStep1 =
+                low_order_moments::PartialResultPtr(new low_order_moments::PartialResult());
 
             dataForStep2FromStep1->deserialize(dataArch);
 
@@ -117,9 +132,11 @@ int main(int argc, char * argv[])
         printNumericTable(res->get(low_order_moments::maximum), "Maximum:");
         printNumericTable(res->get(low_order_moments::sum), "Sum:");
         printNumericTable(res->get(low_order_moments::sumSquares), "Sum of squares:");
-        printNumericTable(res->get(low_order_moments::sumSquaresCentered), "Sum of squared difference from the means:");
+        printNumericTable(res->get(low_order_moments::sumSquaresCentered),
+                          "Sum of squared difference from the means:");
         printNumericTable(res->get(low_order_moments::mean), "Mean:");
-        printNumericTable(res->get(low_order_moments::secondOrderRawMoment), "Second order raw moment:");
+        printNumericTable(res->get(low_order_moments::secondOrderRawMoment),
+                          "Second order raw moment:");
         printNumericTable(res->get(low_order_moments::variance), "Variance:");
         printNumericTable(res->get(low_order_moments::standardDeviation), "Standard deviation:");
         printNumericTable(res->get(low_order_moments::variation), "Variation:");

--- a/samples/daal/cpp/mpi/sources/multinomial_naive_bayes_csr_distributed_mpi.cpp
+++ b/samples/daal/cpp/mpi/sources/multinomial_naive_bayes_csr_distributed_mpi.cpp
@@ -41,16 +41,20 @@ using namespace daal::algorithms::multinomial_naive_bayes;
 typedef float algorithmFPType; /* Algorithm floating-point type */
 
 /* Input data set parameters */
-const string trainDatasetFileNames[4]     = { "./data/distributed/naivebayes_train_csr.csv", "./data/distributed/naivebayes_train_csr.csv",
-                                          "./data/distributed/naivebayes_train_csr.csv", "./data/distributed/naivebayes_train_csr.csv" };
-const string trainGroundTruthFileNames[4] = { "./data/distributed/naivebayes_train_labels.csv", "./data/distributed/naivebayes_train_labels.csv",
-                                              "./data/distributed/naivebayes_train_labels.csv", "./data/distributed/naivebayes_train_labels.csv" };
+const string trainDatasetFileNames[4] = { "./data/distributed/naivebayes_train_csr.csv",
+                                          "./data/distributed/naivebayes_train_csr.csv",
+                                          "./data/distributed/naivebayes_train_csr.csv",
+                                          "./data/distributed/naivebayes_train_csr.csv" };
+const string trainGroundTruthFileNames[4] = { "./data/distributed/naivebayes_train_labels.csv",
+                                              "./data/distributed/naivebayes_train_labels.csv",
+                                              "./data/distributed/naivebayes_train_labels.csv",
+                                              "./data/distributed/naivebayes_train_labels.csv" };
 
-string testDatasetFileName     = "./data/distributed/naivebayes_test_csr.csv";
+string testDatasetFileName = "./data/distributed/naivebayes_test_csr.csv";
 string testGroundTruthFileName = "./data/distributed/naivebayes_test_labels.csv";
 
 const size_t nClasses = 20;
-const size_t nBlocks  = 4;
+const size_t nBlocks = 4;
 
 int rankId, comm_size;
 #define mpi_root 0
@@ -62,16 +66,14 @@ void printResults();
 training::ResultPtr trainingResult;
 classifier::prediction::ResultPtr predictionResult;
 
-int main(int argc, char * argv[])
-{
+int main(int argc, char* argv[]) {
     MPI_Init(&argc, &argv);
     MPI_Comm_size(MPI_COMM_WORLD, &comm_size);
     MPI_Comm_rank(MPI_COMM_WORLD, &rankId);
 
     trainModel();
 
-    if (rankId == mpi_root)
-    {
+    if (rankId == mpi_root) {
         testModel();
         printResults();
     }
@@ -81,13 +83,13 @@ int main(int argc, char * argv[])
     return 0;
 }
 
-void trainModel()
-{
+void trainModel() {
     /* Retrieve the input data from a .csv file */
-    CSRNumericTable * trainDataTable = createSparseTable<float>(trainDatasetFileNames[rankId]);
+    CSRNumericTable* trainDataTable = createSparseTable<float>(trainDatasetFileNames[rankId]);
 
     /* Initialize FileDataSource<CSVFeatureManager> to retrieve the input data from a .csv file */
-    FileDataSource<CSVFeatureManager> trainLabelsSource(trainGroundTruthFileNames[rankId], DataSource::doAllocateNumericTable,
+    FileDataSource<CSVFeatureManager> trainLabelsSource(trainGroundTruthFileNames[rankId],
+                                                        DataSource::doAllocateNumericTable,
                                                         DataSource::doDictionaryFromContext);
 
     /* Retrieve the data from input files */
@@ -110,8 +112,7 @@ void trainModel()
     size_t perNodeArchLength = dataArch.getSizeOfArchive();
 
     /* Serialized data is of equal size on each node if each node called compute() equal number of times */
-    if (rankId == mpi_root)
-    {
+    if (rankId == mpi_root) {
         serializedData.reset(new byte[perNodeArchLength * nBlocks]);
     }
 
@@ -120,18 +121,25 @@ void trainModel()
         dataArch.copyArchiveToArray(nodeResults.get(), perNodeArchLength);
 
         /* Transfer partial results to step 2 on the root node */
-        MPI_Gather(nodeResults.get(), perNodeArchLength, MPI_CHAR, serializedData.get(), perNodeArchLength, MPI_CHAR, mpi_root, MPI_COMM_WORLD);
+        MPI_Gather(nodeResults.get(),
+                   perNodeArchLength,
+                   MPI_CHAR,
+                   serializedData.get(),
+                   perNodeArchLength,
+                   MPI_CHAR,
+                   mpi_root,
+                   MPI_COMM_WORLD);
     }
 
-    if (rankId == mpi_root)
-    {
+    if (rankId == mpi_root) {
         /* Create an algorithm object to build the final Naive Bayes model on the master node */
-        training::Distributed<step2Master, algorithmFPType, training::fastCSR> masterAlgorithm(nClasses);
+        training::Distributed<step2Master, algorithmFPType, training::fastCSR> masterAlgorithm(
+            nClasses);
 
-        for (size_t i = 0; i < nBlocks; i++)
-        {
+        for (size_t i = 0; i < nBlocks; i++) {
             /* Deserialize partial results from step 1 */
-            OutputDataArchive dataArch(serializedData.get() + perNodeArchLength * i, perNodeArchLength);
+            OutputDataArchive dataArch(serializedData.get() + perNodeArchLength * i,
+                                       perNodeArchLength);
 
             training::PartialResultPtr dataForStep2FromStep1(new training::PartialResult());
             dataForStep2FromStep1->deserialize(dataArch);
@@ -149,17 +157,17 @@ void trainModel()
     }
 }
 
-void testModel()
-{
+void testModel() {
     /* Retrieve the input data from a .csv file */
-    CSRNumericTable * testDataTable = createSparseTable<float>(testDatasetFileName);
+    CSRNumericTable* testDataTable = createSparseTable<float>(testDatasetFileName);
 
     /* Create an algorithm object to predict values of the Naive Bayes model */
     prediction::Batch<algorithmFPType, prediction::fastCSR> algorithm(nClasses);
 
     /* Pass a testing data set and the trained model to the algorithm */
     algorithm.input.set(classifier::prediction::data, CSRNumericTablePtr(testDataTable));
-    algorithm.input.set(classifier::prediction::model, trainingResult->get(classifier::training::model));
+    algorithm.input.set(classifier::prediction::model,
+                        trainingResult->get(classifier::training::model));
 
     /* Predict values of the Naive Bayes model */
     algorithm.compute();
@@ -168,12 +176,16 @@ void testModel()
     predictionResult = algorithm.getResult();
 }
 
-void printResults()
-{
-    FileDataSource<CSVFeatureManager> testGroundTruth(testGroundTruthFileName, DataSource::doAllocateNumericTable,
+void printResults() {
+    FileDataSource<CSVFeatureManager> testGroundTruth(testGroundTruthFileName,
+                                                      DataSource::doAllocateNumericTable,
                                                       DataSource::doDictionaryFromContext);
     testGroundTruth.loadDataBlock();
 
-    printNumericTables<int, int>(testGroundTruth.getNumericTable().get(), predictionResult->get(classifier::prediction::prediction).get(),
-                                 "Ground truth", "Classification results", "NaiveBayes classification results (first 20 observations):", 20);
+    printNumericTables<int, int>(testGroundTruth.getNumericTable().get(),
+                                 predictionResult->get(classifier::prediction::prediction).get(),
+                                 "Ground truth",
+                                 "Classification results",
+                                 "NaiveBayes classification results (first 20 observations):",
+                                 20);
 }

--- a/samples/daal/cpp/mpi/sources/multinomial_naive_bayes_dense_distributed_mpi.cpp
+++ b/samples/daal/cpp/mpi/sources/multinomial_naive_bayes_dense_distributed_mpi.cpp
@@ -39,16 +39,20 @@ using namespace daal::algorithms;
 using namespace daal::algorithms::multinomial_naive_bayes;
 
 /* Input data set parameters */
-const string trainDatasetFileNames[4]     = { "./data/distributed/naivebayes_train_dense.csv", "./data/distributed/naivebayes_train_dense.csv",
-                                          "./data/distributed/naivebayes_train_dense.csv", "./data/distributed/naivebayes_train_dense.csv" };
-const string trainGroundTruthFileNames[4] = { "./data/distributed/naivebayes_train_labels.csv", "./data/distributed/naivebayes_train_labels.csv",
-                                              "./data/distributed/naivebayes_train_labels.csv", "./data/distributed/naivebayes_train_labels.csv" };
+const string trainDatasetFileNames[4] = { "./data/distributed/naivebayes_train_dense.csv",
+                                          "./data/distributed/naivebayes_train_dense.csv",
+                                          "./data/distributed/naivebayes_train_dense.csv",
+                                          "./data/distributed/naivebayes_train_dense.csv" };
+const string trainGroundTruthFileNames[4] = { "./data/distributed/naivebayes_train_labels.csv",
+                                              "./data/distributed/naivebayes_train_labels.csv",
+                                              "./data/distributed/naivebayes_train_labels.csv",
+                                              "./data/distributed/naivebayes_train_labels.csv" };
 
-string testDatasetFileName     = "./data/distributed/naivebayes_test_dense.csv";
+string testDatasetFileName = "./data/distributed/naivebayes_test_dense.csv";
 string testGroundTruthFileName = "./data/distributed/naivebayes_test_labels.csv";
 
 const size_t nClasses = 20;
-const size_t nBlocks  = 4;
+const size_t nBlocks = 4;
 
 int rankId, comm_size;
 #define mpi_root 0
@@ -60,16 +64,14 @@ void printResults();
 training::ResultPtr trainingResult;
 classifier::prediction::ResultPtr predictionResult;
 
-int main(int argc, char * argv[])
-{
+int main(int argc, char* argv[]) {
     MPI_Init(&argc, &argv);
     MPI_Comm_size(MPI_COMM_WORLD, &comm_size);
     MPI_Comm_rank(MPI_COMM_WORLD, &rankId);
 
     trainModel();
 
-    if (rankId == mpi_root)
-    {
+    if (rankId == mpi_root) {
         testModel();
         printResults();
     }
@@ -79,12 +81,13 @@ int main(int argc, char * argv[])
     return 0;
 }
 
-void trainModel()
-{
+void trainModel() {
     /* Initialize FileDataSource<CSVFeatureManager> to retrieve the input data from a .csv file */
-    FileDataSource<CSVFeatureManager> trainDataSource(trainDatasetFileNames[rankId], DataSource::doAllocateNumericTable,
+    FileDataSource<CSVFeatureManager> trainDataSource(trainDatasetFileNames[rankId],
+                                                      DataSource::doAllocateNumericTable,
                                                       DataSource::doDictionaryFromContext);
-    FileDataSource<CSVFeatureManager> trainLabelsSource(trainGroundTruthFileNames[rankId], DataSource::doAllocateNumericTable,
+    FileDataSource<CSVFeatureManager> trainLabelsSource(trainGroundTruthFileNames[rankId],
+                                                        DataSource::doAllocateNumericTable,
                                                         DataSource::doDictionaryFromContext);
 
     /* Retrieve the data from input files */
@@ -108,8 +111,7 @@ void trainModel()
     size_t perNodeArchLength = dataArch.getSizeOfArchive();
 
     /* Serialized data is of equal size on each node if each node called compute() equal number of times */
-    if (rankId == mpi_root)
-    {
+    if (rankId == mpi_root) {
         serializedData.reset(new byte[perNodeArchLength * nBlocks]);
     }
 
@@ -118,18 +120,24 @@ void trainModel()
         dataArch.copyArchiveToArray(nodeResults.get(), perNodeArchLength);
 
         /* Transfer partial results to step 2 on the root node */
-        MPI_Gather(nodeResults.get(), perNodeArchLength, MPI_CHAR, serializedData.get(), perNodeArchLength, MPI_CHAR, mpi_root, MPI_COMM_WORLD);
+        MPI_Gather(nodeResults.get(),
+                   perNodeArchLength,
+                   MPI_CHAR,
+                   serializedData.get(),
+                   perNodeArchLength,
+                   MPI_CHAR,
+                   mpi_root,
+                   MPI_COMM_WORLD);
     }
 
-    if (rankId == mpi_root)
-    {
+    if (rankId == mpi_root) {
         /* Create an algorithm object to build the final Naive Bayes model on the master node */
         training::Distributed<step2Master> masterAlgorithm(nClasses);
 
-        for (size_t i = 0; i < nBlocks; i++)
-        {
+        for (size_t i = 0; i < nBlocks; i++) {
             /* Deserialize partial results from step 1 */
-            OutputDataArchive dataArch(serializedData.get() + perNodeArchLength * i, perNodeArchLength);
+            OutputDataArchive dataArch(serializedData.get() + perNodeArchLength * i,
+                                       perNodeArchLength);
 
             training::PartialResultPtr dataForStep2FromStep1(new training::PartialResult());
             dataForStep2FromStep1->deserialize(dataArch);
@@ -147,10 +155,11 @@ void trainModel()
     }
 }
 
-void testModel()
-{
+void testModel() {
     /* Initialize FileDataSource<CSVFeatureManager> to retrieve the input data from a .csv file */
-    FileDataSource<CSVFeatureManager> testDataSource(testDatasetFileName, DataSource::doAllocateNumericTable, DataSource::doDictionaryFromContext);
+    FileDataSource<CSVFeatureManager> testDataSource(testDatasetFileName,
+                                                     DataSource::doAllocateNumericTable,
+                                                     DataSource::doDictionaryFromContext);
 
     /* Retrieve the data from an input file */
     testDataSource.loadDataBlock();
@@ -160,7 +169,8 @@ void testModel()
 
     /* Pass a testing data set and the trained model to the algorithm */
     algorithm.input.set(classifier::prediction::data, testDataSource.getNumericTable());
-    algorithm.input.set(classifier::prediction::model, trainingResult->get(classifier::training::model));
+    algorithm.input.set(classifier::prediction::model,
+                        trainingResult->get(classifier::training::model));
 
     /* Predict values of the Naive Bayes model */
     algorithm.compute();
@@ -169,12 +179,16 @@ void testModel()
     predictionResult = algorithm.getResult();
 }
 
-void printResults()
-{
-    FileDataSource<CSVFeatureManager> testGroundTruth(testGroundTruthFileName, DataSource::doAllocateNumericTable,
+void printResults() {
+    FileDataSource<CSVFeatureManager> testGroundTruth(testGroundTruthFileName,
+                                                      DataSource::doAllocateNumericTable,
                                                       DataSource::doDictionaryFromContext);
     testGroundTruth.loadDataBlock();
 
-    printNumericTables<int, int>(testGroundTruth.getNumericTable().get(), predictionResult->get(classifier::prediction::prediction).get(),
-                                 "Ground truth", "Classification results", "NaiveBayes classification results (first 20 observations):", 20);
+    printNumericTables<int, int>(testGroundTruth.getNumericTable().get(),
+                                 predictionResult->get(classifier::prediction::prediction).get(),
+                                 "Ground truth",
+                                 "Classification results",
+                                 "NaiveBayes classification results (first 20 observations):",
+                                 20);
 }

--- a/samples/daal/cpp/mpi/sources/pca_correlation_dense_distributed_mpi.cpp
+++ b/samples/daal/cpp/mpi/sources/pca_correlation_dense_distributed_mpi.cpp
@@ -42,19 +42,28 @@ size_t nFeatures;
 int rankId, comm_size;
 #define mpi_root 0
 
-const string datasetFileNames[] = { "./data/distributed/pca_normalized_1.csv", "./data/distributed/pca_normalized_2.csv",
-                                    "./data/distributed/pca_normalized_3.csv", "./data/distributed/pca_normalized_4.csv" };
+const string datasetFileNames[] = { "./data/distributed/pca_normalized_1.csv",
+                                    "./data/distributed/pca_normalized_2.csv",
+                                    "./data/distributed/pca_normalized_3.csv",
+                                    "./data/distributed/pca_normalized_4.csv" };
 
-int main(int argc, char * argv[])
-{
-    checkArguments(argc, argv, 4, &datasetFileNames[0], &datasetFileNames[1], &datasetFileNames[2], &datasetFileNames[3]);
+int main(int argc, char* argv[]) {
+    checkArguments(argc,
+                   argv,
+                   4,
+                   &datasetFileNames[0],
+                   &datasetFileNames[1],
+                   &datasetFileNames[2],
+                   &datasetFileNames[3]);
 
     MPI_Init(&argc, &argv);
     MPI_Comm_size(MPI_COMM_WORLD, &comm_size);
     MPI_Comm_rank(MPI_COMM_WORLD, &rankId);
 
     /* Initialize FileDataSource<CSVFeatureManager> to retrieve the input data from a .csv file */
-    FileDataSource<CSVFeatureManager> dataSource(datasetFileNames[rankId], DataSource::doAllocateNumericTable, DataSource::doDictionaryFromContext);
+    FileDataSource<CSVFeatureManager> dataSource(datasetFileNames[rankId],
+                                                 DataSource::doAllocateNumericTable,
+                                                 DataSource::doDictionaryFromContext);
 
     /* Retrieve the input data */
     dataSource.loadDataBlock();
@@ -75,31 +84,37 @@ int main(int argc, char * argv[])
     size_t perNodeArchLength = dataArch.getSizeOfArchive();
 
     /* Serialized data is of equal size on each node if each node called compute() equal number of times */
-    if (rankId == mpi_root)
-    {
+    if (rankId == mpi_root) {
         serializedData = services::SharedPtr<byte>(new byte[perNodeArchLength * nBlocks]);
     }
 
-    byte * nodeResults = new byte[perNodeArchLength];
+    byte* nodeResults = new byte[perNodeArchLength];
     dataArch.copyArchiveToArray(nodeResults, perNodeArchLength);
 
     /* Transfer partial results to step 2 on the root node */
-    MPI_Gather(nodeResults, perNodeArchLength, MPI_CHAR, serializedData.get(), perNodeArchLength, MPI_CHAR, mpi_root, MPI_COMM_WORLD);
+    MPI_Gather(nodeResults,
+               perNodeArchLength,
+               MPI_CHAR,
+               serializedData.get(),
+               perNodeArchLength,
+               MPI_CHAR,
+               mpi_root,
+               MPI_COMM_WORLD);
 
     delete[] nodeResults;
 
-    if (rankId == mpi_root)
-    {
+    if (rankId == mpi_root) {
         /* Create an algorithm for principal component analysis using the correlation method on the master node */
         pca::Distributed<step2Master> masterAlgorithm;
 
-        for (size_t i = 0; i < nBlocks; i++)
-        {
+        for (size_t i = 0; i < nBlocks; i++) {
             /* Deserialize partial results from step 1 */
-            OutputDataArchive dataArch(serializedData.get() + perNodeArchLength * i, perNodeArchLength);
+            OutputDataArchive dataArch(serializedData.get() + perNodeArchLength * i,
+                                       perNodeArchLength);
 
             services::SharedPtr<pca::PartialResult<pca::correlationDense> > dataForStep2FromStep1 =
-                services::SharedPtr<pca::PartialResult<pca::correlationDense> >(new pca::PartialResult<pca::correlationDense>());
+                services::SharedPtr<pca::PartialResult<pca::correlationDense> >(
+                    new pca::PartialResult<pca::correlationDense>());
             dataForStep2FromStep1->deserialize(dataArch);
 
             /* Set local partial results as input for the master-node algorithm */

--- a/samples/daal/cpp/mpi/sources/pca_svd_distributed_mpi.cpp
+++ b/samples/daal/cpp/mpi/sources/pca_svd_distributed_mpi.cpp
@@ -44,19 +44,28 @@ size_t nFeatures;
 int rankId, comm_size;
 #define mpi_root 0
 
-const string datasetFileNames[] = { "./data/distributed/pca_normalized_1.csv", "./data/distributed/pca_normalized_2.csv",
-                                    "./data/distributed/pca_normalized_3.csv", "./data/distributed/pca_normalized_4.csv" };
+const string datasetFileNames[] = { "./data/distributed/pca_normalized_1.csv",
+                                    "./data/distributed/pca_normalized_2.csv",
+                                    "./data/distributed/pca_normalized_3.csv",
+                                    "./data/distributed/pca_normalized_4.csv" };
 
-int main(int argc, char * argv[])
-{
-    checkArguments(argc, argv, 4, &datasetFileNames[0], &datasetFileNames[1], &datasetFileNames[2], &datasetFileNames[3]);
+int main(int argc, char* argv[]) {
+    checkArguments(argc,
+                   argv,
+                   4,
+                   &datasetFileNames[0],
+                   &datasetFileNames[1],
+                   &datasetFileNames[2],
+                   &datasetFileNames[3]);
 
     MPI_Init(&argc, &argv);
     MPI_Comm_size(MPI_COMM_WORLD, &comm_size);
     MPI_Comm_rank(MPI_COMM_WORLD, &rankId);
 
     /* Initialize FileDataSource<CSVFeatureManager> to retrieve the input data from a .csv file */
-    FileDataSource<CSVFeatureManager> dataSource(datasetFileNames[rankId], DataSource::doAllocateNumericTable, DataSource::doDictionaryFromContext);
+    FileDataSource<CSVFeatureManager> dataSource(datasetFileNames[rankId],
+                                                 DataSource::doAllocateNumericTable,
+                                                 DataSource::doDictionaryFromContext);
 
     /* Retrieve the input data */
     dataSource.loadDataBlock();
@@ -77,31 +86,37 @@ int main(int argc, char * argv[])
     size_t perNodeArchLength = dataArch.getSizeOfArchive();
 
     /* Serialized data is of equal size on each node if each node called compute() equal number of times */
-    if (rankId == mpi_root)
-    {
+    if (rankId == mpi_root) {
         serializedData = services::SharedPtr<byte>(new byte[perNodeArchLength * nBlocks]);
     }
 
-    byte * nodeResults = new byte[perNodeArchLength];
+    byte* nodeResults = new byte[perNodeArchLength];
     dataArch.copyArchiveToArray(nodeResults, perNodeArchLength);
 
     /* Transfer partial results to step 2 on the root node */
-    MPI_Gather(nodeResults, perNodeArchLength, MPI_CHAR, serializedData.get(), perNodeArchLength, MPI_CHAR, mpi_root, MPI_COMM_WORLD);
+    MPI_Gather(nodeResults,
+               perNodeArchLength,
+               MPI_CHAR,
+               serializedData.get(),
+               perNodeArchLength,
+               MPI_CHAR,
+               mpi_root,
+               MPI_COMM_WORLD);
 
     delete[] nodeResults;
 
-    if (rankId == mpi_root)
-    {
+    if (rankId == mpi_root) {
         /* Create an algorithm for principal component analysis using the SVD method on the master node */
         pca::Distributed<step2Master, algorithmFPType, pca::svdDense> masterAlgorithm;
 
-        for (size_t i = 0; i < nBlocks; i++)
-        {
+        for (size_t i = 0; i < nBlocks; i++) {
             /* Deserialize partial results from step 1 */
-            OutputDataArchive dataArch(serializedData.get() + perNodeArchLength * i, perNodeArchLength);
+            OutputDataArchive dataArch(serializedData.get() + perNodeArchLength * i,
+                                       perNodeArchLength);
 
             services::SharedPtr<pca::PartialResult<pca::svdDense> > dataForStep2FromStep1 =
-                services::SharedPtr<pca::PartialResult<pca::svdDense> >(new pca::PartialResult<pca::svdDense>());
+                services::SharedPtr<pca::PartialResult<pca::svdDense> >(
+                    new pca::PartialResult<pca::svdDense>());
             dataForStep2FromStep1->deserialize(dataArch);
 
             /* Set local partial results as input for the master-node algorithm */

--- a/samples/daal/cpp/mpi/sources/qr_fast_distributed_mpi.cpp
+++ b/samples/daal/cpp/mpi/sources/qr_fast_distributed_mpi.cpp
@@ -37,7 +37,9 @@ using namespace daal::algorithms;
 /* Input data set parameters */
 const size_t nBlocks = 4;
 
-const string datasetFileNames[] = { "./data/distributed/qr_1.csv", "./data/distributed/qr_2.csv", "./data/distributed/qr_3.csv",
+const string datasetFileNames[] = { "./data/distributed/qr_1.csv",
+                                    "./data/distributed/qr_2.csv",
+                                    "./data/distributed/qr_3.csv",
                                     "./data/distributed/qr_4.csv" };
 
 void computestep1Local();
@@ -55,19 +57,23 @@ NumericTablePtr Qi;
 services::SharedPtr<byte> serializedData;
 size_t perNodeArchLength;
 
-int main(int argc, char * argv[])
-{
-    checkArguments(argc, argv, 4, &datasetFileNames[0], &datasetFileNames[1], &datasetFileNames[2], &datasetFileNames[3]);
+int main(int argc, char* argv[]) {
+    checkArguments(argc,
+                   argv,
+                   4,
+                   &datasetFileNames[0],
+                   &datasetFileNames[1],
+                   &datasetFileNames[2],
+                   &datasetFileNames[3]);
 
     MPI_Init(&argc, &argv);
     MPI_Comm_size(MPI_COMM_WORLD, &commSize);
     MPI_Comm_rank(MPI_COMM_WORLD, &rankId);
 
-    if (nBlocks != commSize)
-    {
-        if (rankId == mpiRoot)
-        {
-            std::cout << commSize << " MPI ranks != " << nBlocks << " datasets available, so please start exactly " << nBlocks << " ranks."
+    if (nBlocks != commSize) {
+        if (rankId == mpiRoot) {
+            std::cout << commSize << " MPI ranks != " << nBlocks
+                      << " datasets available, so please start exactly " << nBlocks << " ranks."
                       << std::endl;
         }
         MPI_Finalize();
@@ -76,16 +82,14 @@ int main(int argc, char * argv[])
 
     computestep1Local();
 
-    if (rankId == mpiRoot)
-    {
+    if (rankId == mpiRoot) {
         computeOnMasterNode();
     }
 
     finalizeComputestep1Local();
 
     /* Print the results */
-    if (rankId == mpiRoot)
-    {
+    if (rankId == mpiRoot) {
         printNumericTable(Qi, "Part of orthogonal matrix Q from 1st node:", 10);
         printNumericTable(R, "Triangular matrix R:");
     }
@@ -95,10 +99,11 @@ int main(int argc, char * argv[])
     return 0;
 }
 
-void computestep1Local()
-{
+void computestep1Local() {
     /* Initialize FileDataSource<CSVFeatureManager> to retrieve the input data from a .csv file */
-    FileDataSource<CSVFeatureManager> dataSource(datasetFileNames[rankId], DataSource::doAllocateNumericTable, DataSource::doDictionaryFromContext);
+    FileDataSource<CSVFeatureManager> dataSource(datasetFileNames[rankId],
+                                                 DataSource::doAllocateNumericTable,
+                                                 DataSource::doDictionaryFromContext);
 
     /* Retrieve the input data */
     dataSource.loadDataBlock();
@@ -121,32 +126,37 @@ void computestep1Local()
     perNodeArchLength = dataArch.getSizeOfArchive();
 
     /* Serialized data is of equal size on each node if each node called compute() equal number of times */
-    if (rankId == mpiRoot)
-    {
+    if (rankId == mpiRoot) {
         serializedData = services::SharedPtr<byte>(new byte[perNodeArchLength * nBlocks]);
     }
 
-    byte * nodeResults = new byte[perNodeArchLength];
+    byte* nodeResults = new byte[perNodeArchLength];
     dataArch.copyArchiveToArray(nodeResults, perNodeArchLength);
 
     /* Transfer partial results to step 2 on the root node */
 
-    MPI_Gather(nodeResults, perNodeArchLength, MPI_CHAR, serializedData.get(), perNodeArchLength, MPI_CHAR, mpiRoot, MPI_COMM_WORLD);
+    MPI_Gather(nodeResults,
+               perNodeArchLength,
+               MPI_CHAR,
+               serializedData.get(),
+               perNodeArchLength,
+               MPI_CHAR,
+               mpiRoot,
+               MPI_COMM_WORLD);
 
     delete[] nodeResults;
 }
 
-void computeOnMasterNode()
-{
+void computeOnMasterNode() {
     /* Create an algorithm to compute QR decomposition on the master node */
     qr::Distributed<step2Master> alg;
 
-    for (size_t i = 0; i < nBlocks; i++)
-    {
+    for (size_t i = 0; i < nBlocks; i++) {
         /* Deserialize partial results from step 1 */
         OutputDataArchive dataArch(serializedData.get() + perNodeArchLength * i, perNodeArchLength);
 
-        data_management::DataCollectionPtr dataForStep2FromStep1 = data_management::DataCollectionPtr(new data_management::DataCollection());
+        data_management::DataCollectionPtr dataForStep2FromStep1 =
+            data_management::DataCollectionPtr(new data_management::DataCollection());
         dataForStep2FromStep1->deserialize(dataArch);
 
         alg.input.add(qr::inputOfStep2FromStep1, i, dataForStep2FromStep1);
@@ -155,23 +165,22 @@ void computeOnMasterNode()
     /* Compute QR decomposition */
     alg.compute();
 
-    qr::DistributedPartialResultPtr pres             = alg.getPartialResult();
+    qr::DistributedPartialResultPtr pres = alg.getPartialResult();
     KeyValueDataCollectionPtr inputForStep3FromStep2 = pres->get(qr::outputOfStep2ForStep3);
 
-    for (size_t i = 0; i < nBlocks; i++)
-    {
+    for (size_t i = 0; i < nBlocks; i++) {
         /* Serialize partial results to transfer to local nodes for step 3 */
         InputDataArchive dataArch;
         (*inputForStep3FromStep2)[i]->serialize(dataArch);
 
-        if (i == 0)
-        {
+        if (i == 0) {
             perNodeArchLength = dataArch.getSizeOfArchive();
             /* Serialized data is of equal size for each node if it was equal in step 1 */
             serializedData = services::SharedPtr<byte>(new byte[perNodeArchLength * nBlocks]);
         }
 
-        dataArch.copyArchiveToArray(serializedData.get() + perNodeArchLength * i, perNodeArchLength);
+        dataArch.copyArchiveToArray(serializedData.get() + perNodeArchLength * i,
+                                    perNodeArchLength);
     }
 
     qr::ResultPtr res = alg.getResult();
@@ -179,21 +188,28 @@ void computeOnMasterNode()
     R = res->get(qr::matrixR);
 }
 
-void finalizeComputestep1Local()
-{
+void finalizeComputestep1Local() {
     /* Get the size of the serialized input */
     MPI_Bcast(&perNodeArchLength, sizeof(size_t), MPI_CHAR, mpiRoot, MPI_COMM_WORLD);
 
-    byte * nodeResults = new byte[perNodeArchLength];
+    byte* nodeResults = new byte[perNodeArchLength];
 
     /* Transfer partial results from the root node */
 
-    MPI_Scatter(serializedData.get(), perNodeArchLength, MPI_CHAR, nodeResults, perNodeArchLength, MPI_CHAR, mpiRoot, MPI_COMM_WORLD);
+    MPI_Scatter(serializedData.get(),
+                perNodeArchLength,
+                MPI_CHAR,
+                nodeResults,
+                perNodeArchLength,
+                MPI_CHAR,
+                mpiRoot,
+                MPI_COMM_WORLD);
 
     /* Deserialize partial results from step 2 */
     OutputDataArchive dataArch(nodeResults, perNodeArchLength);
 
-    data_management::DataCollectionPtr dataFromStep2ForStep3 = data_management::DataCollectionPtr(new data_management::DataCollection());
+    data_management::DataCollectionPtr dataFromStep2ForStep3 =
+        data_management::DataCollectionPtr(new data_management::DataCollection());
     dataFromStep2ForStep3->deserialize(dataArch);
 
     delete[] nodeResults;

--- a/samples/daal/cpp/mpi/sources/ridge_regression_norm_eq_distributed_mpi.cpp
+++ b/samples/daal/cpp/mpi/sources/ridge_regression_norm_eq_distributed_mpi.cpp
@@ -35,14 +35,17 @@ using namespace std;
 using namespace daal;
 using namespace daal::algorithms::ridge_regression;
 
-const string trainDatasetFileNames[] = { "./data/distributed/linear_regression_train_1.csv", "./data/distributed/linear_regression_train_2.csv",
-                                         "./data/distributed/linear_regression_train_3.csv", "./data/distributed/linear_regression_train_4.csv" };
-string testDatasetFileName           = "./data/distributed/linear_regression_test.csv";
+const string trainDatasetFileNames[] = { "./data/distributed/linear_regression_train_1.csv",
+                                         "./data/distributed/linear_regression_train_2.csv",
+                                         "./data/distributed/linear_regression_train_3.csv",
+                                         "./data/distributed/linear_regression_train_4.csv" };
+string testDatasetFileName = "./data/distributed/linear_regression_test.csv";
 
 const size_t nBlocks = 4;
 
-const size_t nFeatures           = 10; /* Number of features in training and testing data sets */
-const size_t nDependentVariables = 2;  /* Number of dependent variables that correspond to each observation */
+const size_t nFeatures = 10; /* Number of features in training and testing data sets */
+const size_t nDependentVariables =
+    2; /* Number of dependent variables that correspond to each observation */
 
 int rankId, comm_size;
 #define mpi_root 0
@@ -53,16 +56,14 @@ void testModel();
 training::ResultPtr trainingResult;
 prediction::ResultPtr predictionResult;
 
-int main(int argc, char * argv[])
-{
+int main(int argc, char* argv[]) {
     MPI_Init(&argc, &argv);
     MPI_Comm_size(MPI_COMM_WORLD, &comm_size);
     MPI_Comm_rank(MPI_COMM_WORLD, &rankId);
 
     trainModel();
 
-    if (rankId == mpi_root)
-    {
+    if (rankId == mpi_root) {
         testModel();
     }
 
@@ -71,15 +72,16 @@ int main(int argc, char * argv[])
     return 0;
 }
 
-void trainModel()
-{
+void trainModel() {
     /* Initialize FileDataSource<CSVFeatureManager> to retrieve the input data from a .csv file */
-    FileDataSource<CSVFeatureManager> trainDataSource(trainDatasetFileNames[rankId], DataSource::notAllocateNumericTable,
+    FileDataSource<CSVFeatureManager> trainDataSource(trainDatasetFileNames[rankId],
+                                                      DataSource::notAllocateNumericTable,
                                                       DataSource::doDictionaryFromContext);
 
     /* Create Numeric Tables for training data and labels */
     NumericTablePtr trainData(new HomogenNumericTable<>(nFeatures, 0, NumericTable::doNotAllocate));
-    NumericTablePtr trainDependentVariables(new HomogenNumericTable<>(nDependentVariables, 0, NumericTable::doNotAllocate));
+    NumericTablePtr trainDependentVariables(
+        new HomogenNumericTable<>(nDependentVariables, 0, NumericTable::doNotAllocate));
     NumericTablePtr mergedData(new MergedNumericTable(trainData, trainDependentVariables));
 
     /* Retrieve the data from the input file */
@@ -102,30 +104,36 @@ void trainModel()
     size_t perNodeArchLength = dataArch.getSizeOfArchive();
 
     /* Serialized data is of equal size on each node if each node called compute() equal number of times */
-    if (rankId == mpi_root)
-    {
+    if (rankId == mpi_root) {
         serializedData = services::SharedPtr<byte>(new byte[perNodeArchLength * nBlocks]);
     }
 
-    byte * nodeResults = new byte[perNodeArchLength];
+    byte* nodeResults = new byte[perNodeArchLength];
     dataArch.copyArchiveToArray(nodeResults, perNodeArchLength);
 
     /* Transfer partial results to step 2 on the root node */
-    MPI_Gather(nodeResults, perNodeArchLength, MPI_CHAR, serializedData.get(), perNodeArchLength, MPI_CHAR, mpi_root, MPI_COMM_WORLD);
+    MPI_Gather(nodeResults,
+               perNodeArchLength,
+               MPI_CHAR,
+               serializedData.get(),
+               perNodeArchLength,
+               MPI_CHAR,
+               mpi_root,
+               MPI_COMM_WORLD);
 
     delete[] nodeResults;
 
-    if (rankId == mpi_root)
-    {
+    if (rankId == mpi_root) {
         /* Create an algorithm object to build the final ridge regression model on the master node */
         training::Distributed<step2Master> masterAlgorithm;
 
-        for (size_t i = 0; i < nBlocks; ++i)
-        {
+        for (size_t i = 0; i < nBlocks; ++i) {
             /* Deserialize partial results from step 1 */
-            OutputDataArchive dataArch(serializedData.get() + perNodeArchLength * i, perNodeArchLength);
+            OutputDataArchive dataArch(serializedData.get() + perNodeArchLength * i,
+                                       perNodeArchLength);
 
-            training::PartialResultPtr dataForStep2FromStep1 = training::PartialResultPtr(new training::PartialResult());
+            training::PartialResultPtr dataForStep2FromStep1 =
+                training::PartialResultPtr(new training::PartialResult());
             dataForStep2FromStep1->deserialize(dataArch);
 
             /* Set the local ridge regression model as input for the master-node algorithm */
@@ -138,18 +146,21 @@ void trainModel()
 
         /* Retrieve the algorithm results */
         trainingResult = masterAlgorithm.getResult();
-        printNumericTable(trainingResult->get(training::model)->getBeta(), "Ridge Regression coefficients:");
+        printNumericTable(trainingResult->get(training::model)->getBeta(),
+                          "Ridge Regression coefficients:");
     }
 }
 
-void testModel()
-{
+void testModel() {
     /* Initialize FileDataSource<CSVFeatureManager> to retrieve the input data from a .csv file */
-    FileDataSource<CSVFeatureManager> testDataSource(testDatasetFileName, DataSource::doAllocateNumericTable, DataSource::doDictionaryFromContext);
+    FileDataSource<CSVFeatureManager> testDataSource(testDatasetFileName,
+                                                     DataSource::doAllocateNumericTable,
+                                                     DataSource::doDictionaryFromContext);
 
     /* Create Numeric Tables for testing data and ground truth values */
     NumericTablePtr testData(new HomogenNumericTable<>(nFeatures, 0, NumericTable::doNotAllocate));
-    NumericTablePtr testGroundTruth(new HomogenNumericTable<>(nDependentVariables, 0, NumericTable::doNotAllocate));
+    NumericTablePtr testGroundTruth(
+        new HomogenNumericTable<>(nDependentVariables, 0, NumericTable::doNotAllocate));
     NumericTablePtr mergedData(new MergedNumericTable(testData, testGroundTruth));
 
     /* Retrieve the data from an input file */
@@ -167,6 +178,8 @@ void testModel()
 
     /* Retrieve the algorithm results */
     predictionResult = algorithm.getResult();
-    printNumericTable(predictionResult->get(prediction::prediction), "Ridge Regression prediction results: (first 10 rows):", 10);
+    printNumericTable(predictionResult->get(prediction::prediction),
+                      "Ridge Regression prediction results: (first 10 rows):",
+                      10);
     printNumericTable(testGroundTruth, "Ground truth (first 10 rows):", 10);
 }

--- a/samples/daal/cpp/mpi/sources/service.h
+++ b/samples/daal/cpp/mpi/sources/service.h
@@ -41,11 +41,9 @@ using namespace daal::data_management;
 
 typedef std::vector<daal::byte> ByteBuffer;
 
-size_t readTextFile(const std::string & datasetFileName, daal::byte ** data)
-{
+size_t readTextFile(const std::string &datasetFileName, daal::byte **data) {
     std::ifstream file(datasetFileName.c_str(), std::ios::binary | std::ios::ate);
-    if (!file.is_open())
-    {
+    if (!file.is_open()) {
         fileOpenError(datasetFileName.c_str());
     }
 
@@ -57,8 +55,7 @@ size_t readTextFile(const std::string & datasetFileName, daal::byte ** data)
     (*data) = new daal::byte[fileSize];
     checkAllocation(data);
 
-    if (!file.read((char *)(*data), fileSize))
-    {
+    if (!file.read((char *)(*data), fileSize)) {
         delete[] data;
         fileReadError();
     }
@@ -67,12 +64,10 @@ size_t readTextFile(const std::string & datasetFileName, daal::byte ** data)
 }
 
 template <typename item_type>
-void readLine(std::string & line, size_t nCols, item_type * data, size_t firstPos = 0)
-{
+void readLine(std::string &line, size_t nCols, item_type *data, size_t firstPos = 0) {
     std::stringstream iss(line);
 
-    for (size_t col = 0; col < nCols; ++col)
-    {
+    for (size_t col = 0; col < nCols; ++col) {
         std::string val;
         std::getline(iss, val, ',');
 
@@ -82,36 +77,32 @@ void readLine(std::string & line, size_t nCols, item_type * data, size_t firstPo
 }
 
 template <typename item_type>
-void readRowUnknownLength(char * line, std::vector<item_type> & data)
-{
-    size_t n               = 0;
-    const char * prevDelim = line - 1;
-    char * ptr             = line;
-    for (; *ptr; ++ptr)
-    {
-        if (*ptr == ',' || *ptr == '\r')
-        {
-            if (prevDelim != ptr - 1) ++n;
-            *ptr      = ' ';
+void readRowUnknownLength(char *line, std::vector<item_type> &data) {
+    size_t n = 0;
+    const char *prevDelim = line - 1;
+    char *ptr = line;
+    for (; *ptr; ++ptr) {
+        if (*ptr == ',' || *ptr == '\r') {
+            if (prevDelim != ptr - 1)
+                ++n;
+            *ptr = ' ';
             prevDelim = ptr;
         }
     }
-    if (prevDelim != ptr - 1) ++n;
+    if (prevDelim != ptr - 1)
+        ++n;
     data.resize(n);
     std::stringstream iss(line);
-    for (size_t i = 0; i < n; ++i)
-    {
+    for (size_t i = 0; i < n; ++i) {
         iss >> data[i];
     }
 }
 
 template <typename item_type>
-CSRNumericTable * createSparseTable(const std::string & datasetFileName)
-{
+CSRNumericTable *createSparseTable(const std::string &datasetFileName) {
     std::ifstream file(datasetFileName.c_str());
 
-    if (!file.is_open())
-    {
+    if (!file.is_open()) {
         fileOpenError(datasetFileName.c_str());
     }
 
@@ -121,7 +112,8 @@ CSRNumericTable * createSparseTable(const std::string & datasetFileName)
     std::getline(file, str);
     std::vector<size_t> rowOffsets;
     readRowUnknownLength<size_t>(&str[0], rowOffsets);
-    if (!rowOffsets.size()) return NULL;
+    if (!rowOffsets.size())
+        return NULL;
     const size_t nVectors = rowOffsets.size() - 1;
 
     //read cols indices
@@ -136,61 +128,59 @@ CSRNumericTable * createSparseTable(const std::string & datasetFileName)
     const size_t nNonZeros = data.size();
 
     size_t maxCol = 0;
-    for (size_t i = 0; i < colIndices.size(); ++i)
-    {
-        if (colIndices[i] > maxCol) maxCol = colIndices[i];
+    for (size_t i = 0; i < colIndices.size(); ++i) {
+        if (colIndices[i] > maxCol)
+            maxCol = colIndices[i];
     }
     const size_t nFeatures = maxCol;
 
-    if (!nFeatures || !nVectors || colIndices.size() != nNonZeros || nNonZeros != (rowOffsets[nVectors] - 1))
-    {
+    if (!nFeatures || !nVectors || colIndices.size() != nNonZeros ||
+        nNonZeros != (rowOffsets[nVectors] - 1)) {
         sparceFileReadError();
     }
 
-    size_t * resultRowOffsets      = NULL;
-    size_t * resultColIndices      = NULL;
-    item_type * resultData         = NULL;
-    CSRNumericTable * numericTable = new CSRNumericTable(resultData, resultColIndices, resultRowOffsets, nFeatures, nVectors);
+    size_t *resultRowOffsets = NULL;
+    size_t *resultColIndices = NULL;
+    item_type *resultData = NULL;
+    CSRNumericTable *numericTable =
+        new CSRNumericTable(resultData, resultColIndices, resultRowOffsets, nFeatures, nVectors);
     numericTable->allocateDataMemory(nNonZeros);
     numericTable->getArrays<item_type>(&resultData, &resultColIndices, &resultRowOffsets);
-    for (size_t i = 0; i < nNonZeros; ++i)
-    {
-        resultData[i]       = data[i];
+    for (size_t i = 0; i < nNonZeros; ++i) {
+        resultData[i] = data[i];
         resultColIndices[i] = colIndices[i];
     }
-    for (size_t i = 0; i < nVectors + 1; ++i)
-    {
+    for (size_t i = 0; i < nVectors + 1; ++i) {
         resultRowOffsets[i] = rowOffsets[i];
     }
     return numericTable;
 }
 
-void printAprioriItemsets(NumericTablePtr largeItemsetsTable, NumericTablePtr largeItemsetsSupportTable, size_t nItemsetToPrint = 20)
-{
-    size_t largeItemsetCount     = largeItemsetsSupportTable->getNumberOfRows();
+void printAprioriItemsets(NumericTablePtr largeItemsetsTable,
+                          NumericTablePtr largeItemsetsSupportTable,
+                          size_t nItemsetToPrint = 20) {
+    size_t largeItemsetCount = largeItemsetsSupportTable->getNumberOfRows();
     size_t nItemsInLargeItemsets = largeItemsetsTable->getNumberOfRows();
 
     BlockDescriptor<int> block1;
     largeItemsetsTable->getBlockOfRows(0, nItemsInLargeItemsets, readOnly, block1);
-    int * largeItemsets = block1.getBlockPtr();
+    int *largeItemsets = block1.getBlockPtr();
 
     BlockDescriptor<int> block2;
     largeItemsetsSupportTable->getBlockOfRows(0, largeItemsetCount, readOnly, block2);
-    int * largeItemsetsSupportData = block2.getBlockPtr();
+    int *largeItemsetsSupportData = block2.getBlockPtr();
 
     std::vector<std::vector<size_t> > largeItemsetsVector;
     largeItemsetsVector.resize(largeItemsetCount);
 
-    for (size_t i = 0; i < nItemsInLargeItemsets; i++)
-    {
+    for (size_t i = 0; i < nItemsInLargeItemsets; i++) {
         largeItemsetsVector[largeItemsets[2 * i]].push_back(largeItemsets[2 * i + 1]);
     }
 
     std::vector<size_t> supportVector;
     supportVector.resize(largeItemsetCount);
 
-    for (size_t i = 0; i < largeItemsetCount; i++)
-    {
+    for (size_t i = 0; i < largeItemsetCount; i++) {
         supportVector[largeItemsetsSupportData[2 * i]] = largeItemsetsSupportData[2 * i + 1];
     }
 
@@ -201,12 +191,12 @@ void printAprioriItemsets(NumericTablePtr largeItemsetsTable, NumericTablePtr la
               << "Itemset"
               << "\t\t\tSupport" << std::endl;
 
-    size_t iMin = (((largeItemsetCount > nItemsetToPrint) && (nItemsetToPrint != 0)) ? largeItemsetCount - nItemsetToPrint : 0);
-    for (size_t i = iMin; i < largeItemsetCount; i++)
-    {
+    size_t iMin = (((largeItemsetCount > nItemsetToPrint) && (nItemsetToPrint != 0))
+                       ? largeItemsetCount - nItemsetToPrint
+                       : 0);
+    for (size_t i = iMin; i < largeItemsetCount; i++) {
         std::cout << "{";
-        for (size_t l = 0; l < largeItemsetsVector[i].size() - 1; l++)
-        {
+        for (size_t l = 0; l < largeItemsetsVector[i].size() - 1; l++) {
             std::cout << largeItemsetsVector[i][l] << ", ";
         }
         std::cout << largeItemsetsVector[i][largeItemsetsVector[i].size() - 1] << "}\t\t";
@@ -218,51 +208,49 @@ void printAprioriItemsets(NumericTablePtr largeItemsetsTable, NumericTablePtr la
     largeItemsetsSupportTable->releaseBlockOfRows(block2);
 }
 
-void printAprioriRules(NumericTablePtr leftItemsTable, NumericTablePtr rightItemsTable, NumericTablePtr confidenceTable, size_t nRulesToPrint = 20)
-{
-    size_t nRules      = confidenceTable->getNumberOfRows();
-    size_t nLeftItems  = leftItemsTable->getNumberOfRows();
+void printAprioriRules(NumericTablePtr leftItemsTable,
+                       NumericTablePtr rightItemsTable,
+                       NumericTablePtr confidenceTable,
+                       size_t nRulesToPrint = 20) {
+    size_t nRules = confidenceTable->getNumberOfRows();
+    size_t nLeftItems = leftItemsTable->getNumberOfRows();
     size_t nRightItems = rightItemsTable->getNumberOfRows();
 
     BlockDescriptor<int> block1;
     leftItemsTable->getBlockOfRows(0, nLeftItems, readOnly, block1);
-    int * leftItems = block1.getBlockPtr();
+    int *leftItems = block1.getBlockPtr();
 
     BlockDescriptor<int> block2;
     rightItemsTable->getBlockOfRows(0, nRightItems, readOnly, block2);
-    int * rightItems = block2.getBlockPtr();
+    int *rightItems = block2.getBlockPtr();
 
     BlockDescriptor<DAAL_DATA_TYPE> block3;
     confidenceTable->getBlockOfRows(0, nRules, readOnly, block3);
-    DAAL_DATA_TYPE * confidence = block3.getBlockPtr();
+    DAAL_DATA_TYPE *confidence = block3.getBlockPtr();
 
     std::vector<std::vector<size_t> > leftItemsVector;
     leftItemsVector.resize(nRules);
 
-    if (nRules == 0)
-    {
+    if (nRules == 0) {
         std::cout << std::endl << "No association rules were found " << std::endl;
         return;
     }
 
-    for (size_t i = 0; i < nLeftItems; i++)
-    {
+    for (size_t i = 0; i < nLeftItems; i++) {
         leftItemsVector[leftItems[2 * i]].push_back(leftItems[2 * i + 1]);
     }
 
     std::vector<std::vector<size_t> > rightItemsVector;
     rightItemsVector.resize(nRules);
 
-    for (size_t i = 0; i < nRightItems; i++)
-    {
+    for (size_t i = 0; i < nRightItems; i++) {
         rightItemsVector[rightItems[2 * i]].push_back(rightItems[2 * i + 1]);
     }
 
     std::vector<DAAL_DATA_TYPE> confidenceVector;
     confidenceVector.resize(nRules);
 
-    for (size_t i = 0; i < nRules; i++)
-    {
+    for (size_t i = 0; i < nRules; i++) {
         confidenceVector[i] = confidence[i];
     }
 
@@ -270,19 +258,17 @@ void printAprioriRules(NumericTablePtr leftItemsTable, NumericTablePtr rightItem
     std::cout << std::endl
               << "Rule"
               << "\t\t\t\tConfidence" << std::endl;
-    size_t iMin = (((nRules > nRulesToPrint) && (nRulesToPrint != 0)) ? (nRules - nRulesToPrint) : 0);
+    size_t iMin =
+        (((nRules > nRulesToPrint) && (nRulesToPrint != 0)) ? (nRules - nRulesToPrint) : 0);
 
-    for (size_t i = iMin; i < nRules; i++)
-    {
+    for (size_t i = iMin; i < nRules; i++) {
         std::cout << "{";
-        for (size_t l = 0; l < leftItemsVector[i].size() - 1; l++)
-        {
+        for (size_t l = 0; l < leftItemsVector[i].size() - 1; l++) {
             std::cout << leftItemsVector[i][l] << ", ";
         }
         std::cout << leftItemsVector[i][leftItemsVector[i].size() - 1] << "} => {";
 
-        for (size_t l = 0; l < rightItemsVector[i].size() - 1; l++)
-        {
+        for (size_t l = 0; l < rightItemsVector[i].size() - 1; l++) {
             std::cout << rightItemsVector[i][l] << ", ";
         }
         std::cout << rightItemsVector[i][rightItemsVector[i].size() - 1] << "}\t\t";
@@ -295,45 +281,43 @@ void printAprioriRules(NumericTablePtr leftItemsTable, NumericTablePtr rightItem
     confidenceTable->releaseBlockOfRows(block3);
 }
 
-bool isFull(NumericTableIface::StorageLayout layout)
-{
+bool isFull(NumericTableIface::StorageLayout layout) {
     int layoutInt = (int)layout;
-    if (packed_mask & layoutInt)
-    {
+    if (packed_mask & layoutInt) {
         return false;
     }
     return true;
 }
 
-bool isUpper(NumericTableIface::StorageLayout layout)
-{
-    if (layout == NumericTableIface::upperPackedSymmetricMatrix || layout == NumericTableIface::upperPackedTriangularMatrix)
-    {
+bool isUpper(NumericTableIface::StorageLayout layout) {
+    if (layout == NumericTableIface::upperPackedSymmetricMatrix ||
+        layout == NumericTableIface::upperPackedTriangularMatrix) {
         return true;
     }
     return false;
 }
 
-bool isLower(NumericTableIface::StorageLayout layout)
-{
-    if (layout == NumericTableIface::lowerPackedSymmetricMatrix || layout == NumericTableIface::lowerPackedTriangularMatrix)
-    {
+bool isLower(NumericTableIface::StorageLayout layout) {
+    if (layout == NumericTableIface::lowerPackedSymmetricMatrix ||
+        layout == NumericTableIface::lowerPackedTriangularMatrix) {
         return true;
     }
     return false;
 }
 
 template <typename T>
-void printArray(T * array, const size_t nPrintedCols, const size_t nPrintedRows, const size_t nCols, const std::string & message,
-                size_t interval = 10)
-{
+void printArray(T *array,
+                const size_t nPrintedCols,
+                const size_t nPrintedRows,
+                const size_t nCols,
+                const std::string &message,
+                size_t interval = 10) {
     std::cout << std::setiosflags(std::ios::left);
     std::cout << message << std::endl;
-    for (size_t i = 0; i < nPrintedRows; i++)
-    {
-        for (size_t j = 0; j < nPrintedCols; j++)
-        {
-            std::cout << std::setw(interval) << std::setiosflags(std::ios::fixed) << std::setprecision(3);
+    for (size_t i = 0; i < nPrintedRows; i++) {
+        for (size_t j = 0; j < nPrintedCols; j++) {
+            std::cout << std::setw(interval) << std::setiosflags(std::ios::fixed)
+                      << std::setprecision(3);
             std::cout << array[i * nCols + j];
         }
         std::cout << std::endl;
@@ -342,22 +326,26 @@ void printArray(T * array, const size_t nPrintedCols, const size_t nPrintedRows,
 }
 
 template <typename T>
-void printArray(T * array, const size_t nCols, const size_t nRows, const std::string & message, size_t interval = 10)
-{
+void printArray(T *array,
+                const size_t nCols,
+                const size_t nRows,
+                const std::string &message,
+                size_t interval = 10) {
     printArray(array, nCols, nRows, nCols, message, interval);
 }
 
 template <typename T>
-void printLowerArray(T * array, const size_t nPrintedRows, const std::string & message, size_t interval = 10)
-{
+void printLowerArray(T *array,
+                     const size_t nPrintedRows,
+                     const std::string &message,
+                     size_t interval = 10) {
     std::cout << std::setiosflags(std::ios::left);
     std::cout << message << std::endl;
     int ind = 0;
-    for (size_t i = 0; i < nPrintedRows; i++)
-    {
-        for (size_t j = 0; j <= i; j++)
-        {
-            std::cout << std::setw(interval) << std::setiosflags(std::ios::fixed) << std::setprecision(3);
+    for (size_t i = 0; i < nPrintedRows; i++) {
+        for (size_t j = 0; j <= i; j++) {
+            std::cout << std::setw(interval) << std::setiosflags(std::ios::fixed)
+                      << std::setprecision(3);
             std::cout << array[ind++];
         }
         std::cout << std::endl;
@@ -366,25 +354,25 @@ void printLowerArray(T * array, const size_t nPrintedRows, const std::string & m
 }
 
 template <typename T>
-void printUpperArray(T * array, const size_t nPrintedCols, const size_t nPrintedRows, const size_t nCols, const std::string & message,
-                     size_t interval = 10)
-{
+void printUpperArray(T *array,
+                     const size_t nPrintedCols,
+                     const size_t nPrintedRows,
+                     const size_t nCols,
+                     const std::string &message,
+                     size_t interval = 10) {
     std::cout << std::setiosflags(std::ios::left);
     std::cout << message << std::endl;
     int ind = 0;
-    for (size_t i = 0; i < nPrintedRows; i++)
-    {
-        for (size_t j = 0; j < i; j++)
-        {
+    for (size_t i = 0; i < nPrintedRows; i++) {
+        for (size_t j = 0; j < i; j++) {
             std::cout << "          ";
         }
-        for (size_t j = i; j < nPrintedCols; j++)
-        {
-            std::cout << std::setw(interval) << std::setiosflags(std::ios::fixed) << std::setprecision(3);
+        for (size_t j = i; j < nPrintedCols; j++) {
+            std::cout << std::setw(interval) << std::setiosflags(std::ios::fixed)
+                      << std::setprecision(3);
             std::cout << array[ind++];
         }
-        for (size_t j = nPrintedCols; j < nCols; j++)
-        {
+        for (size_t j = nPrintedCols; j < nCols; j++) {
             ind++;
         }
         std::cout << std::endl;
@@ -392,80 +380,92 @@ void printUpperArray(T * array, const size_t nPrintedCols, const size_t nPrinted
     std::cout << std::endl;
 }
 
-void printNumericTable(NumericTable * dataTable, const char * message = "", size_t nPrintedRows = 0, size_t nPrintedCols = 0, size_t interval = 10)
-{
-    size_t nRows                            = dataTable->getNumberOfRows();
-    size_t nCols                            = dataTable->getNumberOfColumns();
+void printNumericTable(NumericTable *dataTable,
+                       const char *message = "",
+                       size_t nPrintedRows = 0,
+                       size_t nPrintedCols = 0,
+                       size_t interval = 10) {
+    size_t nRows = dataTable->getNumberOfRows();
+    size_t nCols = dataTable->getNumberOfColumns();
     NumericTableIface::StorageLayout layout = dataTable->getDataLayout();
 
-    if (nPrintedRows != 0)
-    {
+    if (nPrintedRows != 0) {
         nPrintedRows = std::min(nRows, nPrintedRows);
     }
-    else
-    {
+    else {
         nPrintedRows = nRows;
     }
 
-    if (nPrintedCols != 0)
-    {
+    if (nPrintedCols != 0) {
         nPrintedCols = std::min(nCols, nPrintedCols);
     }
-    else
-    {
+    else {
         nPrintedCols = nCols;
     }
 
     BlockDescriptor<DAAL_DATA_TYPE> block;
-    if (isFull(layout) || layout == NumericTableIface::csrArray)
-    {
+    if (isFull(layout) || layout == NumericTableIface::csrArray) {
         dataTable->getBlockOfRows(0, nRows, readOnly, block);
-        printArray<DAAL_DATA_TYPE>(block.getBlockPtr(), nPrintedCols, nPrintedRows, nCols, message, interval);
+        printArray<DAAL_DATA_TYPE>(block.getBlockPtr(),
+                                   nPrintedCols,
+                                   nPrintedRows,
+                                   nCols,
+                                   message,
+                                   interval);
         dataTable->releaseBlockOfRows(block);
     }
-    else
-    {
-        PackedArrayNumericTableIface * packedTable = dynamic_cast<PackedArrayNumericTableIface *>(dataTable);
+    else {
+        PackedArrayNumericTableIface *packedTable =
+            dynamic_cast<PackedArrayNumericTableIface *>(dataTable);
         packedTable->getPackedArray(readOnly, block);
-        if (isLower(layout))
-        {
+        if (isLower(layout)) {
             printLowerArray<DAAL_DATA_TYPE>(block.getBlockPtr(), nPrintedRows, message, interval);
         }
-        else if (isUpper(layout))
-        {
-            printUpperArray<DAAL_DATA_TYPE>(block.getBlockPtr(), nPrintedCols, nPrintedRows, nCols, message, interval);
+        else if (isUpper(layout)) {
+            printUpperArray<DAAL_DATA_TYPE>(block.getBlockPtr(),
+                                            nPrintedCols,
+                                            nPrintedRows,
+                                            nCols,
+                                            message,
+                                            interval);
         }
         packedTable->releasePackedArray(block);
     }
 }
 
-void printNumericTable(NumericTable & dataTable, const char * message = "", size_t nPrintedRows = 0, size_t nPrintedCols = 0, size_t interval = 10)
-{
+void printNumericTable(NumericTable &dataTable,
+                       const char *message = "",
+                       size_t nPrintedRows = 0,
+                       size_t nPrintedCols = 0,
+                       size_t interval = 10) {
     printNumericTable(&dataTable, message, nPrintedRows, nPrintedCols, interval);
 }
 
-void printNumericTable(const NumericTablePtr & dataTable, const char * message = "", size_t nPrintedRows = 0, size_t nPrintedCols = 0,
-                       size_t interval = 10)
-{
+void printNumericTable(const NumericTablePtr &dataTable,
+                       const char *message = "",
+                       size_t nPrintedRows = 0,
+                       size_t nPrintedCols = 0,
+                       size_t interval = 10) {
     printNumericTable(dataTable.get(), message, nPrintedRows, nPrintedCols, interval);
 }
 
-void printPackedNumericTable(NumericTable * dataTable, size_t nFeatures, const char * message = "", size_t interval = 10)
-{
+void printPackedNumericTable(NumericTable *dataTable,
+                             size_t nFeatures,
+                             const char *message = "",
+                             size_t interval = 10) {
     BlockDescriptor<DAAL_DATA_TYPE> block;
 
     dataTable->getBlockOfRows(0, 1, readOnly, block);
 
-    DAAL_DATA_TYPE * data = block.getBlockPtr();
+    DAAL_DATA_TYPE *data = block.getBlockPtr();
 
     std::cout << std::setiosflags(std::ios::left);
     std::cout << message << std::endl;
     size_t index = 0;
-    for (size_t i = 0; i < nFeatures; i++)
-    {
-        for (size_t j = 0; j <= i; j++, index++)
-        {
-            std::cout << std::setw(interval) << std::setiosflags(std::ios::fixed) << std::setprecision(3);
+    for (size_t i = 0; i < nFeatures; i++) {
+        for (size_t j = 0; j <= i; j++, index++) {
+            std::cout << std::setw(interval) << std::setiosflags(std::ios::fixed)
+                      << std::setprecision(3);
             std::cout << data[index];
         }
         std::cout << std::endl;
@@ -475,15 +475,21 @@ void printPackedNumericTable(NumericTable * dataTable, size_t nFeatures, const c
     dataTable->releaseBlockOfRows(block);
 }
 
-void printPackedNumericTable(NumericTable & dataTable, size_t nFeatures, const char * message = "", size_t interval = 10)
-{
+void printPackedNumericTable(NumericTable &dataTable,
+                             size_t nFeatures,
+                             const char *message = "",
+                             size_t interval = 10) {
     printPackedNumericTable(&dataTable, nFeatures, message);
 }
 
 template <typename type1, typename type2>
-void printNumericTables(NumericTable * dataTable1, NumericTable * dataTable2, const char * title1 = "", const char * title2 = "",
-                        const char * message = "", size_t nPrintedRows = 0, size_t interval = 15)
-{
+void printNumericTables(NumericTable *dataTable1,
+                        NumericTable *dataTable2,
+                        const char *title1 = "",
+                        const char *title2 = "",
+                        const char *message = "",
+                        size_t nPrintedRows = 0,
+                        size_t interval = 15) {
     size_t nRows1 = dataTable1->getNumberOfRows();
     size_t nRows2 = dataTable2->getNumberOfRows();
     size_t nCols1 = dataTable1->getNumberOfColumns();
@@ -493,30 +499,27 @@ void printNumericTables(NumericTable * dataTable1, NumericTable * dataTable2, co
     BlockDescriptor<type2> block2;
 
     size_t nRows = std::min(nRows1, nRows2);
-    if (nPrintedRows != 0)
-    {
+    if (nPrintedRows != 0) {
         nRows = std::min(std::min(nRows1, nRows2), nPrintedRows);
     }
 
     dataTable1->getBlockOfRows(0, nRows, readOnly, block1);
     dataTable2->getBlockOfRows(0, nRows, readOnly, block2);
 
-    type1 * data1 = block1.getBlockPtr();
-    type2 * data2 = block2.getBlockPtr();
+    type1 *data1 = block1.getBlockPtr();
+    type2 *data2 = block2.getBlockPtr();
 
     std::cout << std::setiosflags(std::ios::left);
     std::cout << message << std::endl;
     std::cout << std::setw(interval * nCols1) << title1;
     std::cout << std::setw(interval * nCols2) << title2 << std::endl;
-    for (size_t i = 0; i < nRows; i++)
-    {
-        for (size_t j = 0; j < nCols1; j++)
-        {
-            std::cout << std::setw(interval) << std::setiosflags(std::ios::fixed) << std::setprecision(3);
+    for (size_t i = 0; i < nRows; i++) {
+        for (size_t j = 0; j < nCols1; j++) {
+            std::cout << std::setw(interval) << std::setiosflags(std::ios::fixed)
+                      << std::setprecision(3);
             std::cout << data1[i * nCols1 + j];
         }
-        for (size_t j = 0; j < nCols2; j++)
-        {
+        for (size_t j = 0; j < nCols2; j++) {
             std::cout << std::setprecision(0) << std::setw(interval) << data2[i * nCols2 + j];
         }
         std::cout << std::endl;
@@ -528,15 +531,29 @@ void printNumericTables(NumericTable * dataTable1, NumericTable * dataTable2, co
 }
 
 template <typename type1, typename type2>
-void printNumericTables(NumericTable * dataTable1, NumericTable & dataTable2, const char * title1 = "", const char * title2 = "",
-                        const char * message = "", size_t nPrintedRows = 0, size_t interval = 10)
-{
-    printNumericTables<type1, type2>(dataTable1, &dataTable2, title1, title2, message, nPrintedRows, interval);
+void printNumericTables(NumericTable *dataTable1,
+                        NumericTable &dataTable2,
+                        const char *title1 = "",
+                        const char *title2 = "",
+                        const char *message = "",
+                        size_t nPrintedRows = 0,
+                        size_t interval = 10) {
+    printNumericTables<type1, type2>(dataTable1,
+                                     &dataTable2,
+                                     title1,
+                                     title2,
+                                     message,
+                                     nPrintedRows,
+                                     interval);
 }
 
-void printNumericTables(NumericTable * dataTable1, NumericTable * dataTable2, const char * title1 = "", const char * title2 = "",
-                        const char * message = "", size_t nPrintedRows = 0, size_t interval = 10)
-{
+void printNumericTables(NumericTable *dataTable1,
+                        NumericTable *dataTable2,
+                        const char *title1 = "",
+                        const char *title2 = "",
+                        const char *message = "",
+                        size_t nPrintedRows = 0,
+                        size_t interval = 10) {
     size_t nRows1 = dataTable1->getNumberOfRows();
     size_t nRows2 = dataTable2->getNumberOfRows();
     size_t nCols1 = dataTable1->getNumberOfColumns();
@@ -546,30 +563,27 @@ void printNumericTables(NumericTable * dataTable1, NumericTable * dataTable2, co
     BlockDescriptor<DAAL_DATA_TYPE> block2;
 
     size_t nRows = std::min(nRows1, nRows2);
-    if (nPrintedRows != 0)
-    {
+    if (nPrintedRows != 0) {
         nRows = std::min(std::min(nRows1, nRows2), nPrintedRows);
     }
 
     dataTable1->getBlockOfRows(0, nRows, readOnly, block1);
     dataTable2->getBlockOfRows(0, nRows, readOnly, block2);
 
-    DAAL_DATA_TYPE * data1 = block1.getBlockPtr();
-    DAAL_DATA_TYPE * data2 = block2.getBlockPtr();
+    DAAL_DATA_TYPE *data1 = block1.getBlockPtr();
+    DAAL_DATA_TYPE *data2 = block2.getBlockPtr();
 
     std::cout << std::setiosflags(std::ios::left);
     std::cout << message << std::endl;
     std::cout << std::setw(interval * nCols1) << title1;
     std::cout << std::setw(interval * nCols2) << title2 << std::endl;
-    for (size_t i = 0; i < nRows; i++)
-    {
-        for (size_t j = 0; j < nCols1; j++)
-        {
-            std::cout << std::setw(interval) << std::setiosflags(std::ios::fixed) << std::setprecision(3);
+    for (size_t i = 0; i < nRows; i++) {
+        for (size_t j = 0; j < nCols1; j++) {
+            std::cout << std::setw(interval) << std::setiosflags(std::ios::fixed)
+                      << std::setprecision(3);
             std::cout << data1[i * nCols1 + j];
         }
-        for (size_t j = 0; j < nCols2; j++)
-        {
+        for (size_t j = 0; j < nCols2; j++) {
             std::cout << std::setprecision(0) << std::setw(interval) << data2[i * nCols2 + j];
         }
         std::cout << std::endl;
@@ -580,112 +594,103 @@ void printNumericTables(NumericTable * dataTable1, NumericTable * dataTable2, co
     dataTable2->releaseBlockOfRows(block2);
 }
 
-void printNumericTables(NumericTable * dataTable1, NumericTable & dataTable2, const char * title1 = "", const char * title2 = "",
-                        const char * message = "", size_t nPrintedRows = 0, size_t interval = 10)
-{
+void printNumericTables(NumericTable *dataTable1,
+                        NumericTable &dataTable2,
+                        const char *title1 = "",
+                        const char *title2 = "",
+                        const char *message = "",
+                        size_t nPrintedRows = 0,
+                        size_t interval = 10) {
     printNumericTables(dataTable1, &dataTable2, title1, title2, message, nPrintedRows, interval);
 }
 
 template <typename type1, typename type2>
-void printNumericTables(NumericTablePtr dataTable1, NumericTablePtr dataTable2, const char * title1 = "", const char * title2 = "",
-                        const char * message = "", size_t nPrintedRows = 0, size_t interval = 10)
-{
-    printNumericTables<type1, type2>(dataTable1.get(), dataTable2.get(), title1, title2, message, nPrintedRows, interval);
+void printNumericTables(NumericTablePtr dataTable1,
+                        NumericTablePtr dataTable2,
+                        const char *title1 = "",
+                        const char *title2 = "",
+                        const char *message = "",
+                        size_t nPrintedRows = 0,
+                        size_t interval = 10) {
+    printNumericTables<type1, type2>(dataTable1.get(),
+                                     dataTable2.get(),
+                                     title1,
+                                     title2,
+                                     message,
+                                     nPrintedRows,
+                                     interval);
 }
 
-bool checkFileIsAvailable(std::string filename, bool needExit = false)
-{
+bool checkFileIsAvailable(std::string filename, bool needExit = false) {
     std::ifstream file(filename.c_str());
-    if (file.good())
-    {
+    if (file.good()) {
         return true;
     }
-    else
-    {
+    else {
         std::cout << "Can't open file " << filename << std::endl;
-        if (needExit)
-        {
+        if (needExit) {
             exit(fileError);
         }
         return false;
     }
 }
 
-void checkArguments(int argc, char * argv[], int count, ...)
-{
-    std::string ** filelist = new std::string *[count];
+void checkArguments(int argc, char *argv[], int count, ...) {
+    std::string **filelist = new std::string *[count];
     va_list ap;
     va_start(ap, count);
-    for (int i = 0; i < count; i++)
-    {
+    for (int i = 0; i < count; i++) {
         filelist[i] = va_arg(ap, std::string *);
     }
     va_end(ap);
-    if (argc == 1)
-    {
-        for (int i = 0; i < count; i++)
-        {
+    if (argc == 1) {
+        for (int i = 0; i < count; i++) {
             checkFileIsAvailable(*(filelist[i]), true);
         }
     }
-    else if (argc == (count + 1))
-    {
+    else if (argc == (count + 1)) {
         bool isAllCorrect = true;
-        for (int i = 0; i < count; i++)
-        {
-            if (!checkFileIsAvailable(argv[i + 1]))
-            {
+        for (int i = 0; i < count; i++) {
+            if (!checkFileIsAvailable(argv[i + 1])) {
                 isAllCorrect = false;
                 break;
             }
         }
-        if (isAllCorrect == true)
-        {
-            for (int i = 0; i < count; i++)
-            {
+        if (isAllCorrect == true) {
+            for (int i = 0; i < count; i++) {
                 (*filelist[i]) = argv[i + 1];
             }
         }
-        else
-        {
+        else {
             std::cout << "Warning: Try to open default datasetFileNames" << std::endl;
-            for (int i = 0; i < count; i++)
-            {
+            for (int i = 0; i < count; i++) {
                 checkFileIsAvailable(*(filelist[i]), true);
             }
         }
     }
-    else
-    {
+    else {
         std::cout << "Usage: " << argv[0] << " [ ";
-        for (int i = 0; i < count; i++)
-        {
+        for (int i = 0; i < count; i++) {
             std::cout << "<filename_" << i << "> ";
         }
         std::cout << "]" << std::endl;
         std::cout << "Warning: Try to open default datasetFileNames" << std::endl;
-        for (int i = 0; i < count; i++)
-        {
+        for (int i = 0; i < count; i++) {
             checkFileIsAvailable(*(filelist[i]), true);
         }
     }
     delete[] filelist;
 }
 
-void copyBytes(daal::byte * dst, daal::byte * src, size_t size)
-{
-    for (size_t i = 0; i < size; i++)
-    {
+void copyBytes(daal::byte *dst, daal::byte *src, size_t size) {
+    for (size_t i = 0; i < size; i++) {
         dst[i] = src[i];
     }
 }
 
-size_t checkBytes(daal::byte * dst, daal::byte * src, size_t size)
-{
-    for (size_t i = 0; i < size; i++)
-    {
-        if (dst[i] != src[i])
-        {
+size_t checkBytes(daal::byte *dst, daal::byte *src, size_t size) {
+    for (size_t i = 0; i < size; i++) {
+        if (dst[i] != src[i]) {
             return i + 1;
         }
     }
@@ -693,34 +698,43 @@ size_t checkBytes(daal::byte * dst, daal::byte * src, size_t size)
 }
 
 static const unsigned int crcRem[] = {
-    0x00000000, 0x741B8CD6, 0xE83719AC, 0x9C2C957A, 0xA475BF8E, 0xD06E3358, 0x4C42A622, 0x38592AF4, 0x3CF0F3CA, 0x48EB7F1C, 0xD4C7EA66, 0xA0DC66B0,
-    0x98854C44, 0xEC9EC092, 0x70B255E8, 0x04A9D93E, 0x79E1E794, 0x0DFA6B42, 0x91D6FE38, 0xE5CD72EE, 0xDD94581A, 0xA98FD4CC, 0x35A341B6, 0x41B8CD60,
-    0x4511145E, 0x310A9888, 0xAD260DF2, 0xD93D8124, 0xE164ABD0, 0x957F2706, 0x0953B27C, 0x7D483EAA, 0xF3C3CF28, 0x87D843FE, 0x1BF4D684, 0x6FEF5A52,
-    0x57B670A6, 0x23ADFC70, 0xBF81690A, 0xCB9AE5DC, 0xCF333CE2, 0xBB28B034, 0x2704254E, 0x531FA998, 0x6B46836C, 0x1F5D0FBA, 0x83719AC0, 0xF76A1616,
-    0x8A2228BC, 0xFE39A46A, 0x62153110, 0x160EBDC6, 0x2E579732, 0x5A4C1BE4, 0xC6608E9E, 0xB27B0248, 0xB6D2DB76, 0xC2C957A0, 0x5EE5C2DA, 0x2AFE4E0C,
-    0x12A764F8, 0x66BCE82E, 0xFA907D54, 0x8E8BF182, 0x939C1286, 0xE7879E50, 0x7BAB0B2A, 0x0FB087FC, 0x37E9AD08, 0x43F221DE, 0xDFDEB4A4, 0xABC53872,
-    0xAF6CE14C, 0xDB776D9A, 0x475BF8E0, 0x33407436, 0x0B195EC2, 0x7F02D214, 0xE32E476E, 0x9735CBB8, 0xEA7DF512, 0x9E6679C4, 0x024AECBE, 0x76516068,
-    0x4E084A9C, 0x3A13C64A, 0xA63F5330, 0xD224DFE6, 0xD68D06D8, 0xA2968A0E, 0x3EBA1F74, 0x4AA193A2, 0x72F8B956, 0x06E33580, 0x9ACFA0FA, 0xEED42C2C,
-    0x605FDDAE, 0x14445178, 0x8868C402, 0xFC7348D4, 0xC42A6220, 0xB031EEF6, 0x2C1D7B8C, 0x5806F75A, 0x5CAF2E64, 0x28B4A2B2, 0xB49837C8, 0xC083BB1E,
-    0xF8DA91EA, 0x8CC11D3C, 0x10ED8846, 0x64F60490, 0x19BE3A3A, 0x6DA5B6EC, 0xF1892396, 0x8592AF40, 0xBDCB85B4, 0xC9D00962, 0x55FC9C18, 0x21E710CE,
-    0x254EC9F0, 0x51554526, 0xCD79D05C, 0xB9625C8A, 0x813B767E, 0xF520FAA8, 0x690C6FD2, 0x1D17E304, 0x5323A9DA, 0x2738250C, 0xBB14B076, 0xCF0F3CA0,
-    0xF7561654, 0x834D9A82, 0x1F610FF8, 0x6B7A832E, 0x6FD35A10, 0x1BC8D6C6, 0x87E443BC, 0xF3FFCF6A, 0xCBA6E59E, 0xBFBD6948, 0x2391FC32, 0x578A70E4,
-    0x2AC24E4E, 0x5ED9C298, 0xC2F557E2, 0xB6EEDB34, 0x8EB7F1C0, 0xFAAC7D16, 0x6680E86C, 0x129B64BA, 0x1632BD84, 0x62293152, 0xFE05A428, 0x8A1E28FE,
-    0xB247020A, 0xC65C8EDC, 0x5A701BA6, 0x2E6B9770, 0xA0E066F2, 0xD4FBEA24, 0x48D77F5E, 0x3CCCF388, 0x0495D97C, 0x708E55AA, 0xECA2C0D0, 0x98B94C06,
-    0x9C109538, 0xE80B19EE, 0x74278C94, 0x003C0042, 0x38652AB6, 0x4C7EA660, 0xD052331A, 0xA449BFCC, 0xD9018166, 0xAD1A0DB0, 0x313698CA, 0x452D141C,
-    0x7D743EE8, 0x096FB23E, 0x95432744, 0xE158AB92, 0xE5F172AC, 0x91EAFE7A, 0x0DC66B00, 0x79DDE7D6, 0x4184CD22, 0x359F41F4, 0xA9B3D48E, 0xDDA85858,
-    0xC0BFBB5C, 0xB4A4378A, 0x2888A2F0, 0x5C932E26, 0x64CA04D2, 0x10D18804, 0x8CFD1D7E, 0xF8E691A8, 0xFC4F4896, 0x8854C440, 0x1478513A, 0x6063DDEC,
-    0x583AF718, 0x2C217BCE, 0xB00DEEB4, 0xC4166262, 0xB95E5CC8, 0xCD45D01E, 0x51694564, 0x2572C9B2, 0x1D2BE346, 0x69306F90, 0xF51CFAEA, 0x8107763C,
-    0x85AEAF02, 0xF1B523D4, 0x6D99B6AE, 0x19823A78, 0x21DB108C, 0x55C09C5A, 0xC9EC0920, 0xBDF785F6, 0x337C7474, 0x4767F8A2, 0xDB4B6DD8, 0xAF50E10E,
-    0x9709CBFA, 0xE312472C, 0x7F3ED256, 0x0B255E80, 0x0F8C87BE, 0x7B970B68, 0xE7BB9E12, 0x93A012C4, 0xABF93830, 0xDFE2B4E6, 0x43CE219C, 0x37D5AD4A,
-    0x4A9D93E0, 0x3E861F36, 0xA2AA8A4C, 0xD6B1069A, 0xEEE82C6E, 0x9AF3A0B8, 0x06DF35C2, 0x72C4B914, 0x766D602A, 0x0276ECFC, 0x9E5A7986, 0xEA41F550,
-    0xD218DFA4, 0xA6035372, 0x3A2FC608, 0x4E344ADE
+    0x00000000, 0x741B8CD6, 0xE83719AC, 0x9C2C957A, 0xA475BF8E, 0xD06E3358, 0x4C42A622, 0x38592AF4,
+    0x3CF0F3CA, 0x48EB7F1C, 0xD4C7EA66, 0xA0DC66B0, 0x98854C44, 0xEC9EC092, 0x70B255E8, 0x04A9D93E,
+    0x79E1E794, 0x0DFA6B42, 0x91D6FE38, 0xE5CD72EE, 0xDD94581A, 0xA98FD4CC, 0x35A341B6, 0x41B8CD60,
+    0x4511145E, 0x310A9888, 0xAD260DF2, 0xD93D8124, 0xE164ABD0, 0x957F2706, 0x0953B27C, 0x7D483EAA,
+    0xF3C3CF28, 0x87D843FE, 0x1BF4D684, 0x6FEF5A52, 0x57B670A6, 0x23ADFC70, 0xBF81690A, 0xCB9AE5DC,
+    0xCF333CE2, 0xBB28B034, 0x2704254E, 0x531FA998, 0x6B46836C, 0x1F5D0FBA, 0x83719AC0, 0xF76A1616,
+    0x8A2228BC, 0xFE39A46A, 0x62153110, 0x160EBDC6, 0x2E579732, 0x5A4C1BE4, 0xC6608E9E, 0xB27B0248,
+    0xB6D2DB76, 0xC2C957A0, 0x5EE5C2DA, 0x2AFE4E0C, 0x12A764F8, 0x66BCE82E, 0xFA907D54, 0x8E8BF182,
+    0x939C1286, 0xE7879E50, 0x7BAB0B2A, 0x0FB087FC, 0x37E9AD08, 0x43F221DE, 0xDFDEB4A4, 0xABC53872,
+    0xAF6CE14C, 0xDB776D9A, 0x475BF8E0, 0x33407436, 0x0B195EC2, 0x7F02D214, 0xE32E476E, 0x9735CBB8,
+    0xEA7DF512, 0x9E6679C4, 0x024AECBE, 0x76516068, 0x4E084A9C, 0x3A13C64A, 0xA63F5330, 0xD224DFE6,
+    0xD68D06D8, 0xA2968A0E, 0x3EBA1F74, 0x4AA193A2, 0x72F8B956, 0x06E33580, 0x9ACFA0FA, 0xEED42C2C,
+    0x605FDDAE, 0x14445178, 0x8868C402, 0xFC7348D4, 0xC42A6220, 0xB031EEF6, 0x2C1D7B8C, 0x5806F75A,
+    0x5CAF2E64, 0x28B4A2B2, 0xB49837C8, 0xC083BB1E, 0xF8DA91EA, 0x8CC11D3C, 0x10ED8846, 0x64F60490,
+    0x19BE3A3A, 0x6DA5B6EC, 0xF1892396, 0x8592AF40, 0xBDCB85B4, 0xC9D00962, 0x55FC9C18, 0x21E710CE,
+    0x254EC9F0, 0x51554526, 0xCD79D05C, 0xB9625C8A, 0x813B767E, 0xF520FAA8, 0x690C6FD2, 0x1D17E304,
+    0x5323A9DA, 0x2738250C, 0xBB14B076, 0xCF0F3CA0, 0xF7561654, 0x834D9A82, 0x1F610FF8, 0x6B7A832E,
+    0x6FD35A10, 0x1BC8D6C6, 0x87E443BC, 0xF3FFCF6A, 0xCBA6E59E, 0xBFBD6948, 0x2391FC32, 0x578A70E4,
+    0x2AC24E4E, 0x5ED9C298, 0xC2F557E2, 0xB6EEDB34, 0x8EB7F1C0, 0xFAAC7D16, 0x6680E86C, 0x129B64BA,
+    0x1632BD84, 0x62293152, 0xFE05A428, 0x8A1E28FE, 0xB247020A, 0xC65C8EDC, 0x5A701BA6, 0x2E6B9770,
+    0xA0E066F2, 0xD4FBEA24, 0x48D77F5E, 0x3CCCF388, 0x0495D97C, 0x708E55AA, 0xECA2C0D0, 0x98B94C06,
+    0x9C109538, 0xE80B19EE, 0x74278C94, 0x003C0042, 0x38652AB6, 0x4C7EA660, 0xD052331A, 0xA449BFCC,
+    0xD9018166, 0xAD1A0DB0, 0x313698CA, 0x452D141C, 0x7D743EE8, 0x096FB23E, 0x95432744, 0xE158AB92,
+    0xE5F172AC, 0x91EAFE7A, 0x0DC66B00, 0x79DDE7D6, 0x4184CD22, 0x359F41F4, 0xA9B3D48E, 0xDDA85858,
+    0xC0BFBB5C, 0xB4A4378A, 0x2888A2F0, 0x5C932E26, 0x64CA04D2, 0x10D18804, 0x8CFD1D7E, 0xF8E691A8,
+    0xFC4F4896, 0x8854C440, 0x1478513A, 0x6063DDEC, 0x583AF718, 0x2C217BCE, 0xB00DEEB4, 0xC4166262,
+    0xB95E5CC8, 0xCD45D01E, 0x51694564, 0x2572C9B2, 0x1D2BE346, 0x69306F90, 0xF51CFAEA, 0x8107763C,
+    0x85AEAF02, 0xF1B523D4, 0x6D99B6AE, 0x19823A78, 0x21DB108C, 0x55C09C5A, 0xC9EC0920, 0xBDF785F6,
+    0x337C7474, 0x4767F8A2, 0xDB4B6DD8, 0xAF50E10E, 0x9709CBFA, 0xE312472C, 0x7F3ED256, 0x0B255E80,
+    0x0F8C87BE, 0x7B970B68, 0xE7BB9E12, 0x93A012C4, 0xABF93830, 0xDFE2B4E6, 0x43CE219C, 0x37D5AD4A,
+    0x4A9D93E0, 0x3E861F36, 0xA2AA8A4C, 0xD6B1069A, 0xEEE82C6E, 0x9AF3A0B8, 0x06DF35C2, 0x72C4B914,
+    0x766D602A, 0x0276ECFC, 0x9E5A7986, 0xEA41F550, 0xD218DFA4, 0xA6035372, 0x3A2FC608, 0x4E344ADE
 };
 
-unsigned int getCRC32(daal::byte * input, unsigned int prevRes, size_t len)
-{
+unsigned int getCRC32(daal::byte *input, unsigned int prevRes, size_t len) {
     size_t i;
-    daal::byte * p;
+    daal::byte *p;
 
     unsigned int res, highDigit, nextDigit;
     const unsigned int crcPoly = 0xBA0DC66B;
@@ -729,30 +743,29 @@ unsigned int getCRC32(daal::byte * input, unsigned int prevRes, size_t len)
 
     res = prevRes;
 
-    for (i = 0; i < len; i++)
-    {
+    for (i = 0; i < len; i++) {
         highDigit = res >> 24;
         nextDigit = (unsigned int)(p[len - 1 - i]);
-        res       = (res << 8) ^ nextDigit;
-        res       = res ^ crcRem[highDigit];
+        res = (res << 8) ^ nextDigit;
+        res = res ^ crcRem[highDigit];
     }
 
-    if (res >= crcPoly)
-    {
+    if (res >= crcPoly) {
         res = res ^ crcPoly;
     }
 
     return res;
 }
 
-void printALSRatings(NumericTablePtr usersOffsetTable, NumericTablePtr itemsOffsetTable, NumericTablePtr ratings)
-{
+void printALSRatings(NumericTablePtr usersOffsetTable,
+                     NumericTablePtr itemsOffsetTable,
+                     NumericTablePtr ratings) {
     size_t nUsers = ratings->getNumberOfRows();
     size_t nItems = ratings->getNumberOfColumns();
 
     BlockDescriptor<DAAL_DATA_TYPE> block1;
     ratings->getBlockOfRows(0, nUsers, readOnly, block1);
-    DAAL_DATA_TYPE * ratingsData = block1.getBlockPtr();
+    DAAL_DATA_TYPE *ratingsData = block1.getBlockPtr();
 
     size_t usersOffset, itemsOffset;
     BlockDescriptor<int> block;
@@ -765,18 +778,16 @@ void printALSRatings(NumericTablePtr usersOffsetTable, NumericTablePtr itemsOffs
     itemsOffsetTable->releaseBlockOfRows(block);
 
     std::cout << " User ID, Item ID, rating" << std::endl;
-    for (size_t i = 0; i < nUsers; i++)
-    {
-        for (size_t j = 0; j < nItems; j++)
-        {
-            std::cout << i + usersOffset << ", " << j + itemsOffset << ", " << ratingsData[i * nItems + j] << std::endl;
+    for (size_t i = 0; i < nUsers; i++) {
+        for (size_t j = 0; j < nItems; j++) {
+            std::cout << i + usersOffset << ", " << j + itemsOffset << ", "
+                      << ratingsData[i * nItems + j] << std::endl;
         }
     }
     ratings->releaseBlockOfRows(block1);
 }
 
-size_t serializeDAALObject(SerializationIface * pData, ByteBuffer & buffer)
-{
+size_t serializeDAALObject(SerializationIface *pData, ByteBuffer &buffer) {
     /* Create a data archive to serialize the numeric table */
     InputDataArchive dataArch;
 
@@ -788,12 +799,12 @@ size_t serializeDAALObject(SerializationIface * pData, ByteBuffer & buffer)
 
     /* Store the serialized data in an array */
     buffer.resize(length);
-    if (length) dataArch.copyArchiveToArray(&buffer[0], length);
+    if (length)
+        dataArch.copyArchiveToArray(&buffer[0], length);
     return length;
 }
 
-SerializationIfacePtr deserializeDAALObject(daal::byte * buff, size_t length)
-{
+SerializationIfacePtr deserializeDAALObject(daal::byte *buff, size_t length) {
     /* Create a data archive to deserialize the object */
     OutputDataArchive dataArch(buff, length);
 

--- a/samples/daal/cpp/mpi/sources/svd_fast_distributed_mpi.cpp
+++ b/samples/daal/cpp/mpi/sources/svd_fast_distributed_mpi.cpp
@@ -37,7 +37,9 @@ using namespace daal::algorithms;
 /* Input data set parameters */
 const size_t nBlocks = 4;
 
-const string datasetFileNames[] = { "./data/distributed/svd_1.csv", "./data/distributed/svd_2.csv", "./data/distributed/svd_3.csv",
+const string datasetFileNames[] = { "./data/distributed/svd_1.csv",
+                                    "./data/distributed/svd_2.csv",
+                                    "./data/distributed/svd_3.csv",
                                     "./data/distributed/svd_4.csv" };
 
 void computestep1Local();
@@ -56,19 +58,23 @@ NumericTablePtr Ui;
 services::SharedPtr<byte> serializedData;
 size_t perNodeArchLength;
 
-int main(int argc, char * argv[])
-{
-    checkArguments(argc, argv, 4, &datasetFileNames[0], &datasetFileNames[1], &datasetFileNames[2], &datasetFileNames[3]);
+int main(int argc, char* argv[]) {
+    checkArguments(argc,
+                   argv,
+                   4,
+                   &datasetFileNames[0],
+                   &datasetFileNames[1],
+                   &datasetFileNames[2],
+                   &datasetFileNames[3]);
 
     MPI_Init(&argc, &argv);
     MPI_Comm_size(MPI_COMM_WORLD, &commSize);
     MPI_Comm_rank(MPI_COMM_WORLD, &rankId);
 
-    if (nBlocks != commSize)
-    {
-        if (rankId == mpiRoot)
-        {
-            std::cout << commSize << " MPI ranks != " << nBlocks << " datasets available, so please start exactly " << nBlocks << " ranks.\n"
+    if (nBlocks != commSize) {
+        if (rankId == mpiRoot) {
+            std::cout << commSize << " MPI ranks != " << nBlocks
+                      << " datasets available, so please start exactly " << nBlocks << " ranks.\n"
                       << std::endl;
         }
         MPI_Finalize();
@@ -77,16 +83,14 @@ int main(int argc, char * argv[])
 
     computestep1Local();
 
-    if (rankId == mpiRoot)
-    {
+    if (rankId == mpiRoot) {
         computeOnMasterNode();
     }
 
     finalizeComputestep1Local();
 
     /* Print the results */
-    if (rankId == mpiRoot)
-    {
+    if (rankId == mpiRoot) {
         printNumericTable(Sigma, "Singular values:");
         printNumericTable(V, "Right orthogonal matrix V:");
         printNumericTable(Ui, "Part of left orthogonal matrix U from root node:", 10);
@@ -97,10 +101,11 @@ int main(int argc, char * argv[])
     return 0;
 }
 
-void computestep1Local()
-{
+void computestep1Local() {
     /* Initialize FileDataSource<CSVFeatureManager> to retrieve the input data from a .csv file */
-    FileDataSource<CSVFeatureManager> dataSource(datasetFileNames[rankId], DataSource::doAllocateNumericTable, DataSource::doDictionaryFromContext);
+    FileDataSource<CSVFeatureManager> dataSource(datasetFileNames[rankId],
+                                                 DataSource::doAllocateNumericTable,
+                                                 DataSource::doDictionaryFromContext);
 
     /* Retrieve the input data */
     dataSource.loadDataBlock();
@@ -123,31 +128,36 @@ void computestep1Local()
     perNodeArchLength = dataArch.getSizeOfArchive();
 
     /* Serialized data is of equal size on each node if each node called compute() equal number of times */
-    if (rankId == mpiRoot)
-    {
+    if (rankId == mpiRoot) {
         serializedData = services::SharedPtr<byte>(new byte[perNodeArchLength * nBlocks]);
     }
 
-    byte * nodeResults = new byte[perNodeArchLength];
+    byte* nodeResults = new byte[perNodeArchLength];
     dataArch.copyArchiveToArray(nodeResults, perNodeArchLength);
 
     /* Transfer partial results to step 2 on the root node */
-    MPI_Gather(nodeResults, perNodeArchLength, MPI_CHAR, serializedData.get(), perNodeArchLength, MPI_CHAR, mpiRoot, MPI_COMM_WORLD);
+    MPI_Gather(nodeResults,
+               perNodeArchLength,
+               MPI_CHAR,
+               serializedData.get(),
+               perNodeArchLength,
+               MPI_CHAR,
+               mpiRoot,
+               MPI_COMM_WORLD);
 
     delete[] nodeResults;
 }
 
-void computeOnMasterNode()
-{
+void computeOnMasterNode() {
     /* Create an algorithm to compute SVD on the master node */
     svd::Distributed<step2Master> alg;
 
-    for (size_t i = 0; i < nBlocks; i++)
-    {
+    for (size_t i = 0; i < nBlocks; i++) {
         /* Deserialize partial results from step 1 */
         OutputDataArchive dataArch(serializedData.get() + perNodeArchLength * i, perNodeArchLength);
 
-        data_management::DataCollectionPtr dataForStep2FromStep1 = data_management::DataCollectionPtr(new data_management::DataCollection());
+        data_management::DataCollectionPtr dataForStep2FromStep1 =
+            data_management::DataCollectionPtr(new data_management::DataCollection());
         dataForStep2FromStep1->deserialize(dataArch);
 
         alg.input.add(svd::inputOfStep2FromStep1, i, dataForStep2FromStep1);
@@ -156,46 +166,52 @@ void computeOnMasterNode()
     /* Compute SVD */
     alg.compute();
 
-    svd::DistributedPartialResultPtr pres            = alg.getPartialResult();
+    svd::DistributedPartialResultPtr pres = alg.getPartialResult();
     KeyValueDataCollectionPtr inputForStep3FromStep2 = pres->get(svd::outputOfStep2ForStep3);
 
-    for (size_t i = 0; i < nBlocks; i++)
-    {
+    for (size_t i = 0; i < nBlocks; i++) {
         /* Serialize partial results to transfer to local nodes for step 3 */
         InputDataArchive dataArch;
         (*inputForStep3FromStep2)[i]->serialize(dataArch);
 
-        if (i == 0)
-        {
+        if (i == 0) {
             perNodeArchLength = dataArch.getSizeOfArchive();
             /* Serialized data is of equal size for each node if it was equal in step 1 */
             serializedData = services::SharedPtr<byte>(new byte[perNodeArchLength * nBlocks]);
         }
 
-        dataArch.copyArchiveToArray(serializedData.get() + perNodeArchLength * i, perNodeArchLength);
+        dataArch.copyArchiveToArray(serializedData.get() + perNodeArchLength * i,
+                                    perNodeArchLength);
     }
 
     svd::ResultPtr res = alg.getResult();
 
     Sigma = res->get(svd::singularValues);
-    V     = res->get(svd::rightSingularMatrix);
+    V = res->get(svd::rightSingularMatrix);
 }
 
-void finalizeComputestep1Local()
-{
+void finalizeComputestep1Local() {
     /* Get the size of the serialized input */
     MPI_Bcast(&perNodeArchLength, sizeof(size_t), MPI_CHAR, mpiRoot, MPI_COMM_WORLD);
 
-    byte * nodeResults = new byte[perNodeArchLength];
+    byte* nodeResults = new byte[perNodeArchLength];
 
     /* Transfer partial results from the root node */
 
-    MPI_Scatter(serializedData.get(), perNodeArchLength, MPI_CHAR, nodeResults, perNodeArchLength, MPI_CHAR, mpiRoot, MPI_COMM_WORLD);
+    MPI_Scatter(serializedData.get(),
+                perNodeArchLength,
+                MPI_CHAR,
+                nodeResults,
+                perNodeArchLength,
+                MPI_CHAR,
+                mpiRoot,
+                MPI_COMM_WORLD);
 
     /* Deserialize partial results from step 2 */
     OutputDataArchive dataArch(nodeResults, perNodeArchLength);
 
-    data_management::DataCollectionPtr dataFromStep2ForStep3 = data_management::DataCollectionPtr(new data_management::DataCollection());
+    data_management::DataCollectionPtr dataFromStep2ForStep3 =
+        data_management::DataCollectionPtr(new data_management::DataCollection());
     dataFromStep2ForStep3->deserialize(dataArch);
 
     delete[] nodeResults;

--- a/samples/daal/cpp/mysql/sources/datasource_mysql.cpp
+++ b/samples/daal/cpp/mysql/sources/datasource_mysql.cpp
@@ -43,8 +43,7 @@
 
 using namespace daal::data_management;
 
-int main(int argc, char const * argv[])
-{
+int main(int argc, char const* argv[]) {
     /*
      * This sample demonstrates how to connect to MySQL server using connection string and
      * perform basic data selection and loading with ODBCDataSource component.
@@ -52,13 +51,11 @@ int main(int argc, char const * argv[])
 
     std::string connectionString;
 
-    if (argc > 1)
-    {
+    if (argc > 1) {
         connectionString = argv[1];
     }
 
-    if (utils::trim(connectionString).empty())
-    {
+    if (utils::trim(connectionString).empty()) {
         utils::printHelp();
         return 0;
     }
@@ -79,7 +76,8 @@ int main(int argc, char const * argv[])
     connection.execute("INSERT INTO ? VALUES (1.23, 4.56), (7.89, 1.56), (2.62, 9.35)", tableName);
 
     /* Crate ODBC Data Source via connection string */
-    const ODBCDataSourceOptions options = ODBCDataSourceOptions::allocateNumericTable | ODBCDataSourceOptions::createDictionaryFromContext;
+    const ODBCDataSourceOptions options = ODBCDataSourceOptions::allocateNumericTable |
+                                          ODBCDataSourceOptions::createDictionaryFromContext;
     ODBCDataSource<SQLFeatureManager> ds(connectionString, options);
 
     /* Execute SQL query, you can execute arbitrary query supported by your DB */

--- a/samples/daal/cpp/mysql/sources/datasource_mysql_modifiers.cpp
+++ b/samples/daal/cpp/mysql/sources/datasource_mysql_modifiers.cpp
@@ -41,13 +41,11 @@
 using namespace daal::data_management;
 
 /** User-defined feature modifier that computes a square for every feature */
-class MySquaringModifier : public modifiers::sql::FeatureModifier
-{
+class MySquaringModifier : public modifiers::sql::FeatureModifier {
 public:
     /* This method is called for every row in CSV file */
-    virtual void apply(modifiers::sql::Context & context)
-    {
-        const size_t numberOfColumns                            = context.getNumberOfColumns();
+    virtual void apply(modifiers::sql::Context& context) {
+        const size_t numberOfColumns = context.getNumberOfColumns();
         daal::services::BufferView<DAAL_DATA_TYPE> outputBuffer = context.getOutputBuffer();
 
         /* By default buffer size is equal to the number of columns.
@@ -55,21 +53,18 @@ public:
          * initialization stage of the modifier (see 'MyMaxFeatureModifier') */
         assert(numberOfColumns == outputBuffer.size());
 
-        for (size_t i = 0; i < numberOfColumns; i++)
-        {
-            const float x   = context.getValue<float>(i);
+        for (size_t i = 0; i < numberOfColumns; i++) {
+            const float x = context.getValue<float>(i);
             outputBuffer[i] = x * x;
         }
     }
 };
 
 /** User-defined feature modifier that selects max element among all features  */
-class MyMaxFeatureModifier : public modifiers::sql::FeatureModifier
-{
+class MyMaxFeatureModifier : public modifiers::sql::FeatureModifier {
 public:
     /* This method is called once before CSV parsing */
-    virtual void initialize(modifiers::sql::Config & config)
-    {
+    virtual void initialize(modifiers::sql::Config& config) {
         /* Set number of output features for the modifier. We assume modifier
          * computes function y = max { x_1, ..., x_n }, where x_i is input
          * features and y is output feature, so there is single output feature  */
@@ -77,14 +72,12 @@ public:
     }
 
     /* This method is called for every row in CSV file */
-    virtual void apply(modifiers::sql::Context & context)
-    {
+    virtual void apply(modifiers::sql::Context& context) {
         const size_t numberOfColumns = context.getNumberOfColumns();
 
         /* Iterate throughout tokens, parse every token as float and compute max value  */
         float maxFeature = context.getValue<float>(0);
-        for (size_t i = 1; i < numberOfColumns; i++)
-        {
+        for (size_t i = 1; i < numberOfColumns; i++) {
             maxFeature = (std::max)(maxFeature, context.getValue<float>(i));
         }
 
@@ -94,8 +87,7 @@ public:
     }
 };
 
-int main(int argc, char const * argv[])
-{
+int main(int argc, char const* argv[]) {
     /*
      * This sample demonstrates how to connect to MySQL server using connection string and
      * perform basic data selection and loading with ODBCDataSource component.
@@ -103,13 +95,11 @@ int main(int argc, char const * argv[])
 
     std::string connectionString;
 
-    if (argc > 1)
-    {
+    if (argc > 1) {
         connectionString = argv[1];
     }
 
-    if (utils::trim(connectionString).empty())
-    {
+    if (utils::trim(connectionString).empty()) {
         utils::printHelp();
         return 0;
     }
@@ -130,7 +120,8 @@ int main(int argc, char const * argv[])
     connection.execute("INSERT INTO ? VALUES (2.71, 3.90), (1.11, 0.538), (3.44, 1.41)", tableName);
 
     /* Crate ODBC Data Source via connection string */
-    const ODBCDataSourceOptions options = ODBCDataSourceOptions::allocateNumericTable | ODBCDataSourceOptions::createDictionaryFromContext;
+    const ODBCDataSourceOptions options = ODBCDataSourceOptions::allocateNumericTable |
+                                          ODBCDataSourceOptions::createDictionaryFromContext;
     ODBCDataSource<SQLFeatureManager> ds(connectionString, options);
 
     /* Execute SQL query, you can execute arbitrary query supported by your DB */

--- a/samples/daal/cpp/mysql/sources/odbc_wrapper.h
+++ b/samples/daal/cpp/mysql/sources/odbc_wrapper.h
@@ -25,8 +25,8 @@
 #include <stdexcept>
 
 #if defined(_WIN32) || defined(_WIN64)
-    #define NOMINMAX
-    #include <windows.h>
+#define NOMINMAX
+#include <windows.h>
 #endif
 
 #include <sql.h>
@@ -35,23 +35,18 @@
 
 #include "daal.h"
 
-namespace odbc_wrapper
-{
-namespace utils
-{
-std::vector<std::string> split(const std::string & input, char delim)
-{
+namespace odbc_wrapper {
+namespace utils {
+std::vector<std::string> split(const std::string &input, char delim) {
     std::stringstream ss(input);
     std::vector<std::string> parts;
 
     std::string item;
-    while (std::getline(ss, item, delim))
-    {
+    while (std::getline(ss, item, delim)) {
         parts.push_back(item);
     }
 
-    if (input[input.size() - 1] == delim)
-    {
+    if (input[input.size() - 1] == delim) {
         parts.push_back(std::string());
     }
 
@@ -60,45 +55,43 @@ std::vector<std::string> split(const std::string & input, char delim)
 
 } // namespace utils
 
-class Exception : public std::exception
-{
+class Exception : public std::exception {
 public:
     virtual ~Exception() throw() {}
 
-    void add(const SQLINTEGER & e) { _errors.push_back(e); }
+    void add(const SQLINTEGER &e) {
+        _errors.push_back(e);
+    }
 
-    virtual const char * what() const throw()
-    {
-        if (_errors.empty())
-        {
+    virtual const char *what() const throw() {
+        if (_errors.empty()) {
             return "";
         }
-        else
-        {
+        else {
             return "Errors have occurred. Result of method \"errors()\" contains error codes.";
         }
     }
 
-    const std::vector<SQLINTEGER> & errors() const { return _errors; }
+    const std::vector<SQLINTEGER> &errors() const {
+        return _errors;
+    }
 
 private:
     std::vector<SQLINTEGER> _errors;
 };
 
-inline Exception formatException(SQLSMALLINT handleType, SQLHANDLE handle)
-{
+inline Exception formatException(SQLSMALLINT handleType, SQLHANDLE handle) {
     Exception ex;
     static const int SQL_STATE_SIZE = 6;
-    SQLRETURN ret                   = SQL_SUCCESS;
-    for (SQLRETURN i = 1; ret != SQL_NO_DATA; i++)
-    {
+    SQLRETURN ret = SQL_SUCCESS;
+    for (SQLRETURN i = 1; ret != SQL_NO_DATA; i++) {
         SQLINTEGER e;
         SQLCHAR state[SQL_STATE_SIZE];
         SQLCHAR text[SQL_MAX_MESSAGE_LENGTH];
         SQLSMALLINT messageActualSize;
-        ret = SQLGetDiagRec(handleType, handle, i, state, &e, text, sizeof(text), &messageActualSize);
-        if (SQL_SUCCEEDED(ret))
-        {
+        ret =
+            SQLGetDiagRec(handleType, handle, i, state, &e, text, sizeof(text), &messageActualSize);
+        if (SQL_SUCCEEDED(ret)) {
             ex.add(e);
         }
     }
@@ -106,40 +99,43 @@ inline Exception formatException(SQLSMALLINT handleType, SQLHANDLE handle)
     return ex;
 }
 
-inline SQLRETURN call(SQLSMALLINT handleType, SQLHANDLE handle, SQLRETURN code)
-{
-    if (!SQL_SUCCEEDED(code))
-    {
+inline SQLRETURN call(SQLSMALLINT handleType, SQLHANDLE handle, SQLRETURN code) {
+    if (!SQL_SUCCEEDED(code)) {
         throw formatException(handleType, handle);
     }
     return code;
 }
 
-class ColumnAttributes
-{
+class ColumnAttributes {
 public:
     ColumnAttributes() : _hstmt(NULL), _column(0), _sqlType(SQL_UNKNOWN_TYPE), _octetLength(0) {}
 
-    explicit ColumnAttributes(SQLHSTMT hstmt, SQLUSMALLINT column) : _hstmt(hstmt), _column(column), _sqlType(SQL_UNKNOWN_TYPE), _octetLength(0)
-    {
-        if (!hstmt)
-        {
+    explicit ColumnAttributes(SQLHSTMT hstmt, SQLUSMALLINT column)
+            : _hstmt(hstmt),
+              _column(column),
+              _sqlType(SQL_UNKNOWN_TYPE),
+              _octetLength(0) {
+        if (!hstmt) {
             throw std::invalid_argument("hstmt can't be nullptr");
         }
     }
 
-    const std::string & name() const
-    {
-        if (!_name.size())
-        {
+    const std::string &name() const {
+        if (!_name.size()) {
             const size_t maxNameLength = 2048;
 
-            std::string & nameMutable = const_cast<std::string &>(_name);
+            std::string &nameMutable = const_cast<std::string &>(_name);
             nameMutable.resize(maxNameLength);
 
             SQLSMALLINT nameSizeActual;
-            call(SQL_HANDLE_STMT, _hstmt,
-                 SQLColAttributes(_hstmt, _column, SQL_DESC_NAME, (SQLPOINTER)nameMutable.c_str(), (SQLSMALLINT)nameMutable.size(), &nameSizeActual,
+            call(SQL_HANDLE_STMT,
+                 _hstmt,
+                 SQLColAttributes(_hstmt,
+                                  _column,
+                                  SQL_DESC_NAME,
+                                  (SQLPOINTER)nameMutable.c_str(),
+                                  (SQLSMALLINT)nameMutable.size(),
+                                  &nameSizeActual,
                                   NULL));
 
             nameMutable.resize(nameSizeActual);
@@ -147,18 +143,22 @@ public:
         return _name;
     }
 
-    SQLLEN octetLength() const { return extractAttribute<SQLLEN>(!_octetLength, SQL_DESC_OCTET_LENGTH, _octetLength); }
+    SQLLEN octetLength() const {
+        return extractAttribute<SQLLEN>(!_octetLength, SQL_DESC_OCTET_LENGTH, _octetLength);
+    }
 
-    SQLLEN type() const { return extractAttribute<SQLLEN>(_sqlType == SQL_UNKNOWN_TYPE, SQL_DESC_TYPE, _sqlType); }
+    SQLLEN type() const {
+        return extractAttribute<SQLLEN>(_sqlType == SQL_UNKNOWN_TYPE, SQL_DESC_TYPE, _sqlType);
+    }
 
 private:
     template <typename T>
-    T extractAttribute(bool condition, SQLUSMALLINT attribute, const T & value) const
-    {
-        if (condition)
-        {
+    T extractAttribute(bool condition, SQLUSMALLINT attribute, const T &value) const {
+        if (condition) {
             SQLLEN valueMutable;
-            call(SQL_HANDLE_STMT, _hstmt, SQLColAttributes(_hstmt, _column, attribute, NULL, 0, NULL, &valueMutable));
+            call(SQL_HANDLE_STMT,
+                 _hstmt,
+                 SQLColAttributes(_hstmt, _column, attribute, NULL, 0, NULL, &valueMutable));
             const_cast<T &>(value) = (T)valueMutable;
         }
         return value;
@@ -172,35 +172,37 @@ private:
     SQLLEN _octetLength;
 };
 
-class FetchBuffer
-{
+class FetchBuffer {
 public:
     FetchBuffer() {}
 
-    void allocate(SQLHSTMT hstmt, const std::vector<ColumnAttributes> & attributes)
-    {
+    void allocate(SQLHSTMT hstmt, const std::vector<ColumnAttributes> &attributes) {
         allocateBuffers(attributes);
         bindBuffers(hstmt);
     }
 
-    const char * offset(size_t columnIndex) const { return &_buffer[_bufferOffsets[columnIndex]]; }
+    const char *offset(size_t columnIndex) const {
+        return &_buffer[_bufferOffsets[columnIndex]];
+    }
 
-    SQLLEN size(size_t columnIndex) const { return _bufferOffsets[columnIndex + 1] - _bufferOffsets[columnIndex]; }
+    SQLLEN size(size_t columnIndex) const {
+        return _bufferOffsets[columnIndex + 1] - _bufferOffsets[columnIndex];
+    }
 
-    SQLLEN actualSize(size_t columnIndex) const { return _bufferActualSizes[columnIndex]; }
+    SQLLEN actualSize(size_t columnIndex) const {
+        return _bufferActualSizes[columnIndex];
+    }
 
 private:
-    FetchBuffer(const FetchBuffer & fetchBuffer);
+    FetchBuffer(const FetchBuffer &fetchBuffer);
 
-    void allocateBuffers(const std::vector<ColumnAttributes> & attributes)
-    {
+    void allocateBuffers(const std::vector<ColumnAttributes> &attributes) {
         const size_t columnsNumber = attributes.size();
         _bufferOffsets.resize(columnsNumber + 1);
         _bufferActualSizes.resize(columnsNumber);
 
         _bufferOffsets[0] = 0;
-        for (size_t i = 0; i < columnsNumber; i++)
-        {
+        for (size_t i = 0; i < columnsNumber; i++) {
             _bufferActualSizes[i] = 0;
             _bufferOffsets[i + 1] = _bufferOffsets[i] + attributes[i].octetLength();
         }
@@ -209,32 +211,34 @@ private:
         _buffer.resize(fetchBufferSize);
     }
 
-    void bindBuffers(SQLHSTMT hstmt)
-    {
-        for (size_t i = 0; i < _bufferActualSizes.size(); i++)
-        {
-            call(SQL_HANDLE_STMT, hstmt,
-                 SQLBindCol(hstmt, (SQLUSMALLINT)(i + 1), SQL_C_DEFAULT, (SQLPOINTER)offset(i), size(i), &_bufferActualSizes[i]));
+    void bindBuffers(SQLHSTMT hstmt) {
+        for (size_t i = 0; i < _bufferActualSizes.size(); i++) {
+            call(SQL_HANDLE_STMT,
+                 hstmt,
+                 SQLBindCol(hstmt,
+                            (SQLUSMALLINT)(i + 1),
+                            SQL_C_DEFAULT,
+                            (SQLPOINTER)offset(i),
+                            size(i),
+                            &_bufferActualSizes[i]));
         }
     }
 
-    char * offset(size_t columnIndex) { return &_buffer[_bufferOffsets[columnIndex]]; }
+    char *offset(size_t columnIndex) {
+        return &_buffer[_bufferOffsets[columnIndex]];
+    }
 
     std::vector<char> _buffer;
     std::vector<SQLLEN> _bufferOffsets;
     std::vector<SQLLEN> _bufferActualSizes;
 };
 
-class Statement
-{
+class Statement {
 private:
-    class Impl
-    {
+    class Impl {
     public:
-        explicit Impl(SQLHDBC hdbc, const std::string & query) : _hstmt(NULL)
-        {
-            if (!hdbc)
-            {
+        explicit Impl(SQLHDBC hdbc, const std::string &query) : _hstmt(NULL) {
+            if (!hdbc) {
                 throw std::invalid_argument("hdbc can't be nullptr");
             }
 
@@ -245,19 +249,25 @@ private:
             _fetchBuffer.allocate(_hstmt, _attributes);
         }
 
-        ~Impl() { call(SQL_HANDLE_STMT, _hstmt, SQLFreeHandle(SQL_HANDLE_STMT, _hstmt)); }
+        ~Impl() {
+            call(SQL_HANDLE_STMT, _hstmt, SQLFreeHandle(SQL_HANDLE_STMT, _hstmt));
+        }
 
-        size_t columns() const { return _attributes.size(); }
+        size_t columns() const {
+            return _attributes.size();
+        }
 
-        const ColumnAttributes & attributes(size_t column) const { return _attributes[column]; }
+        const ColumnAttributes &attributes(size_t column) const {
+            return _attributes[column];
+        }
 
-        const ColumnAttributes & attributes(const std::string & column) const { return attributes(toColumnIndex(column)); }
+        const ColumnAttributes &attributes(const std::string &column) const {
+            return attributes(toColumnIndex(column));
+        }
 
         template <typename T>
-        T get(size_t column) const
-        {
-            if (sizeof(T) != getRawSize(column))
-            {
+        T get(size_t column) const {
+            if (sizeof(T) != getRawSize(column)) {
                 throw std::invalid_argument("Size of T is not equal to the size "
                                             "of data received from SQL table");
             }
@@ -266,22 +276,17 @@ private:
         }
 
         template <typename T>
-        T get(const std::string & column) const
-        {
+        T get(const std::string &column) const {
             return get<T>(toColumnIndex(column));
         }
 
-        bool fetch(bool throwExceptionIfNoData = false)
-        {
+        bool fetch(bool throwExceptionIfNoData = false) {
             SQLRETURN ret = SQLFetchScroll(_hstmt, SQL_FETCH_NEXT, 0);
-            if (SQL_SUCCEEDED(ret))
-            {
+            if (SQL_SUCCEEDED(ret)) {
                 return true;
             }
-            else
-            {
-                if (ret != SQL_NO_DATA || throwExceptionIfNoData)
-                {
+            else {
+                if (ret != SQL_NO_DATA || throwExceptionIfNoData) {
                     throw formatException(SQL_HANDLE_STMT, _hstmt);
                 }
                 return false;
@@ -291,35 +296,35 @@ private:
     private:
         Impl(const Impl &);
 
-        void createAttributes(std::vector<ColumnAttributes> & attributes)
-        {
+        void createAttributes(std::vector<ColumnAttributes> &attributes) {
             const size_t columnsNumber = fetchColumnsNumber();
             attributes.resize(columnsNumber);
 
-            for (size_t i = 0; i < columnsNumber; i++)
-            {
-                attributes[i]                        = ColumnAttributes(_hstmt, (SQLUSMALLINT)(i + 1));
+            for (size_t i = 0; i < columnsNumber; i++) {
+                attributes[i] = ColumnAttributes(_hstmt, (SQLUSMALLINT)(i + 1));
                 _attributesMap[attributes[i].name()] = i;
             }
         }
 
-        size_t fetchColumnsNumber() const
-        {
+        size_t fetchColumnsNumber() const {
             SQLSMALLINT columnsNum;
             call(SQL_HANDLE_STMT, _hstmt, SQLNumResultCols(_hstmt, &columnsNum));
             return (size_t)columnsNum;
         }
 
-        size_t toColumnIndex(const std::string & column) const
-        {
+        size_t toColumnIndex(const std::string &column) const {
             typedef std::map<std::string, size_t> MapType;
-            MapType & map = const_cast<MapType &>(_attributesMap);
+            MapType &map = const_cast<MapType &>(_attributesMap);
             return map[column];
         }
 
-        const char * getRaw(size_t column) const { return _fetchBuffer.offset(column); }
+        const char *getRaw(size_t column) const {
+            return _fetchBuffer.offset(column);
+        }
 
-        size_t getRawSize(size_t column) const { return _fetchBuffer.actualSize(column); }
+        size_t getRawSize(size_t column) const {
+            return _fetchBuffer.actualSize(column);
+        }
 
         SQLHSTMT _hstmt;
         FetchBuffer _fetchBuffer;
@@ -329,75 +334,88 @@ private:
     };
 
 public:
-    explicit Statement(SQLHDBC hdbc, const std::string & query) { _impl.reset(new Impl(hdbc, query)); }
+    explicit Statement(SQLHDBC hdbc, const std::string &query) {
+        _impl.reset(new Impl(hdbc, query));
+    }
 
-    const ColumnAttributes & attributes(size_t column = 0) const { return _impl->attributes(column); }
+    const ColumnAttributes &attributes(size_t column = 0) const {
+        return _impl->attributes(column);
+    }
 
-    const ColumnAttributes & attributes(const std::string & column) const { return _impl->attributes(column); }
+    const ColumnAttributes &attributes(const std::string &column) const {
+        return _impl->attributes(column);
+    }
 
     template <typename T>
-    T get(size_t column = 0) const
-    {
+    T get(size_t column = 0) const {
         return _impl->get<T>(column);
     }
 
     template <typename T>
-    T get(const std::string & column) const
-    {
+    T get(const std::string &column) const {
         return _impl->get<T>(column);
     }
 
     template <typename T>
-    T first(size_t column = 0)
-    {
+    T first(size_t column = 0) {
         _impl->fetch(/* throwExceptionIfNoData = */ true);
         return _impl->get<T>(column);
     }
 
-    bool fetch() { return _impl->fetch(); }
+    bool fetch() {
+        return _impl->fetch();
+    }
 
 private:
     daal::services::SharedPtr<Impl> _impl;
 };
 
 template <>
-std::string Statement::Impl::get<std::string>(size_t column) const
-{
+std::string Statement::Impl::get<std::string>(size_t column) const {
     return std::string(getRaw(column), getRawSize(column));
 }
 
 template <>
-std::vector<char> Statement::Impl::get<std::vector<char> >(size_t column) const
-{
+std::vector<char> Statement::Impl::get<std::vector<char> >(size_t column) const {
     return std::vector<char>(getRaw(column), getRaw(column) + getRawSize(column));
 }
 
-class Connection
-{
+class Connection {
 private:
-    class Impl
-    {
+    class Impl {
     public:
-        explicit Impl(const std::string & connectionString) : _henv(NULL), _hdbc(NULL)
-        {
+        explicit Impl(const std::string &connectionString) : _henv(NULL), _hdbc(NULL) {
             call(SQL_HANDLE_ENV, _henv, SQLAllocHandle(SQL_HANDLE_ENV, SQL_NULL_HANDLE, &_henv));
-            call(SQL_HANDLE_ENV, _henv, SQLSetEnvAttr(_henv, SQL_ATTR_ODBC_VERSION, (SQLPOINTER)SQL_OV_ODBC3, SQL_IS_UINTEGER));
+            call(SQL_HANDLE_ENV,
+                 _henv,
+                 SQLSetEnvAttr(_henv,
+                               SQL_ATTR_ODBC_VERSION,
+                               (SQLPOINTER)SQL_OV_ODBC3,
+                               SQL_IS_UINTEGER));
             call(SQL_HANDLE_ENV, _henv, SQLAllocHandle(SQL_HANDLE_DBC, _henv, &_hdbc));
 
             SQLSMALLINT outConnectionStringLength;
-            call(SQL_HANDLE_DBC, _hdbc,
-                 SQLDriverConnect(_hdbc, SQL_NULL_HANDLE, (SQLCHAR *)connectionString.c_str(), (SQLSMALLINT)connectionString.size(), (SQLCHAR *)NULL,
-                                  (SQLSMALLINT)0, &outConnectionStringLength, SQL_DRIVER_NOPROMPT));
+            call(SQL_HANDLE_DBC,
+                 _hdbc,
+                 SQLDriverConnect(_hdbc,
+                                  SQL_NULL_HANDLE,
+                                  (SQLCHAR *)connectionString.c_str(),
+                                  (SQLSMALLINT)connectionString.size(),
+                                  (SQLCHAR *)NULL,
+                                  (SQLSMALLINT)0,
+                                  &outConnectionStringLength,
+                                  SQL_DRIVER_NOPROMPT));
         }
 
-        ~Impl()
-        {
+        ~Impl() {
             call(SQL_HANDLE_DBC, _hdbc, SQLDisconnect(_hdbc));
             call(SQL_HANDLE_DBC, _hdbc, SQLFreeHandle(SQL_HANDLE_DBC, _hdbc));
             call(SQL_HANDLE_ENV, _henv, SQLFreeHandle(SQL_HANDLE_ENV, _henv));
         }
 
-        Statement execute(const std::string & query) { return Statement(_hdbc, query); }
+        Statement execute(const std::string &query) {
+            return Statement(_hdbc, query);
+        }
 
     private:
         Impl(const Impl &);
@@ -407,22 +425,26 @@ private:
     };
 
 public:
-    explicit Connection(const std::string & connectionString) { _impl.reset(new Impl(connectionString)); }
+    explicit Connection(const std::string &connectionString) {
+        _impl.reset(new Impl(connectionString));
+    }
 
-    Statement execute(const std::string & query) { return _impl->execute(query); }
+    Statement execute(const std::string &query) {
+        return _impl->execute(query);
+    }
 
-    Statement execute(const std::string & query, const std::string & arg)
-    {
+    Statement execute(const std::string &query, const std::string &arg) {
         const std::vector<std::string> parts = utils::split(query, '?');
-        if (parts.size() != 2)
-        {
+        if (parts.size() != 2) {
             throw std::invalid_argument("query must contain exactly one ? character");
         }
 
         return execute(parts[0] + arg + parts[1]);
     }
 
-    std::string id() { return execute("select connection_id()").first<std::string>(); }
+    std::string id() {
+        return execute("select connection_id()").first<std::string>();
+    }
 
 private:
     daal::services::SharedPtr<Impl> _impl;

--- a/samples/daal/cpp/mysql/sources/utils.h
+++ b/samples/daal/cpp/mysql/sources/utils.h
@@ -32,18 +32,15 @@
 
 #include "daal.h"
 
-namespace utils
-{
-inline std::string trim(std::string & str)
-{
-    const char * ignore = " \n\t\r";
+namespace utils {
+inline std::string trim(std::string& str) {
+    const char* ignore = " \n\t\r";
     str.erase(0, str.find_first_not_of(ignore));
     str.erase(str.find_last_not_of(ignore) + 1);
     return str;
 }
 
-inline std::string generateTableName(const std::string & connectionId)
-{
+inline std::string generateTableName(const std::string& connectionId) {
     std::stringstream ss;
 
     ss << "daal_table"
@@ -52,26 +49,28 @@ inline std::string generateTableName(const std::string & connectionId)
     return ss.str();
 }
 
-inline void printHelp()
-{
-    std::cout << "Usage example:\n"
-              << "  datasource_mysql.exe <connection_string>\n"
-              << "\n"
-              << "For more information about <connection_string> see\n"
-              << "https://dev.mysql.com/doc/connector-odbc/en/connector-odbc-configuration-connection-without-dsn.html\n";
+inline void printHelp() {
+    std::cout
+        << "Usage example:\n"
+        << "  datasource_mysql.exe <connection_string>\n"
+        << "\n"
+        << "For more information about <connection_string> see\n"
+        << "https://dev.mysql.com/doc/connector-odbc/en/connector-odbc-configuration-connection-without-dsn.html\n";
 }
 
 template <typename T>
-inline void printArray(T * array, const size_t nPrintedCols, const size_t nPrintedRows, const size_t nCols, const std::string & message,
-                       size_t interval = 10)
-{
+inline void printArray(T* array,
+                       const size_t nPrintedCols,
+                       const size_t nPrintedRows,
+                       const size_t nCols,
+                       const std::string& message,
+                       size_t interval = 10) {
     std::cout << std::setiosflags(std::ios::left);
     std::cout << message << std::endl;
-    for (size_t i = 0; i < nPrintedRows; i++)
-    {
-        for (size_t j = 0; j < nPrintedCols; j++)
-        {
-            std::cout << std::setw(interval) << std::setiosflags(std::ios::fixed) << std::setprecision(3);
+    for (size_t i = 0; i < nPrintedRows; i++) {
+        for (size_t j = 0; j < nPrintedCols; j++) {
+            std::cout << std::setw(interval) << std::setiosflags(std::ios::fixed)
+                      << std::setprecision(3);
             std::cout << array[i * nCols + j];
         }
         std::cout << std::endl;
@@ -79,36 +78,39 @@ inline void printArray(T * array, const size_t nPrintedCols, const size_t nPrint
     std::cout << std::endl;
 }
 
-inline void printNumericTable(const daal::data_management::NumericTablePtr & dataTable, const char * message = "", size_t nPrintedRows = 0,
-                              size_t nPrintedCols = 0, size_t interval = 10)
-{
+inline void printNumericTable(const daal::data_management::NumericTablePtr& dataTable,
+                              const char* message = "",
+                              size_t nPrintedRows = 0,
+                              size_t nPrintedCols = 0,
+                              size_t interval = 10) {
     using namespace daal::data_management;
 
     size_t nRows = dataTable->getNumberOfRows();
     size_t nCols = dataTable->getNumberOfColumns();
 
-    if (nPrintedRows != 0)
-    {
+    if (nPrintedRows != 0) {
         nPrintedRows = (std::min)(nRows, nPrintedRows);
     }
-    else
-    {
+    else {
         nPrintedRows = nRows;
     }
 
-    if (nPrintedCols != 0)
-    {
+    if (nPrintedCols != 0) {
         nPrintedCols = (std::min)(nCols, nPrintedCols);
     }
-    else
-    {
+    else {
         nPrintedCols = nCols;
     }
 
     BlockDescriptor<DAAL_DATA_TYPE> block;
     {
         dataTable->getBlockOfRows(0, nRows, readOnly, block);
-        printArray<DAAL_DATA_TYPE>(block.getBlockPtr(), nPrintedCols, nPrintedRows, nCols, message, interval);
+        printArray<DAAL_DATA_TYPE>(block.getBlockPtr(),
+                                   nPrintedCols,
+                                   nPrintedRows,
+                                   nCols,
+                                   message,
+                                   interval);
     }
     dataTable->releaseBlockOfRows(block);
 }

--- a/samples/daal/cpp/oneccl/sources/covariance_dense_batch_distributed_oneccl.cpp
+++ b/samples/daal/cpp/oneccl/sources/covariance_dense_batch_distributed_oneccl.cpp
@@ -42,13 +42,14 @@ using namespace daal::algorithms;
 const size_t nProcs = 4;
 
 /* Input data set parameters */
-const string dataFileNames[4] = { "./data/covcormoments_dense_1.csv", "./data/covcormoments_dense_2.csv", "./data/covcormoments_dense_3.csv",
+const string dataFileNames[4] = { "./data/covcormoments_dense_1.csv",
+                                  "./data/covcormoments_dense_2.csv",
+                                  "./data/covcormoments_dense_3.csv",
                                   "./data/covcormoments_dense_4.csv" };
 
 #define ccl_root 0
 
-int getLocalRank(ccl::communicator & comm, int size, int rank)
-{
+int getLocalRank(ccl::communicator &comm, int size, int rank) {
     /* Obtain local rank among nodes sharing the same host name */
     char zero = static_cast<char>(0);
     std::vector<char> name(MPI_MAX_PROCESSOR_NAME + 1, zero);
@@ -57,32 +58,40 @@ int getLocalRank(ccl::communicator & comm, int size, int rank)
     std::string str(name.begin(), name.end());
     std::vector<char> allNames((MPI_MAX_PROCESSOR_NAME + 1) * size, zero);
     std::vector<size_t> aReceiveCount(size, MPI_MAX_PROCESSOR_NAME + 1);
-    ccl::allgatherv((int8_t *)name.data(), name.size(), (int8_t *)allNames.data(), aReceiveCount, comm).wait();
+    ccl::allgatherv((int8_t *)name.data(),
+                    name.size(),
+                    (int8_t *)allNames.data(),
+                    aReceiveCount,
+                    comm)
+        .wait();
     int localRank = 0;
-    for (int i = 0; i < rank; i++)
-    {
+    for (int i = 0; i < rank; i++) {
         auto nameBegin = allNames.begin() + i * (MPI_MAX_PROCESSOR_NAME + 1);
         std::string nbrName(nameBegin, nameBegin + (MPI_MAX_PROCESSOR_NAME + 1));
-        if (nbrName == str) localRank++;
+        if (nbrName == str)
+            localRank++;
     }
     return localRank;
 }
 
-NumericTablePtr loadData(int rankId)
-{
+NumericTablePtr loadData(int rankId) {
     /* Initialize FileDataSource<CSVFeatureManager> to retrieve the input data from a .csv file */
-    FileDataSource<CSVFeatureManager> dataSource(dataFileNames[rankId], DataSource::doAllocateNumericTable, DataSource::doDictionaryFromContext);
+    FileDataSource<CSVFeatureManager> dataSource(dataFileNames[rankId],
+                                                 DataSource::doAllocateNumericTable,
+                                                 DataSource::doDictionaryFromContext);
 
     /* Retrieve the data from the input file */
     dataSource.loadDataBlock();
     return dataSource.getNumericTable();
 }
 
-NumericTablePtr init(int rankId, const NumericTablePtr & pData, ccl::communicator & comm);
-NumericTablePtr compute(int rankId, const NumericTablePtr & pData, const NumericTablePtr & initialCentroids, ccl::communicator & comm);
+NumericTablePtr init(int rankId, const NumericTablePtr &pData, ccl::communicator &comm);
+NumericTablePtr compute(int rankId,
+                        const NumericTablePtr &pData,
+                        const NumericTablePtr &initialCentroids,
+                        ccl::communicator &comm);
 
-int main(int argc, char * argv[])
-{
+int main(int argc, char *argv[]) {
     /* Initialize oneCCL */
     ccl::init();
 
@@ -93,14 +102,12 @@ int main(int argc, char * argv[])
 
     ccl::shared_ptr_class<ccl::kvs> kvs;
     ccl::kvs::address_type main_addr;
-    if (rank == 0)
-    {
-        kvs       = ccl::create_main_kvs();
+    if (rank == 0) {
+        kvs = ccl::create_main_kvs();
         main_addr = kvs->get_address();
         MPI_Bcast((void *)main_addr.data(), main_addr.size(), MPI_BYTE, 0, MPI_COMM_WORLD);
     }
-    else
-    {
+    else {
         MPI_Bcast((void *)main_addr.data(), main_addr.size(), MPI_BYTE, 0, MPI_COMM_WORLD);
         kvs = ccl::create_kvs(main_addr);
     }
@@ -109,8 +116,8 @@ int main(int argc, char * argv[])
 
     /* Create GPU device from local rank and set execution context */
     auto local_rank = getLocalRank(comm, size, rank);
-    auto gpus       = get_gpus();
-    auto rank_gpu   = gpus[local_rank % gpus.size()];
+    auto gpus = get_gpus();
+    auto rank_gpu = gpus[local_rank % gpus.size()];
     cl::sycl::queue queue(rank_gpu);
     daal::services::SyclExecutionContext ctx(queue);
     services::Environment::getInstance()->setDefaultExecutionContext(ctx);
@@ -142,8 +149,7 @@ int main(int argc, char * argv[])
     /* Calculate total archive length */
     int totalArchLength = 0;
 
-    for (size_t i = 0; i < nProcs; ++i)
-    {
+    for (size_t i = 0; i < nProcs; ++i) {
         totalArchLength += aPerNodeArchLength[i];
     }
     aReceiveCount[ccl_root] = totalArchLength;
@@ -154,14 +160,17 @@ int main(int argc, char * argv[])
     dataArch.copyArchiveToArray(&nodeResults[0], perNodeArchLength);
 
     /* Transfer partial results to step 2 on the root node */
-    ccl::allgatherv((int8_t *)&nodeResults[0], perNodeArchLength, (int8_t *)&serializedData[0], aPerNodeArchLength, comm).wait();
+    ccl::allgatherv((int8_t *)&nodeResults[0],
+                    perNodeArchLength,
+                    (int8_t *)&serializedData[0],
+                    aPerNodeArchLength,
+                    comm)
+        .wait();
 
-    if (isRoot)
-    {
+    if (isRoot) {
         /* Create an algorithm to compute covariance on the master node */
         covariance::Distributed<step2Master> masterAlgorithm;
-        for (size_t i = 0, shift = 0; i < nProcs; shift += aPerNodeArchLength[i], ++i)
-        {
+        for (size_t i = 0, shift = 0; i < nProcs; shift += aPerNodeArchLength[i], ++i) {
             /* Deserialize partial results from step 1 */
             OutputDataArchive dataArch(&serializedData[shift], aPerNodeArchLength[i]);
 

--- a/samples/daal/cpp/oneccl/sources/covariance_dense_online_distributed_oneccl.cpp
+++ b/samples/daal/cpp/oneccl/sources/covariance_dense_online_distributed_oneccl.cpp
@@ -41,17 +41,18 @@ using namespace daal::algorithms;
 typedef services::SharedPtr<FileDataSource<CSVFeatureManager> > FileDataSourcePtr;
 
 /* Covariance algorithm parameters */
-const size_t nProcs          = 4;
+const size_t nProcs = 4;
 const size_t nVectorsInBlock = 25;
 
 /* Input data set parameters */
-const string dataFileNames[4] = { "./data/covcormoments_dense_1.csv", "./data/covcormoments_dense_2.csv", "./data/covcormoments_dense_3.csv",
+const string dataFileNames[4] = { "./data/covcormoments_dense_1.csv",
+                                  "./data/covcormoments_dense_2.csv",
+                                  "./data/covcormoments_dense_3.csv",
                                   "./data/covcormoments_dense_4.csv" };
 
 #define ccl_root 0
 
-int getLocalRank(ccl::communicator & comm, int size, int rank)
-{
+int getLocalRank(ccl::communicator &comm, int size, int rank) {
     /* Obtain local rank among nodes sharing the same host name */
     char zero = static_cast<char>(0);
     std::vector<char> name(MPI_MAX_PROCESSOR_NAME + 1, zero);
@@ -60,32 +61,40 @@ int getLocalRank(ccl::communicator & comm, int size, int rank)
     std::string str(name.begin(), name.end());
     std::vector<char> allNames((MPI_MAX_PROCESSOR_NAME + 1) * size, zero);
     std::vector<size_t> aReceiveCount(size, MPI_MAX_PROCESSOR_NAME + 1);
-    ccl::allgatherv((int8_t *)name.data(), name.size(), (int8_t *)allNames.data(), aReceiveCount, comm).wait();
+    ccl::allgatherv((int8_t *)name.data(),
+                    name.size(),
+                    (int8_t *)allNames.data(),
+                    aReceiveCount,
+                    comm)
+        .wait();
     int localRank = 0;
-    for (int i = 0; i < rank; i++)
-    {
+    for (int i = 0; i < rank; i++) {
         auto nameBegin = allNames.begin() + i * (MPI_MAX_PROCESSOR_NAME + 1);
         std::string nbrName(nameBegin, nameBegin + (MPI_MAX_PROCESSOR_NAME + 1));
-        if (nbrName == str) localRank++;
+        if (nbrName == str)
+            localRank++;
     }
     return localRank;
 }
 
-FileDataSourcePtr loadData(int rankId)
-{
+FileDataSourcePtr loadData(int rankId) {
     /* Initialize FileDataSource<CSVFeatureManager> to retrieve the input data
    * from a .csv file */
     auto data = SyclHomogenNumericTable<>::create(10, 0, NumericTable::notAllocate);
 
     return FileDataSourcePtr(
-        new FileDataSource<CSVFeatureManager>(dataFileNames[rankId], DataSource::doAllocateNumericTable, DataSource::doDictionaryFromContext));
+        new FileDataSource<CSVFeatureManager>(dataFileNames[rankId],
+                                              DataSource::doAllocateNumericTable,
+                                              DataSource::doDictionaryFromContext));
 }
 
-NumericTablePtr init(int rankId, const NumericTablePtr & pData, ccl::communicator & comm);
-NumericTablePtr compute(int rankId, const NumericTablePtr & pData, const NumericTablePtr & initialCentroids, ccl::communicator & comm);
+NumericTablePtr init(int rankId, const NumericTablePtr &pData, ccl::communicator &comm);
+NumericTablePtr compute(int rankId,
+                        const NumericTablePtr &pData,
+                        const NumericTablePtr &initialCentroids,
+                        ccl::communicator &comm);
 
-int main(int argc, char * argv[])
-{
+int main(int argc, char *argv[]) {
     /* Initialize oneCCL */
     ccl::init();
 
@@ -96,14 +105,12 @@ int main(int argc, char * argv[])
 
     ccl::shared_ptr_class<ccl::kvs> kvs;
     ccl::kvs::address_type main_addr;
-    if (rank == 0)
-    {
-        kvs       = ccl::create_main_kvs();
+    if (rank == 0) {
+        kvs = ccl::create_main_kvs();
         main_addr = kvs->get_address();
         MPI_Bcast((void *)main_addr.data(), main_addr.size(), MPI_BYTE, 0, MPI_COMM_WORLD);
     }
-    else
-    {
+    else {
         MPI_Bcast((void *)main_addr.data(), main_addr.size(), MPI_BYTE, 0, MPI_COMM_WORLD);
         kvs = ccl::create_kvs(main_addr);
     }
@@ -112,8 +119,8 @@ int main(int argc, char * argv[])
 
     /* Create GPU device from local rank and set execution context */
     auto local_rank = getLocalRank(comm, size, rank);
-    auto gpus       = get_gpus();
-    auto rank_gpu   = gpus[local_rank % gpus.size()];
+    auto gpus = get_gpus();
+    auto rank_gpu = gpus[local_rank % gpus.size()];
     cl::sycl::queue queue(rank_gpu);
     daal::services::SyclExecutionContext ctx(queue);
     services::Environment::getInstance()->setDefaultExecutionContext(ctx);
@@ -125,8 +132,7 @@ int main(int argc, char * argv[])
 
     covariance::Distributed<step1Local> localAlgorithm;
 
-    while (pData->loadDataBlock(nVectorsInBlock) == nVectorsInBlock)
-    {
+    while (pData->loadDataBlock(nVectorsInBlock) == nVectorsInBlock) {
         /* Set input objects for the algorithm */
         localAlgorithm.input.set(covariance::data, pData->getNumericTable());
 
@@ -148,8 +154,7 @@ int main(int argc, char * argv[])
     /* Calculate total archive length */
     int totalArchLength = 0;
 
-    for (size_t i = 0; i < nProcs; ++i)
-    {
+    for (size_t i = 0; i < nProcs; ++i) {
         totalArchLength += aPerNodeArchLength[i];
     }
     aReceiveCount[ccl_root] = totalArchLength;
@@ -160,14 +165,17 @@ int main(int argc, char * argv[])
     dataArch.copyArchiveToArray(&nodeResults[0], perNodeArchLength);
 
     /* Transfer partial results to step 2 on the root node */
-    ccl::allgatherv((int8_t *)&nodeResults[0], perNodeArchLength, (int8_t *)&serializedData[0], aPerNodeArchLength, comm).wait();
+    ccl::allgatherv((int8_t *)&nodeResults[0],
+                    perNodeArchLength,
+                    (int8_t *)&serializedData[0],
+                    aPerNodeArchLength,
+                    comm)
+        .wait();
 
-    if (isRoot)
-    {
+    if (isRoot) {
         /* Create an algorithm to compute covariance on the master node */
         covariance::Distributed<step2Master> masterAlgorithm;
-        for (size_t i = 0, shift = 0; i < nProcs; shift += aPerNodeArchLength[i], ++i)
-        {
+        for (size_t i = 0, shift = 0; i < nProcs; shift += aPerNodeArchLength[i], ++i) {
             /* Deserialize partial results from step 1 */
             OutputDataArchive dataArch(&serializedData[shift], aPerNodeArchLength[i]);
 

--- a/samples/daal/cpp/oneccl/sources/error_handling.h
+++ b/samples/daal/cpp/oneccl/sources/error_handling.h
@@ -23,42 +23,35 @@
 #ifndef _ERROR_HANDLING_H
 #define _ERROR_HANDLING_H
 
-const int fileError    = -1001;
+const int fileError = -1001;
 const int nullPtrError = -2;
-const int allocError   = -1;
+const int allocError = -1;
 
-void checkAllocation(void * ptr)
-{
-    if (!ptr)
-    {
+void checkAllocation(void* ptr) {
+    if (!ptr) {
         std::cout << "Error: Memory allocation failed" << std::endl;
         exit(allocError);
     }
 }
 
-void checkPtr(void * ptr)
-{
-    if (!ptr)
-    {
+void checkPtr(void* ptr) {
+    if (!ptr) {
         std::cout << "Error: NULL pointer" << std::endl;
         exit(nullPtrError);
     }
 }
 
-void fileOpenError(const char * filename)
-{
+void fileOpenError(const char* filename) {
     std::cout << "Unable to open file '" << filename << "'" << std::endl;
     exit(fileError);
 }
 
-void fileReadError()
-{
+void fileReadError() {
     std::cout << "Unable to read next line" << std::endl;
     exit(fileError);
 }
 
-void sparceFileReadError()
-{
+void sparceFileReadError() {
     std::cout << "Incorrect format of file" << std::endl;
     exit(fileError);
 }

--- a/samples/daal/cpp/oneccl/sources/kmeans_dense_distributed_oneccl.cpp
+++ b/samples/daal/cpp/oneccl/sources/kmeans_dense_distributed_oneccl.cpp
@@ -40,17 +40,19 @@ using namespace daal::algorithms;
 typedef float algorithmFPType; /* Algorithm floating-point type */
 
 /* K-Means algorithm parameters */
-const size_t nClusters   = 20;
+const size_t nClusters = 20;
 const size_t nIterations = 5;
-const size_t nProcs      = 4;
+const size_t nProcs = 4;
 
 /* Input data set parameters */
-const string dataFileNames[4] = { "./data/kmeans_dense.csv", "./data/kmeans_dense.csv", "./data/kmeans_dense.csv", "./data/kmeans_dense.csv" };
+const string dataFileNames[4] = { "./data/kmeans_dense.csv",
+                                  "./data/kmeans_dense.csv",
+                                  "./data/kmeans_dense.csv",
+                                  "./data/kmeans_dense.csv" };
 
 #define ccl_root 0
 
-int getLocalRank(ccl::communicator & comm, int size, int rank)
-{
+int getLocalRank(ccl::communicator &comm, int size, int rank) {
     /* Obtain local rank among nodes sharing the same host name */
     char zero = static_cast<char>(0);
     std::vector<char> name(MPI_MAX_PROCESSOR_NAME + 1, zero);
@@ -59,32 +61,40 @@ int getLocalRank(ccl::communicator & comm, int size, int rank)
     std::string str(name.begin(), name.end());
     std::vector<char> allNames((MPI_MAX_PROCESSOR_NAME + 1) * size, zero);
     std::vector<size_t> aReceiveCount(size, MPI_MAX_PROCESSOR_NAME + 1);
-    ccl::allgatherv((int8_t *)name.data(), name.size(), (int8_t *)allNames.data(), aReceiveCount, comm).wait();
+    ccl::allgatherv((int8_t *)name.data(),
+                    name.size(),
+                    (int8_t *)allNames.data(),
+                    aReceiveCount,
+                    comm)
+        .wait();
     int localRank = 0;
-    for (int i = 0; i < rank; i++)
-    {
+    for (int i = 0; i < rank; i++) {
         auto nameBegin = allNames.begin() + i * (MPI_MAX_PROCESSOR_NAME + 1);
         std::string nbrName(nameBegin, nameBegin + (MPI_MAX_PROCESSOR_NAME + 1));
-        if (nbrName == str) localRank++;
+        if (nbrName == str)
+            localRank++;
     }
     return localRank;
 }
 
-NumericTablePtr loadData(int rankId)
-{
+NumericTablePtr loadData(int rankId) {
     /* Initialize FileDataSource<CSVFeatureManager> to retrieve the input data from a .csv file */
-    FileDataSource<CSVFeatureManager> dataSource(dataFileNames[rankId], DataSource::doAllocateNumericTable, DataSource::doDictionaryFromContext);
+    FileDataSource<CSVFeatureManager> dataSource(dataFileNames[rankId],
+                                                 DataSource::doAllocateNumericTable,
+                                                 DataSource::doDictionaryFromContext);
 
     /* Retrieve the data from the input file */
     dataSource.loadDataBlock();
     return dataSource.getNumericTable();
 }
 
-NumericTablePtr init(int rankId, const NumericTablePtr & pData, ccl::communicator & comm);
-NumericTablePtr compute(int rankId, const NumericTablePtr & pData, const NumericTablePtr & initialCentroids, ccl::communicator & comm);
+NumericTablePtr init(int rankId, const NumericTablePtr &pData, ccl::communicator &comm);
+NumericTablePtr compute(int rankId,
+                        const NumericTablePtr &pData,
+                        const NumericTablePtr &initialCentroids,
+                        ccl::communicator &comm);
 
-int main(int argc, char * argv[])
-{
+int main(int argc, char *argv[]) {
     /* Initialize oneCCL */
     ccl::init();
 
@@ -95,14 +105,12 @@ int main(int argc, char * argv[])
 
     ccl::shared_ptr_class<ccl::kvs> kvs;
     ccl::kvs::address_type main_addr;
-    if (rank == 0)
-    {
-        kvs       = ccl::create_main_kvs();
+    if (rank == 0) {
+        kvs = ccl::create_main_kvs();
         main_addr = kvs->get_address();
         MPI_Bcast((void *)main_addr.data(), main_addr.size(), MPI_BYTE, 0, MPI_COMM_WORLD);
     }
-    else
-    {
+    else {
         MPI_Bcast((void *)main_addr.data(), main_addr.size(), MPI_BYTE, 0, MPI_COMM_WORLD);
         kvs = ccl::create_kvs(main_addr);
     }
@@ -111,34 +119,37 @@ int main(int argc, char * argv[])
 
     /* Create GPU device from local rank and set execution context */
     auto local_rank = getLocalRank(comm, size, rank);
-    auto gpus       = get_gpus();
-    auto rank_gpu   = gpus[local_rank % gpus.size()];
+    auto gpus = get_gpus();
+    auto rank_gpu = gpus[local_rank % gpus.size()];
     cl::sycl::queue queue(rank_gpu);
     daal::services::SyclExecutionContext ctx(queue);
     services::Environment::getInstance()->setDefaultExecutionContext(ctx);
 
     /* Start data processing */
-    NumericTablePtr pData     = loadData(rank);
+    NumericTablePtr pData = loadData(rank);
     NumericTablePtr centroids = init(rank, pData, comm);
 
-    for (size_t it = 0; it < nIterations; it++) centroids = compute(rank, pData, centroids, comm);
+    for (size_t it = 0; it < nIterations; it++)
+        centroids = compute(rank, pData, centroids, comm);
 
     /* Print the clusterization results */
-    if (rank == ccl_root) printNumericTable(centroids, "First 10 dimensions of centroids:", 20, 10);
+    if (rank == ccl_root)
+        printNumericTable(centroids, "First 10 dimensions of centroids:", 20, 10);
 
     MPI_Finalize();
     return 0;
 }
 
-NumericTablePtr init(int rankId, const NumericTablePtr & pData, ccl::communicator & comm)
-{
+NumericTablePtr init(int rankId, const NumericTablePtr &pData, ccl::communicator &comm) {
     const bool isRoot = (rankId == ccl_root);
 
     const size_t nVectorsInBlock = pData->getNumberOfRows();
 
     /* Create an algorithm to compute k-means on local nodes */
-    kmeans::init::Distributed<step1Local, algorithmFPType, kmeans::init::randomDense> localInit(nClusters, nProcs * nVectorsInBlock,
-                                                                                                rankId * nVectorsInBlock);
+    kmeans::init::Distributed<step1Local, algorithmFPType, kmeans::init::randomDense> localInit(
+        nClusters,
+        nProcs * nVectorsInBlock,
+        rankId * nVectorsInBlock);
 
     /* Set the input data set to the algorithm */
     localInit.input.set(kmeans::init::data, pData);
@@ -160,8 +171,7 @@ NumericTablePtr init(int rankId, const NumericTablePtr & pData, ccl::communicato
     /* Calculate total archive length */
     int totalArchLength = 0;
     int displs[nProcs];
-    for (size_t i = 0; i < nProcs; ++i)
-    {
+    for (size_t i = 0; i < nProcs; ++i) {
         totalArchLength += aPerNodeArchLength[i];
     }
     aReceiveCount[ccl_root] = totalArchLength;
@@ -172,13 +182,17 @@ NumericTablePtr init(int rankId, const NumericTablePtr & pData, ccl::communicato
     dataArch.copyArchiveToArray(&nodeResults[0], perNodeArchLength);
 
     /* Transfer partial results to step 2 on the root node */
-    ccl::allgatherv((int8_t *)&nodeResults[0], perNodeArchLength, (int8_t *)&serializedData[0], aPerNodeArchLength, comm).wait();
-    if (isRoot)
-    {
+    ccl::allgatherv((int8_t *)&nodeResults[0],
+                    perNodeArchLength,
+                    (int8_t *)&serializedData[0],
+                    aPerNodeArchLength,
+                    comm)
+        .wait();
+    if (isRoot) {
         /* Create an algorithm to compute k-means on the master node */
-        kmeans::init::Distributed<step2Master, algorithmFPType, kmeans::init::randomDense> masterInit(nClusters);
-        for (size_t i = 0, shift = 0; i < nProcs; shift += aPerNodeArchLength[i], ++i)
-        {
+        kmeans::init::Distributed<step2Master, algorithmFPType, kmeans::init::randomDense>
+            masterInit(nClusters);
+        for (size_t i = 0, shift = 0; i < nProcs; shift += aPerNodeArchLength[i], ++i) {
             /* Deserialize partial results from step 1 */
             OutputDataArchive dataArch(&serializedData[shift], aPerNodeArchLength[i]);
 
@@ -197,13 +211,14 @@ NumericTablePtr init(int rankId, const NumericTablePtr & pData, ccl::communicato
     return NumericTablePtr();
 }
 
-NumericTablePtr compute(int rankId, const NumericTablePtr & pData, const NumericTablePtr & initialCentroids, ccl::communicator & comm)
-{
-    const bool isRoot            = (rankId == ccl_root);
+NumericTablePtr compute(int rankId,
+                        const NumericTablePtr &pData,
+                        const NumericTablePtr &initialCentroids,
+                        ccl::communicator &comm) {
+    const bool isRoot = (rankId == ccl_root);
     uint64_t CentroidsArchLength = 0;
     InputDataArchive inputArch;
-    if (isRoot)
-    {
+    if (isRoot) {
         /*Retrieve the algorithm results and serialize them */
         initialCentroids->serialize(inputArch);
         CentroidsArchLength = inputArch.getSizeOfArchive();
@@ -213,7 +228,8 @@ NumericTablePtr compute(int rankId, const NumericTablePtr & pData, const Numeric
     ccl::broadcast(&CentroidsArchLength, 1, ccl_root, comm).wait();
 
     ByteBuffer nodeCentroids(CentroidsArchLength);
-    if (isRoot) inputArch.copyArchiveToArray(&nodeCentroids[0], CentroidsArchLength);
+    if (isRoot)
+        inputArch.copyArchiveToArray(&nodeCentroids[0], CentroidsArchLength);
 
     ccl::broadcast((int8_t *)&nodeCentroids[0], CentroidsArchLength, ccl_root, comm).wait();
 
@@ -247,15 +263,18 @@ NumericTablePtr compute(int rankId, const NumericTablePtr & pData, const Numeric
     dataArch.copyArchiveToArray(&nodeResults[0], perNodeArchLength);
     std::vector<size_t> aReceiveCount(comm.size(), perNodeArchLength);
     /* Transfer partial results to step 2 on the root node */
-    ccl::allgatherv((int8_t *)&nodeResults[0], perNodeArchLength, (int8_t *)&serializedData[0], aReceiveCount, comm).wait();
+    ccl::allgatherv((int8_t *)&nodeResults[0],
+                    perNodeArchLength,
+                    (int8_t *)&serializedData[0],
+                    aReceiveCount,
+                    comm)
+        .wait();
 
-    if (isRoot)
-    {
+    if (isRoot) {
         /* Create an algorithm to compute k-means on the master node */
         kmeans::Distributed<step2Master> masterAlgorithm(nClusters);
 
-        for (size_t i = 0; i < nProcs; i++)
-        {
+        for (size_t i = 0; i < nProcs; i++) {
             /* Deserialize partial results from step 1 */
             OutputDataArchive dataArch(&serializedData[perNodeArchLength * i], perNodeArchLength);
 

--- a/samples/daal/cpp/oneccl/sources/low_order_moments_dense_batch_distributed_oneccl.cpp
+++ b/samples/daal/cpp/oneccl/sources/low_order_moments_dense_batch_distributed_oneccl.cpp
@@ -45,13 +45,14 @@ typedef services::SharedPtr<SyclHomogenNumericTable<> > SyclHomogenNumericTableP
 const size_t nProcs = 4;
 
 /* Input data set parameters */
-const string dataFileNames[4] = { "./data/covcormoments_dense_1.csv", "./data/covcormoments_dense_2.csv", "./data/covcormoments_dense_3.csv",
+const string dataFileNames[4] = { "./data/covcormoments_dense_1.csv",
+                                  "./data/covcormoments_dense_2.csv",
+                                  "./data/covcormoments_dense_3.csv",
                                   "./data/covcormoments_dense_4.csv" };
 
 #define ccl_root 0
 
-int getLocalRank(ccl::communicator & comm, int size, int rank)
-{
+int getLocalRank(ccl::communicator &comm, int size, int rank) {
     /* Obtain local rank among nodes sharing the same host name */
     char zero = static_cast<char>(0);
     std::vector<char> name(MPI_MAX_PROCESSOR_NAME + 1, zero);
@@ -60,22 +61,28 @@ int getLocalRank(ccl::communicator & comm, int size, int rank)
     std::string str(name.begin(), name.end());
     std::vector<char> allNames((MPI_MAX_PROCESSOR_NAME + 1) * size, zero);
     std::vector<size_t> aReceiveCount(size, MPI_MAX_PROCESSOR_NAME + 1);
-    ccl::allgatherv((int8_t *)name.data(), name.size(), (int8_t *)allNames.data(), aReceiveCount, comm).wait();
+    ccl::allgatherv((int8_t *)name.data(),
+                    name.size(),
+                    (int8_t *)allNames.data(),
+                    aReceiveCount,
+                    comm)
+        .wait();
     int localRank = 0;
-    for (int i = 0; i < rank; i++)
-    {
+    for (int i = 0; i < rank; i++) {
         auto nameBegin = allNames.begin() + i * (MPI_MAX_PROCESSOR_NAME + 1);
         std::string nbrName(nameBegin, nameBegin + (MPI_MAX_PROCESSOR_NAME + 1));
-        if (nbrName == str) localRank++;
+        if (nbrName == str)
+            localRank++;
     }
     return localRank;
 }
 
-SyclHomogenNumericTablePtr loadData(int rankId)
-{
+SyclHomogenNumericTablePtr loadData(int rankId) {
     /* Initialize FileDataSource<CSVFeatureManager> to retrieve the input data
    * from a .csv file */
-    FileDataSource<CSVFeatureManager> dataSource(dataFileNames[rankId], DataSource::notAllocateNumericTable, DataSource::doDictionaryFromContext);
+    FileDataSource<CSVFeatureManager> dataSource(dataFileNames[rankId],
+                                                 DataSource::notAllocateNumericTable,
+                                                 DataSource::doDictionaryFromContext);
 
     /* Retrieve the data from the input file */
     auto data = SyclHomogenNumericTable<>::create(10, 0, NumericTable::notAllocate);
@@ -83,11 +90,16 @@ SyclHomogenNumericTablePtr loadData(int rankId)
     return data;
 }
 
-int main(int argc, char * argv[])
-{
+int main(int argc, char *argv[]) {
     /* Initialize oneCCL */
     ccl::init();
-    checkArguments(argc, argv, 4, &dataFileNames[0], &dataFileNames[1], &dataFileNames[2], &dataFileNames[3]);
+    checkArguments(argc,
+                   argv,
+                   4,
+                   &dataFileNames[0],
+                   &dataFileNames[1],
+                   &dataFileNames[2],
+                   &dataFileNames[3]);
 
     MPI_Init(NULL, NULL);
     int size, rank;
@@ -98,14 +110,12 @@ int main(int argc, char * argv[])
 
     ccl::shared_ptr_class<ccl::kvs> kvs;
     ccl::kvs::address_type main_addr;
-    if (rank == 0)
-    {
-        kvs       = ccl::create_main_kvs();
+    if (rank == 0) {
+        kvs = ccl::create_main_kvs();
         main_addr = kvs->get_address();
         MPI_Bcast((void *)main_addr.data(), main_addr.size(), MPI_BYTE, 0, MPI_COMM_WORLD);
     }
-    else
-    {
+    else {
         MPI_Bcast((void *)main_addr.data(), main_addr.size(), MPI_BYTE, 0, MPI_COMM_WORLD);
         kvs = ccl::create_kvs(main_addr);
     }
@@ -114,7 +124,7 @@ int main(int argc, char * argv[])
 
     /* Create GPU device from local rank and set execution context */
     auto local_rank = getLocalRank(comm, size, rank);
-    auto gpus       = get_gpus();
+    auto gpus = get_gpus();
 
     auto rank_gpu = gpus[local_rank % gpus.size()];
     cl::sycl::queue queue(rank_gpu);
@@ -147,19 +157,23 @@ int main(int argc, char * argv[])
     dataArch.copyArchiveToArray(&nodeResults[0], perNodeArchLength);
     std::vector<size_t> aReceiveCount(comm.size(), perNodeArchLength);
     /* Transfer partial results to step 2 on the root node */
-    ccl::allgatherv((int8_t *)&nodeResults[0], perNodeArchLength, (int8_t *)&serializedData[0], aReceiveCount, comm).wait();
+    ccl::allgatherv((int8_t *)&nodeResults[0],
+                    perNodeArchLength,
+                    (int8_t *)&serializedData[0],
+                    aReceiveCount,
+                    comm)
+        .wait();
 
-    if (isRoot)
-    {
+    if (isRoot) {
         /* Create an algorithm to compute low order moments on the master node */
         low_order_moments::Distributed<step2Master> masterAlgorithm;
 
-        for (int i = 0; i < nProcs; i++)
-        {
+        for (int i = 0; i < nProcs; i++) {
             /* Deserialize partial results from step 1 */
             OutputDataArchive dataArch(&serializedData[perNodeArchLength * i], perNodeArchLength);
 
-            low_order_moments::PartialResultPtr dataForStep2FromStep1(new low_order_moments::PartialResult());
+            low_order_moments::PartialResultPtr dataForStep2FromStep1(
+                new low_order_moments::PartialResult());
 
             dataForStep2FromStep1->deserialize(dataArch);
 
@@ -179,9 +193,11 @@ int main(int argc, char * argv[])
         printNumericTable(res->get(low_order_moments::maximum), "Maximum:");
         printNumericTable(res->get(low_order_moments::sum), "Sum:");
         printNumericTable(res->get(low_order_moments::sumSquares), "Sum of squares:");
-        printNumericTable(res->get(low_order_moments::sumSquaresCentered), "Sum of squared difference from the means:");
+        printNumericTable(res->get(low_order_moments::sumSquaresCentered),
+                          "Sum of squared difference from the means:");
         printNumericTable(res->get(low_order_moments::mean), "Mean:");
-        printNumericTable(res->get(low_order_moments::secondOrderRawMoment), "Second order raw moment:");
+        printNumericTable(res->get(low_order_moments::secondOrderRawMoment),
+                          "Second order raw moment:");
         printNumericTable(res->get(low_order_moments::variance), "Variance:");
         printNumericTable(res->get(low_order_moments::standardDeviation), "Standard deviation:");
         printNumericTable(res->get(low_order_moments::variation), "Variation:");

--- a/samples/daal/cpp/oneccl/sources/pca_dense_online_distributed_oneccl.cpp
+++ b/samples/daal/cpp/oneccl/sources/pca_dense_online_distributed_oneccl.cpp
@@ -46,13 +46,14 @@ const size_t nProcs = 4;
 const size_t nVectorsInBlock = 25;
 
 /* Input data set parameters */
-const string dataFileNames[4] = { "./data/pca_normalized_1.csv", "./data/pca_normalized_2.csv", "./data/pca_normalized_3.csv",
+const string dataFileNames[4] = { "./data/pca_normalized_1.csv",
+                                  "./data/pca_normalized_2.csv",
+                                  "./data/pca_normalized_3.csv",
                                   "./data/pca_normalized_4.csv" };
 
 #define ccl_root 0
 
-int getLocalRank(ccl::communicator & comm, int size, int rank)
-{
+int getLocalRank(ccl::communicator &comm, int size, int rank) {
     /* Obtain local rank among nodes sharing the same host name */
     char zero = static_cast<char>(0);
     std::vector<char> name(MPI_MAX_PROCESSOR_NAME + 1, zero);
@@ -61,29 +62,34 @@ int getLocalRank(ccl::communicator & comm, int size, int rank)
     std::string str(name.begin(), name.end());
     std::vector<char> allNames((MPI_MAX_PROCESSOR_NAME + 1) * size, zero);
     std::vector<size_t> aReceiveCount(size, MPI_MAX_PROCESSOR_NAME + 1);
-    ccl::allgatherv((int8_t *)name.data(), name.size(), (int8_t *)allNames.data(), aReceiveCount, comm).wait();
+    ccl::allgatherv((int8_t *)name.data(),
+                    name.size(),
+                    (int8_t *)allNames.data(),
+                    aReceiveCount,
+                    comm)
+        .wait();
     int localRank = 0;
-    for (int i = 0; i < rank; i++)
-    {
+    for (int i = 0; i < rank; i++) {
         auto nameBegin = allNames.begin() + i * (MPI_MAX_PROCESSOR_NAME + 1);
         std::string nbrName(nameBegin, nameBegin + (MPI_MAX_PROCESSOR_NAME + 1));
-        if (nbrName == str) localRank++;
+        if (nbrName == str)
+            localRank++;
     }
     return localRank;
 }
 
-FileDataSourcePtr loadData(int rankId)
-{
+FileDataSourcePtr loadData(int rankId) {
     /* Initialize FileDataSource<CSVFeatureManager> to retrieve the input data
    * from a .csv file */
     auto data = SyclHomogenNumericTable<>::create(10, 0, NumericTable::notAllocate);
 
     return FileDataSourcePtr(
-        new FileDataSource<CSVFeatureManager>(dataFileNames[rankId], DataSource::doAllocateNumericTable, DataSource::doDictionaryFromContext));
+        new FileDataSource<CSVFeatureManager>(dataFileNames[rankId],
+                                              DataSource::doAllocateNumericTable,
+                                              DataSource::doDictionaryFromContext));
 }
 
-int main(int argc, char * argv[])
-{
+int main(int argc, char *argv[]) {
     /* Initialize oneCCL */
     ccl::init();
 
@@ -94,14 +100,12 @@ int main(int argc, char * argv[])
 
     ccl::shared_ptr_class<ccl::kvs> kvs;
     ccl::kvs::address_type main_addr;
-    if (rank == 0)
-    {
-        kvs       = ccl::create_main_kvs();
+    if (rank == 0) {
+        kvs = ccl::create_main_kvs();
         main_addr = kvs->get_address();
         MPI_Bcast((void *)main_addr.data(), main_addr.size(), MPI_BYTE, 0, MPI_COMM_WORLD);
     }
-    else
-    {
+    else {
         MPI_Bcast((void *)main_addr.data(), main_addr.size(), MPI_BYTE, 0, MPI_COMM_WORLD);
         kvs = ccl::create_kvs(main_addr);
     }
@@ -110,8 +114,8 @@ int main(int argc, char * argv[])
 
     /* Create GPU device from local rank and set execution context */
     auto local_rank = getLocalRank(comm, size, rank);
-    auto gpus       = get_gpus();
-    auto rank_gpu   = gpus[local_rank % gpus.size()];
+    auto gpus = get_gpus();
+    auto rank_gpu = gpus[local_rank % gpus.size()];
     cl::sycl::queue queue(rank_gpu);
     daal::services::SyclExecutionContext ctx(queue);
     services::Environment::getInstance()->setDefaultExecutionContext(ctx);
@@ -123,8 +127,7 @@ int main(int argc, char * argv[])
 
     pca::Distributed<step1Local> localAlgorithm;
 
-    while (pData->loadDataBlock(nVectorsInBlock) == nVectorsInBlock)
-    {
+    while (pData->loadDataBlock(nVectorsInBlock) == nVectorsInBlock) {
         /* Set input objects for the algorithm */
         localAlgorithm.input.set(pca::data, pData->getNumericTable());
 
@@ -146,8 +149,7 @@ int main(int argc, char * argv[])
     /* Calculate total archive length */
     int totalArchLength = 0;
     int displs[nProcs];
-    for (size_t i = 0; i < nProcs; ++i)
-    {
+    for (size_t i = 0; i < nProcs; ++i) {
         totalArchLength += aPerNodeArchLength[i];
     }
     aReceiveCount[ccl_root] = totalArchLength;
@@ -158,18 +160,22 @@ int main(int argc, char * argv[])
     dataArch.copyArchiveToArray(&nodeResults[0], perNodeArchLength);
 
     /* Transfer partial results to step 2 on the root node */
-    ccl::allgatherv((int8_t *)&nodeResults[0], perNodeArchLength, (int8_t *)&serializedData[0], aPerNodeArchLength, comm).wait();
+    ccl::allgatherv((int8_t *)&nodeResults[0],
+                    perNodeArchLength,
+                    (int8_t *)&serializedData[0],
+                    aPerNodeArchLength,
+                    comm)
+        .wait();
 
-    if (isRoot)
-    {
+    if (isRoot) {
         /* Create an algorithm for principal component analysis using the correlation method on the master node */
         pca::Distributed<step2Master> masterAlgorithm;
-        for (size_t i = 0, shift = 0; i < nProcs; shift += aPerNodeArchLength[i], ++i)
-        {
+        for (size_t i = 0, shift = 0; i < nProcs; shift += aPerNodeArchLength[i], ++i) {
             /* Deserialize partial results from step 1 */
             OutputDataArchive dataArch(&serializedData[shift], aPerNodeArchLength[i]);
 
-            services::SharedPtr<pca::PartialResult<pca::correlationDense> > dataForStep2FromStep1(new pca::PartialResult<pca::correlationDense>());
+            services::SharedPtr<pca::PartialResult<pca::correlationDense> > dataForStep2FromStep1(
+                new pca::PartialResult<pca::correlationDense>());
             dataForStep2FromStep1->deserialize(dataArch);
 
             /* Set local partial results as input for the master-node algorithm */

--- a/samples/daal/cpp/oneccl/sources/service.h
+++ b/samples/daal/cpp/oneccl/sources/service.h
@@ -40,11 +40,9 @@ using namespace daal::data_management;
 
 typedef std::vector<daal::byte> ByteBuffer;
 
-size_t readTextFile(const std::string & datasetFileName, daal::byte ** data)
-{
+size_t readTextFile(const std::string &datasetFileName, daal::byte **data) {
     std::ifstream file(datasetFileName.c_str(), std::ios::binary | std::ios::ate);
-    if (!file.is_open())
-    {
+    if (!file.is_open()) {
         fileOpenError(datasetFileName.c_str());
     }
 
@@ -56,8 +54,7 @@ size_t readTextFile(const std::string & datasetFileName, daal::byte ** data)
     (*data) = new daal::byte[fileSize];
     checkAllocation(data);
 
-    if (!file.read((char *)(*data), fileSize))
-    {
+    if (!file.read((char *)(*data), fileSize)) {
         delete[] data;
         fileReadError();
     }
@@ -66,12 +63,10 @@ size_t readTextFile(const std::string & datasetFileName, daal::byte ** data)
 }
 
 template <typename item_type>
-void readLine(std::string & line, size_t nCols, item_type * data, size_t firstPos = 0)
-{
+void readLine(std::string &line, size_t nCols, item_type *data, size_t firstPos = 0) {
     std::stringstream iss(line);
 
-    for (size_t col = 0; col < nCols; ++col)
-    {
+    for (size_t col = 0; col < nCols; ++col) {
         std::string val;
         std::getline(iss, val, ',');
 
@@ -81,36 +76,32 @@ void readLine(std::string & line, size_t nCols, item_type * data, size_t firstPo
 }
 
 template <typename item_type>
-void readRowUnknownLength(char * line, std::vector<item_type> & data)
-{
-    size_t n               = 0;
-    const char * prevDelim = line - 1;
-    char * ptr             = line;
-    for (; *ptr; ++ptr)
-    {
-        if (*ptr == ',' || *ptr == '\r')
-        {
-            if (prevDelim != ptr - 1) ++n;
-            *ptr      = ' ';
+void readRowUnknownLength(char *line, std::vector<item_type> &data) {
+    size_t n = 0;
+    const char *prevDelim = line - 1;
+    char *ptr = line;
+    for (; *ptr; ++ptr) {
+        if (*ptr == ',' || *ptr == '\r') {
+            if (prevDelim != ptr - 1)
+                ++n;
+            *ptr = ' ';
             prevDelim = ptr;
         }
     }
-    if (prevDelim != ptr - 1) ++n;
+    if (prevDelim != ptr - 1)
+        ++n;
     data.resize(n);
     std::stringstream iss(line);
-    for (size_t i = 0; i < n; ++i)
-    {
+    for (size_t i = 0; i < n; ++i) {
         iss >> data[i];
     }
 }
 
 template <typename item_type>
-CSRNumericTable * createSparseTable(const std::string & datasetFileName)
-{
+CSRNumericTable *createSparseTable(const std::string &datasetFileName) {
     std::ifstream file(datasetFileName.c_str());
 
-    if (!file.is_open())
-    {
+    if (!file.is_open()) {
         fileOpenError(datasetFileName.c_str());
     }
 
@@ -120,7 +111,8 @@ CSRNumericTable * createSparseTable(const std::string & datasetFileName)
     std::getline(file, str);
     std::vector<size_t> rowOffsets;
     readRowUnknownLength<size_t>(&str[0], rowOffsets);
-    if (!rowOffsets.size()) return NULL;
+    if (!rowOffsets.size())
+        return NULL;
     const size_t nVectors = rowOffsets.size() - 1;
 
     //read cols indices
@@ -135,61 +127,59 @@ CSRNumericTable * createSparseTable(const std::string & datasetFileName)
     const size_t nNonZeros = data.size();
 
     size_t maxCol = 0;
-    for (size_t i = 0; i < colIndices.size(); ++i)
-    {
-        if (colIndices[i] > maxCol) maxCol = colIndices[i];
+    for (size_t i = 0; i < colIndices.size(); ++i) {
+        if (colIndices[i] > maxCol)
+            maxCol = colIndices[i];
     }
     const size_t nFeatures = maxCol;
 
-    if (!nFeatures || !nVectors || colIndices.size() != nNonZeros || nNonZeros != (rowOffsets[nVectors] - 1))
-    {
+    if (!nFeatures || !nVectors || colIndices.size() != nNonZeros ||
+        nNonZeros != (rowOffsets[nVectors] - 1)) {
         sparceFileReadError();
     }
 
-    size_t * resultRowOffsets      = NULL;
-    size_t * resultColIndices      = NULL;
-    item_type * resultData         = NULL;
-    CSRNumericTable * numericTable = new CSRNumericTable(resultData, resultColIndices, resultRowOffsets, nFeatures, nVectors);
+    size_t *resultRowOffsets = NULL;
+    size_t *resultColIndices = NULL;
+    item_type *resultData = NULL;
+    CSRNumericTable *numericTable =
+        new CSRNumericTable(resultData, resultColIndices, resultRowOffsets, nFeatures, nVectors);
     numericTable->allocateDataMemory(nNonZeros);
     numericTable->getArrays<item_type>(&resultData, &resultColIndices, &resultRowOffsets);
-    for (size_t i = 0; i < nNonZeros; ++i)
-    {
-        resultData[i]       = data[i];
+    for (size_t i = 0; i < nNonZeros; ++i) {
+        resultData[i] = data[i];
         resultColIndices[i] = colIndices[i];
     }
-    for (size_t i = 0; i < nVectors + 1; ++i)
-    {
+    for (size_t i = 0; i < nVectors + 1; ++i) {
         resultRowOffsets[i] = rowOffsets[i];
     }
     return numericTable;
 }
 
-void printAprioriItemsets(NumericTablePtr largeItemsetsTable, NumericTablePtr largeItemsetsSupportTable, size_t nItemsetToPrint = 20)
-{
-    size_t largeItemsetCount     = largeItemsetsSupportTable->getNumberOfRows();
+void printAprioriItemsets(NumericTablePtr largeItemsetsTable,
+                          NumericTablePtr largeItemsetsSupportTable,
+                          size_t nItemsetToPrint = 20) {
+    size_t largeItemsetCount = largeItemsetsSupportTable->getNumberOfRows();
     size_t nItemsInLargeItemsets = largeItemsetsTable->getNumberOfRows();
 
     BlockDescriptor<int> block1;
     largeItemsetsTable->getBlockOfRows(0, nItemsInLargeItemsets, readOnly, block1);
-    int * largeItemsets = block1.getBlockPtr();
+    int *largeItemsets = block1.getBlockPtr();
 
     BlockDescriptor<int> block2;
     largeItemsetsSupportTable->getBlockOfRows(0, largeItemsetCount, readOnly, block2);
-    int * largeItemsetsSupportData = block2.getBlockPtr();
+    int *largeItemsetsSupportData = block2.getBlockPtr();
 
     std::vector<std::vector<size_t> > largeItemsetsVector;
     largeItemsetsVector.resize(largeItemsetCount);
 
-    for (size_t i = 0; i < nItemsInLargeItemsets; i++)
-    {
+    for (size_t i = 0; i < nItemsInLargeItemsets; i++) {
         largeItemsetsVector[largeItemsets[2 * i]].push_back(largeItemsets[2 * i + 1]);
     }
 
     std::vector<size_t> supportVector;
     supportVector.resize(largeItemsetCount);
 
-    for (size_t i = 0; i < largeItemsetCount; i++)
-    {
+    for (size_t i = 0; i < largeItemsetCount; i++) {
         supportVector[largeItemsetsSupportData[2 * i]] = largeItemsetsSupportData[2 * i + 1];
     }
 
@@ -200,12 +190,12 @@ void printAprioriItemsets(NumericTablePtr largeItemsetsTable, NumericTablePtr la
               << "Itemset"
               << "\t\t\tSupport" << std::endl;
 
-    size_t iMin = (((largeItemsetCount > nItemsetToPrint) && (nItemsetToPrint != 0)) ? largeItemsetCount - nItemsetToPrint : 0);
-    for (size_t i = iMin; i < largeItemsetCount; i++)
-    {
+    size_t iMin = (((largeItemsetCount > nItemsetToPrint) && (nItemsetToPrint != 0))
+                       ? largeItemsetCount - nItemsetToPrint
+                       : 0);
+    for (size_t i = iMin; i < largeItemsetCount; i++) {
         std::cout << "{";
-        for (size_t l = 0; l < largeItemsetsVector[i].size() - 1; l++)
-        {
+        for (size_t l = 0; l < largeItemsetsVector[i].size() - 1; l++) {
             std::cout << largeItemsetsVector[i][l] << ", ";
         }
         std::cout << largeItemsetsVector[i][largeItemsetsVector[i].size() - 1] << "}\t\t";
@@ -217,51 +207,49 @@ void printAprioriItemsets(NumericTablePtr largeItemsetsTable, NumericTablePtr la
     largeItemsetsSupportTable->releaseBlockOfRows(block2);
 }
 
-void printAprioriRules(NumericTablePtr leftItemsTable, NumericTablePtr rightItemsTable, NumericTablePtr confidenceTable, size_t nRulesToPrint = 20)
-{
-    size_t nRules      = confidenceTable->getNumberOfRows();
-    size_t nLeftItems  = leftItemsTable->getNumberOfRows();
+void printAprioriRules(NumericTablePtr leftItemsTable,
+                       NumericTablePtr rightItemsTable,
+                       NumericTablePtr confidenceTable,
+                       size_t nRulesToPrint = 20) {
+    size_t nRules = confidenceTable->getNumberOfRows();
+    size_t nLeftItems = leftItemsTable->getNumberOfRows();
     size_t nRightItems = rightItemsTable->getNumberOfRows();
 
     BlockDescriptor<int> block1;
     leftItemsTable->getBlockOfRows(0, nLeftItems, readOnly, block1);
-    int * leftItems = block1.getBlockPtr();
+    int *leftItems = block1.getBlockPtr();
 
     BlockDescriptor<int> block2;
     rightItemsTable->getBlockOfRows(0, nRightItems, readOnly, block2);
-    int * rightItems = block2.getBlockPtr();
+    int *rightItems = block2.getBlockPtr();
 
     BlockDescriptor<DAAL_DATA_TYPE> block3;
     confidenceTable->getBlockOfRows(0, nRules, readOnly, block3);
-    DAAL_DATA_TYPE * confidence = block3.getBlockPtr();
+    DAAL_DATA_TYPE *confidence = block3.getBlockPtr();
 
     std::vector<std::vector<size_t> > leftItemsVector;
     leftItemsVector.resize(nRules);
 
-    if (nRules == 0)
-    {
+    if (nRules == 0) {
         std::cout << std::endl << "No association rules were found " << std::endl;
         return;
     }
 
-    for (size_t i = 0; i < nLeftItems; i++)
-    {
+    for (size_t i = 0; i < nLeftItems; i++) {
         leftItemsVector[leftItems[2 * i]].push_back(leftItems[2 * i + 1]);
     }
 
     std::vector<std::vector<size_t> > rightItemsVector;
     rightItemsVector.resize(nRules);
 
-    for (size_t i = 0; i < nRightItems; i++)
-    {
+    for (size_t i = 0; i < nRightItems; i++) {
         rightItemsVector[rightItems[2 * i]].push_back(rightItems[2 * i + 1]);
     }
 
     std::vector<DAAL_DATA_TYPE> confidenceVector;
     confidenceVector.resize(nRules);
 
-    for (size_t i = 0; i < nRules; i++)
-    {
+    for (size_t i = 0; i < nRules; i++) {
         confidenceVector[i] = confidence[i];
     }
 
@@ -269,19 +257,17 @@ void printAprioriRules(NumericTablePtr leftItemsTable, NumericTablePtr rightItem
     std::cout << std::endl
               << "Rule"
               << "\t\t\t\tConfidence" << std::endl;
-    size_t iMin = (((nRules > nRulesToPrint) && (nRulesToPrint != 0)) ? (nRules - nRulesToPrint) : 0);
+    size_t iMin =
+        (((nRules > nRulesToPrint) && (nRulesToPrint != 0)) ? (nRules - nRulesToPrint) : 0);
 
-    for (size_t i = iMin; i < nRules; i++)
-    {
+    for (size_t i = iMin; i < nRules; i++) {
         std::cout << "{";
-        for (size_t l = 0; l < leftItemsVector[i].size() - 1; l++)
-        {
+        for (size_t l = 0; l < leftItemsVector[i].size() - 1; l++) {
             std::cout << leftItemsVector[i][l] << ", ";
         }
         std::cout << leftItemsVector[i][leftItemsVector[i].size() - 1] << "} => {";
 
-        for (size_t l = 0; l < rightItemsVector[i].size() - 1; l++)
-        {
+        for (size_t l = 0; l < rightItemsVector[i].size() - 1; l++) {
             std::cout << rightItemsVector[i][l] << ", ";
         }
         std::cout << rightItemsVector[i][rightItemsVector[i].size() - 1] << "}\t\t";
@@ -294,45 +280,43 @@ void printAprioriRules(NumericTablePtr leftItemsTable, NumericTablePtr rightItem
     confidenceTable->releaseBlockOfRows(block3);
 }
 
-bool isFull(NumericTableIface::StorageLayout layout)
-{
+bool isFull(NumericTableIface::StorageLayout layout) {
     int layoutInt = (int)layout;
-    if (packed_mask & layoutInt)
-    {
+    if (packed_mask & layoutInt) {
         return false;
     }
     return true;
 }
 
-bool isUpper(NumericTableIface::StorageLayout layout)
-{
-    if (layout == NumericTableIface::upperPackedSymmetricMatrix || layout == NumericTableIface::upperPackedTriangularMatrix)
-    {
+bool isUpper(NumericTableIface::StorageLayout layout) {
+    if (layout == NumericTableIface::upperPackedSymmetricMatrix ||
+        layout == NumericTableIface::upperPackedTriangularMatrix) {
         return true;
     }
     return false;
 }
 
-bool isLower(NumericTableIface::StorageLayout layout)
-{
-    if (layout == NumericTableIface::lowerPackedSymmetricMatrix || layout == NumericTableIface::lowerPackedTriangularMatrix)
-    {
+bool isLower(NumericTableIface::StorageLayout layout) {
+    if (layout == NumericTableIface::lowerPackedSymmetricMatrix ||
+        layout == NumericTableIface::lowerPackedTriangularMatrix) {
         return true;
     }
     return false;
 }
 
 template <typename T>
-void printArray(T * array, const size_t nPrintedCols, const size_t nPrintedRows, const size_t nCols, const std::string & message,
-                size_t interval = 10)
-{
+void printArray(T *array,
+                const size_t nPrintedCols,
+                const size_t nPrintedRows,
+                const size_t nCols,
+                const std::string &message,
+                size_t interval = 10) {
     std::cout << std::setiosflags(std::ios::left);
     std::cout << message << std::endl;
-    for (size_t i = 0; i < nPrintedRows; i++)
-    {
-        for (size_t j = 0; j < nPrintedCols; j++)
-        {
-            std::cout << std::setw(interval) << std::setiosflags(std::ios::fixed) << std::setprecision(3);
+    for (size_t i = 0; i < nPrintedRows; i++) {
+        for (size_t j = 0; j < nPrintedCols; j++) {
+            std::cout << std::setw(interval) << std::setiosflags(std::ios::fixed)
+                      << std::setprecision(3);
             std::cout << array[i * nCols + j];
         }
         std::cout << std::endl;
@@ -341,22 +325,26 @@ void printArray(T * array, const size_t nPrintedCols, const size_t nPrintedRows,
 }
 
 template <typename T>
-void printArray(T * array, const size_t nCols, const size_t nRows, const std::string & message, size_t interval = 10)
-{
+void printArray(T *array,
+                const size_t nCols,
+                const size_t nRows,
+                const std::string &message,
+                size_t interval = 10) {
     printArray(array, nCols, nRows, nCols, message, interval);
 }
 
 template <typename T>
-void printLowerArray(T * array, const size_t nPrintedRows, const std::string & message, size_t interval = 10)
-{
+void printLowerArray(T *array,
+                     const size_t nPrintedRows,
+                     const std::string &message,
+                     size_t interval = 10) {
     std::cout << std::setiosflags(std::ios::left);
     std::cout << message << std::endl;
     int ind = 0;
-    for (size_t i = 0; i < nPrintedRows; i++)
-    {
-        for (size_t j = 0; j <= i; j++)
-        {
-            std::cout << std::setw(interval) << std::setiosflags(std::ios::fixed) << std::setprecision(3);
+    for (size_t i = 0; i < nPrintedRows; i++) {
+        for (size_t j = 0; j <= i; j++) {
+            std::cout << std::setw(interval) << std::setiosflags(std::ios::fixed)
+                      << std::setprecision(3);
             std::cout << array[ind++];
         }
         std::cout << std::endl;
@@ -365,25 +353,25 @@ void printLowerArray(T * array, const size_t nPrintedRows, const std::string & m
 }
 
 template <typename T>
-void printUpperArray(T * array, const size_t nPrintedCols, const size_t nPrintedRows, const size_t nCols, const std::string & message,
-                     size_t interval = 10)
-{
+void printUpperArray(T *array,
+                     const size_t nPrintedCols,
+                     const size_t nPrintedRows,
+                     const size_t nCols,
+                     const std::string &message,
+                     size_t interval = 10) {
     std::cout << std::setiosflags(std::ios::left);
     std::cout << message << std::endl;
     int ind = 0;
-    for (size_t i = 0; i < nPrintedRows; i++)
-    {
-        for (size_t j = 0; j < i; j++)
-        {
+    for (size_t i = 0; i < nPrintedRows; i++) {
+        for (size_t j = 0; j < i; j++) {
             std::cout << "          ";
         }
-        for (size_t j = i; j < nPrintedCols; j++)
-        {
-            std::cout << std::setw(interval) << std::setiosflags(std::ios::fixed) << std::setprecision(3);
+        for (size_t j = i; j < nPrintedCols; j++) {
+            std::cout << std::setw(interval) << std::setiosflags(std::ios::fixed)
+                      << std::setprecision(3);
             std::cout << array[ind++];
         }
-        for (size_t j = nPrintedCols; j < nCols; j++)
-        {
+        for (size_t j = nPrintedCols; j < nCols; j++) {
             ind++;
         }
         std::cout << std::endl;
@@ -391,80 +379,92 @@ void printUpperArray(T * array, const size_t nPrintedCols, const size_t nPrinted
     std::cout << std::endl;
 }
 
-void printNumericTable(NumericTable * dataTable, const char * message = "", size_t nPrintedRows = 0, size_t nPrintedCols = 0, size_t interval = 10)
-{
-    size_t nRows                            = dataTable->getNumberOfRows();
-    size_t nCols                            = dataTable->getNumberOfColumns();
+void printNumericTable(NumericTable *dataTable,
+                       const char *message = "",
+                       size_t nPrintedRows = 0,
+                       size_t nPrintedCols = 0,
+                       size_t interval = 10) {
+    size_t nRows = dataTable->getNumberOfRows();
+    size_t nCols = dataTable->getNumberOfColumns();
     NumericTableIface::StorageLayout layout = dataTable->getDataLayout();
 
-    if (nPrintedRows != 0)
-    {
+    if (nPrintedRows != 0) {
         nPrintedRows = std::min(nRows, nPrintedRows);
     }
-    else
-    {
+    else {
         nPrintedRows = nRows;
     }
 
-    if (nPrintedCols != 0)
-    {
+    if (nPrintedCols != 0) {
         nPrintedCols = std::min(nCols, nPrintedCols);
     }
-    else
-    {
+    else {
         nPrintedCols = nCols;
     }
 
     BlockDescriptor<DAAL_DATA_TYPE> block;
-    if (isFull(layout) || layout == NumericTableIface::csrArray)
-    {
+    if (isFull(layout) || layout == NumericTableIface::csrArray) {
         dataTable->getBlockOfRows(0, nRows, readOnly, block);
-        printArray<DAAL_DATA_TYPE>(block.getBlockPtr(), nPrintedCols, nPrintedRows, nCols, message, interval);
+        printArray<DAAL_DATA_TYPE>(block.getBlockPtr(),
+                                   nPrintedCols,
+                                   nPrintedRows,
+                                   nCols,
+                                   message,
+                                   interval);
         dataTable->releaseBlockOfRows(block);
     }
-    else
-    {
-        PackedArrayNumericTableIface * packedTable = dynamic_cast<PackedArrayNumericTableIface *>(dataTable);
+    else {
+        PackedArrayNumericTableIface *packedTable =
+            dynamic_cast<PackedArrayNumericTableIface *>(dataTable);
         packedTable->getPackedArray(readOnly, block);
-        if (isLower(layout))
-        {
+        if (isLower(layout)) {
             printLowerArray<DAAL_DATA_TYPE>(block.getBlockPtr(), nPrintedRows, message, interval);
         }
-        else if (isUpper(layout))
-        {
-            printUpperArray<DAAL_DATA_TYPE>(block.getBlockPtr(), nPrintedCols, nPrintedRows, nCols, message, interval);
+        else if (isUpper(layout)) {
+            printUpperArray<DAAL_DATA_TYPE>(block.getBlockPtr(),
+                                            nPrintedCols,
+                                            nPrintedRows,
+                                            nCols,
+                                            message,
+                                            interval);
         }
         packedTable->releasePackedArray(block);
     }
 }
 
-void printNumericTable(NumericTable & dataTable, const char * message = "", size_t nPrintedRows = 0, size_t nPrintedCols = 0, size_t interval = 10)
-{
+void printNumericTable(NumericTable &dataTable,
+                       const char *message = "",
+                       size_t nPrintedRows = 0,
+                       size_t nPrintedCols = 0,
+                       size_t interval = 10) {
     printNumericTable(&dataTable, message, nPrintedRows, nPrintedCols, interval);
 }
 
-void printNumericTable(const NumericTablePtr & dataTable, const char * message = "", size_t nPrintedRows = 0, size_t nPrintedCols = 0,
-                       size_t interval = 10)
-{
+void printNumericTable(const NumericTablePtr &dataTable,
+                       const char *message = "",
+                       size_t nPrintedRows = 0,
+                       size_t nPrintedCols = 0,
+                       size_t interval = 10) {
     printNumericTable(dataTable.get(), message, nPrintedRows, nPrintedCols, interval);
 }
 
-void printPackedNumericTable(NumericTable * dataTable, size_t nFeatures, const char * message = "", size_t interval = 10)
-{
+void printPackedNumericTable(NumericTable *dataTable,
+                             size_t nFeatures,
+                             const char *message = "",
+                             size_t interval = 10) {
     BlockDescriptor<DAAL_DATA_TYPE> block;
 
     dataTable->getBlockOfRows(0, 1, readOnly, block);
 
-    DAAL_DATA_TYPE * data = block.getBlockPtr();
+    DAAL_DATA_TYPE *data = block.getBlockPtr();
 
     std::cout << std::setiosflags(std::ios::left);
     std::cout << message << std::endl;
     size_t index = 0;
-    for (size_t i = 0; i < nFeatures; i++)
-    {
-        for (size_t j = 0; j <= i; j++, index++)
-        {
-            std::cout << std::setw(interval) << std::setiosflags(std::ios::fixed) << std::setprecision(3);
+    for (size_t i = 0; i < nFeatures; i++) {
+        for (size_t j = 0; j <= i; j++, index++) {
+            std::cout << std::setw(interval) << std::setiosflags(std::ios::fixed)
+                      << std::setprecision(3);
             std::cout << data[index];
         }
         std::cout << std::endl;
@@ -474,15 +474,21 @@ void printPackedNumericTable(NumericTable * dataTable, size_t nFeatures, const c
     dataTable->releaseBlockOfRows(block);
 }
 
-void printPackedNumericTable(NumericTable & dataTable, size_t nFeatures, const char * message = "", size_t interval = 10)
-{
+void printPackedNumericTable(NumericTable &dataTable,
+                             size_t nFeatures,
+                             const char *message = "",
+                             size_t interval = 10) {
     printPackedNumericTable(&dataTable, nFeatures, message);
 }
 
 template <typename type1, typename type2>
-void printNumericTables(NumericTable * dataTable1, NumericTable * dataTable2, const char * title1 = "", const char * title2 = "",
-                        const char * message = "", size_t nPrintedRows = 0, size_t interval = 15)
-{
+void printNumericTables(NumericTable *dataTable1,
+                        NumericTable *dataTable2,
+                        const char *title1 = "",
+                        const char *title2 = "",
+                        const char *message = "",
+                        size_t nPrintedRows = 0,
+                        size_t interval = 15) {
     size_t nRows1 = dataTable1->getNumberOfRows();
     size_t nRows2 = dataTable2->getNumberOfRows();
     size_t nCols1 = dataTable1->getNumberOfColumns();
@@ -492,30 +498,27 @@ void printNumericTables(NumericTable * dataTable1, NumericTable * dataTable2, co
     BlockDescriptor<type2> block2;
 
     size_t nRows = std::min(nRows1, nRows2);
-    if (nPrintedRows != 0)
-    {
+    if (nPrintedRows != 0) {
         nRows = std::min(std::min(nRows1, nRows2), nPrintedRows);
     }
 
     dataTable1->getBlockOfRows(0, nRows, readOnly, block1);
     dataTable2->getBlockOfRows(0, nRows, readOnly, block2);
 
-    type1 * data1 = block1.getBlockPtr();
-    type2 * data2 = block2.getBlockPtr();
+    type1 *data1 = block1.getBlockPtr();
+    type2 *data2 = block2.getBlockPtr();
 
     std::cout << std::setiosflags(std::ios::left);
     std::cout << message << std::endl;
     std::cout << std::setw(interval * nCols1) << title1;
     std::cout << std::setw(interval * nCols2) << title2 << std::endl;
-    for (size_t i = 0; i < nRows; i++)
-    {
-        for (size_t j = 0; j < nCols1; j++)
-        {
-            std::cout << std::setw(interval) << std::setiosflags(std::ios::fixed) << std::setprecision(3);
+    for (size_t i = 0; i < nRows; i++) {
+        for (size_t j = 0; j < nCols1; j++) {
+            std::cout << std::setw(interval) << std::setiosflags(std::ios::fixed)
+                      << std::setprecision(3);
             std::cout << data1[i * nCols1 + j];
         }
-        for (size_t j = 0; j < nCols2; j++)
-        {
+        for (size_t j = 0; j < nCols2; j++) {
             std::cout << std::setprecision(0) << std::setw(interval) << data2[i * nCols2 + j];
         }
         std::cout << std::endl;
@@ -527,15 +530,29 @@ void printNumericTables(NumericTable * dataTable1, NumericTable * dataTable2, co
 }
 
 template <typename type1, typename type2>
-void printNumericTables(NumericTable * dataTable1, NumericTable & dataTable2, const char * title1 = "", const char * title2 = "",
-                        const char * message = "", size_t nPrintedRows = 0, size_t interval = 10)
-{
-    printNumericTables<type1, type2>(dataTable1, &dataTable2, title1, title2, message, nPrintedRows, interval);
+void printNumericTables(NumericTable *dataTable1,
+                        NumericTable &dataTable2,
+                        const char *title1 = "",
+                        const char *title2 = "",
+                        const char *message = "",
+                        size_t nPrintedRows = 0,
+                        size_t interval = 10) {
+    printNumericTables<type1, type2>(dataTable1,
+                                     &dataTable2,
+                                     title1,
+                                     title2,
+                                     message,
+                                     nPrintedRows,
+                                     interval);
 }
 
-void printNumericTables(NumericTable * dataTable1, NumericTable * dataTable2, const char * title1 = "", const char * title2 = "",
-                        const char * message = "", size_t nPrintedRows = 0, size_t interval = 10)
-{
+void printNumericTables(NumericTable *dataTable1,
+                        NumericTable *dataTable2,
+                        const char *title1 = "",
+                        const char *title2 = "",
+                        const char *message = "",
+                        size_t nPrintedRows = 0,
+                        size_t interval = 10) {
     size_t nRows1 = dataTable1->getNumberOfRows();
     size_t nRows2 = dataTable2->getNumberOfRows();
     size_t nCols1 = dataTable1->getNumberOfColumns();
@@ -545,30 +562,27 @@ void printNumericTables(NumericTable * dataTable1, NumericTable * dataTable2, co
     BlockDescriptor<DAAL_DATA_TYPE> block2;
 
     size_t nRows = std::min(nRows1, nRows2);
-    if (nPrintedRows != 0)
-    {
+    if (nPrintedRows != 0) {
         nRows = std::min(std::min(nRows1, nRows2), nPrintedRows);
     }
 
     dataTable1->getBlockOfRows(0, nRows, readOnly, block1);
     dataTable2->getBlockOfRows(0, nRows, readOnly, block2);
 
-    DAAL_DATA_TYPE * data1 = block1.getBlockPtr();
-    DAAL_DATA_TYPE * data2 = block2.getBlockPtr();
+    DAAL_DATA_TYPE *data1 = block1.getBlockPtr();
+    DAAL_DATA_TYPE *data2 = block2.getBlockPtr();
 
     std::cout << std::setiosflags(std::ios::left);
     std::cout << message << std::endl;
     std::cout << std::setw(interval * nCols1) << title1;
     std::cout << std::setw(interval * nCols2) << title2 << std::endl;
-    for (size_t i = 0; i < nRows; i++)
-    {
-        for (size_t j = 0; j < nCols1; j++)
-        {
-            std::cout << std::setw(interval) << std::setiosflags(std::ios::fixed) << std::setprecision(3);
+    for (size_t i = 0; i < nRows; i++) {
+        for (size_t j = 0; j < nCols1; j++) {
+            std::cout << std::setw(interval) << std::setiosflags(std::ios::fixed)
+                      << std::setprecision(3);
             std::cout << data1[i * nCols1 + j];
         }
-        for (size_t j = 0; j < nCols2; j++)
-        {
+        for (size_t j = 0; j < nCols2; j++) {
             std::cout << std::setprecision(0) << std::setw(interval) << data2[i * nCols2 + j];
         }
         std::cout << std::endl;
@@ -579,112 +593,103 @@ void printNumericTables(NumericTable * dataTable1, NumericTable * dataTable2, co
     dataTable2->releaseBlockOfRows(block2);
 }
 
-void printNumericTables(NumericTable * dataTable1, NumericTable & dataTable2, const char * title1 = "", const char * title2 = "",
-                        const char * message = "", size_t nPrintedRows = 0, size_t interval = 10)
-{
+void printNumericTables(NumericTable *dataTable1,
+                        NumericTable &dataTable2,
+                        const char *title1 = "",
+                        const char *title2 = "",
+                        const char *message = "",
+                        size_t nPrintedRows = 0,
+                        size_t interval = 10) {
     printNumericTables(dataTable1, &dataTable2, title1, title2, message, nPrintedRows, interval);
 }
 
 template <typename type1, typename type2>
-void printNumericTables(NumericTablePtr dataTable1, NumericTablePtr dataTable2, const char * title1 = "", const char * title2 = "",
-                        const char * message = "", size_t nPrintedRows = 0, size_t interval = 10)
-{
-    printNumericTables<type1, type2>(dataTable1.get(), dataTable2.get(), title1, title2, message, nPrintedRows, interval);
+void printNumericTables(NumericTablePtr dataTable1,
+                        NumericTablePtr dataTable2,
+                        const char *title1 = "",
+                        const char *title2 = "",
+                        const char *message = "",
+                        size_t nPrintedRows = 0,
+                        size_t interval = 10) {
+    printNumericTables<type1, type2>(dataTable1.get(),
+                                     dataTable2.get(),
+                                     title1,
+                                     title2,
+                                     message,
+                                     nPrintedRows,
+                                     interval);
 }
 
-bool checkFileIsAvailable(std::string filename, bool needExit = false)
-{
+bool checkFileIsAvailable(std::string filename, bool needExit = false) {
     std::ifstream file(filename.c_str());
-    if (file.good())
-    {
+    if (file.good()) {
         return true;
     }
-    else
-    {
+    else {
         std::cout << "Can't open file " << filename << std::endl;
-        if (needExit)
-        {
+        if (needExit) {
             exit(fileError);
         }
         return false;
     }
 }
 
-void checkArguments(int argc, char * argv[], int count, ...)
-{
-    std::string ** filelist = new std::string *[count];
+void checkArguments(int argc, char *argv[], int count, ...) {
+    std::string **filelist = new std::string *[count];
     va_list ap;
     va_start(ap, count);
-    for (int i = 0; i < count; i++)
-    {
+    for (int i = 0; i < count; i++) {
         filelist[i] = va_arg(ap, std::string *);
     }
     va_end(ap);
-    if (argc == 1)
-    {
-        for (int i = 0; i < count; i++)
-        {
+    if (argc == 1) {
+        for (int i = 0; i < count; i++) {
             checkFileIsAvailable(*(filelist[i]), true);
         }
     }
-    else if (argc == (count + 1))
-    {
+    else if (argc == (count + 1)) {
         bool isAllCorrect = true;
-        for (int i = 0; i < count; i++)
-        {
-            if (!checkFileIsAvailable(argv[i + 1]))
-            {
+        for (int i = 0; i < count; i++) {
+            if (!checkFileIsAvailable(argv[i + 1])) {
                 isAllCorrect = false;
                 break;
             }
         }
-        if (isAllCorrect == true)
-        {
-            for (int i = 0; i < count; i++)
-            {
+        if (isAllCorrect == true) {
+            for (int i = 0; i < count; i++) {
                 (*filelist[i]) = argv[i + 1];
             }
         }
-        else
-        {
+        else {
             std::cout << "Warning: Try to open default datasetFileNames" << std::endl;
-            for (int i = 0; i < count; i++)
-            {
+            for (int i = 0; i < count; i++) {
                 checkFileIsAvailable(*(filelist[i]), true);
             }
         }
     }
-    else
-    {
+    else {
         std::cout << "Usage: " << argv[0] << " [ ";
-        for (int i = 0; i < count; i++)
-        {
+        for (int i = 0; i < count; i++) {
             std::cout << "<filename_" << i << "> ";
         }
         std::cout << "]" << std::endl;
         std::cout << "Warning: Try to open default datasetFileNames" << std::endl;
-        for (int i = 0; i < count; i++)
-        {
+        for (int i = 0; i < count; i++) {
             checkFileIsAvailable(*(filelist[i]), true);
         }
     }
     delete[] filelist;
 }
 
-void copyBytes(daal::byte * dst, daal::byte * src, size_t size)
-{
-    for (size_t i = 0; i < size; i++)
-    {
+void copyBytes(daal::byte *dst, daal::byte *src, size_t size) {
+    for (size_t i = 0; i < size; i++) {
         dst[i] = src[i];
     }
 }
 
-size_t checkBytes(daal::byte * dst, daal::byte * src, size_t size)
-{
-    for (size_t i = 0; i < size; i++)
-    {
-        if (dst[i] != src[i])
-        {
+size_t checkBytes(daal::byte *dst, daal::byte *src, size_t size) {
+    for (size_t i = 0; i < size; i++) {
+        if (dst[i] != src[i]) {
             return i + 1;
         }
     }
@@ -692,34 +697,43 @@ size_t checkBytes(daal::byte * dst, daal::byte * src, size_t size)
 }
 
 static const unsigned int crcRem[] = {
-    0x00000000, 0x741B8CD6, 0xE83719AC, 0x9C2C957A, 0xA475BF8E, 0xD06E3358, 0x4C42A622, 0x38592AF4, 0x3CF0F3CA, 0x48EB7F1C, 0xD4C7EA66, 0xA0DC66B0,
-    0x98854C44, 0xEC9EC092, 0x70B255E8, 0x04A9D93E, 0x79E1E794, 0x0DFA6B42, 0x91D6FE38, 0xE5CD72EE, 0xDD94581A, 0xA98FD4CC, 0x35A341B6, 0x41B8CD60,
-    0x4511145E, 0x310A9888, 0xAD260DF2, 0xD93D8124, 0xE164ABD0, 0x957F2706, 0x0953B27C, 0x7D483EAA, 0xF3C3CF28, 0x87D843FE, 0x1BF4D684, 0x6FEF5A52,
-    0x57B670A6, 0x23ADFC70, 0xBF81690A, 0xCB9AE5DC, 0xCF333CE2, 0xBB28B034, 0x2704254E, 0x531FA998, 0x6B46836C, 0x1F5D0FBA, 0x83719AC0, 0xF76A1616,
-    0x8A2228BC, 0xFE39A46A, 0x62153110, 0x160EBDC6, 0x2E579732, 0x5A4C1BE4, 0xC6608E9E, 0xB27B0248, 0xB6D2DB76, 0xC2C957A0, 0x5EE5C2DA, 0x2AFE4E0C,
-    0x12A764F8, 0x66BCE82E, 0xFA907D54, 0x8E8BF182, 0x939C1286, 0xE7879E50, 0x7BAB0B2A, 0x0FB087FC, 0x37E9AD08, 0x43F221DE, 0xDFDEB4A4, 0xABC53872,
-    0xAF6CE14C, 0xDB776D9A, 0x475BF8E0, 0x33407436, 0x0B195EC2, 0x7F02D214, 0xE32E476E, 0x9735CBB8, 0xEA7DF512, 0x9E6679C4, 0x024AECBE, 0x76516068,
-    0x4E084A9C, 0x3A13C64A, 0xA63F5330, 0xD224DFE6, 0xD68D06D8, 0xA2968A0E, 0x3EBA1F74, 0x4AA193A2, 0x72F8B956, 0x06E33580, 0x9ACFA0FA, 0xEED42C2C,
-    0x605FDDAE, 0x14445178, 0x8868C402, 0xFC7348D4, 0xC42A6220, 0xB031EEF6, 0x2C1D7B8C, 0x5806F75A, 0x5CAF2E64, 0x28B4A2B2, 0xB49837C8, 0xC083BB1E,
-    0xF8DA91EA, 0x8CC11D3C, 0x10ED8846, 0x64F60490, 0x19BE3A3A, 0x6DA5B6EC, 0xF1892396, 0x8592AF40, 0xBDCB85B4, 0xC9D00962, 0x55FC9C18, 0x21E710CE,
-    0x254EC9F0, 0x51554526, 0xCD79D05C, 0xB9625C8A, 0x813B767E, 0xF520FAA8, 0x690C6FD2, 0x1D17E304, 0x5323A9DA, 0x2738250C, 0xBB14B076, 0xCF0F3CA0,
-    0xF7561654, 0x834D9A82, 0x1F610FF8, 0x6B7A832E, 0x6FD35A10, 0x1BC8D6C6, 0x87E443BC, 0xF3FFCF6A, 0xCBA6E59E, 0xBFBD6948, 0x2391FC32, 0x578A70E4,
-    0x2AC24E4E, 0x5ED9C298, 0xC2F557E2, 0xB6EEDB34, 0x8EB7F1C0, 0xFAAC7D16, 0x6680E86C, 0x129B64BA, 0x1632BD84, 0x62293152, 0xFE05A428, 0x8A1E28FE,
-    0xB247020A, 0xC65C8EDC, 0x5A701BA6, 0x2E6B9770, 0xA0E066F2, 0xD4FBEA24, 0x48D77F5E, 0x3CCCF388, 0x0495D97C, 0x708E55AA, 0xECA2C0D0, 0x98B94C06,
-    0x9C109538, 0xE80B19EE, 0x74278C94, 0x003C0042, 0x38652AB6, 0x4C7EA660, 0xD052331A, 0xA449BFCC, 0xD9018166, 0xAD1A0DB0, 0x313698CA, 0x452D141C,
-    0x7D743EE8, 0x096FB23E, 0x95432744, 0xE158AB92, 0xE5F172AC, 0x91EAFE7A, 0x0DC66B00, 0x79DDE7D6, 0x4184CD22, 0x359F41F4, 0xA9B3D48E, 0xDDA85858,
-    0xC0BFBB5C, 0xB4A4378A, 0x2888A2F0, 0x5C932E26, 0x64CA04D2, 0x10D18804, 0x8CFD1D7E, 0xF8E691A8, 0xFC4F4896, 0x8854C440, 0x1478513A, 0x6063DDEC,
-    0x583AF718, 0x2C217BCE, 0xB00DEEB4, 0xC4166262, 0xB95E5CC8, 0xCD45D01E, 0x51694564, 0x2572C9B2, 0x1D2BE346, 0x69306F90, 0xF51CFAEA, 0x8107763C,
-    0x85AEAF02, 0xF1B523D4, 0x6D99B6AE, 0x19823A78, 0x21DB108C, 0x55C09C5A, 0xC9EC0920, 0xBDF785F6, 0x337C7474, 0x4767F8A2, 0xDB4B6DD8, 0xAF50E10E,
-    0x9709CBFA, 0xE312472C, 0x7F3ED256, 0x0B255E80, 0x0F8C87BE, 0x7B970B68, 0xE7BB9E12, 0x93A012C4, 0xABF93830, 0xDFE2B4E6, 0x43CE219C, 0x37D5AD4A,
-    0x4A9D93E0, 0x3E861F36, 0xA2AA8A4C, 0xD6B1069A, 0xEEE82C6E, 0x9AF3A0B8, 0x06DF35C2, 0x72C4B914, 0x766D602A, 0x0276ECFC, 0x9E5A7986, 0xEA41F550,
-    0xD218DFA4, 0xA6035372, 0x3A2FC608, 0x4E344ADE
+    0x00000000, 0x741B8CD6, 0xE83719AC, 0x9C2C957A, 0xA475BF8E, 0xD06E3358, 0x4C42A622, 0x38592AF4,
+    0x3CF0F3CA, 0x48EB7F1C, 0xD4C7EA66, 0xA0DC66B0, 0x98854C44, 0xEC9EC092, 0x70B255E8, 0x04A9D93E,
+    0x79E1E794, 0x0DFA6B42, 0x91D6FE38, 0xE5CD72EE, 0xDD94581A, 0xA98FD4CC, 0x35A341B6, 0x41B8CD60,
+    0x4511145E, 0x310A9888, 0xAD260DF2, 0xD93D8124, 0xE164ABD0, 0x957F2706, 0x0953B27C, 0x7D483EAA,
+    0xF3C3CF28, 0x87D843FE, 0x1BF4D684, 0x6FEF5A52, 0x57B670A6, 0x23ADFC70, 0xBF81690A, 0xCB9AE5DC,
+    0xCF333CE2, 0xBB28B034, 0x2704254E, 0x531FA998, 0x6B46836C, 0x1F5D0FBA, 0x83719AC0, 0xF76A1616,
+    0x8A2228BC, 0xFE39A46A, 0x62153110, 0x160EBDC6, 0x2E579732, 0x5A4C1BE4, 0xC6608E9E, 0xB27B0248,
+    0xB6D2DB76, 0xC2C957A0, 0x5EE5C2DA, 0x2AFE4E0C, 0x12A764F8, 0x66BCE82E, 0xFA907D54, 0x8E8BF182,
+    0x939C1286, 0xE7879E50, 0x7BAB0B2A, 0x0FB087FC, 0x37E9AD08, 0x43F221DE, 0xDFDEB4A4, 0xABC53872,
+    0xAF6CE14C, 0xDB776D9A, 0x475BF8E0, 0x33407436, 0x0B195EC2, 0x7F02D214, 0xE32E476E, 0x9735CBB8,
+    0xEA7DF512, 0x9E6679C4, 0x024AECBE, 0x76516068, 0x4E084A9C, 0x3A13C64A, 0xA63F5330, 0xD224DFE6,
+    0xD68D06D8, 0xA2968A0E, 0x3EBA1F74, 0x4AA193A2, 0x72F8B956, 0x06E33580, 0x9ACFA0FA, 0xEED42C2C,
+    0x605FDDAE, 0x14445178, 0x8868C402, 0xFC7348D4, 0xC42A6220, 0xB031EEF6, 0x2C1D7B8C, 0x5806F75A,
+    0x5CAF2E64, 0x28B4A2B2, 0xB49837C8, 0xC083BB1E, 0xF8DA91EA, 0x8CC11D3C, 0x10ED8846, 0x64F60490,
+    0x19BE3A3A, 0x6DA5B6EC, 0xF1892396, 0x8592AF40, 0xBDCB85B4, 0xC9D00962, 0x55FC9C18, 0x21E710CE,
+    0x254EC9F0, 0x51554526, 0xCD79D05C, 0xB9625C8A, 0x813B767E, 0xF520FAA8, 0x690C6FD2, 0x1D17E304,
+    0x5323A9DA, 0x2738250C, 0xBB14B076, 0xCF0F3CA0, 0xF7561654, 0x834D9A82, 0x1F610FF8, 0x6B7A832E,
+    0x6FD35A10, 0x1BC8D6C6, 0x87E443BC, 0xF3FFCF6A, 0xCBA6E59E, 0xBFBD6948, 0x2391FC32, 0x578A70E4,
+    0x2AC24E4E, 0x5ED9C298, 0xC2F557E2, 0xB6EEDB34, 0x8EB7F1C0, 0xFAAC7D16, 0x6680E86C, 0x129B64BA,
+    0x1632BD84, 0x62293152, 0xFE05A428, 0x8A1E28FE, 0xB247020A, 0xC65C8EDC, 0x5A701BA6, 0x2E6B9770,
+    0xA0E066F2, 0xD4FBEA24, 0x48D77F5E, 0x3CCCF388, 0x0495D97C, 0x708E55AA, 0xECA2C0D0, 0x98B94C06,
+    0x9C109538, 0xE80B19EE, 0x74278C94, 0x003C0042, 0x38652AB6, 0x4C7EA660, 0xD052331A, 0xA449BFCC,
+    0xD9018166, 0xAD1A0DB0, 0x313698CA, 0x452D141C, 0x7D743EE8, 0x096FB23E, 0x95432744, 0xE158AB92,
+    0xE5F172AC, 0x91EAFE7A, 0x0DC66B00, 0x79DDE7D6, 0x4184CD22, 0x359F41F4, 0xA9B3D48E, 0xDDA85858,
+    0xC0BFBB5C, 0xB4A4378A, 0x2888A2F0, 0x5C932E26, 0x64CA04D2, 0x10D18804, 0x8CFD1D7E, 0xF8E691A8,
+    0xFC4F4896, 0x8854C440, 0x1478513A, 0x6063DDEC, 0x583AF718, 0x2C217BCE, 0xB00DEEB4, 0xC4166262,
+    0xB95E5CC8, 0xCD45D01E, 0x51694564, 0x2572C9B2, 0x1D2BE346, 0x69306F90, 0xF51CFAEA, 0x8107763C,
+    0x85AEAF02, 0xF1B523D4, 0x6D99B6AE, 0x19823A78, 0x21DB108C, 0x55C09C5A, 0xC9EC0920, 0xBDF785F6,
+    0x337C7474, 0x4767F8A2, 0xDB4B6DD8, 0xAF50E10E, 0x9709CBFA, 0xE312472C, 0x7F3ED256, 0x0B255E80,
+    0x0F8C87BE, 0x7B970B68, 0xE7BB9E12, 0x93A012C4, 0xABF93830, 0xDFE2B4E6, 0x43CE219C, 0x37D5AD4A,
+    0x4A9D93E0, 0x3E861F36, 0xA2AA8A4C, 0xD6B1069A, 0xEEE82C6E, 0x9AF3A0B8, 0x06DF35C2, 0x72C4B914,
+    0x766D602A, 0x0276ECFC, 0x9E5A7986, 0xEA41F550, 0xD218DFA4, 0xA6035372, 0x3A2FC608, 0x4E344ADE
 };
 
-unsigned int getCRC32(daal::byte * input, unsigned int prevRes, size_t len)
-{
+unsigned int getCRC32(daal::byte *input, unsigned int prevRes, size_t len) {
     size_t i;
-    daal::byte * p;
+    daal::byte *p;
 
     unsigned int res, highDigit, nextDigit;
     const unsigned int crcPoly = 0xBA0DC66B;
@@ -728,30 +742,29 @@ unsigned int getCRC32(daal::byte * input, unsigned int prevRes, size_t len)
 
     res = prevRes;
 
-    for (i = 0; i < len; i++)
-    {
+    for (i = 0; i < len; i++) {
         highDigit = res >> 24;
         nextDigit = (unsigned int)(p[len - 1 - i]);
-        res       = (res << 8) ^ nextDigit;
-        res       = res ^ crcRem[highDigit];
+        res = (res << 8) ^ nextDigit;
+        res = res ^ crcRem[highDigit];
     }
 
-    if (res >= crcPoly)
-    {
+    if (res >= crcPoly) {
         res = res ^ crcPoly;
     }
 
     return res;
 }
 
-void printALSRatings(NumericTablePtr usersOffsetTable, NumericTablePtr itemsOffsetTable, NumericTablePtr ratings)
-{
+void printALSRatings(NumericTablePtr usersOffsetTable,
+                     NumericTablePtr itemsOffsetTable,
+                     NumericTablePtr ratings) {
     size_t nUsers = ratings->getNumberOfRows();
     size_t nItems = ratings->getNumberOfColumns();
 
     BlockDescriptor<DAAL_DATA_TYPE> block1;
     ratings->getBlockOfRows(0, nUsers, readOnly, block1);
-    DAAL_DATA_TYPE * ratingsData = block1.getBlockPtr();
+    DAAL_DATA_TYPE *ratingsData = block1.getBlockPtr();
 
     size_t usersOffset, itemsOffset;
     BlockDescriptor<int> block;
@@ -764,18 +777,16 @@ void printALSRatings(NumericTablePtr usersOffsetTable, NumericTablePtr itemsOffs
     itemsOffsetTable->releaseBlockOfRows(block);
 
     std::cout << " User ID, Item ID, rating" << std::endl;
-    for (size_t i = 0; i < nUsers; i++)
-    {
-        for (size_t j = 0; j < nItems; j++)
-        {
-            std::cout << i + usersOffset << ", " << j + itemsOffset << ", " << ratingsData[i * nItems + j] << std::endl;
+    for (size_t i = 0; i < nUsers; i++) {
+        for (size_t j = 0; j < nItems; j++) {
+            std::cout << i + usersOffset << ", " << j + itemsOffset << ", "
+                      << ratingsData[i * nItems + j] << std::endl;
         }
     }
     ratings->releaseBlockOfRows(block1);
 }
 
-size_t serializeDAALObject(SerializationIface * pData, ByteBuffer & buffer)
-{
+size_t serializeDAALObject(SerializationIface *pData, ByteBuffer &buffer) {
     /* Create a data archive to serialize the numeric table */
     InputDataArchive dataArch;
 
@@ -787,12 +798,12 @@ size_t serializeDAALObject(SerializationIface * pData, ByteBuffer & buffer)
 
     /* Store the serialized data in an array */
     buffer.resize(length);
-    if (length) dataArch.copyArchiveToArray(&buffer[0], length);
+    if (length)
+        dataArch.copyArchiveToArray(&buffer[0], length);
     return length;
 }
 
-SerializationIfacePtr deserializeDAALObject(daal::byte * buff, size_t length)
-{
+SerializationIfacePtr deserializeDAALObject(daal::byte *buff, size_t length) {
     /* Create a data archive to deserialize the object */
     OutputDataArchive dataArch(buff, length);
 

--- a/samples/daal/cpp/oneccl/sources/service_sycl.h
+++ b/samples/daal/cpp/oneccl/sources/service_sycl.h
@@ -31,14 +31,11 @@
 
 #include "service.h"
 
-std::vector<sycl::device> get_gpus()
-{
+std::vector<sycl::device> get_gpus() {
     auto platforms = sycl::platform::get_platforms();
-    for (auto p : platforms)
-    {
+    for (auto p : platforms) {
         auto devices = p.get_devices(sycl::info::device_type::gpu);
-        if (!devices.empty())
-        {
+        if (!devices.empty()) {
             return devices;
         }
     }

--- a/samples/oneapi/.clang-format
+++ b/samples/oneapi/.clang-format
@@ -1,0 +1,145 @@
+---
+Language: Cpp
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignConsecutiveMacros: true
+AlignEscapedNewlines: Left
+AlignOperands: true
+AlignTrailingComments: false
+AllowAllArgumentsOnNextLine: false
+AllowAllConstructorInitializersOnNextLine: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: Empty
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: false
+BinPackParameters: false
+BraceWrapping:
+  AfterCaseLabel: false
+  AfterClass: false
+  AfterControlStatement: false
+  AfterEnum: false
+  AfterFunction: false
+  AfterNamespace: false
+  AfterObjCDeclaration: false
+  AfterStruct: false
+  AfterUnion: false
+  AfterExternBlock: false
+  BeforeCatch: true
+  BeforeElse: true
+  IndentBraces: false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeColon
+BreakInheritanceList: BeforeColon
+BreakStringLiterals: false
+ColumnLimit: 100
+CommentPragmas: '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 8
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: false
+DerivePointerAlignment: true
+DisableFormat: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks: Preserve
+IncludeCategories:
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+  - Regex:           '^<.*'
+    Priority:        2
+  - Regex:           '.*'
+    Priority:        3
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IndentCaseLabels: true
+IndentPPDirectives: None
+IndentWidth: 4
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+RawStringFormats:
+  - Language: Cpp
+    Delimiters:
+      - cc
+      - CC
+      - cpp
+      - Cpp
+      - CPP
+      - 'c++'
+      - 'C++'
+    CanonicalDelimiter: ''
+    BasedOnStyle: google
+  - Language: TextProto
+    Delimiters:
+      - pb
+      - PB
+      - proto
+      - PROTO
+    EnclosingFunctions:
+      - EqualsProto
+      - EquivToProto
+      - PARSE_PARTIAL_TEXT_PROTO
+      - PARSE_TEST_PROTO
+      - PARSE_TEXT_PROTO
+      - ParseTextOrDie
+      - ParseTextProtoOrDie
+    CanonicalDelimiter: ''
+    BasedOnStyle: google
+ReflowComments: false
+SortIncludes: false
+SortUsingDeclarations: false
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: false
+SpacesInContainerLiterals: false
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard: Cpp11
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth: 1
+UseTab: Never
+...

--- a/samples/oneapi/dpc/ccl/sources/basic_statistics_distr_ccl.cpp
+++ b/samples/oneapi/dpc/ccl/sources/basic_statistics_distr_ccl.cpp
@@ -33,14 +33,11 @@ namespace dal = oneapi::dal;
 void run(sycl::queue &queue) {
     const auto data_file_name = get_data_path("data/covcormoments_dense.csv");
 
-    const auto data =
-        dal::read<dal::table>(queue, dal::csv::data_source{data_file_name});
+    const auto data = dal::read<dal::table>(queue, dal::csv::data_source{ data_file_name });
 
     const auto bs_desc = dal::basic_statistics::descriptor{};
 
-    auto comm =
-        dal::preview::spmd::make_communicator<dal::preview::spmd::backend::ccl>(
-            queue);
+    auto comm = dal::preview::spmd::make_communicator<dal::preview::spmd::backend::ccl>(queue);
     auto rank_id = comm.get_rank();
     auto rank_count = comm.get_rank_count();
 
@@ -58,8 +55,7 @@ void run(sycl::queue &queue) {
         std::cout << "Second order raw moment:\n"
                   << result.get_second_order_raw_moment() << std::endl;
         std::cout << "Variance:\n" << result.get_variance() << std::endl;
-        std::cout << "Standard deviation:\n"
-                  << result.get_standard_deviation() << std::endl;
+        std::cout << "Standard deviation:\n" << result.get_standard_deviation() << std::endl;
         std::cout << "Variation:\n" << result.get_variation() << std::endl;
     }
 }
@@ -68,18 +64,18 @@ int main(int argc, char const *argv[]) {
     ccl::init();
     int status = MPI_Init(nullptr, nullptr);
     if (status != MPI_SUCCESS) {
-        throw std::runtime_error{"Problem occurred during MPI init"};
+        throw std::runtime_error{ "Problem occurred during MPI init" };
     }
 
     auto device = sycl::device(sycl::gpu_selector_v);
-    std::cout << "Running on " << device.get_platform().get_info<sycl::info::platform::name>() << ", " << device.get_info<sycl::info::device::name>()
-              << std::endl;
-    sycl::queue q{device};
+    std::cout << "Running on " << device.get_platform().get_info<sycl::info::platform::name>()
+              << ", " << device.get_info<sycl::info::device::name>() << std::endl;
+    sycl::queue q{ device };
     run(q);
 
     status = MPI_Finalize();
     if (status != MPI_SUCCESS) {
-        throw std::runtime_error{"Problem occurred during MPI finalize"};
+        throw std::runtime_error{ "Problem occurred during MPI finalize" };
     }
     return 0;
 }

--- a/samples/oneapi/dpc/ccl/sources/comm_helpers.hpp
+++ b/samples/oneapi/dpc/ccl/sources/comm_helpers.hpp
@@ -37,12 +37,13 @@ dal::table combine_tables(const Comm& comm, const dal::table& t) {
 
     auto displs = dal::array<std::int64_t>::empty(comm.get_rank_count());
     std::int64_t offset = 0;
-    for(std::int64_t i = 0; i < comm.get_rank_count(); i++) {
+    for (std::int64_t i = 0; i < comm.get_rank_count(); i++) {
         displs.get_mutable_data()[i] = offset;
         offset += recv_counts[i];
     }
 
-    auto send_buffer = dal::row_accessor<const D>{ t }.pull(queue, dal::range{0, -1}, sycl::usm::alloc::device);
+    auto send_buffer =
+        dal::row_accessor<const D>{ t }.pull(queue, dal::range{ 0, -1 }, sycl::usm::alloc::device);
     comm.allgatherv(send_buffer, recv_buffer, recv_counts.get_data(), displs.get_data()).wait();
     return dal::homogen_table::wrap(recv_buffer, total_count, column_count);
 }

--- a/samples/oneapi/dpc/ccl/sources/cor_distr_ccl.cpp
+++ b/samples/oneapi/dpc/ccl/sources/cor_distr_ccl.cpp
@@ -34,8 +34,7 @@ namespace dal = oneapi::dal;
 void run(sycl::queue& queue) {
     const auto data_file_name = get_data_path("data/covcormoments_dense.csv");
 
-    const auto data = dal::read<dal::table>(
-      queue, dal::csv::data_source{data_file_name});
+    const auto data = dal::read<dal::table>(queue, dal::csv::data_source{ data_file_name });
 
     const auto cov_desc = dal::covariance::descriptor{}.set_result_options(
         dal::covariance::result_options::cor_matrix | dal::covariance::result_options::means);
@@ -44,32 +43,31 @@ void run(sycl::queue& queue) {
     auto rank_id = comm.get_rank();
     auto rank_count = comm.get_rank_count();
 
-    auto input_vec =
-      split_table_by_rows<float>(queue, data, rank_count);
+    auto input_vec = split_table_by_rows<float>(queue, data, rank_count);
 
     const auto result = dal::preview::compute(comm, cov_desc, input_vec[rank_id]);
     if (comm.get_rank() == 0) {
         std::cout << "Mean:\n" << result.get_means() << std::endl;
         std::cout << "Correlation:\n" << result.get_cor_matrix() << std::endl;
-  }
+    }
 }
 
-int main(int argc, char const *argv[]) {
+int main(int argc, char const* argv[]) {
     ccl::init();
     int status = MPI_Init(nullptr, nullptr);
     if (status != MPI_SUCCESS) {
-        throw std::runtime_error{"Problem occurred during MPI init"};
+        throw std::runtime_error{ "Problem occurred during MPI init" };
     }
 
     auto device = sycl::device(sycl::gpu_selector_v);
-    std::cout << "Running on " << device.get_platform().get_info<sycl::info::platform::name>() << ", " << device.get_info<sycl::info::device::name>()
-            << std::endl;
-    sycl::queue q{device};
+    std::cout << "Running on " << device.get_platform().get_info<sycl::info::platform::name>()
+              << ", " << device.get_info<sycl::info::device::name>() << std::endl;
+    sycl::queue q{ device };
     run(q);
 
     status = MPI_Finalize();
     if (status != MPI_SUCCESS) {
-        throw std::runtime_error{"Problem occurred during MPI finalize"};
+        throw std::runtime_error{ "Problem occurred during MPI finalize" };
     }
     return 0;
 }

--- a/samples/oneapi/dpc/ccl/sources/cov_distr_ccl.cpp
+++ b/samples/oneapi/dpc/ccl/sources/cov_distr_ccl.cpp
@@ -34,8 +34,7 @@ namespace dal = oneapi::dal;
 void run(sycl::queue& queue) {
     const auto data_file_name = get_data_path("data/covcormoments_dense.csv");
 
-    const auto data = dal::read<dal::table>(
-      queue, dal::csv::data_source{data_file_name});
+    const auto data = dal::read<dal::table>(queue, dal::csv::data_source{ data_file_name });
 
     const auto cov_desc = dal::covariance::descriptor{}.set_result_options(
         dal::covariance::result_options::cov_matrix);
@@ -44,8 +43,7 @@ void run(sycl::queue& queue) {
     auto rank_id = comm.get_rank();
     auto rank_count = comm.get_rank_count();
 
-    auto input_vec =
-      split_table_by_rows<float>(queue, data, rank_count);
+    auto input_vec = split_table_by_rows<float>(queue, data, rank_count);
 
     const auto result = dal::preview::compute(comm, cov_desc, input_vec[rank_id]);
     if (comm.get_rank() == 0) {
@@ -53,22 +51,22 @@ void run(sycl::queue& queue) {
     }
 }
 
-int main(int argc, char const *argv[]) {
+int main(int argc, char const* argv[]) {
     ccl::init();
     int status = MPI_Init(nullptr, nullptr);
     if (status != MPI_SUCCESS) {
-        throw std::runtime_error{"Problem occurred during MPI init"};
+        throw std::runtime_error{ "Problem occurred during MPI init" };
     }
 
     auto device = sycl::device(sycl::gpu_selector_v);
-    std::cout << "Running on " << device.get_platform().get_info<sycl::info::platform::name>() << ", " << device.get_info<sycl::info::device::name>()
-            << std::endl;
-    sycl::queue q{device};
+    std::cout << "Running on " << device.get_platform().get_info<sycl::info::platform::name>()
+              << ", " << device.get_info<sycl::info::device::name>() << std::endl;
+    sycl::queue q{ device };
     run(q);
 
     status = MPI_Finalize();
     if (status != MPI_SUCCESS) {
-        throw std::runtime_error{"Problem occurred during MPI finalize"};
+        throw std::runtime_error{ "Problem occurred during MPI finalize" };
     }
     return 0;
 }

--- a/samples/oneapi/dpc/ccl/sources/dbscan_distr_ccl.cpp
+++ b/samples/oneapi/dpc/ccl/sources/dbscan_distr_ccl.cpp
@@ -43,12 +43,12 @@ void run(sycl::queue &queue) {
     auto rank_count = comm.get_rank_count();
 
     auto input_vec = split_table_by_rows<float>(queue, x_data, rank_count);
-    dal::dbscan::compute_input local_input { input_vec[rank_id], dal::table() };
+    dal::dbscan::compute_input local_input{ input_vec[rank_id], dal::table() };
     const auto result_compute = dal::preview::compute(comm, dbscan_desc, local_input);
 
     auto final_responces = combine_tables(comm, result_compute.get_responses());
 
-    if(comm.get_rank() == 0) {
+    if (comm.get_rank() == 0) {
         std::cout << "Cluster count: " << result_compute.get_cluster_count() << std::endl;
         std::cout << "Responses:\n" << final_responces << std::endl;
     }
@@ -62,7 +62,8 @@ int main(int argc, char const *argv[]) {
     }
 
     auto device = sycl::device(sycl::gpu_selector_v);
-    std::cout << "Running on " << device.get_platform().get_info<sycl::info::platform::name>() << ", " << device.get_info<sycl::info::device::name>() << std::endl;
+    std::cout << "Running on " << device.get_platform().get_info<sycl::info::platform::name>()
+              << ", " << device.get_info<sycl::info::device::name>() << std::endl;
     sycl::queue q{ device };
     run(q);
 

--- a/samples/oneapi/dpc/ccl/sources/decision_forest_reg_hist_distr_ccl.cpp
+++ b/samples/oneapi/dpc/ccl/sources/decision_forest_reg_hist_distr_ccl.cpp
@@ -32,26 +32,20 @@ namespace dal = oneapi::dal;
 namespace df = dal::decision_forest;
 
 void run(sycl::queue &queue) {
-    const auto train_data_file_name =
-        get_data_path("df_regression_train_data.csv");
-    const auto train_response_file_name =
-        get_data_path("df_regression_train_label.csv");
+    const auto train_data_file_name = get_data_path("df_regression_train_data.csv");
+    const auto train_response_file_name = get_data_path("df_regression_train_label.csv");
     const auto test_data_file_name = get_data_path("df_regression_test_data.csv");
-    const auto test_response_file_name =
-        get_data_path("df_regression_test_label.csv");
+    const auto test_response_file_name = get_data_path("df_regression_test_label.csv");
 
     const auto x_train =
-        dal::read<dal::table>(queue, dal::csv::data_source{train_data_file_name});
-    const auto y_train = dal::read<dal::table>(
-        queue, dal::csv::data_source{train_response_file_name});
-    const auto x_test =
-        dal::read<dal::table>(queue, dal::csv::data_source{test_data_file_name});
-    const auto y_test = dal::read<dal::table>(
-        queue, dal::csv::data_source{test_response_file_name});
+        dal::read<dal::table>(queue, dal::csv::data_source{ train_data_file_name });
+    const auto y_train =
+        dal::read<dal::table>(queue, dal::csv::data_source{ train_response_file_name });
+    const auto x_test = dal::read<dal::table>(queue, dal::csv::data_source{ test_data_file_name });
+    const auto y_test =
+        dal::read<dal::table>(queue, dal::csv::data_source{ test_response_file_name });
 
-    auto comm =
-        dal::preview::spmd::make_communicator<dal::preview::spmd::backend::ccl>(
-            queue);
+    auto comm = dal::preview::spmd::make_communicator<dal::preview::spmd::backend::ccl>(queue);
     auto rank_id = comm.get_rank();
     auto rank_count = comm.get_rank_count();
 
@@ -65,13 +59,12 @@ void run(sycl::queue &queue) {
             .set_tree_count(100)
             .set_features_per_node(0)
             .set_min_observations_in_leaf_node(1)
-            .set_error_metric_mode(
-                df::error_metric_mode::out_of_bag_error |
-                df::error_metric_mode::out_of_bag_error_per_observation)
+            .set_error_metric_mode(df::error_metric_mode::out_of_bag_error |
+                                   df::error_metric_mode::out_of_bag_error_per_observation)
             .set_variable_importance_mode(df::variable_importance_mode::mdi);
 
-    const auto result_train = dal::preview::train(
-        comm, df_desc, x_train_vec[rank_id], y_train_vec[rank_id]);
+    const auto result_train =
+        dal::preview::train(comm, df_desc, x_train_vec[rank_id], y_train_vec[rank_id]);
 
     if (comm.get_rank() == 0) {
         std::cout << "Variable importance results:\n"
@@ -82,12 +75,11 @@ void run(sycl::queue &queue) {
                   << result_train.get_oob_err_per_observation() << std::endl;
     }
 
-    const auto result_infer = dal::preview::infer(
-        comm, df_desc, result_train.get_model(), x_test_vec[rank_id]);
+    const auto result_infer =
+        dal::preview::infer(comm, df_desc, result_train.get_model(), x_test_vec[rank_id]);
 
     if (comm.get_rank() == 0) {
-        std::cout << "Prediction results:\n"
-                  << result_infer.get_responses() << std::endl;
+        std::cout << "Prediction results:\n" << result_infer.get_responses() << std::endl;
 
         std::cout << "Ground truth:\n" << y_test_vec[rank_id] << std::endl;
     }
@@ -97,18 +89,18 @@ int main(int argc, char const *argv[]) {
     ccl::init();
     int status = MPI_Init(nullptr, nullptr);
     if (status != MPI_SUCCESS) {
-        throw std::runtime_error{"Problem occurred during MPI init"};
+        throw std::runtime_error{ "Problem occurred during MPI init" };
     }
 
     auto device = sycl::device(sycl::gpu_selector_v);
-    std::cout << "Running on " << device.get_platform().get_info<sycl::info::platform::name>() << ", " << device.get_info<sycl::info::device::name>()
-              << std::endl;
-    sycl::queue q{device};
+    std::cout << "Running on " << device.get_platform().get_info<sycl::info::platform::name>()
+              << ", " << device.get_info<sycl::info::device::name>() << std::endl;
+    sycl::queue q{ device };
     run(q);
 
     status = MPI_Finalize();
     if (status != MPI_SUCCESS) {
-        throw std::runtime_error{"Problem occurred during MPI finalize"};
+        throw std::runtime_error{ "Problem occurred during MPI finalize" };
     }
     return 0;
 }

--- a/samples/oneapi/dpc/ccl/sources/input_helpers.hpp
+++ b/samples/oneapi/dpc/ccl/sources/input_helpers.hpp
@@ -62,7 +62,8 @@ std::vector<dal::table> split_table_by_rows(sycl::queue& queue,
         const std::int64_t block_size = block_size_regular + tail;
 
         const auto row_range = dal::range{ row_offset, row_offset + block_size };
-        const auto block = dal::row_accessor<const Float>{ t }.pull(queue, row_range, sycl::usm::alloc::device);
+        const auto block =
+            dal::row_accessor<const Float>{ t }.pull(queue, row_range, sycl::usm::alloc::device);
         result[i] = dal::homogen_table::wrap(block, block_size, column_count);
         row_offset += block_size;
     }

--- a/samples/oneapi/dpc/ccl/sources/kmeans_distr_ccl.cpp
+++ b/samples/oneapi/dpc/ccl/sources/kmeans_distr_ccl.cpp
@@ -32,7 +32,8 @@ void run(sycl::queue& queue) {
     const auto train_data_file_name = get_data_path("data/kmeans_dense_train_data.csv");
     const auto initial_centroids_file_name = get_data_path("data/kmeans_dense_train_centroids.csv");
 
-    const auto x_train = dal::read<dal::table>(queue, dal::csv::data_source{ train_data_file_name });
+    const auto x_train =
+        dal::read<dal::table>(queue, dal::csv::data_source{ train_data_file_name });
     const auto initial_centroids =
         dal::read<dal::table>(queue, dal::csv::data_source{ initial_centroids_file_name });
 
@@ -45,18 +46,18 @@ void run(sycl::queue& queue) {
     auto rank_count = comm.get_rank_count();
 
     auto input_vec = split_table_by_rows<float>(queue, x_train, rank_count);
-    dal::kmeans::train_input local_input { input_vec[rank_id], initial_centroids };
+    dal::kmeans::train_input local_input{ input_vec[rank_id], initial_centroids };
 
     const auto result_train = dal::preview::train(comm, kmeans_desc, local_input);
-    if(comm.get_rank() == 0) {
+    if (comm.get_rank() == 0) {
         std::cout << "Iteration count: " << result_train.get_iteration_count() << std::endl;
         std::cout << "Objective function value: " << result_train.get_objective_function_value()
-                << std::endl;
+                  << std::endl;
         std::cout << "Centroids:\n" << result_train.get_model().get_centroids() << std::endl;
     }
 }
 
-int main(int argc, char const *argv[]) {
+int main(int argc, char const* argv[]) {
     ccl::init();
     int status = MPI_Init(nullptr, nullptr);
     if (status != MPI_SUCCESS) {
@@ -64,7 +65,8 @@ int main(int argc, char const *argv[]) {
     }
 
     auto device = sycl::device(sycl::gpu_selector_v);
-    std::cout << "Running on " << device.get_platform().get_info<sycl::info::platform::name>() << ", " << device.get_info<sycl::info::device::name>() << std::endl;
+    std::cout << "Running on " << device.get_platform().get_info<sycl::info::platform::name>()
+              << ", " << device.get_info<sycl::info::device::name>() << std::endl;
     sycl::queue q{ device };
     run(q);
 

--- a/samples/oneapi/dpc/ccl/sources/pca_distr_ccl.cpp
+++ b/samples/oneapi/dpc/ccl/sources/pca_distr_ccl.cpp
@@ -34,8 +34,7 @@ namespace dal = oneapi::dal;
 void run(sycl::queue& queue) {
     const auto data_file_name = get_data_path("data/pca_normalized.csv");
 
-    const auto data = dal::read<dal::table>(
-      queue, dal::csv::data_source{data_file_name});
+    const auto data = dal::read<dal::table>(queue, dal::csv::data_source{ data_file_name });
 
     const auto pca_desc = dal::pca::descriptor{};
 
@@ -43,8 +42,7 @@ void run(sycl::queue& queue) {
     auto rank_id = comm.get_rank();
     auto rank_count = comm.get_rank_count();
 
-    auto input_vec =
-      split_table_by_rows<float>(queue, data, rank_count);
+    auto input_vec = split_table_by_rows<float>(queue, data, rank_count);
 
     const auto result = dal::preview::train(comm, pca_desc, input_vec[rank_id]);
     if (comm.get_rank() == 0) {
@@ -53,22 +51,22 @@ void run(sycl::queue& queue) {
     }
 }
 
-int main(int argc, char const *argv[]) {
+int main(int argc, char const* argv[]) {
     ccl::init();
     int status = MPI_Init(nullptr, nullptr);
     if (status != MPI_SUCCESS) {
-        throw std::runtime_error{"Problem occurred during MPI init"};
+        throw std::runtime_error{ "Problem occurred during MPI init" };
     }
 
     auto device = sycl::device(sycl::gpu_selector_v);
-    std::cout << "Running on " << device.get_platform().get_info<sycl::info::platform::name>() << ", " << device.get_info<sycl::info::device::name>()
-            << std::endl;
-    sycl::queue q{device};
+    std::cout << "Running on " << device.get_platform().get_info<sycl::info::platform::name>()
+              << ", " << device.get_info<sycl::info::device::name>() << std::endl;
+    sycl::queue q{ device };
     run(q);
 
     status = MPI_Finalize();
     if (status != MPI_SUCCESS) {
-        throw std::runtime_error{"Problem occurred during MPI finalize"};
+        throw std::runtime_error{ "Problem occurred during MPI finalize" };
     }
     return 0;
 }

--- a/samples/oneapi/dpc/mpi/sources/basic_statistics_distr_mpi.cpp
+++ b/samples/oneapi/dpc/mpi/sources/basic_statistics_distr_mpi.cpp
@@ -33,14 +33,11 @@ namespace dal = oneapi::dal;
 void run(sycl::queue &queue) {
     const auto data_file_name = get_data_path("data/covcormoments_dense.csv");
 
-    const auto data =
-        dal::read<dal::table>(queue, dal::csv::data_source{data_file_name});
+    const auto data = dal::read<dal::table>(queue, dal::csv::data_source{ data_file_name });
 
     const auto bs_desc = dal::basic_statistics::descriptor{};
 
-    auto comm =
-        dal::preview::spmd::make_communicator<dal::preview::spmd::backend::mpi>(
-            queue);
+    auto comm = dal::preview::spmd::make_communicator<dal::preview::spmd::backend::mpi>(queue);
     auto rank_id = comm.get_rank();
     auto rank_count = comm.get_rank_count();
 
@@ -58,8 +55,7 @@ void run(sycl::queue &queue) {
         std::cout << "Second order raw moment:\n"
                   << result.get_second_order_raw_moment() << std::endl;
         std::cout << "Variance:\n" << result.get_variance() << std::endl;
-        std::cout << "Standard deviation:\n"
-                  << result.get_standard_deviation() << std::endl;
+        std::cout << "Standard deviation:\n" << result.get_standard_deviation() << std::endl;
         std::cout << "Variation:\n" << result.get_variation() << std::endl;
     }
 }
@@ -67,18 +63,18 @@ void run(sycl::queue &queue) {
 int main(int argc, char const *argv[]) {
     int status = MPI_Init(nullptr, nullptr);
     if (status != MPI_SUCCESS) {
-        throw std::runtime_error{"Problem occurred during MPI init"};
+        throw std::runtime_error{ "Problem occurred during MPI init" };
     }
 
     auto device = sycl::device(sycl::gpu_selector_v);
-    std::cout << "Running on " << device.get_platform().get_info<sycl::info::platform::name>() << ", " << device.get_info<sycl::info::device::name>()
-              << std::endl;
-    sycl::queue q{device};
+    std::cout << "Running on " << device.get_platform().get_info<sycl::info::platform::name>()
+              << ", " << device.get_info<sycl::info::device::name>() << std::endl;
+    sycl::queue q{ device };
     run(q);
 
     status = MPI_Finalize();
     if (status != MPI_SUCCESS) {
-        throw std::runtime_error{"Problem occurred during MPI finalize"};
+        throw std::runtime_error{ "Problem occurred during MPI finalize" };
     }
     return 0;
 }

--- a/samples/oneapi/dpc/mpi/sources/comm_helpers.hpp
+++ b/samples/oneapi/dpc/mpi/sources/comm_helpers.hpp
@@ -37,12 +37,13 @@ dal::table combine_tables(const Comm& comm, const dal::table& t) {
 
     auto displs = dal::array<std::int64_t>::empty(comm.get_rank_count());
     std::int64_t offset = 0;
-    for(std::int64_t i = 0; i < comm.get_rank_count(); i++) {
+    for (std::int64_t i = 0; i < comm.get_rank_count(); i++) {
         displs.get_mutable_data()[i] = offset;
         offset += recv_counts[i];
     }
 
-    auto send_buffer = dal::row_accessor<const D>{ t }.pull(queue, dal::range{0, -1}, sycl::usm::alloc::device);
+    auto send_buffer =
+        dal::row_accessor<const D>{ t }.pull(queue, dal::range{ 0, -1 }, sycl::usm::alloc::device);
     comm.allgatherv(send_buffer, recv_buffer, recv_counts.get_data(), displs.get_data()).wait();
     return dal::homogen_table::wrap(recv_buffer, total_count, column_count);
 }

--- a/samples/oneapi/dpc/mpi/sources/cor_distr_mpi.cpp
+++ b/samples/oneapi/dpc/mpi/sources/cor_distr_mpi.cpp
@@ -34,8 +34,7 @@ namespace dal = oneapi::dal;
 void run(sycl::queue& queue) {
     const auto data_file_name = get_data_path("data/covcormoments_dense.csv");
 
-    const auto data = dal::read<dal::table>(
-        queue, dal::csv::data_source{data_file_name});
+    const auto data = dal::read<dal::table>(queue, dal::csv::data_source{ data_file_name });
 
     const auto cov_desc = dal::covariance::descriptor{}.set_result_options(
         dal::covariance::result_options::cor_matrix | dal::covariance::result_options::means);
@@ -44,8 +43,7 @@ void run(sycl::queue& queue) {
     auto rank_id = comm.get_rank();
     auto rank_count = comm.get_rank_count();
 
-    auto input_vec =
-      split_table_by_rows<float>(queue, data, rank_count);
+    auto input_vec = split_table_by_rows<float>(queue, data, rank_count);
 
     const auto result = dal::preview::compute(comm, cov_desc, input_vec[rank_id]);
     if (comm.get_rank() == 0) {
@@ -54,21 +52,21 @@ void run(sycl::queue& queue) {
     }
 }
 
-int main(int argc, char const *argv[]) {
+int main(int argc, char const* argv[]) {
     int status = MPI_Init(nullptr, nullptr);
     if (status != MPI_SUCCESS) {
-        throw std::runtime_error{"Problem occurred during MPI init"};
+        throw std::runtime_error{ "Problem occurred during MPI init" };
     }
 
     auto device = sycl::device(sycl::gpu_selector_v);
-    std::cout << "Running on " << device.get_platform().get_info<sycl::info::platform::name>() << ", " << device.get_info<sycl::info::device::name>()
-            << std::endl;
-    sycl::queue q{device};
+    std::cout << "Running on " << device.get_platform().get_info<sycl::info::platform::name>()
+              << ", " << device.get_info<sycl::info::device::name>() << std::endl;
+    sycl::queue q{ device };
     run(q);
 
     status = MPI_Finalize();
     if (status != MPI_SUCCESS) {
-        throw std::runtime_error{"Problem occurred during MPI finalize"};
+        throw std::runtime_error{ "Problem occurred during MPI finalize" };
     }
     return 0;
 }

--- a/samples/oneapi/dpc/mpi/sources/cov_distr_mpi.cpp
+++ b/samples/oneapi/dpc/mpi/sources/cov_distr_mpi.cpp
@@ -34,8 +34,7 @@ namespace dal = oneapi::dal;
 void run(sycl::queue& queue) {
     const auto data_file_name = get_data_path("data/covcormoments_dense.csv");
 
-    const auto data = dal::read<dal::table>(
-      queue, dal::csv::data_source{data_file_name});
+    const auto data = dal::read<dal::table>(queue, dal::csv::data_source{ data_file_name });
 
     const auto cov_desc = dal::covariance::descriptor{}.set_result_options(
         dal::covariance::result_options::cov_matrix);
@@ -44,8 +43,7 @@ void run(sycl::queue& queue) {
     auto rank_id = comm.get_rank();
     auto rank_count = comm.get_rank_count();
 
-    auto input_vec =
-      split_table_by_rows<float>(queue, data, rank_count);
+    auto input_vec = split_table_by_rows<float>(queue, data, rank_count);
 
     const auto result = dal::preview::compute(comm, cov_desc, input_vec[rank_id]);
     if (comm.get_rank() == 0) {
@@ -53,21 +51,21 @@ void run(sycl::queue& queue) {
     }
 }
 
-int main(int argc, char const *argv[]) {
+int main(int argc, char const* argv[]) {
     int status = MPI_Init(nullptr, nullptr);
     if (status != MPI_SUCCESS) {
-        throw std::runtime_error{"Problem occurred during MPI init"};
+        throw std::runtime_error{ "Problem occurred during MPI init" };
     }
 
     auto device = sycl::device(sycl::gpu_selector_v);
-    std::cout << "Running on " << device.get_platform().get_info<sycl::info::platform::name>() << ", " << device.get_info<sycl::info::device::name>()
-            << std::endl;
-    sycl::queue q{device};
+    std::cout << "Running on " << device.get_platform().get_info<sycl::info::platform::name>()
+              << ", " << device.get_info<sycl::info::device::name>() << std::endl;
+    sycl::queue q{ device };
     run(q);
 
     status = MPI_Finalize();
     if (status != MPI_SUCCESS) {
-        throw std::runtime_error{"Problem occurred during MPI finalize"};
+        throw std::runtime_error{ "Problem occurred during MPI finalize" };
     }
     return 0;
 }

--- a/samples/oneapi/dpc/mpi/sources/dbscan_distr_mpi.cpp
+++ b/samples/oneapi/dpc/mpi/sources/dbscan_distr_mpi.cpp
@@ -43,12 +43,12 @@ void run(sycl::queue &queue) {
     auto rank_count = comm.get_rank_count();
 
     auto input_vec = split_table_by_rows<float>(queue, x_data, rank_count);
-    dal::dbscan::compute_input local_input { input_vec[rank_id], dal::table() };
+    dal::dbscan::compute_input local_input{ input_vec[rank_id], dal::table() };
     const auto result_compute = dal::preview::compute(comm, dbscan_desc, local_input);
 
     auto final_responces = combine_tables(comm, result_compute.get_responses());
 
-    if(comm.get_rank() == 0) {
+    if (comm.get_rank() == 0) {
         std::cout << "Cluster count: " << result_compute.get_cluster_count() << std::endl;
         std::cout << "Responses:\n" << final_responces << std::endl;
     }
@@ -61,7 +61,8 @@ int main(int argc, char const *argv[]) {
     }
 
     auto device = sycl::device(sycl::gpu_selector_v);
-    std::cout << "Running on " << device.get_platform().get_info<sycl::info::platform::name>() << ", " << device.get_info<sycl::info::device::name>() << std::endl;
+    std::cout << "Running on " << device.get_platform().get_info<sycl::info::platform::name>()
+              << ", " << device.get_info<sycl::info::device::name>() << std::endl;
     sycl::queue q{ device };
     run(q);
 

--- a/samples/oneapi/dpc/mpi/sources/decision_forest_cls_hist_distr_mpi.cpp
+++ b/samples/oneapi/dpc/mpi/sources/decision_forest_cls_hist_distr_mpi.cpp
@@ -32,27 +32,20 @@ namespace dal = oneapi::dal;
 namespace df = dal::decision_forest;
 
 void run(sycl::queue &queue) {
-    const auto train_data_file_name =
-        get_data_path("df_classification_train_data.csv");
-    const auto train_response_file_name =
-        get_data_path("df_classification_train_label.csv");
-    const auto test_data_file_name =
-        get_data_path("df_classification_test_data.csv");
-    const auto test_response_file_name =
-        get_data_path("df_classification_test_label.csv");
+    const auto train_data_file_name = get_data_path("df_classification_train_data.csv");
+    const auto train_response_file_name = get_data_path("df_classification_train_label.csv");
+    const auto test_data_file_name = get_data_path("df_classification_test_data.csv");
+    const auto test_response_file_name = get_data_path("df_classification_test_label.csv");
 
     const auto x_train =
-        dal::read<dal::table>(queue, dal::csv::data_source{train_data_file_name});
-    const auto y_train = dal::read<dal::table>(
-        queue, dal::csv::data_source{train_response_file_name});
-    const auto x_test =
-        dal::read<dal::table>(queue, dal::csv::data_source{test_data_file_name});
-    const auto y_test = dal::read<dal::table>(
-        queue, dal::csv::data_source{test_response_file_name});
+        dal::read<dal::table>(queue, dal::csv::data_source{ train_data_file_name });
+    const auto y_train =
+        dal::read<dal::table>(queue, dal::csv::data_source{ train_response_file_name });
+    const auto x_test = dal::read<dal::table>(queue, dal::csv::data_source{ test_data_file_name });
+    const auto y_test =
+        dal::read<dal::table>(queue, dal::csv::data_source{ test_response_file_name });
 
-    auto comm =
-        dal::preview::spmd::make_communicator<dal::preview::spmd::backend::mpi>(
-            queue);
+    auto comm = dal::preview::spmd::make_communicator<dal::preview::spmd::backend::mpi>(queue);
     auto rank_id = comm.get_rank();
     auto rank_count = comm.get_rank_count();
 
@@ -72,12 +65,11 @@ void run(sycl::queue &queue) {
             .set_min_impurity_decrease_in_split_node(0.0)
             .set_error_metric_mode(df::error_metric_mode::out_of_bag_error)
             .set_variable_importance_mode(df::variable_importance_mode::mdi)
-            .set_infer_mode(df::infer_mode::class_responses |
-                            df::infer_mode::class_probabilities)
+            .set_infer_mode(df::infer_mode::class_responses | df::infer_mode::class_probabilities)
             .set_voting_mode(df::voting_mode::weighted);
 
-    const auto result_train = dal::preview::train(
-        comm, df_desc, x_train_vec[rank_id], y_train_vec[rank_id]);
+    const auto result_train =
+        dal::preview::train(comm, df_desc, x_train_vec[rank_id], y_train_vec[rank_id]);
 
     if (comm.get_rank() == 0) {
         std::cout << "Variable importance results:\n"
@@ -86,14 +78,12 @@ void run(sycl::queue &queue) {
         std::cout << "OOB error: " << result_train.get_oob_err() << std::endl;
     }
 
-    const auto result_infer = dal::preview::infer(
-        comm, df_desc, result_train.get_model(), x_test_vec[rank_id]);
+    const auto result_infer =
+        dal::preview::infer(comm, df_desc, result_train.get_model(), x_test_vec[rank_id]);
 
     if (comm.get_rank() == 0) {
-        std::cout << "Prediction results:\n"
-                  << result_infer.get_responses() << std::endl;
-        std::cout << "Probabilities results:\n"
-                  << result_infer.get_probabilities() << std::endl;
+        std::cout << "Prediction results:\n" << result_infer.get_responses() << std::endl;
+        std::cout << "Probabilities results:\n" << result_infer.get_probabilities() << std::endl;
 
         std::cout << "Ground truth:\n" << y_test_vec[rank_id] << std::endl;
     }
@@ -102,18 +92,18 @@ void run(sycl::queue &queue) {
 int main(int argc, char const *argv[]) {
     int status = MPI_Init(nullptr, nullptr);
     if (status != MPI_SUCCESS) {
-        throw std::runtime_error{"Problem occurred during MPI init"};
+        throw std::runtime_error{ "Problem occurred during MPI init" };
     }
 
     auto device = sycl::device(sycl::gpu_selector_v);
-    std::cout << "Running on " << device.get_platform().get_info<sycl::info::platform::name>() << ", " << device.get_info<sycl::info::device::name>()
-              << std::endl;
-    sycl::queue q{device};
+    std::cout << "Running on " << device.get_platform().get_info<sycl::info::platform::name>()
+              << ", " << device.get_info<sycl::info::device::name>() << std::endl;
+    sycl::queue q{ device };
     run(q);
 
     status = MPI_Finalize();
     if (status != MPI_SUCCESS) {
-        throw std::runtime_error{"Problem occurred during MPI finalize"};
+        throw std::runtime_error{ "Problem occurred during MPI finalize" };
     }
     return 0;
 }

--- a/samples/oneapi/dpc/mpi/sources/decision_forest_reg_hist_distr_mpi.cpp
+++ b/samples/oneapi/dpc/mpi/sources/decision_forest_reg_hist_distr_mpi.cpp
@@ -32,26 +32,20 @@ namespace dal = oneapi::dal;
 namespace df = dal::decision_forest;
 
 void run(sycl::queue &queue) {
-    const auto train_data_file_name =
-        get_data_path("df_regression_train_data.csv");
-    const auto train_response_file_name =
-        get_data_path("df_regression_train_label.csv");
+    const auto train_data_file_name = get_data_path("df_regression_train_data.csv");
+    const auto train_response_file_name = get_data_path("df_regression_train_label.csv");
     const auto test_data_file_name = get_data_path("df_regression_test_data.csv");
-    const auto test_response_file_name =
-        get_data_path("df_regression_test_label.csv");
+    const auto test_response_file_name = get_data_path("df_regression_test_label.csv");
 
     const auto x_train =
-        dal::read<dal::table>(queue, dal::csv::data_source{train_data_file_name});
-    const auto y_train = dal::read<dal::table>(
-        queue, dal::csv::data_source{train_response_file_name});
-    const auto x_test =
-        dal::read<dal::table>(queue, dal::csv::data_source{test_data_file_name});
-    const auto y_test = dal::read<dal::table>(
-        queue, dal::csv::data_source{test_response_file_name});
+        dal::read<dal::table>(queue, dal::csv::data_source{ train_data_file_name });
+    const auto y_train =
+        dal::read<dal::table>(queue, dal::csv::data_source{ train_response_file_name });
+    const auto x_test = dal::read<dal::table>(queue, dal::csv::data_source{ test_data_file_name });
+    const auto y_test =
+        dal::read<dal::table>(queue, dal::csv::data_source{ test_response_file_name });
 
-    auto comm =
-        dal::preview::spmd::make_communicator<dal::preview::spmd::backend::mpi>(
-            queue);
+    auto comm = dal::preview::spmd::make_communicator<dal::preview::spmd::backend::mpi>(queue);
     auto rank_id = comm.get_rank();
     auto rank_count = comm.get_rank_count();
 
@@ -65,13 +59,12 @@ void run(sycl::queue &queue) {
             .set_tree_count(100)
             .set_features_per_node(0)
             .set_min_observations_in_leaf_node(1)
-            .set_error_metric_mode(
-                df::error_metric_mode::out_of_bag_error |
-                df::error_metric_mode::out_of_bag_error_per_observation)
+            .set_error_metric_mode(df::error_metric_mode::out_of_bag_error |
+                                   df::error_metric_mode::out_of_bag_error_per_observation)
             .set_variable_importance_mode(df::variable_importance_mode::mdi);
 
-    const auto result_train = dal::preview::train(
-        comm, df_desc, x_train_vec[rank_id], y_train_vec[rank_id]);
+    const auto result_train =
+        dal::preview::train(comm, df_desc, x_train_vec[rank_id], y_train_vec[rank_id]);
 
     if (comm.get_rank() == 0) {
         std::cout << "Variable importance results:\n"
@@ -82,12 +75,11 @@ void run(sycl::queue &queue) {
                   << result_train.get_oob_err_per_observation() << std::endl;
     }
 
-    const auto result_infer = dal::preview::infer(
-        comm, df_desc, result_train.get_model(), x_test_vec[rank_id]);
+    const auto result_infer =
+        dal::preview::infer(comm, df_desc, result_train.get_model(), x_test_vec[rank_id]);
 
     if (comm.get_rank() == 0) {
-        std::cout << "Prediction results:\n"
-                  << result_infer.get_responses() << std::endl;
+        std::cout << "Prediction results:\n" << result_infer.get_responses() << std::endl;
 
         std::cout << "Ground truth:\n" << y_test_vec[rank_id] << std::endl;
     }
@@ -96,18 +88,18 @@ void run(sycl::queue &queue) {
 int main(int argc, char const *argv[]) {
     int status = MPI_Init(nullptr, nullptr);
     if (status != MPI_SUCCESS) {
-        throw std::runtime_error{"Problem occurred during MPI init"};
+        throw std::runtime_error{ "Problem occurred during MPI init" };
     }
 
     auto device = sycl::device(sycl::gpu_selector_v);
-    std::cout << "Running on " << device.get_platform().get_info<sycl::info::platform::name>() << ", " << device.get_info<sycl::info::device::name>()
-              << std::endl;
-    sycl::queue q{device};
+    std::cout << "Running on " << device.get_platform().get_info<sycl::info::platform::name>()
+              << ", " << device.get_info<sycl::info::device::name>() << std::endl;
+    sycl::queue q{ device };
     run(q);
 
     status = MPI_Finalize();
     if (status != MPI_SUCCESS) {
-        throw std::runtime_error{"Problem occurred during MPI finalize"};
+        throw std::runtime_error{ "Problem occurred during MPI finalize" };
     }
     return 0;
 }

--- a/samples/oneapi/dpc/mpi/sources/input_helpers.hpp
+++ b/samples/oneapi/dpc/mpi/sources/input_helpers.hpp
@@ -62,7 +62,8 @@ std::vector<dal::table> split_table_by_rows(sycl::queue& queue,
         const std::int64_t block_size = block_size_regular + tail;
 
         const auto row_range = dal::range{ row_offset, row_offset + block_size };
-        const auto block = dal::row_accessor<const Float>{ t }.pull(queue, row_range, sycl::usm::alloc::device);
+        const auto block =
+            dal::row_accessor<const Float>{ t }.pull(queue, row_range, sycl::usm::alloc::device);
         result[i] = dal::homogen_table::wrap(block, block_size, column_count);
         row_offset += block_size;
     }

--- a/samples/oneapi/dpc/mpi/sources/kmeans_distr_mpi.cpp
+++ b/samples/oneapi/dpc/mpi/sources/kmeans_distr_mpi.cpp
@@ -34,7 +34,8 @@ void run(sycl::queue& queue) {
     const auto train_data_file_name = get_data_path("data/kmeans_dense_train_data.csv");
     const auto initial_centroids_file_name = get_data_path("data/kmeans_dense_train_centroids.csv");
 
-    const auto x_train = dal::read<dal::table>(queue, dal::csv::data_source{ train_data_file_name });
+    const auto x_train =
+        dal::read<dal::table>(queue, dal::csv::data_source{ train_data_file_name });
     const auto initial_centroids =
         dal::read<dal::table>(queue, dal::csv::data_source{ initial_centroids_file_name });
 
@@ -47,25 +48,26 @@ void run(sycl::queue& queue) {
     auto rank_count = comm.get_rank_count();
 
     auto input_vec = split_table_by_rows<float>(queue, x_train, rank_count);
-    dal::kmeans::train_input local_input { input_vec[rank_id], initial_centroids };
+    dal::kmeans::train_input local_input{ input_vec[rank_id], initial_centroids };
 
     const auto result_train = dal::preview::train(comm, kmeans_desc, local_input);
-    if(comm.get_rank() == 0) {
+    if (comm.get_rank() == 0) {
         std::cout << "Iteration count: " << result_train.get_iteration_count() << std::endl;
         std::cout << "Objective function value: " << result_train.get_objective_function_value()
-                << std::endl;
+                  << std::endl;
         std::cout << "Centroids:\n" << result_train.get_model().get_centroids() << std::endl;
     }
 }
 
-int main(int argc, char const *argv[]) {
+int main(int argc, char const* argv[]) {
     int status = MPI_Init(nullptr, nullptr);
     if (status != MPI_SUCCESS) {
         throw std::runtime_error{ "Problem occurred during MPI init" };
     }
 
     auto device = sycl::device(sycl::gpu_selector_v);
-    std::cout << "Running on " << device.get_platform().get_info<sycl::info::platform::name>() << ", " << device.get_info<sycl::info::device::name>() << std::endl;
+    std::cout << "Running on " << device.get_platform().get_info<sycl::info::platform::name>()
+              << ", " << device.get_info<sycl::info::device::name>() << std::endl;
 
     sycl::queue q{ device };
     run(q);

--- a/samples/oneapi/dpc/mpi/sources/pca_distr_mpi.cpp
+++ b/samples/oneapi/dpc/mpi/sources/pca_distr_mpi.cpp
@@ -34,8 +34,7 @@ namespace dal = oneapi::dal;
 void run(sycl::queue& queue) {
     const auto data_file_name = get_data_path("data/pca_normalized.csv");
 
-    const auto data = dal::read<dal::table>(
-      queue, dal::csv::data_source{data_file_name});
+    const auto data = dal::read<dal::table>(queue, dal::csv::data_source{ data_file_name });
 
     const auto pca_desc = dal::pca::descriptor{};
 
@@ -43,8 +42,7 @@ void run(sycl::queue& queue) {
     auto rank_id = comm.get_rank();
     auto rank_count = comm.get_rank_count();
 
-    auto input_vec =
-      split_table_by_rows<float>(queue, data, rank_count);
+    auto input_vec = split_table_by_rows<float>(queue, data, rank_count);
 
     const auto result = dal::preview::train(comm, pca_desc, input_vec[rank_id]);
     if (comm.get_rank() == 0) {
@@ -53,21 +51,21 @@ void run(sycl::queue& queue) {
     }
 }
 
-int main(int argc, char const *argv[]) {
+int main(int argc, char const* argv[]) {
     int status = MPI_Init(nullptr, nullptr);
     if (status != MPI_SUCCESS) {
-        throw std::runtime_error{"Problem occurred during MPI init"};
+        throw std::runtime_error{ "Problem occurred during MPI init" };
     }
 
     auto device = sycl::device(sycl::gpu_selector_v);
-    std::cout << "Running on " << device.get_platform().get_info<sycl::info::platform::name>() << ", " << device.get_info<sycl::info::device::name>()
-            << std::endl;
-    sycl::queue q{device};
+    std::cout << "Running on " << device.get_platform().get_info<sycl::info::platform::name>()
+              << ", " << device.get_info<sycl::info::device::name>() << std::endl;
+    sycl::queue q{ device };
     run(q);
 
     status = MPI_Finalize();
     if (status != MPI_SUCCESS) {
-        throw std::runtime_error{"Problem occurred during MPI finalize"};
+        throw std::runtime_error{ "Problem occurred during MPI finalize" };
     }
     return 0;
 }


### PR DESCRIPTION
Reusing `.clang-format` files from the corresponding `examples` subdirectories in `samples` 