### PR TITLE
SVM inference for small number of samples

### DIFF
--- a/cpp/daal/src/algorithms/kernel_function/kernel_function.cpp
+++ b/cpp/daal/src/algorithms/kernel_function/kernel_function.cpp
@@ -118,22 +118,14 @@ Status Result::check(const daal::algorithms::Input * input, const daal::algorith
     Input * algInput             = static_cast<Input *>(const_cast<daal::algorithms::Input *>(input));
     ParameterBase * algParameter = static_cast<ParameterBase *>(const_cast<daal::algorithms::Parameter *>(par));
 
-    const size_t nRowsX = algInput->get(X)->getNumberOfRows();
-    const size_t nRowsY = algInput->get(Y)->getNumberOfRows();
-
-    const int unexpectedLayouts = packed_mask;
-
-    if (algParameter->computationMode == kernel_function::matrixVector)
-    {
-        DAAL_CHECK_STATUS(s, checkNumericTable(get(values).get(), valuesStr(), unexpectedLayouts, 0, 0, nRowsY));
-    }
-    else
-    {
-        DAAL_CHECK_STATUS(s, checkNumericTable(get(values).get(), valuesStr(), unexpectedLayouts, 0, 0, nRowsX));
-    }
-
+    const size_t nRowsX         = algInput->get(X)->getNumberOfRows();
+    const size_t nRowsY         = algInput->get(Y)->getNumberOfRows();
     const size_t nVectorsValues = get(values)->getNumberOfRows();
 
+    if (nVectorsValues != nRowsX && nVectorsValues != nRowsY)
+    {
+        return Status(Error::create(ErrorIncorrectNumberOfRows, ParameterName, valuesStr()));
+    }
     if (algParameter->rowIndexResult >= nVectorsValues)
     {
         return Status(Error::create(ErrorIncorrectParameter, ParameterName, rowIndexResultStr()));

--- a/cpp/daal/src/algorithms/kernel_function/kernel_function.cpp
+++ b/cpp/daal/src/algorithms/kernel_function/kernel_function.cpp
@@ -122,7 +122,15 @@ Status Result::check(const daal::algorithms::Input * input, const daal::algorith
     const size_t nRowsY = algInput->get(Y)->getNumberOfRows();
 
     const int unexpectedLayouts = packed_mask;
-    DAAL_CHECK_STATUS(s, checkNumericTable(get(values).get(), valuesStr(), unexpectedLayouts, 0, 0, nRowsX));
+
+    if (algParameter->computationMode == kernel_function::matrixVector)
+    {
+        DAAL_CHECK_STATUS(s, checkNumericTable(get(values).get(), valuesStr(), unexpectedLayouts, 0, 0, nRowsY));
+    }
+    else
+    {
+        DAAL_CHECK_STATUS(s, checkNumericTable(get(values).get(), valuesStr(), unexpectedLayouts, 0, 0, nRowsX));
+    }
 
     const size_t nVectorsValues = get(values)->getNumberOfRows();
 

--- a/cpp/daal/src/algorithms/kernel_function/kernel_function.cpp
+++ b/cpp/daal/src/algorithms/kernel_function/kernel_function.cpp
@@ -114,7 +114,7 @@ void Result::set(ResultId id, const NumericTablePtr & ptr)
 */
 Status Result::check(const daal::algorithms::Input * input, const daal::algorithms::Parameter * par, int method) const
 {
-    Status s;
+    Status st;
     Input * algInput             = static_cast<Input *>(const_cast<daal::algorithms::Input *>(input));
     ParameterBase * algParameter = static_cast<ParameterBase *>(const_cast<daal::algorithms::Parameter *>(par));
 
@@ -124,21 +124,21 @@ Status Result::check(const daal::algorithms::Input * input, const daal::algorith
 
     if (nVectorsValues != nRowsX && nVectorsValues != nRowsY)
     {
-        return Status(Error::create(ErrorIncorrectNumberOfRows, ParameterName, valuesStr()));
+        st.add(Error::create(ErrorIncorrectNumberOfRows, ParameterName, valuesStr()));
     }
     if (algParameter->rowIndexResult >= nVectorsValues)
     {
-        return Status(Error::create(ErrorIncorrectParameter, ParameterName, rowIndexResultStr()));
+        st.add(Error::create(ErrorIncorrectParameter, ParameterName, rowIndexResultStr()));
     }
     if (algParameter->rowIndexX >= nRowsX)
     {
-        return Status(Error::create(ErrorIncorrectParameter, ParameterName, rowIndexXStr()));
+        st.add(Error::create(ErrorIncorrectParameter, ParameterName, rowIndexXStr()));
     }
     if (algParameter->rowIndexY >= nRowsY)
     {
-        return Status(Error::create(ErrorIncorrectParameter, ParameterName, rowIndexYStr()));
+        st.add(Error::create(ErrorIncorrectParameter, ParameterName, rowIndexYStr()));
     }
-    return s;
+    return st;
 }
 
 } // namespace interface1

--- a/cpp/daal/src/algorithms/kernel_function/polynomial/kernel_function_polynomial_csr_fast_impl.i
+++ b/cpp/daal/src/algorithms/kernel_function/polynomial/kernel_function_polynomial_csr_fast_impl.i
@@ -69,11 +69,6 @@ template <typename algorithmFPType, CpuType cpu>
 services::Status KernelImplPolynomial<fastCSR, algorithmFPType, cpu>::computeInternalMatrixVector(const NumericTable * a1, const NumericTable * a2,
                                                                                                   NumericTable * r, const KernelParameter * par)
 {
-    if (par->kernelType != KernelType::linear)
-    {
-        return services::ErrorMethodNotImplemented;
-    }
-
     //prepareData
     const size_t nVectors1 = a1->getNumberOfRows();
 
@@ -98,6 +93,14 @@ services::Status KernelImplPolynomial<fastCSR, algorithmFPType, cpu>::computeInt
         dataR[i] = computeDotProduct(rowOffsetsA1[i] - 1, rowOffsetsA1[i + 1] - 1, mtA1.values(), mtA1.cols(), rowOffsetsA2[0] - 1,
                                      rowOffsetsA2[1] - 1, mtA2.values(), mtA2.cols());
         dataR[i] = dataR[i] * k + b;
+    }
+    if (par->kernelType == KernelType::sigmoid)
+    {
+        daal::internal::Math<algorithmFPType, cpu>::vTanh(nVectors1, dataR, dataR);
+    }
+    if (par->kernelType == KernelType::polynomial)
+    {
+        daal::internal::Math<algorithmFPType, cpu>::vPowx(nVectors1, dataR, par->degree, dataR);
     }
 
     return services::Status();

--- a/cpp/daal/src/algorithms/kernel_function/polynomial/kernel_function_polynomial_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/kernel_function/polynomial/kernel_function_polynomial_dense_default_impl.i
@@ -43,7 +43,7 @@ services::Status KernelImplPolynomial<defaultDense, algorithmFPType, cpu>::compu
 {
     if (par->kernelType != KernelType::linear)
     {
-        return services::ErrorMethodNotImplemented;
+        return computeInternalMatrixMatrix(a1, a2, r, par);
     }
 
     //prepareData
@@ -81,7 +81,7 @@ services::Status KernelImplPolynomial<defaultDense, algorithmFPType, cpu>::compu
 {
     if (par->kernelType != KernelType::linear)
     {
-        return services::ErrorMethodNotImplemented;
+        return computeInternalMatrixMatrix(a1, a2, r, par);
     }
 
     //prepareData
@@ -103,11 +103,12 @@ services::Status KernelImplPolynomial<defaultDense, algorithmFPType, cpu>::compu
     //compute
     algorithmFPType k = (algorithmFPType)(par->scale);
     algorithmFPType b = (algorithmFPType)(par->shift);
+
+    PRAGMA_IVDEP
+    PRAGMA_VECTOR_ALWAYS
     for (size_t i = 0; i < nVectors1; i++)
     {
         dataR[i] = 0.0;
-        PRAGMA_IVDEP
-        PRAGMA_VECTOR_ALWAYS
         for (size_t j = 0; j < nFeatures; j++)
         {
             dataR[i] += dataA1[i * nFeatures + j] * dataA2[j];

--- a/cpp/daal/src/algorithms/kernel_function/polynomial/kernel_function_polynomial_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/kernel_function/polynomial/kernel_function_polynomial_dense_default_impl.i
@@ -109,10 +109,6 @@ services::Status KernelImplPolynomial<defaultDense, algorithmFPType, cpu>::compu
             dataR[i] += dataA1[i * nFeatures + j] * dataA2[j];
         }
         dataR[i] = k * dataR[i];
-        if (dataR[i] < Math<algorithmFPType, cpu>::vExpThreshold())
-        {
-            dataR[i] = Math<algorithmFPType, cpu>::vExpThreshold();
-        }
     }
     if (par->kernelType == KernelType::sigmoid)
     {

--- a/cpp/daal/src/algorithms/kernel_function/polynomial/kernel_function_polynomial_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/kernel_function/polynomial/kernel_function_polynomial_dense_default_impl.i
@@ -98,16 +98,15 @@ services::Status KernelImplPolynomial<defaultDense, algorithmFPType, cpu>::compu
     //compute
     const algorithmFPType k = (algorithmFPType)(par->scale);
     const algorithmFPType b = (algorithmFPType)(par->shift);
-
+    const char trans = 'T';
+    const DAAL_INT m = nFeatures;
+    const DAAL_INT n = nVectors1;
+    const algorithmFPType alpha(k);
+    const DAAL_INT ldA = nFeatures;
+    const DAAL_INT incX(1);
+    const algorithmFPType beta(1.0);
+    const DAAL_INT incY(1);
     services::internal::service_memset_seq<algorithmFPType, cpu>(dataR, b, nVectors1);
-    char trans = 'T';
-    DAAL_INT m = nFeatures;
-    DAAL_INT n = nVectors1;
-    algorithmFPType alpha(1.0);
-    DAAL_INT ldA = nFeatures;
-    DAAL_INT incX(1);
-    algorithmFPType beta(1.0);
-    DAAL_INT incY(1);
     Blas<algorithmFPType, cpu>::xgemv(&trans, &m, &n, &alpha, dataA1, &ldA, dataA2, &incX, &beta, dataR, &incY);
 
     if (par->kernelType == KernelType::sigmoid)

--- a/cpp/daal/src/algorithms/kernel_function/polynomial/kernel_function_polynomial_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/kernel_function/polynomial/kernel_function_polynomial_dense_default_impl.i
@@ -79,11 +79,6 @@ services::Status KernelImplPolynomial<defaultDense, algorithmFPType, cpu>::compu
                                                                                                        const NumericTable * a2, NumericTable * r,
                                                                                                        const KernelParameter * par)
 {
-    if (par->kernelType != KernelType::linear)
-    {
-        return computeInternalMatrixMatrix(a2, a1, r, par);
-    }
-
     //prepareData
     const size_t nVectors1 = a1->getNumberOfRows();
     const size_t nFeatures = a1->getNumberOfColumns();
@@ -115,6 +110,14 @@ services::Status KernelImplPolynomial<defaultDense, algorithmFPType, cpu>::compu
         }
         dataR[i] = k * dataR[i];
         dataR[i] += b;
+    }
+    if (par->kernelType == KernelType::sigmoid)
+    {
+        daal::internal::Math<algorithmFPType, cpu>::vTanh(nVectors1, dataR, dataR);
+    }
+    if (par->kernelType == KernelType::polynomial)
+    {
+        daal::internal::Math<algorithmFPType, cpu>::vPowx(nVectors1, dataR, par->degree, dataR);
     }
 
     return services::Status();

--- a/cpp/daal/src/algorithms/kernel_function/polynomial/kernel_function_polynomial_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/kernel_function/polynomial/kernel_function_polynomial_dense_default_impl.i
@@ -43,7 +43,7 @@ services::Status KernelImplPolynomial<defaultDense, algorithmFPType, cpu>::compu
 {
     if (par->kernelType != KernelType::linear)
     {
-        return computeInternalMatrixMatrix(a1, a2, r, par);
+        return services::ErrorMethodNotImplemented;
     }
 
     //prepareData
@@ -81,7 +81,7 @@ services::Status KernelImplPolynomial<defaultDense, algorithmFPType, cpu>::compu
 {
     if (par->kernelType != KernelType::linear)
     {
-        return computeInternalMatrixMatrix(a1, a2, r, par);
+        return computeInternalMatrixMatrix(a2, a1, r, par);
     }
 
     //prepareData

--- a/cpp/daal/src/algorithms/kernel_function/polynomial/kernel_function_polynomial_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/kernel_function/polynomial/kernel_function_polynomial_dense_default_impl.i
@@ -96,20 +96,20 @@ services::Status KernelImplPolynomial<defaultDense, algorithmFPType, cpu>::compu
     algorithmFPType * dataR = mtR.get();
 
     //compute
-    algorithmFPType k = (algorithmFPType)(par->scale);
-    algorithmFPType b = (algorithmFPType)(par->shift);
+    const algorithmFPType k = (algorithmFPType)(par->scale);
+    const algorithmFPType b = (algorithmFPType)(par->shift);
 
     services::internal::service_memset_seq<algorithmFPType, cpu>(dataR, b, nVectors1);
-    for (size_t i = 0; i < nVectors1; i++)
-    {
-        PRAGMA_IVDEP
-        PRAGMA_VECTOR_ALWAYS
-        for (size_t j = 0; j < nFeatures; j++)
-        {
-            dataR[i] += dataA1[i * nFeatures + j] * dataA2[j];
-        }
-        dataR[i] = k * dataR[i];
-    }
+    char trans = 'T';
+    DAAL_INT m = nFeatures;
+    DAAL_INT n = nVectors1;
+    algorithmFPType alpha(1.0);
+    DAAL_INT ldA = nFeatures;
+    DAAL_INT incX(1);
+    algorithmFPType beta(1.0);
+    DAAL_INT incY(1);
+    Blas<algorithmFPType, cpu>::xgemv(&trans, &m, &n, &alpha, dataA1, &ldA, dataA2, &incX, &beta, dataR, &incY);
+
     if (par->kernelType == KernelType::sigmoid)
     {
         daal::internal::Math<algorithmFPType, cpu>::vTanh(nVectors1, dataR, dataR);

--- a/cpp/daal/src/algorithms/kernel_function/polynomial/kernel_function_polynomial_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/kernel_function/polynomial/kernel_function_polynomial_dense_default_impl.i
@@ -99,9 +99,9 @@ services::Status KernelImplPolynomial<defaultDense, algorithmFPType, cpu>::compu
     algorithmFPType k = (algorithmFPType)(par->scale);
     algorithmFPType b = (algorithmFPType)(par->shift);
 
+    services::internal::service_memset_seq<algorithmFPType, cpu>(dataR, b, nVectors1);
     for (size_t i = 0; i < nVectors1; i++)
     {
-        dataR[i] = 0.0;
         PRAGMA_IVDEP
         PRAGMA_VECTOR_ALWAYS
         for (size_t j = 0; j < nFeatures; j++)
@@ -109,7 +109,6 @@ services::Status KernelImplPolynomial<defaultDense, algorithmFPType, cpu>::compu
             dataR[i] += dataA1[i * nFeatures + j] * dataA2[j];
         }
         dataR[i] = k * dataR[i];
-        dataR[i] += b;
         if (dataR[i] < Math<algorithmFPType, cpu>::vExpThreshold())
         {
             dataR[i] = Math<algorithmFPType, cpu>::vExpThreshold();

--- a/cpp/daal/src/algorithms/kernel_function/polynomial/kernel_function_polynomial_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/kernel_function/polynomial/kernel_function_polynomial_dense_default_impl.i
@@ -99,17 +99,22 @@ services::Status KernelImplPolynomial<defaultDense, algorithmFPType, cpu>::compu
     algorithmFPType k = (algorithmFPType)(par->scale);
     algorithmFPType b = (algorithmFPType)(par->shift);
 
-    char notrans = 'N';
-    const algorithmFPType alpha(k);
-    const algorithmFPType beta(1.0);
-    DAAL_INT incX(1);
-    DAAL_INT incY(1);
-    DAAL_INT m(nVectors1);
-    DAAL_INT n(nFeatures);
-
-    services::internal::service_memset_seq<algorithmFPType, cpu>(dataR, b, nVectors1);
-    Blas<algorithmFPType, cpu>::xxgemv(&notrans, &m, &n, &alpha, dataA1, &m, dataA2, &incX, &beta, dataR, &incY);
-
+    for (size_t i = 0; i < nVectors1; i++)
+    {
+        dataR[i] = 0.0;
+        PRAGMA_IVDEP
+        PRAGMA_VECTOR_ALWAYS
+        for (size_t j = 0; j < nFeatures; j++)
+        {
+            dataR[i] += dataA1[i * nFeatures + j] * dataA2[j];
+        }
+        dataR[i] = k * dataR[i];
+        dataR[i] += b;
+        if (dataR[i] < Math<algorithmFPType, cpu>::vExpThreshold())
+        {
+            dataR[i] = Math<algorithmFPType, cpu>::vExpThreshold();
+        }
+    }
     if (par->kernelType == KernelType::sigmoid)
     {
         daal::internal::Math<algorithmFPType, cpu>::vTanh(nVectors1, dataR, dataR);

--- a/cpp/daal/src/algorithms/kernel_function/polynomial/kernel_function_polynomial_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/kernel_function/polynomial/kernel_function_polynomial_dense_default_impl.i
@@ -99,17 +99,21 @@ services::Status KernelImplPolynomial<defaultDense, algorithmFPType, cpu>::compu
     algorithmFPType k = (algorithmFPType)(par->scale);
     algorithmFPType b = (algorithmFPType)(par->shift);
 
-    PRAGMA_IVDEP
-    PRAGMA_VECTOR_ALWAYS
     for (size_t i = 0; i < nVectors1; i++)
     {
         dataR[i] = 0.0;
+        PRAGMA_IVDEP
+        PRAGMA_VECTOR_ALWAYS
         for (size_t j = 0; j < nFeatures; j++)
         {
             dataR[i] += dataA1[i * nFeatures + j] * dataA2[j];
         }
         dataR[i] = k * dataR[i];
         dataR[i] += b;
+        if (dataR[i] < Math<algorithmFPType, cpu>::vExpThreshold())
+        {
+            dataR[i] = Math<algorithmFPType, cpu>::vExpThreshold();
+        }
     }
     if (par->kernelType == KernelType::sigmoid)
     {

--- a/cpp/daal/src/algorithms/svm/svm_predict_impl.i
+++ b/cpp/daal/src/algorithms/svm/svm_predict_impl.i
@@ -200,10 +200,129 @@ private:
 template <typename algorithmFPType, CpuType cpu>
 struct SVMPredictImpl<defaultDense, algorithmFPType, cpu> : public Kernel
 {
+    using TPredictTask = PredictTask<algorithmFPType, cpu>;
+
+    services::Status computeSequential(const NumericTablePtr & xTable, const NumericTablePtr & svCoeffTable, const NumericTablePtr & svTable,
+                                       NumericTable & r, kernel_function::KernelIfacePtr & kernel, const algorithmFPType bias, const size_t nVectors,
+                                       const size_t nSV, const bool isSparse)
+    {
+        TArray<algorithmFPType, cpu> distances(nVectors);
+        TPredictTask * prTask;
+        if (isSparse)
+        {
+            prTask = PredictTaskCSR<algorithmFPType, cpu>::create(nVectors, nSV, xTable, svTable, kernel);
+        }
+        else
+        {
+            prTask = PredictTaskDense<algorithmFPType, cpu>::create(nVectors, nSV, xTable, svTable, kernel);
+        }
+        prTask->kernelCompute(0, nVectors, 0, nSV);
+        const algorithmFPType * const buffBlock = prTask->getBuff();
+
+        char trans = 'T';
+        DAAL_INT m = nSV;
+        DAAL_INT n = nVectors;
+        algorithmFPType alpha(1.0);
+        DAAL_INT ldA = nSV;
+        DAAL_INT incX(1);
+        algorithmFPType beta(0.0);
+        DAAL_INT incY(1);
+
+        ReadColumns<algorithmFPType, cpu> mtSVCoeff(*svCoeffTable, 0, 0, nSV);
+        DAAL_CHECK_BLOCK_STATUS(mtSVCoeff);
+        const algorithmFPType * const svCoeff = mtSVCoeff.get();
+        algorithmFPType * const distanceSV    = distances.get();
+
+        Blas<algorithmFPType, cpu>::xxgemv(&trans, &m, &n, &alpha, buffBlock, &ldA, svCoeff, &incX, &beta, distanceSV, &incY);
+
+        WriteOnlyColumns<algorithmFPType, cpu> mtR(r, 0, 0, nVectors);
+        DAAL_CHECK_BLOCK_STATUS(mtR);
+        algorithmFPType * const distanceBlock = mtR.get();
+        service_memset_seq<algorithmFPType, cpu>(distanceBlock, bias, nVectors);
+        Blas<algorithmFPType, cpu>::xxaxpy(&n, &alpha, distanceSV, &incX, distanceBlock, &incY);
+
+        return services::Status();
+    }
+
+    services::Status computeThreading(const NumericTablePtr & xTable, const NumericTablePtr & svCoeffTable, const NumericTablePtr & svTable,
+                                      NumericTable & r, kernel_function::KernelIfacePtr & kernel, const algorithmFPType bias, const size_t nVectors,
+                                      const size_t nSV, const bool isSparse, const size_t nRowsPerBlock, const size_t nBlocks)
+    {
+        size_t nSVPerBlock = 0;
+        DAAL_SAFE_CPU_CALL((nSVPerBlock = 128), (nSVPerBlock = nSV));
+        const size_t nBlocksSV = nSV / nSVPerBlock + !!(nSV % nSVPerBlock);
+
+        /* TLS data initialization */
+        daal::tls<TPredictTask *> tlsTask([&]() {
+            if (isSparse)
+            {
+                return PredictTaskCSR<algorithmFPType, cpu>::create(nRowsPerBlock, nSVPerBlock, xTable, svTable, kernel);
+            }
+            else
+            {
+                return PredictTaskDense<algorithmFPType, cpu>::create(nRowsPerBlock, nSVPerBlock, xTable, svTable, kernel);
+            }
+        });
+
+        DAAL_OVERFLOW_CHECK_BY_MULTIPLICATION(size_t, nBlocksSV, nRowsPerBlock);
+        daal::StaticTlsMem<algorithmFPType, cpu> lsDistance(nBlocksSV * nRowsPerBlock);
+        SafeStatus safeStat;
+        daal::static_threader_for(nBlocks, [&, nVectors, nBlocks](const size_t iBlock, const size_t tid) {
+            const size_t startRow          = iBlock * nRowsPerBlock;
+            const size_t nRowsPerBlockReal = (iBlock != nBlocks - 1) ? nRowsPerBlock : nVectors - startRow;
+
+            algorithmFPType * const distanceLocal = lsDistance.local(tid);
+            DAAL_CHECK_MALLOC_THR(distanceLocal);
+
+            daal::conditional_threader_for(nSV > 256, nBlocksSV, [&, nSV, nBlocksSV](const size_t iBlockSV) {
+                TPredictTask * lsLocal = tlsTask.local();
+                DAAL_CHECK_MALLOC_THR(lsLocal);
+
+                const size_t startSV         = iBlockSV * nSVPerBlock;
+                const size_t nSVPerBlockReal = (iBlockSV != nBlocksSV - 1) ? nSVPerBlock : nSV - startSV;
+
+                DAAL_CHECK_THR(lsLocal->kernelCompute(startRow, nRowsPerBlockReal, startSV, nSVPerBlockReal),
+                               services::ErrorSVMPredictKernerFunctionCall);
+
+                const algorithmFPType * const buffBlock = lsLocal->getBuff();
+
+                char trans = 'T';
+                DAAL_INT m = nSVPerBlockReal;
+                DAAL_INT n = nRowsPerBlockReal;
+                algorithmFPType alpha(1.0);
+                DAAL_INT ldA = nSVPerBlockReal;
+                DAAL_INT incX(1);
+                algorithmFPType beta(0.0);
+                DAAL_INT incY(1);
+
+                ReadColumns<algorithmFPType, cpu> mtSVCoeff(*svCoeffTable, 0, startSV, nSVPerBlockReal);
+                DAAL_CHECK_BLOCK_STATUS_THR(mtSVCoeff);
+                const algorithmFPType * const svCoeff = mtSVCoeff.get();
+                algorithmFPType * const distanceSV    = &distanceLocal[iBlockSV * nRowsPerBlock];
+
+                Blas<algorithmFPType, cpu>::xxgemv(&trans, &m, &n, &alpha, buffBlock, &ldA, svCoeff, &incX, &beta, distanceSV, &incY);
+            });
+
+            WriteOnlyColumns<algorithmFPType, cpu> mtR(r, 0, startRow, nRowsPerBlockReal);
+            DAAL_CHECK_BLOCK_STATUS_THR(mtR);
+            algorithmFPType * const distanceBlock = mtR.get();
+            service_memset_seq<algorithmFPType, cpu>(distanceBlock, bias, nRowsPerBlockReal);
+            DAAL_INT n = nRowsPerBlockReal;
+            algorithmFPType alpha(1.0);
+            DAAL_INT incY(1);
+            DAAL_INT incX(1);
+            for (size_t iBlockSV = 0; iBlockSV < nBlocksSV; ++iBlockSV)
+            {
+                Blas<algorithmFPType, cpu>::xxaxpy(&n, &alpha, &distanceLocal[iBlockSV * nRowsPerBlock], &incX, distanceBlock, &incY);
+            }
+        });
+
+        tlsTask.reduce([](PredictTask<algorithmFPType, cpu> * local) { delete local; });
+        return safeStat.detach();
+    }
+
     services::Status compute(const NumericTablePtr & xTable, Model * model, NumericTable & r, const svm::Parameter * par)
     {
-        using TPredictTask = PredictTask<algorithmFPType, cpu>;
-
         kernel_function::KernelIfacePtr kernel = par->kernel->clone();
         DAAL_CHECK(kernel, ErrorNullParameterNotSupported);
 
@@ -222,118 +341,11 @@ struct SVMPredictImpl<defaultDense, algorithmFPType, cpu> : public Kernel
 
         if (nBlocks < 4)
         {
-            // sequential branch
-            TArray<algorithmFPType, cpu> distances(nVectors);
-            TPredictTask * prTask;
-            if (isSparse)
-            {
-                prTask = PredictTaskCSR<algorithmFPType, cpu>::create(nVectors, nSV, xTable, svTable, kernel);
-            }
-            else
-            {
-                prTask = PredictTaskDense<algorithmFPType, cpu>::create(nVectors, nSV, xTable, svTable, kernel);
-            }
-            prTask->kernelCompute(0, nVectors, 0, nSV);
-            const algorithmFPType * const buffBlock = prTask->getBuff();
-
-            char trans = 'T';
-            DAAL_INT m = nSV;
-            DAAL_INT n = nVectors;
-            algorithmFPType alpha(1.0);
-            DAAL_INT ldA = nSV;
-            DAAL_INT incX(1);
-            algorithmFPType beta(0.0);
-            DAAL_INT incY(1);
-
-            ReadColumns<algorithmFPType, cpu> mtSVCoeff(*svCoeffTable, 0, 0, nSV);
-            DAAL_CHECK_BLOCK_STATUS(mtSVCoeff);
-            const algorithmFPType * const svCoeff = mtSVCoeff.get();
-            algorithmFPType * const distanceSV    = distances.get();
-
-            Blas<algorithmFPType, cpu>::xxgemv(&trans, &m, &n, &alpha, buffBlock, &ldA, svCoeff, &incX, &beta, distanceSV, &incY);
-
-            WriteOnlyColumns<algorithmFPType, cpu> mtR(r, 0, 0, nVectors);
-            DAAL_CHECK_BLOCK_STATUS(mtR);
-            algorithmFPType * const distanceBlock = mtR.get();
-            service_memset_seq<algorithmFPType, cpu>(distanceBlock, bias, nVectors);
-            Blas<algorithmFPType, cpu>::xxaxpy(&n, &alpha, distanceSV, &incX, distanceBlock, &incY);
-
-            return services::Status();
+            computeSequential(xTable, svCoeffTable, svTable, r, kernel, bias, nVectors, nSV, isSparse);
         }
         else
         {
-            // threading branch
-            size_t nSVPerBlock = 0;
-            DAAL_SAFE_CPU_CALL((nSVPerBlock = 128), (nSVPerBlock = nSV));
-            const size_t nBlocksSV = nSV / nSVPerBlock + !!(nSV % nSVPerBlock);
-
-            /* TLS data initialization */
-            daal::tls<TPredictTask *> tlsTask([&]() {
-                if (isSparse)
-                {
-                    return PredictTaskCSR<algorithmFPType, cpu>::create(nRowsPerBlock, nSVPerBlock, xTable, svTable, kernel);
-                }
-                else
-                {
-                    return PredictTaskDense<algorithmFPType, cpu>::create(nRowsPerBlock, nSVPerBlock, xTable, svTable, kernel);
-                }
-            });
-
-            DAAL_OVERFLOW_CHECK_BY_MULTIPLICATION(size_t, nBlocksSV, nRowsPerBlock);
-            daal::StaticTlsMem<algorithmFPType, cpu> lsDistance(nBlocksSV * nRowsPerBlock);
-            SafeStatus safeStat;
-            daal::static_threader_for(nBlocks, [&, nVectors, nBlocks](const size_t iBlock, const size_t tid) {
-                const size_t startRow          = iBlock * nRowsPerBlock;
-                const size_t nRowsPerBlockReal = (iBlock != nBlocks - 1) ? nRowsPerBlock : nVectors - startRow;
-
-                algorithmFPType * const distanceLocal = lsDistance.local(tid);
-                DAAL_CHECK_MALLOC_THR(distanceLocal);
-
-                daal::conditional_threader_for(nSV > 256, nBlocksSV, [&, nSV, nBlocksSV](const size_t iBlockSV) {
-                    TPredictTask * lsLocal = tlsTask.local();
-                    DAAL_CHECK_MALLOC_THR(lsLocal);
-
-                    const size_t startSV         = iBlockSV * nSVPerBlock;
-                    const size_t nSVPerBlockReal = (iBlockSV != nBlocksSV - 1) ? nSVPerBlock : nSV - startSV;
-
-                    DAAL_CHECK_THR(lsLocal->kernelCompute(startRow, nRowsPerBlockReal, startSV, nSVPerBlockReal),
-                                   services::ErrorSVMPredictKernerFunctionCall);
-
-                    const algorithmFPType * const buffBlock = lsLocal->getBuff();
-
-                    char trans = 'T';
-                    DAAL_INT m = nSVPerBlockReal;
-                    DAAL_INT n = nRowsPerBlockReal;
-                    algorithmFPType alpha(1.0);
-                    DAAL_INT ldA = nSVPerBlockReal;
-                    DAAL_INT incX(1);
-                    algorithmFPType beta(0.0);
-                    DAAL_INT incY(1);
-
-                    ReadColumns<algorithmFPType, cpu> mtSVCoeff(*svCoeffTable, 0, startSV, nSVPerBlockReal);
-                    DAAL_CHECK_BLOCK_STATUS_THR(mtSVCoeff);
-                    const algorithmFPType * const svCoeff = mtSVCoeff.get();
-                    algorithmFPType * const distanceSV    = &distanceLocal[iBlockSV * nRowsPerBlock];
-
-                    Blas<algorithmFPType, cpu>::xxgemv(&trans, &m, &n, &alpha, buffBlock, &ldA, svCoeff, &incX, &beta, distanceSV, &incY);
-                });
-
-                WriteOnlyColumns<algorithmFPType, cpu> mtR(r, 0, startRow, nRowsPerBlockReal);
-                DAAL_CHECK_BLOCK_STATUS_THR(mtR);
-                algorithmFPType * const distanceBlock = mtR.get();
-                service_memset_seq<algorithmFPType, cpu>(distanceBlock, bias, nRowsPerBlockReal);
-                DAAL_INT n = nRowsPerBlockReal;
-                algorithmFPType alpha(1.0);
-                DAAL_INT incY(1);
-                DAAL_INT incX(1);
-                for (size_t iBlockSV = 0; iBlockSV < nBlocksSV; ++iBlockSV)
-                {
-                    Blas<algorithmFPType, cpu>::xxaxpy(&n, &alpha, &distanceLocal[iBlockSV * nRowsPerBlock], &incX, distanceBlock, &incY);
-                }
-            });
-
-            tlsTask.reduce([](PredictTask<algorithmFPType, cpu> * local) { delete local; });
-            return safeStat.detach();
+            computeThreading(xTable, svCoeffTable, svTable, r, kernel, bias, nVectors, nSV, isSparse, nRowsPerBlock, nBlocks);
         }
         return services::Status();
     }

--- a/cpp/daal/src/algorithms/svm/svm_predict_impl.i
+++ b/cpp/daal/src/algorithms/svm/svm_predict_impl.i
@@ -66,9 +66,18 @@ public:
         DAAL_CHECK_STATUS_VAR(status);
 
         _shRes->set(kernel_function::values, shResNT);
-        _kernel->getInput()->set(kernel_function::X, xBlockNT);
-        _kernel->getInput()->set(kernel_function::Y, svBlockNT);
-        _kernel->getParameter()->computationMode = kernel_function::matrixMatrix;
+        if (nRows == 1)
+        {
+            _kernel->getInput()->set(kernel_function::X, svBlockNT);
+            _kernel->getInput()->set(kernel_function::Y, xBlockNT);
+            _kernel->getParameter()->computationMode = kernel_function::matrixVector;
+        }
+        else
+        {
+            _kernel->getInput()->set(kernel_function::X, xBlockNT);
+            _kernel->getInput()->set(kernel_function::Y, svBlockNT);
+            _kernel->getParameter()->computationMode = kernel_function::matrixMatrix;
+        }
 
         return _kernel->computeNoThrow();
     }
@@ -193,6 +202,8 @@ struct SVMPredictImpl<defaultDense, algorithmFPType, cpu> : public Kernel
 {
     services::Status compute(const NumericTablePtr & xTable, Model * model, NumericTable & r, const svm::Parameter * par)
     {
+        using TPredictTask = PredictTask<algorithmFPType, cpu>;
+
         kernel_function::KernelIfacePtr kernel = par->kernel->clone();
         DAAL_CHECK(kernel, ErrorNullParameterNotSupported);
 
@@ -207,80 +218,124 @@ struct SVMPredictImpl<defaultDense, algorithmFPType, cpu> : public Kernel
         const size_t nRowsPerBlock = 128;
         const size_t nBlocks       = nVectors / nRowsPerBlock + !!(nVectors % nRowsPerBlock);
 
-        size_t nSVPerBlock = 0;
-        DAAL_SAFE_CPU_CALL((nSVPerBlock = 128), (nSVPerBlock = nSV));
-        const size_t nBlocksSV = nSV / nSVPerBlock + !!(nSV % nSVPerBlock);
-
         const bool isSparse = xTable->getDataLayout() == NumericTableIface::csrArray;
 
-        /* TLS data initialization */
-        using TPredictTask = PredictTask<algorithmFPType, cpu>;
-        daal::tls<TPredictTask *> tlsTask([&]() {
+        if (nBlocks < 4)
+        {
+            // sequential branch
+            TArray<algorithmFPType, cpu> distances(nVectors);
+            TPredictTask * prTask;
             if (isSparse)
             {
-                return PredictTaskCSR<algorithmFPType, cpu>::create(nRowsPerBlock, nSVPerBlock, xTable, svTable, kernel);
+                prTask = PredictTaskCSR<algorithmFPType, cpu>::create(nVectors, nSV, xTable, svTable, kernel);
             }
             else
             {
-                return PredictTaskDense<algorithmFPType, cpu>::create(nRowsPerBlock, nSVPerBlock, xTable, svTable, kernel);
+                prTask = PredictTaskDense<algorithmFPType, cpu>::create(nVectors, nSV, xTable, svTable, kernel);
             }
-        });
+            prTask->kernelCompute(0, nVectors, 0, nSV);
+            const algorithmFPType * const buffBlock = prTask->getBuff();
 
-        DAAL_OVERFLOW_CHECK_BY_MULTIPLICATION(size_t, nBlocksSV, nRowsPerBlock);
-        daal::StaticTlsMem<algorithmFPType, cpu> lsDistance(nBlocksSV * nRowsPerBlock);
-        SafeStatus safeStat;
-        daal::static_threader_for(nBlocks, [&, nVectors, nBlocks](const size_t iBlock, const size_t tid) {
-            const size_t startRow          = iBlock * nRowsPerBlock;
-            const size_t nRowsPerBlockReal = (iBlock != nBlocks - 1) ? nRowsPerBlock : nVectors - startRow;
+            char trans = 'T';
+            DAAL_INT m = nSV;
+            DAAL_INT n = nVectors;
+            algorithmFPType alpha(1.0);
+            DAAL_INT ldA = nSV;
+            DAAL_INT incX(1);
+            algorithmFPType beta(0.0);
+            DAAL_INT incY(1);
 
-            algorithmFPType * const distanceLocal = lsDistance.local(tid);
-            DAAL_CHECK_MALLOC_THR(distanceLocal);
+            ReadColumns<algorithmFPType, cpu> mtSVCoeff(*svCoeffTable, 0, 0, nSV);
+            DAAL_CHECK_BLOCK_STATUS(mtSVCoeff);
+            const algorithmFPType * const svCoeff = mtSVCoeff.get();
+            algorithmFPType * const distanceSV    = distances.get();
 
-            daal::conditional_threader_for(nSV > 256, nBlocksSV, [&, nSV, nBlocksSV](const size_t iBlockSV) {
-                TPredictTask * lsLocal = tlsTask.local();
-                DAAL_CHECK_MALLOC_THR(lsLocal);
+            Blas<algorithmFPType, cpu>::xxgemv(&trans, &m, &n, &alpha, buffBlock, &ldA, svCoeff, &incX, &beta, distanceSV, &incY);
 
-                const size_t startSV         = iBlockSV * nSVPerBlock;
-                const size_t nSVPerBlockReal = (iBlockSV != nBlocksSV - 1) ? nSVPerBlock : nSV - startSV;
+            WriteOnlyColumns<algorithmFPType, cpu> mtR(r, 0, 0, nVectors);
+            DAAL_CHECK_BLOCK_STATUS(mtR);
+            algorithmFPType * const distanceBlock = mtR.get();
+            service_memset_seq<algorithmFPType, cpu>(distanceBlock, bias, nVectors);
+            Blas<algorithmFPType, cpu>::xxaxpy(&n, &alpha, distanceSV, &incX, distanceBlock, &incY);
 
-                DAAL_CHECK_THR(lsLocal->kernelCompute(startRow, nRowsPerBlockReal, startSV, nSVPerBlockReal),
-                               services::ErrorSVMPredictKernerFunctionCall);
+            return services::Status();
+        }
+        else
+        {
+            // threading branch
+            size_t nSVPerBlock = 0;
+            DAAL_SAFE_CPU_CALL((nSVPerBlock = 128), (nSVPerBlock = nSV));
+            const size_t nBlocksSV = nSV / nSVPerBlock + !!(nSV % nSVPerBlock);
 
-                const algorithmFPType * const buffBlock = lsLocal->getBuff();
-
-                char trans = 'T';
-                DAAL_INT m = nSVPerBlockReal;
-                DAAL_INT n = nRowsPerBlockReal;
-                algorithmFPType alpha(1.0);
-                DAAL_INT ldA = nSVPerBlockReal;
-                DAAL_INT incX(1);
-                algorithmFPType beta(0.0);
-                DAAL_INT incY(1);
-
-                ReadColumns<algorithmFPType, cpu> mtSVCoeff(*svCoeffTable, 0, startSV, nSVPerBlockReal);
-                DAAL_CHECK_BLOCK_STATUS_THR(mtSVCoeff);
-                const algorithmFPType * const svCoeff = mtSVCoeff.get();
-                algorithmFPType * const distanceSV    = &distanceLocal[iBlockSV * nRowsPerBlock];
-
-                Blas<algorithmFPType, cpu>::xxgemv(&trans, &m, &n, &alpha, buffBlock, &ldA, svCoeff, &incX, &beta, distanceSV, &incY);
+            /* TLS data initialization */
+            daal::tls<TPredictTask *> tlsTask([&]() {
+                if (isSparse)
+                {
+                    return PredictTaskCSR<algorithmFPType, cpu>::create(nRowsPerBlock, nSVPerBlock, xTable, svTable, kernel);
+                }
+                else
+                {
+                    return PredictTaskDense<algorithmFPType, cpu>::create(nRowsPerBlock, nSVPerBlock, xTable, svTable, kernel);
+                }
             });
 
-            WriteOnlyColumns<algorithmFPType, cpu> mtR(r, 0, startRow, nRowsPerBlockReal);
-            DAAL_CHECK_BLOCK_STATUS_THR(mtR);
-            algorithmFPType * const distanceBlock = mtR.get();
-            service_memset_seq<algorithmFPType, cpu>(distanceBlock, bias, nRowsPerBlockReal);
-            DAAL_INT n = nRowsPerBlockReal;
-            algorithmFPType alpha(1.0);
-            DAAL_INT incY(1);
-            DAAL_INT incX(1);
-            for (size_t iBlockSV = 0; iBlockSV < nBlocksSV; ++iBlockSV)
-            {
-                Blas<algorithmFPType, cpu>::xxaxpy(&n, &alpha, &distanceLocal[iBlockSV * nRowsPerBlock], &incX, distanceBlock, &incY);
-            }
-        });
+            DAAL_OVERFLOW_CHECK_BY_MULTIPLICATION(size_t, nBlocksSV, nRowsPerBlock);
+            daal::StaticTlsMem<algorithmFPType, cpu> lsDistance(nBlocksSV * nRowsPerBlock);
+            SafeStatus safeStat;
+            daal::static_threader_for(nBlocks, [&, nVectors, nBlocks](const size_t iBlock, const size_t tid) {
+                const size_t startRow          = iBlock * nRowsPerBlock;
+                const size_t nRowsPerBlockReal = (iBlock != nBlocks - 1) ? nRowsPerBlock : nVectors - startRow;
 
-        tlsTask.reduce([](PredictTask<algorithmFPType, cpu> * local) { delete local; });
-        return safeStat.detach();
+                algorithmFPType * const distanceLocal = lsDistance.local(tid);
+                DAAL_CHECK_MALLOC_THR(distanceLocal);
+
+                daal::conditional_threader_for(nSV > 256, nBlocksSV, [&, nSV, nBlocksSV](const size_t iBlockSV) {
+                    TPredictTask * lsLocal = tlsTask.local();
+                    DAAL_CHECK_MALLOC_THR(lsLocal);
+
+                    const size_t startSV         = iBlockSV * nSVPerBlock;
+                    const size_t nSVPerBlockReal = (iBlockSV != nBlocksSV - 1) ? nSVPerBlock : nSV - startSV;
+
+                    DAAL_CHECK_THR(lsLocal->kernelCompute(startRow, nRowsPerBlockReal, startSV, nSVPerBlockReal),
+                                   services::ErrorSVMPredictKernerFunctionCall);
+
+                    const algorithmFPType * const buffBlock = lsLocal->getBuff();
+
+                    char trans = 'T';
+                    DAAL_INT m = nSVPerBlockReal;
+                    DAAL_INT n = nRowsPerBlockReal;
+                    algorithmFPType alpha(1.0);
+                    DAAL_INT ldA = nSVPerBlockReal;
+                    DAAL_INT incX(1);
+                    algorithmFPType beta(0.0);
+                    DAAL_INT incY(1);
+
+                    ReadColumns<algorithmFPType, cpu> mtSVCoeff(*svCoeffTable, 0, startSV, nSVPerBlockReal);
+                    DAAL_CHECK_BLOCK_STATUS_THR(mtSVCoeff);
+                    const algorithmFPType * const svCoeff = mtSVCoeff.get();
+                    algorithmFPType * const distanceSV    = &distanceLocal[iBlockSV * nRowsPerBlock];
+
+                    Blas<algorithmFPType, cpu>::xxgemv(&trans, &m, &n, &alpha, buffBlock, &ldA, svCoeff, &incX, &beta, distanceSV, &incY);
+                });
+
+                WriteOnlyColumns<algorithmFPType, cpu> mtR(r, 0, startRow, nRowsPerBlockReal);
+                DAAL_CHECK_BLOCK_STATUS_THR(mtR);
+                algorithmFPType * const distanceBlock = mtR.get();
+                service_memset_seq<algorithmFPType, cpu>(distanceBlock, bias, nRowsPerBlockReal);
+                DAAL_INT n = nRowsPerBlockReal;
+                algorithmFPType alpha(1.0);
+                DAAL_INT incY(1);
+                DAAL_INT incX(1);
+                for (size_t iBlockSV = 0; iBlockSV < nBlocksSV; ++iBlockSV)
+                {
+                    Blas<algorithmFPType, cpu>::xxaxpy(&n, &alpha, &distanceLocal[iBlockSV * nRowsPerBlock], &incX, distanceBlock, &incY);
+                }
+            });
+
+            tlsTask.reduce([](PredictTask<algorithmFPType, cpu> * local) { delete local; });
+            return safeStat.detach();
+        }
+        return services::Status();
     }
 };
 

--- a/cpp/daal/src/algorithms/svm/svm_predict_impl.i
+++ b/cpp/daal/src/algorithms/svm/svm_predict_impl.i
@@ -340,7 +340,7 @@ struct SVMPredictImpl<defaultDense, algorithmFPType, cpu> : public Kernel
 
         const bool isSparse = xTable->getDataLayout() == NumericTableIface::csrArray;
 
-        if (nBlocks * nBlocksSV < 16)
+        if (nBlocks == 1 || nBlocks * nBlocksSV < 16)
         {
             computeSequential(xTable, svCoeffTable, svTable, r, kernel, bias, nVectors, nSV, isSparse);
         }

--- a/cpp/daal/src/algorithms/svm/svm_predict_impl.i
+++ b/cpp/daal/src/algorithms/svm/svm_predict_impl.i
@@ -350,7 +350,8 @@ struct SVMPredictImpl<defaultDense, algorithmFPType, cpu> : public Kernel
         }
         else
         {
-            st |= computeThreading(xTable, svCoeffTable, svTable, r, kernel, bias, nVectors, nSV, isSparse, nRowsPerBlock, nBlocks, nSVPerBlock, nBlocksSV);
+            st |= computeThreading(xTable, svCoeffTable, svTable, r, kernel, bias, nVectors, nSV, isSparse, nRowsPerBlock, nBlocks, nSVPerBlock,
+                                   nBlocksSV);
         }
         return st;
     }

--- a/cpp/daal/src/algorithms/svm/svm_predict_kernel.h
+++ b/cpp/daal/src/algorithms/svm/svm_predict_kernel.h
@@ -45,6 +45,16 @@ struct SVMPredictImpl : public Kernel
 {
     services::Status compute(const data_management::NumericTablePtr & xTable, Model * model, data_management::NumericTable & r,
                              const svm::Parameter * par);
+
+    services::Status computeSequential(const data_management::NumericTablePtr & xTable, const data_management::NumericTablePtr & svCoeffTable,
+                                       const data_management::NumericTablePtr & svTable, data_management::NumericTable & r,
+                                       kernel_function::KernelIfacePtr & kernel, const algorithmFPType bias, const size_t nVectors, const size_t nSV,
+                                       const bool isSparse);
+
+    services::Status computeThreading(const data_management::NumericTablePtr & xTable, const data_management::NumericTablePtr & svCoeffTable,
+                                      const data_management::NumericTablePtr & svTable, data_management::NumericTable & r,
+                                      kernel_function::KernelIfacePtr & kernel, const algorithmFPType bias, const size_t nVectors, const size_t nSV,
+                                      const bool isSparse, const size_t nRowsPerBlock, const size_t nBlocks);
 };
 
 } // namespace internal


### PR DESCRIPTION
# Description

New branch of SVM inference for small number of samples:
- Avoid threading in SVM inference when nBlocks == 1 or nBlocks * nBlocksSV < 16
- Use `matrixVector` instead of `matrixMatrix` method of kernel function if number of rows in X == 1
- Implement `matrixVector` method for `polynomial` and `sigmoid` kernels