### PR TITLE
Update DPC++ compiler to 2023.0.0 in public CI

### DIFF
--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -85,7 +85,7 @@ jobs:
       ls -lh __nuget/inteldal*.nupkg
     displayName: 'nuget pkg'
 
-- job: 'LinuxMakeClang'
+- job: 'LinuxMakeDPCPP'
   timeoutInMinutes: 0
   variables:
     release.dir: '__release_lnx_clang'
@@ -95,40 +95,8 @@ jobs:
   steps:
   - script: |
       sudo apt-get update && sudo apt-get install -y gcc-multilib g++-multilib dos2unix
-      conda create -n ci-env -q -y -c intel -c conda-forge impi-devel=2021.7.1 openjdk=17.0.3
+      conda create -n ci-env -q -y -c conda-forge -c intel impi-devel=2021.7.1 openjdk=17.0.3
     displayName: 'apt-get and conda install'
-  - script: |
-      .ci/scripts/describe_system.sh
-    displayName: 'System info'
-  - script: |
-      .ci/scripts/build.sh --platform $(platform.type) --compiler clang --target daal --conda-env ci-env
-    displayName: 'make daal'
-  - script: |
-      .ci/scripts/build.sh --platform $(platform.type) --compiler clang --target oneapi_c
-    displayName: 'make oneapi_c'
-  - script: |
-      .ci/scripts/test.sh --test-kind examples --build-dir $(release.dir) --platform $(platform.type) --compiler clang --interface daal/java --conda-env ci-env
-    displayName: 'daal/java examples'
-  - script: |
-      .ci/scripts/test.sh --test-kind examples --build-dir $(release.dir) --platform $(platform.type) --compiler clang --interface daal/cpp
-    displayName: 'daal/cpp examples'
-  - script: |
-      .ci/scripts/test.sh --test-kind examples --build-dir $(release.dir) --platform $(platform.type) --compiler clang --interface oneapi/cpp
-    displayName: 'oneapi/cpp examples'
-  - script: |
-      .ci/scripts/test.sh --test-kind samples --build-dir $(release.dir) --platform $(platform.type) --compiler gnu --interface daal/cpp/mpi --conda-env ci-env
-    displayName: 'daal/cpp/mpi samples'
-
-- job: 'LinuxMakeDPCPP'
-  timeoutInMinutes: 0
-  variables:
-    release.dir: '__release_lnx_clang'
-    platform.type : 'lnx32e'
-  pool:
-    vmImage: 'ubuntu-22.04'
-  steps:
-  - script: sudo apt-get update && sudo apt-get install -y gcc-multilib g++-multilib dos2unix wget
-    displayName: 'apt-get'
   - script: |
       wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
       sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
@@ -145,25 +113,24 @@ jobs:
       .ci/scripts/describe_system.sh
     displayName: 'System info'
   - script: |
+      .ci/scripts/build.sh --platform $(platform.type) --compiler clang --target daal --conda-env ci-env
+    displayName: 'make daal'
+  - script: |
       source /opt/intel/oneapi/compiler/latest/env/vars.sh
       .ci/scripts/build.sh --platform $(platform.type) --compiler clang --target onedal_dpc
     displayName: 'make onedal_dpc'
   - script: |
-      source /opt/intel/oneapi/compiler/latest/env/vars.sh
+      .ci/scripts/test.sh --test-kind examples --build-dir $(release.dir) --platform $(platform.type) --compiler clang --interface daal/java --conda-env ci-env
+    displayName: 'daal/java examples'
+  - script: |
       .ci/scripts/test.sh --test-kind examples --build-dir $(release.dir) --platform $(platform.type) --compiler clang --interface daal/cpp
     displayName: 'daal/cpp examples'
   - script: |
-      source /opt/intel/oneapi/compiler/latest/env/vars.sh
-      .ci/scripts/test.sh --test-kind examples --build-dir $(release.dir) --platform $(platform.type) --compiler dpcpp --interface daal/cpp_sycl
-    displayName: 'daal/cpp_sycl examples'
-  - script: |
-      source /opt/intel/oneapi/compiler/latest/env/vars.sh
       .ci/scripts/test.sh --test-kind examples --build-dir $(release.dir) --platform $(platform.type) --compiler clang --interface oneapi/cpp
     displayName: 'oneapi/cpp examples'
   - script: |
-      source /opt/intel/oneapi/compiler/latest/env/vars.sh
-      .ci/scripts/test.sh --test-kind examples --build-dir $(release.dir) --platform $(platform.type) --compiler dpcpp --interface oneapi/dpc
-    displayName: 'oneapi/dpc examples'
+      .ci/scripts/test.sh --test-kind samples --build-dir $(release.dir) --platform $(platform.type) --compiler gnu --interface daal/cpp/mpi --conda-env ci-env
+    displayName: 'daal/cpp/mpi samples'
 
 - job: 'LinuxBazel'
   timeoutInMinutes: 0

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -141,27 +141,27 @@ jobs:
       sudo mv -f /opt/intel/oneapi/compiler/latest/linux/lib/oclfpga /opt/intel/oneapi/compiler/latest/linux/lib/oclfpga_
     displayName: 'dpcpp installation'
   - script: |
-      export DPCPPROOT=/opt/intel/oneapi/compiler/latest
-      export PATH="${DPCPPROOT}/linux/bin:${DPCPPROOT}/linux/bin-llvm:${PATH}"
-      echo "##vso[task.setvariable variable=DPCPPROOT;]${DPCPPROOT}"
-      echo "##vso[task.setvariable variable=PATH;]${PATH}"
-    displayName: 'dpcpp env set'
-  - script: |
+      source /opt/intel/oneapi/compiler/latest/env/vars.sh
       .ci/scripts/describe_system.sh
     displayName: 'System info'
   - script: |
+      source /opt/intel/oneapi/compiler/latest/env/vars.sh
       .ci/scripts/build.sh --platform $(platform.type) --compiler clang --target onedal_dpc
     displayName: 'make onedal_dpc'
   - script: |
+      source /opt/intel/oneapi/compiler/latest/env/vars.sh
       .ci/scripts/test.sh --test-kind examples --build-dir $(release.dir) --platform $(platform.type) --compiler clang --interface daal/cpp
     displayName: 'daal/cpp examples'
   - script: |
+      source /opt/intel/oneapi/compiler/latest/env/vars.sh
       .ci/scripts/test.sh --test-kind examples --build-dir $(release.dir) --platform $(platform.type) --compiler dpcpp --interface daal/cpp_sycl
     displayName: 'daal/cpp_sycl examples'
   - script: |
+      source /opt/intel/oneapi/compiler/latest/env/vars.sh
       .ci/scripts/test.sh --test-kind examples --build-dir $(release.dir) --platform $(platform.type) --compiler clang --interface oneapi/cpp
     displayName: 'oneapi/cpp examples'
   - script: |
+      source /opt/intel/oneapi/compiler/latest/env/vars.sh
       .ci/scripts/test.sh --test-kind examples --build-dir $(release.dir) --platform $(platform.type) --compiler dpcpp --interface oneapi/dpc
     displayName: 'oneapi/dpc examples'
 

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -127,30 +127,37 @@ jobs:
   pool:
     vmImage: 'ubuntu-22.04'
   steps:
-  - script: sudo apt-get update && sudo apt-get install -y gcc-multilib g++-multilib dos2unix wget libtinfo5
+  - script: sudo apt-get update && sudo apt-get install -y gcc-multilib g++-multilib dos2unix wget
     displayName: 'apt-get'
   - script: |
-      wget "https://github.com/intel/llvm/releases/download/sycl-nightly%2F20221129/dpcpp-compiler.tar.gz"
-      tar -xzf dpcpp-compiler.tar.gz
-      ln -s clang++ dpcpp_compiler/bin/icpx
-      ln -s clang dpcpp_compiler/bin/icx
-    displayName: 'download dpcpp daily build'
+      wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+      sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+      rm GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+      echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
+      sudo add-apt-repository -y "deb https://apt.repos.intel.com/oneapi all main"
+      sudo apt-get update
+      sudo apt-get install -y intel-dpcpp-cpp-compiler-2023.0.0
+      sudo bash -c 'echo libintelocl.so > /etc/OpenCL/vendors/intel-cpu.icd'
+      sudo mv -f /opt/intel/oneapi/compiler/latest/linux/lib/oclfpga /opt/intel/oneapi/compiler/latest/linux/lib/oclfpga_
+    displayName: 'dpcpp installation'
   - script: |
-      source dpcpp_compiler/startup.sh
       .ci/scripts/describe_system.sh
     displayName: 'System info'
   - script: |
-      source dpcpp_compiler/startup.sh
       .ci/scripts/build.sh --platform $(platform.type) --compiler clang --target onedal_dpc
     displayName: 'make onedal_dpc'
   - script: |
-      source dpcpp_compiler/startup.sh
       .ci/scripts/test.sh --test-kind examples --build-dir $(release.dir) --platform $(platform.type) --compiler clang --interface daal/cpp
     displayName: 'daal/cpp examples'
   - script: |
-      source dpcpp_compiler/startup.sh
+      .ci/scripts/test.sh --test-kind examples --build-dir $(release.dir) --platform $(platform.type) --compiler dpcpp --interface daal/cpp_sycl
+    displayName: 'daal/cpp_sycl examples'
+  - script: |
       .ci/scripts/test.sh --test-kind examples --build-dir $(release.dir) --platform $(platform.type) --compiler clang --interface oneapi/cpp
     displayName: 'oneapi/cpp examples'
+  - script: |
+      .ci/scripts/test.sh --test-kind examples --build-dir $(release.dir) --platform $(platform.type) --compiler dpcpp --interface oneapi/dpc
+    displayName: 'oneapi/dpc examples'
 
 - job: 'LinuxBazel'
   timeoutInMinutes: 0

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -141,6 +141,12 @@ jobs:
       sudo mv -f /opt/intel/oneapi/compiler/latest/linux/lib/oclfpga /opt/intel/oneapi/compiler/latest/linux/lib/oclfpga_
     displayName: 'dpcpp installation'
   - script: |
+      export DPCPPROOT=/opt/intel/oneapi/compiler/latest
+      export PATH="${DPCPPROOT}/linux/bin:${DPCPPROOT}/linux/bin-llvm:${PATH}"
+      echo "##vso[task.setvariable variable=DPCPPROOT;]${DPCPPROOT}"
+      echo "##vso[task.setvariable variable=PATH;]${PATH}"
+    displayName: 'dpcpp env set'
+  - script: |
       .ci/scripts/describe_system.sh
     displayName: 'System info'
   - script: |


### PR DESCRIPTION
- Update DPC++ compiler to 2023.0.0 from APT
- Remove LinuxMakeClang as partial duplicate of LinuxMakeDPCPP