### PR TITLE
Change namespace to SYCL2020 specification

### DIFF
--- a/cpp/daal/include/daal_sycl.h
+++ b/cpp/daal/include/daal_sycl.h
@@ -17,7 +17,7 @@
 #ifndef __DAAL_SYCL_H__
 #define __DAAL_SYCL_H__
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 #define DAAL_SYCL_INTERFACE
 #include "daal.h"

--- a/cpp/daal/include/data_management/data/internal/numeric_table_sycl_homogen.h
+++ b/cpp/daal/include/data_management/data/internal/numeric_table_sycl_homogen.h
@@ -19,7 +19,7 @@
 #define __SYCL_HOMOGEN_NUMERIC_TABLE_H__
 
 #ifdef DAAL_SYCL_INTERFACE
-    #include <CL/sycl.hpp>
+    #include <sycl/sycl.hpp>
 #endif
 
 #include "data_management/data/internal/numeric_table_sycl.h"
@@ -72,7 +72,7 @@ public:
 
 #ifdef DAAL_SYCL_INTERFACE_USM
     static services::SharedPtr<SyclHomogenNumericTable<DataType> > create(const services::SharedPtr<DataType> & usmData, size_t nColumns,
-                                                                          size_t nRows, const cl::sycl::queue & queue, services::Status * stat = NULL)
+                                                                          size_t nRows, const sycl::queue & queue, services::Status * stat = NULL)
     {
         const size_t bufferSize = nColumns * nRows;
 
@@ -91,7 +91,7 @@ public:
 
 #ifdef DAAL_SYCL_INTERFACE_USM
     static services::SharedPtr<SyclHomogenNumericTable<DataType> > create(DataType * usmData, size_t nColumns, size_t nRows,
-                                                                          const cl::sycl::queue & queue, services::Status * stat = NULL)
+                                                                          const sycl::queue & queue, services::Status * stat = NULL)
     {
         const auto overflow_status = checkSizeOverflow(nRows, nColumns);
         if (!overflow_status)

--- a/cpp/daal/include/services/daal_defines.h
+++ b/cpp/daal/include/services/daal_defines.h
@@ -104,7 +104,7 @@
 #endif
 
 #ifdef DAAL_SYCL_INTERFACE
-    #include <CL/sycl.hpp>
+    #include <sycl/sycl.hpp>
     #if (defined(__SYCL_COMPILER_VERSION) && (__SYCL_COMPILER_VERSION >= 20191001))
         #define DAAL_SYCL_INTERFACE_USM
     #endif

--- a/cpp/daal/include/services/internal/buffer.h
+++ b/cpp/daal/include/services/internal/buffer.h
@@ -65,14 +65,14 @@ public:
      *  \param[in]  buffer  SYCL* buffer
      *  \param[out] status  Status of operation
      */
-    Buffer(const cl::sycl::buffer<T, 1> & buffer, Status & status) : _impl(internal::SyclBuffer<T>::create(buffer, status)) {}
+    Buffer(const ::sycl::buffer<T, 1> & buffer, Status & status) : _impl(internal::SyclBuffer<T>::create(buffer, status)) {}
 
     #ifndef DAAL_NOTHROW_EXCEPTIONS
     /**
      *  Creates a Buffer object referencing a SYCL* buffer
      *  Does not copy the data from the SYCL* buffer
      */
-    Buffer(const cl::sycl::buffer<T, 1> & buffer)
+    Buffer(const ::sycl::buffer<T, 1> & buffer)
     {
         Status status;
         _impl.reset(internal::SyclBuffer<T>::create(buffer, status));
@@ -90,7 +90,7 @@ public:
      *  \param[in] queue      The SYCL* queue object
      *  \param[out] status    Status of operation
      */
-    Buffer(T * usmData, size_t size, const cl::sycl::queue & queue, Status & status)
+    Buffer(T * usmData, size_t size, const ::sycl::queue & queue, Status & status)
         : _impl(internal::UsmBuffer<T>::create(usmData, size, queue, status))
     {}
 
@@ -102,7 +102,7 @@ public:
      *  \param[in] size       Number of elements of type T stored in USM memory block
      *  \param[in] queue      The SYCL* queue object
      */
-    Buffer(T * usmData, size_t size, const cl::sycl::queue & queue)
+    Buffer(T * usmData, size_t size, const ::sycl::queue & queue)
     {
         Status status;
         _impl.reset(internal::UsmBuffer<T>::create(usmData, size, queue, status));
@@ -120,7 +120,7 @@ public:
      *  \param[in] queue      The SYCL* queue object
      *  \param[out] status    Status of operation
      */
-    Buffer(const SharedPtr<T> & usmData, size_t size, const cl::sycl::queue & queue, Status & status)
+    Buffer(const SharedPtr<T> & usmData, size_t size, const ::sycl::queue & queue, Status & status)
         : _impl(internal::UsmBuffer<T>::create(usmData, size, queue, status))
     {}
 
@@ -132,7 +132,7 @@ public:
      *  \param[in] size       Number of elements of type T stored in USM block
      *  \param[in] queue      The SYCL* queue object
      */
-    Buffer(const SharedPtr<T> & usmData, size_t size, const cl::sycl::queue & queue)
+    Buffer(const SharedPtr<T> & usmData, size_t size, const ::sycl::queue & queue)
     {
         Status status;
         _impl.reset(internal::UsmBuffer<T>::create(usmData, size, queue, status));
@@ -238,12 +238,12 @@ public:
      *  \param[out] status  Status of operation
      *  \return one-dimensional SYCL* buffer
      */
-    cl::sycl::buffer<T, 1> toSycl(Status & status) const
+    ::sycl::buffer<T, 1> toSycl(Status & status) const
     {
         if (!_impl)
         {
             status |= ErrorEmptyBuffer;
-            return cl::sycl::buffer<T, 1>(cl::sycl::range<1>(1));
+            return ::sycl::buffer<T, 1>(::sycl::range<1>(1));
         }
         return internal::SyclBufferConverter<T>().toSycl(*_impl, status);
     }
@@ -253,10 +253,10 @@ public:
      *  Converts buffer to the SYCL* buffer, throws exception if conversion fails
      *  \return one-dimensional SYCL* buffer
      */
-    cl::sycl::buffer<T, 1> toSycl() const
+    ::sycl::buffer<T, 1> toSycl() const
     {
         Status status;
-        const cl::sycl::buffer<T, 1> buffer = toSycl(status);
+        const ::sycl::buffer<T, 1> buffer = toSycl(status);
         throwIfPossible(status);
         return buffer;
     }
@@ -271,7 +271,7 @@ public:
      *  \param[out] status Status of operation
      *  \return USM shared pointer
      */
-    SharedPtr<T> toUSM(cl::sycl::queue & queue, const data_management::ReadWriteMode & rwFlag, Status & status) const
+    SharedPtr<T> toUSM(::sycl::queue & queue, const data_management::ReadWriteMode & rwFlag, Status & status) const
     {
         if (!_impl)
         {
@@ -288,7 +288,7 @@ public:
      *  \param[in] rwFlag  Flag specifying read/write access to the buffer
      *  \return USM shared pointer
      */
-    SharedPtr<T> toUSM(cl::sycl::queue & queue, const data_management::ReadWriteMode & rwFlag) const
+    SharedPtr<T> toUSM(::sycl::queue & queue, const data_management::ReadWriteMode & rwFlag) const
     {
         Status status;
         const SharedPtr<T> ptr = toUSM(queue, rwFlag, status);

--- a/cpp/daal/include/services/internal/execution_context.h
+++ b/cpp/daal/include/services/internal/execution_context.h
@@ -127,10 +127,10 @@ public:
      *  are performed on the device associated with the queue
      *  \param[in] deviceQueue SYCL* queue object to the device that is selected to perform computations
      */
-    SyclExecutionContext(const cl::sycl::queue & deviceQueue) : ExecutionContext(createContext(deviceQueue), !deviceQueue.get_device().is_cpu()) {}
+    SyclExecutionContext(const ::sycl::queue & deviceQueue) : ExecutionContext(createContext(deviceQueue), !deviceQueue.get_device().is_cpu()) {}
 
 private:
-    static daal::services::internal::sycl::ExecutionContextIface * createContext(const cl::sycl::queue & queue)
+    static daal::services::internal::sycl::ExecutionContextIface * createContext(const ::sycl::queue & queue)
     {
         /* XXX: Workaround to fix performance on CPU: SYCL* runtime loads one
                 thread with active spin-lock that waits for submissions in a queue.

--- a/cpp/daal/include/services/internal/sycl/buffer_utils_sycl.h
+++ b/cpp/daal/include/services/internal/sycl/buffer_utils_sycl.h
@@ -41,25 +41,25 @@ private:
 #ifdef DAAL_SYCL_INTERFACE_USM
     struct UsmDeleter
     {
-        cl::sycl::queue queue;
+        ::sycl::queue queue;
 
-        explicit UsmDeleter(const cl::sycl::queue & q) : queue(q) {}
+        explicit UsmDeleter(const ::sycl::queue & q) : queue(q) {}
 
-        void operator()(const void * ptr) const { cl::sycl::free(const_cast<void *>(ptr), queue); }
+        void operator()(const void * ptr) const { ::sycl::free(const_cast<void *>(ptr), queue); }
     };
 
     struct AllocateUSMBacked
     {
-        const cl::sycl::queue & queue;
+        const ::sycl::queue & queue;
         size_t bufferSize;
         UniversalBuffer buffer;
 
-        explicit AllocateUSMBacked(const cl::sycl::queue & q, size_t size) : queue(q), bufferSize(size) {}
+        explicit AllocateUSMBacked(const ::sycl::queue & q, size_t size) : queue(q), bufferSize(size) {}
 
         template <typename T>
         void operator()(Typelist<T>, Status & status)
         {
-            T * usmPtr = cl::sycl::malloc_device<T>(bufferSize, queue);
+            T * usmPtr = ::sycl::malloc_device<T>(bufferSize, queue);
             if (usmPtr == nullptr)
             {
                 status |= services::ErrorMemoryAllocationFailed;
@@ -70,7 +70,7 @@ private:
         }
     };
 
-    static UniversalBuffer allocateUSMBacked(const cl::sycl::queue & q, TypeId type, size_t bufferSize, Status & status)
+    static UniversalBuffer allocateUSMBacked(const ::sycl::queue & q, TypeId type, size_t bufferSize, Status & status)
     {
         AllocateUSMBacked allocateOp(q, bufferSize);
         TypeDispatcher::dispatch(type, allocateOp, status);
@@ -79,7 +79,7 @@ private:
 #endif
 
 public:
-    static UniversalBuffer allocate(const cl::sycl::queue & q, TypeId type, size_t bufferSize, Status & status)
+    static UniversalBuffer allocate(const ::sycl::queue & q, TypeId type, size_t bufferSize, Status & status)
     {
 #ifdef DAAL_SYCL_INTERFACE_USM
         return BufferAllocator::allocateUSMBacked(q, type, bufferSize, status);
@@ -94,14 +94,14 @@ class BufferCopier
 private:
     struct Execute
     {
-        cl::sycl::queue & queue;
+        ::sycl::queue & queue;
         UniversalBuffer & dstUnivers;
         size_t dstOffset;
         UniversalBuffer & srcUnivers;
         size_t srcOffset;
         size_t count;
 
-        explicit Execute(cl::sycl::queue & queue, UniversalBuffer & dst, size_t desOffset, UniversalBuffer & src, size_t srcOffset, size_t count)
+        explicit Execute(::sycl::queue & queue, UniversalBuffer & dst, size_t desOffset, UniversalBuffer & src, size_t srcOffset, size_t count)
             : queue(queue), dstUnivers(dst), dstOffset(desOffset), srcUnivers(src), srcOffset(srcOffset), count(count)
         {}
 
@@ -109,7 +109,7 @@ private:
         template <typename T>
         Status copyOp(const Buffer<T> & srcBuffer, const Buffer<T> & dstBuffer)
         {
-            using namespace cl::sycl;
+            using namespace ::sycl;
 
             Status status;
             auto src = srcBuffer.toUSM(queue, data_management::readOnly, status);
@@ -152,7 +152,7 @@ private:
     };
 
 public:
-    static void copy(cl::sycl::queue & queue, UniversalBuffer & dest, size_t dstOffset, UniversalBuffer & src, size_t srcOffset, size_t count,
+    static void copy(::sycl::queue & queue, UniversalBuffer & dest, size_t dstOffset, UniversalBuffer & src, size_t srcOffset, size_t count,
                      Status & status)
     {
         DAAL_ASSERT(!src.empty());
@@ -169,7 +169,7 @@ class ArrayCopier
 private:
     struct Execute
     {
-        cl::sycl::queue & queue;
+        ::sycl::queue & queue;
         UniversalBuffer & dstUnivers;
         size_t dstOffset;
         void * srcArray;
@@ -177,7 +177,7 @@ private:
         size_t srcOffset;
         size_t count;
 
-        explicit Execute(cl::sycl::queue & queue, UniversalBuffer & dst, size_t desOffset, void * src, size_t srcCount, size_t srcOffset,
+        explicit Execute(::sycl::queue & queue, UniversalBuffer & dst, size_t desOffset, void * src, size_t srcCount, size_t srcOffset,
                          size_t count)
             : queue(queue), dstUnivers(dst), dstOffset(desOffset), srcArray(src), srcCount(srcCount), srcOffset(srcOffset), count(count)
         {}
@@ -186,7 +186,7 @@ private:
         template <typename T>
         Status copyOp(const T * src, const Buffer<T> & dstBuffer)
         {
-            using namespace cl::sycl;
+            using namespace ::sycl;
 
             Status status;
 
@@ -234,7 +234,7 @@ private:
     };
 
 public:
-    static void copy(cl::sycl::queue & queue, UniversalBuffer & dest, size_t dstOffset, void * src, size_t srcCount, size_t srcOffset, size_t count,
+    static void copy(::sycl::queue & queue, UniversalBuffer & dest, size_t dstOffset, void * src, size_t srcCount, size_t srcOffset, size_t count,
                      Status & status)
     {
         DAAL_ASSERT(!dest.empty());
@@ -249,11 +249,11 @@ class BufferFiller
 private:
     struct Execute
     {
-        cl::sycl::queue & queue;
+        ::sycl::queue & queue;
         UniversalBuffer & dstUnivers;
         double value;
 
-        explicit Execute(cl::sycl::queue & queue, UniversalBuffer & dest, double value) : queue(queue), dstUnivers(dest), value(value) {}
+        explicit Execute(::sycl::queue & queue, UniversalBuffer & dest, double value) : queue(queue), dstUnivers(dest), value(value) {}
 
 #ifdef DAAL_SYCL_INTERFACE_USM
         template <typename T>
@@ -286,7 +286,7 @@ private:
     };
 
 public:
-    static void fill(cl::sycl::queue & queue, UniversalBuffer & dest, double value, Status & status)
+    static void fill(::sycl::queue & queue, UniversalBuffer & dest, double value, Status & status)
     {
         DAAL_ASSERT(!dest.empty());
 

--- a/cpp/daal/include/services/internal/sycl/error_handling_sycl.h
+++ b/cpp/daal/include/services/internal/sycl/error_handling_sycl.h
@@ -23,7 +23,7 @@
 #endif
 
 #include <CL/cl.h>
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 #include "services/error_handling.h"
 #ifndef DAAL_DISABLE_LEVEL_ZERO

--- a/cpp/daal/include/services/internal/sycl/execution_context_sycl.h
+++ b/cpp/daal/include/services/internal/sycl/execution_context_sycl.h
@@ -23,7 +23,7 @@
 #endif
 
 #include <CL/cl.h>
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <backend/opencl.hpp>
 
 #include "services/daal_string.h"
@@ -48,7 +48,7 @@ namespace interface1
 class OpenClKernelFactory : public Base, public ClKernelFactoryIface
 {
 public:
-    explicit OpenClKernelFactory(cl::sycl::queue & deviceQueue)
+    explicit OpenClKernelFactory(::sycl::queue & deviceQueue)
         : _currentProgramRef(nullptr), _executionTarget(ExecutionTargetIds::unspecified), _deviceQueue(deviceQueue)
     {}
 
@@ -67,14 +67,14 @@ public:
         if (!res)
         {
 #ifndef DAAL_DISABLE_LEVEL_ZERO
-            const bool isOpenCLBackendAvailable = !_deviceQueue.get_device().template get_info<cl::sycl::info::device::opencl_c_version>().empty();
+            const bool isOpenCLBackendAvailable = !_deviceQueue.get_device().template get_info<::sycl::info::device::opencl_c_version>().empty();
             if (isOpenCLBackendAvailable)
             {
 #endif // DAAL_DISABLE_LEVEL_ZERO
 
                 // OpenCl branch
-                auto programPtr = OpenClProgramRef::create(cl::sycl::get_native<cl::sycl::backend::opencl>(_deviceQueue.get_context()),
-                                                           cl::sycl::get_native<cl::sycl::backend::opencl>(_deviceQueue.get_device()), name, program,
+                auto programPtr = OpenClProgramRef::create(::sycl::get_native<::sycl::backend::opencl>(_deviceQueue.get_context()),
+                                                           ::sycl::get_native<::sycl::backend::opencl>(_deviceQueue.get_device()), name, program,
                                                            options, status);
                 DAAL_CHECK_STATUS_RETURN_VOID_IF_FAIL(status);
 
@@ -149,7 +149,7 @@ public:
         {
             KernelPtr kernel;
 #ifndef DAAL_DISABLE_LEVEL_ZERO
-            const bool isOpenCLBackendAvailable = !_deviceQueue.get_device().template get_info<cl::sycl::info::device::opencl_c_version>().empty();
+            const bool isOpenCLBackendAvailable = !_deviceQueue.get_device().template get_info<::sycl::info::device::opencl_c_version>().empty();
             if (isOpenCLBackendAvailable)
             {
 #endif // DAAL_DISABLE_LEVEL_ZERO
@@ -192,20 +192,20 @@ private:
 #endif // DAAL_DISABLE_LEVEL_ZERO
 
     ExecutionTargetId _executionTarget;
-    cl::sycl::queue & _deviceQueue;
+    ::sycl::queue & _deviceQueue;
 };
 
 class SyclExecutionContextImpl : public Base, public ExecutionContextIface
 {
 public:
-    explicit SyclExecutionContextImpl(const cl::sycl::queue & deviceQueue)
+    explicit SyclExecutionContextImpl(const ::sycl::queue & deviceQueue)
         : _deviceQueue(deviceQueue), _kernelFactory(_deviceQueue), _kernelScheduler(_deviceQueue)
     {
         const auto & device          = _deviceQueue.get_device();
         _infoDevice.isCpu            = device.is_cpu();
-        _infoDevice.maxWorkGroupSize = device.get_info<cl::sycl::info::device::max_work_group_size>();
-        _infoDevice.maxMemAllocSize  = device.get_info<cl::sycl::info::device::max_mem_alloc_size>();
-        _infoDevice.globalMemSize    = device.get_info<cl::sycl::info::device::global_mem_size>();
+        _infoDevice.maxWorkGroupSize = device.get_info<::sycl::info::device::max_work_group_size>();
+        _infoDevice.maxMemAllocSize  = device.get_info<::sycl::info::device::max_mem_alloc_size>();
+        _infoDevice.globalMemSize    = device.get_info<::sycl::info::device::global_mem_size>();
     }
 
     void run(const KernelRange & range, const KernelPtr & kernel, const KernelArguments & args, Status & status) DAAL_C11_OVERRIDE
@@ -270,10 +270,10 @@ public:
 
     InfoDevice & getInfoDevice() DAAL_C11_OVERRIDE { return _infoDevice; }
 
-    const cl::sycl::queue & getQueue() const { return _deviceQueue; }
+    const ::sycl::queue & getQueue() const { return _deviceQueue; }
 
 private:
-    cl::sycl::queue _deviceQueue;
+    ::sycl::queue _deviceQueue;
     OpenClKernelFactory _kernelFactory;
     SyclKernelScheduler _kernelScheduler;
     InfoDevice _infoDevice;

--- a/cpp/daal/include/services/internal/sycl/kernel_scheduler_sycl.h
+++ b/cpp/daal/include/services/internal/sycl/kernel_scheduler_sycl.h
@@ -25,7 +25,7 @@
 #include <cstring>
 
 #include <CL/cl.h>
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 #include "services/internal/sycl/error_handling_sycl.h"
 #include "services/internal/sycl/execution_context.h"
@@ -146,13 +146,13 @@ public:
 
     LevelZeroOpenClInteropContext(const LevelZeroOpenClInteropContext &) = delete;
 
-    explicit LevelZeroOpenClInteropContext(cl::sycl::queue & deviceQueue, Status & status) { reset(deviceQueue, status); }
+    explicit LevelZeroOpenClInteropContext(::sycl::queue & deviceQueue, Status & status) { reset(deviceQueue, status); }
 
-    void reset(cl::sycl::queue & deviceQueue, Status & status)
+    void reset(::sycl::queue & deviceQueue, Status & status)
     {
         cl_device_id clDevice;
-        findDevice(&clDevice, deviceQueue.get_device().get_info<cl::sycl::info::device::vendor_id>(),
-                   deviceQueue.get_device().get_info<cl::sycl::info::device::max_clock_frequency>(), status);
+        findDevice(&clDevice, deviceQueue.get_device().get_info<::sycl::info::device::vendor_id>(),
+                   deviceQueue.get_device().get_info<::sycl::info::device::max_clock_frequency>(), status);
         DAAL_CHECK_STATUS_RETURN_VOID_IF_FAIL(status);
 
         _clDeviceRef.reset(clDevice);
@@ -216,7 +216,7 @@ public:
     }
 
 #ifndef DAAL_DISABLE_LEVEL_ZERO
-    static SharedPtr<OpenClProgramRef> create(cl_context clContext, cl_device_id clDevice, cl::sycl::queue & deviceQueue, const char * programName,
+    static SharedPtr<OpenClProgramRef> create(cl_context clContext, cl_device_id clDevice, ::sycl::queue & deviceQueue, const char * programName,
                                               const char * programSrc, const char * options, Status & status)
     {
         auto ptr = new OpenClProgramRef();
@@ -278,7 +278,7 @@ private:
     }
 
 #ifndef DAAL_DISABLE_LEVEL_ZERO
-    void initModuleLevelZero(cl::sycl::queue & deviceQueue, Status & status)
+    void initModuleLevelZero(::sycl::queue & deviceQueue, Status & status)
     {
         size_t binarySize = 0;
         DAAL_CHECK_OPENCL(clGetProgramInfo(get(), CL_PROGRAM_BINARY_SIZES, sizeof(size_t), &binarySize, nullptr), status);
@@ -355,7 +355,7 @@ public:
 
     ExecutionTargetId getTarget() const { return _executionTarget; }
 
-    virtual cl::sycl::kernel toSycl(const cl::sycl::context & ctx) const = 0;
+    virtual ::sycl::kernel toSycl(const ::sycl::context & ctx) const = 0;
 
     const OpenClProgramRef & getProgramRef() const { return _clProgramRef; }
 
@@ -375,9 +375,9 @@ public:
         return SharedPtr<OpenClKernelNative>(ptr);
     }
 
-    cl::sycl::kernel toSycl(const cl::sycl::context & ctx) const DAAL_C11_OVERRIDE
+    ::sycl::kernel toSycl(const ::sycl::context & ctx) const DAAL_C11_OVERRIDE
     {
-        return cl::sycl::make_kernel<cl::sycl::backend::opencl>(_clKernelRef.get(), ctx);
+        return ::sycl::make_kernel<::sycl::backend::opencl>(_clKernelRef.get(), ctx);
     }
 
 private:
@@ -400,9 +400,9 @@ public:
         return SharedPtr<OpenClKernelLevelZero>(ptr);
     }
 
-    cl::sycl::kernel toSycl(const cl::sycl::context & ctx) const DAAL_C11_OVERRIDE
+    ::sycl::kernel toSycl(const ::sycl::context & ctx) const DAAL_C11_OVERRIDE
     {
-        using namespace cl::sycl;
+        using namespace ::sycl;
         kernel_bundle<bundle_state::executable> _kernelBundle =
             make_kernel_bundle<backend::ext_oneapi_level_zero, bundle_state::executable>({ getProgramRef().getModuleLevelZeroPtr()->get() }, ctx);
         return make_kernel<backend::ext_oneapi_level_zero>({ _kernelBundle, _zeKernelRef.getKernelLevelZeroPtr()->get() }, ctx);
@@ -437,7 +437,7 @@ private:
 class SyclKernelSchedulerArgHandler
 {
 public:
-    SyclKernelSchedulerArgHandler(cl::sycl::queue & queue, cl::sycl::handler & handler, UsmPointerStorage & storage, size_t argumentIndex,
+    SyclKernelSchedulerArgHandler(::sycl::queue & queue, ::sycl::handler & handler, UsmPointerStorage & storage, size_t argumentIndex,
                                   const KernelArgument & arg)
         : _queue(queue), _handler(handler), _storage(storage), _argumentIndex(argumentIndex), _argument(arg)
     {}
@@ -507,73 +507,73 @@ private:
         _handler.set_arg((int)_argumentIndex, value);
     }
 
-    cl::sycl::queue & _queue;
-    cl::sycl::handler & _handler;
+    ::sycl::queue & _queue;
+    ::sycl::handler & _handler;
     UsmPointerStorage & _storage;
     size_t _argumentIndex;
     const KernelArgument & _argument;
 };
 
 template <int dim>
-inline cl::sycl::range<dim> convertToSyclRange(const KernelRange &);
+inline ::sycl::range<dim> convertToSyclRange(const KernelRange &);
 
 template <>
-inline cl::sycl::range<1> convertToSyclRange<1>(const KernelRange & r)
+inline ::sycl::range<1> convertToSyclRange<1>(const KernelRange & r)
 {
-    return cl::sycl::range<1>(r.upper1());
+    return ::sycl::range<1>(r.upper1());
 }
 
 template <>
-inline cl::sycl::range<2> convertToSyclRange<2>(const KernelRange & r)
+inline ::sycl::range<2> convertToSyclRange<2>(const KernelRange & r)
 {
 #ifdef DAAL_SYCL_INTERFACE_REVERSED_RANGE
-    return cl::sycl::range<2>(r.upper2(), r.upper1());
+    return ::sycl::range<2>(r.upper2(), r.upper1());
 #else
-    return cl::sycl::range<2>(r.upper1(), r.upper2());
+    return ::sycl::range<2>(r.upper1(), r.upper2());
 #endif
 }
 
 template <>
-inline cl::sycl::range<3> convertToSyclRange<3>(const KernelRange & r)
+inline ::sycl::range<3> convertToSyclRange<3>(const KernelRange & r)
 {
 #ifdef DAAL_SYCL_INTERFACE_REVERSED_RANGE
-    return cl::sycl::range<3>(r.upper3(), r.upper2(), r.upper1());
+    return ::sycl::range<3>(r.upper3(), r.upper2(), r.upper1());
 #else
-    return cl::sycl::range<3>(r.upper1(), r.upper2(), r.upper3());
+    return ::sycl::range<3>(r.upper1(), r.upper2(), r.upper3());
 #endif
 }
 
 template <int dim>
-inline cl::sycl::nd_range<dim> convertToSyclRange(const KernelNDRange &);
+inline ::sycl::nd_range<dim> convertToSyclRange(const KernelNDRange &);
 
 template <>
-inline cl::sycl::nd_range<1> convertToSyclRange<1>(const KernelNDRange & r)
+inline ::sycl::nd_range<1> convertToSyclRange<1>(const KernelNDRange & r)
 {
-    return cl::sycl::nd_range<1>(cl::sycl::range<1>(r.global().upper1()), cl::sycl::range<1>(r.local().upper1()));
+    return ::sycl::nd_range<1>(::sycl::range<1>(r.global().upper1()), ::sycl::range<1>(r.local().upper1()));
 }
 
 template <>
-inline cl::sycl::nd_range<2> convertToSyclRange<2>(const KernelNDRange & r)
+inline ::sycl::nd_range<2> convertToSyclRange<2>(const KernelNDRange & r)
 {
-    return cl::sycl::nd_range<2>(
+    return ::sycl::nd_range<2>(
 #ifdef DAAL_SYCL_INTERFACE_REVERSED_RANGE
-        cl::sycl::range<2>(r.global().upper2(), r.global().upper1()), cl::sycl::range<2>(r.local().upper2(), r.local().upper1())
+        ::sycl::range<2>(r.global().upper2(), r.global().upper1()), ::sycl::range<2>(r.local().upper2(), r.local().upper1())
 #else
-        cl::sycl::range<2>(r.global().upper1(), r.global().upper2()), cl::sycl::range<2>(r.local().upper1(), r.local().upper2())
+        ::sycl::range<2>(r.global().upper1(), r.global().upper2()), ::sycl::range<2>(r.local().upper1(), r.local().upper2())
 #endif
     );
 }
 
 template <>
-inline cl::sycl::nd_range<3> convertToSyclRange<3>(const KernelNDRange & r)
+inline ::sycl::nd_range<3> convertToSyclRange<3>(const KernelNDRange & r)
 {
-    return cl::sycl::nd_range<3>(
+    return ::sycl::nd_range<3>(
 #ifdef DAAL_SYCL_INTERFACE_REVERSED_RANGE
-        cl::sycl::range<3>(r.global().upper3(), r.global().upper2(), r.global().upper1()),
-        cl::sycl::range<3>(r.local().upper3(), r.local().upper2(), r.local().upper1())
+        ::sycl::range<3>(r.global().upper3(), r.global().upper2(), r.global().upper1()),
+        ::sycl::range<3>(r.local().upper3(), r.local().upper2(), r.local().upper1())
 #else
-        cl::sycl::range<3>(r.global().upper1(), r.global().upper2(), r.global().upper3()),
-        cl::sycl::range<3>(r.local().upper1(), r.local().upper2(), r.local().upper3())
+        ::sycl::range<3>(r.global().upper1(), r.global().upper2(), r.global().upper3()),
+        ::sycl::range<3>(r.local().upper1(), r.local().upper2(), r.local().upper3())
 #endif
     );
 }
@@ -581,7 +581,7 @@ inline cl::sycl::nd_range<3> convertToSyclRange<3>(const KernelNDRange & r)
 class SyclKernelScheduler : public Base, public KernelSchedulerIface
 {
 public:
-    explicit SyclKernelScheduler(cl::sycl::queue & deviceQueue) : _queue(deviceQueue) {}
+    explicit SyclKernelScheduler(::sycl::queue & deviceQueue) : _queue(deviceQueue) {}
 
     void schedule(const OpenClKernel & kernel, const KernelRange & range, const KernelArguments & args, Status & status) DAAL_C11_OVERRIDE
     {
@@ -625,9 +625,9 @@ private:
         UsmPointerStorage bufferStorage;
 
         status |= catchSyclExceptions([&]() mutable {
-            cl::sycl::kernel syclKernel = kernel.toSycl(_queue.get_context());
+            ::sycl::kernel syclKernel = kernel.toSycl(_queue.get_context());
 
-            auto event = _queue.submit([&](cl::sycl::handler & cgh) {
+            auto event = _queue.submit([&](::sycl::handler & cgh) {
                 passArguments(_queue, cgh, bufferStorage, args, status);
                 DAAL_CHECK_STATUS_RETURN_VOID_IF_FAIL(status);
                 cgh.parallel_for(range, syclKernel);
@@ -636,7 +636,7 @@ private:
         });
     }
 
-    void passArguments(cl::sycl::queue & queue, cl::sycl::handler & cgh, UsmPointerStorage & storage, const KernelArguments & args,
+    void passArguments(::sycl::queue & queue, ::sycl::handler & cgh, UsmPointerStorage & storage, const KernelArguments & args,
                        Status & status) const
     {
         for (size_t i = 0; i < args.size(); i++)
@@ -649,7 +649,7 @@ private:
     }
 
 private:
-    cl::sycl::queue & _queue;
+    ::sycl::queue & _queue;
 };
 
 } // namespace interface1

--- a/cpp/daal/include/services/internal/sycl/level_zero_module_sycl.h
+++ b/cpp/daal/include/services/internal/sycl/level_zero_module_sycl.h
@@ -26,7 +26,7 @@
     #error "DAAL_DISABLE_LEVEL_ZERO must be undefined to include this file"
 #endif
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 #include "services/daal_shared_ptr.h"
 #include "services/internal/dynamic_lib_helper.h"
@@ -111,7 +111,7 @@ typedef SharedPtr<ZeKernel> ZeKernelPtr;
 class ZeModule : public Base
 {
 public:
-    static SharedPtr<ZeModule> create(cl::sycl::queue & deviceQueue, size_t binarySize, const uint8_t * pBinary, Status & status)
+    static SharedPtr<ZeModule> create(::sycl::queue & deviceQueue, size_t binarySize, const uint8_t * pBinary, Status & status)
     {
         auto ptr = new ZeModule(deviceQueue, binarySize, pBinary, status);
         if (!status)
@@ -143,7 +143,7 @@ public:
     ze_module_handle_t get() const { return _moduleLevelZero; }
 
 private:
-    explicit ZeModule(cl::sycl::queue & deviceQueue, size_t binarySize, const uint8_t * pBinary, Status & status)
+    explicit ZeModule(::sycl::queue & deviceQueue, size_t binarySize, const uint8_t * pBinary, Status & status)
     {
         static DynamicLibHelper zeLib(zeLoaderName, libLoadFlags, status);
         DAAL_CHECK_STATUS_RETURN_VOID_IF_FAIL(status);
@@ -162,8 +162,8 @@ private:
         desc.pConstants   = nullptr;
         desc.pNext        = nullptr;
 
-        DAAL_CHECK_LEVEL_ZERO(_zeModuleCreateF(cl::sycl::get_native<cl::sycl::backend::ext_oneapi_level_zero>(deviceQueue.get_context()),
-                                               cl::sycl::get_native<cl::sycl::backend::ext_oneapi_level_zero>(deviceQueue.get_device()), &desc,
+        DAAL_CHECK_LEVEL_ZERO(_zeModuleCreateF(::sycl::get_native<::sycl::backend::ext_oneapi_level_zero>(deviceQueue.get_context()),
+                                               ::sycl::get_native<::sycl::backend::ext_oneapi_level_zero>(deviceQueue.get_device()), &desc,
                                                &_moduleLevelZero, nullptr),
                               status);
     }

--- a/cpp/daal/include/services/internal/sycl/math/blas_executor.h
+++ b/cpp/daal/include/services/internal/sycl/math/blas_executor.h
@@ -24,7 +24,7 @@
 //--
 */
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 #if (!defined(ONEAPI_DAAL_NO_MKL_GPU_FUNC) && defined(__SYCL_COMPILER_VERSION))
     #include "services/internal/sycl/math/mkl_blas.h"
@@ -62,7 +62,7 @@ class GemmExecutor
 private:
     struct Execute
     {
-        cl::sycl::queue & queue;
+        ::sycl::queue & queue;
         const math::Transpose transa;
         const math::Transpose transb;
         const size_t m;
@@ -80,7 +80,7 @@ private:
         const size_t ldc;
         const size_t offsetC;
 
-        explicit Execute(cl::sycl::queue & queue, const math::Transpose transa, const math::Transpose transb, const size_t m, const size_t n,
+        explicit Execute(::sycl::queue & queue, const math::Transpose transa, const math::Transpose transb, const size_t m, const size_t n,
                          const size_t k, const double alpha, const UniversalBuffer & a_buffer, const size_t lda, const size_t offsetA,
                          const UniversalBuffer & b_buffer, const size_t ldb, const size_t offsetB, const double beta, UniversalBuffer & c_buffer,
                          const size_t ldc, const size_t offsetC)
@@ -132,7 +132,7 @@ private:
     };
 
 public:
-    static void run(cl::sycl::queue & queue, const math::Transpose transa, const math::Transpose transb, const size_t m, const size_t n,
+    static void run(::sycl::queue & queue, const math::Transpose transa, const math::Transpose transb, const size_t m, const size_t n,
                     const size_t k, const double alpha, const UniversalBuffer & a_buffer, const size_t lda, const size_t offsetA,
                     const UniversalBuffer & b_buffer, const size_t ldb, const size_t offsetB, const double beta, UniversalBuffer & c_buffer,
                     const size_t ldc, const size_t offsetC, Status & status)
@@ -157,7 +157,7 @@ class SyrkExecutor
 private:
     struct Execute
     {
-        cl::sycl::queue & queue;
+        ::sycl::queue & queue;
         const math::UpLo upper_lower;
         const math::Transpose trans;
         const size_t n;
@@ -171,7 +171,7 @@ private:
         const size_t ldc;
         const size_t offsetC;
 
-        explicit Execute(cl::sycl::queue & queue, const math::UpLo upper_lower, const math::Transpose trans, const size_t n, const size_t k,
+        explicit Execute(::sycl::queue & queue, const math::UpLo upper_lower, const math::Transpose trans, const size_t n, const size_t k,
                          const double alpha, const UniversalBuffer & a_buffer, const size_t lda, const size_t offsetA, const double beta,
                          UniversalBuffer & c_buffer, const size_t ldc, const size_t offsetC)
             : queue(queue),
@@ -216,7 +216,7 @@ private:
     };
 
 public:
-    static void run(cl::sycl::queue & queue, const math::UpLo upper_lower, const math::Transpose trans, const size_t n, const size_t k,
+    static void run(::sycl::queue & queue, const math::UpLo upper_lower, const math::Transpose trans, const size_t n, const size_t k,
                     const double alpha, const UniversalBuffer & a_buffer, const size_t lda, const size_t offsetA, const double beta,
                     UniversalBuffer & c_buffer, const size_t ldc, const size_t offsetC, Status & status)
     {
@@ -244,7 +244,7 @@ private:
 
     struct Execute
     {
-        cl::sycl::queue & queue;
+        ::sycl::queue & queue;
         const uint32_t n;
         const double a;
         const UniversalBuffer & x_buffer;
@@ -252,7 +252,7 @@ private:
         UniversalBuffer & y_buffer;
         const int incy;
 
-        explicit Execute(cl::sycl::queue & queue, const uint32_t n, const double a, const UniversalBuffer & x_buffer, const int incx,
+        explicit Execute(::sycl::queue & queue, const uint32_t n, const double a, const UniversalBuffer & x_buffer, const int incx,
                          UniversalBuffer & y_buffer, const int incy)
             : queue(queue), n(n), a(a), x_buffer(x_buffer), incx(incx), y_buffer(y_buffer), incy(incy)
         {}
@@ -280,7 +280,7 @@ private:
     };
 
 public:
-    static void run(cl::sycl::queue & queue, const uint32_t n, const double a, const UniversalBuffer x_buffer, const int incx,
+    static void run(::sycl::queue & queue, const uint32_t n, const double a, const UniversalBuffer x_buffer, const int incx,
                     UniversalBuffer y_buffer, const int incy, Status & status)
     {
         DAAL_ASSERT(!x_buffer.empty());

--- a/cpp/daal/include/services/internal/sycl/math/lapack_executor.h
+++ b/cpp/daal/include/services/internal/sycl/math/lapack_executor.h
@@ -24,7 +24,7 @@
 //--
 */
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 #if (!defined(ONEAPI_DAAL_NO_MKL_GPU_FUNC) && defined(__SYCL_COMPILER_VERSION))
     #include "services/internal/sycl/math/mkl_lapack.h"
@@ -59,12 +59,12 @@ class PotrfExecutor
 private:
     struct Execute
     {
-        cl::sycl::queue & queue;
+        ::sycl::queue & queue;
         const math::UpLo uplo;
         const size_t n;
         UniversalBuffer & a_buffer;
         const size_t lda;
-        explicit Execute(cl::sycl::queue & queue, const math::UpLo uplo, const size_t n, UniversalBuffer & a_buffer, const size_t lda)
+        explicit Execute(::sycl::queue & queue, const math::UpLo uplo, const size_t n, UniversalBuffer & a_buffer, const size_t lda)
             : queue(queue), uplo(uplo), n(n), a_buffer(a_buffer), lda(lda)
         {}
 
@@ -85,7 +85,7 @@ private:
     };
 
 public:
-    static void run(cl::sycl::queue & queue, const math::UpLo uplo, const size_t n, UniversalBuffer & a_buffer, const size_t lda, Status & status)
+    static void run(::sycl::queue & queue, const math::UpLo uplo, const size_t n, UniversalBuffer & a_buffer, const size_t lda, Status & status)
     {
         DAAL_ASSERT(!a_buffer.empty());
 
@@ -103,7 +103,7 @@ class PotrsExecutor
 private:
     struct Execute
     {
-        cl::sycl::queue & queue;
+        ::sycl::queue & queue;
         const math::UpLo uplo;
         const size_t n;
         const size_t ny;
@@ -112,7 +112,7 @@ private:
         UniversalBuffer & b_buffer;
         const size_t ldb;
 
-        explicit Execute(cl::sycl::queue & queue, const math::UpLo uplo, const size_t n, const size_t ny, UniversalBuffer & a_buffer,
+        explicit Execute(::sycl::queue & queue, const math::UpLo uplo, const size_t n, const size_t ny, UniversalBuffer & a_buffer,
                          const size_t lda, UniversalBuffer & b_buffer, const size_t ldb)
             : queue(queue), uplo(uplo), n(n), ny(ny), a_buffer(a_buffer), lda(lda), b_buffer(b_buffer), ldb(ldb)
         {}
@@ -137,7 +137,7 @@ private:
     };
 
 public:
-    static void run(cl::sycl::queue & queue, const math::UpLo uplo, const size_t n, const size_t ny, UniversalBuffer & a_buffer, const size_t lda,
+    static void run(::sycl::queue & queue, const math::UpLo uplo, const size_t n, const size_t ny, UniversalBuffer & a_buffer, const size_t lda,
                     UniversalBuffer & b_buffer, const size_t ldb, Status & status)
     {
         DAAL_ASSERT(!a_buffer.empty());

--- a/cpp/daal/include/services/internal/sycl/math/mkl_blas.h
+++ b/cpp/daal/include/services/internal/sycl/math/mkl_blas.h
@@ -51,7 +51,7 @@ namespace interface1
 template <typename algorithmFPType>
 struct MKLGemm
 {
-    MKLGemm(cl::sycl::queue & queue) : _queue(queue) {}
+    MKLGemm(::sycl::queue & queue) : _queue(queue) {}
 
     Status operator()(const math::Transpose transa, const math::Transpose transb, const size_t m, const size_t n, const size_t k,
                       const algorithmFPType alpha, const Buffer<algorithmFPType> & a_buffer, const size_t lda, const size_t offsetA,
@@ -87,27 +87,27 @@ struct MKLGemm
 
 private:
     template <typename T>
-    void innerGemm(MKL_TRANSPOSE transa, MKL_TRANSPOSE transb, int64_t m, int64_t n, int64_t k, T alpha, cl::sycl::buffer<T, 1> a, int64_t lda,
-                   cl::sycl::buffer<T, 1> b, int64_t ldb, T beta, cl::sycl::buffer<T, 1> c, int64_t ldc, int64_t offset_a, int64_t offset_b,
+    void innerGemm(MKL_TRANSPOSE transa, MKL_TRANSPOSE transb, int64_t m, int64_t n, int64_t k, T alpha, ::sycl::buffer<T, 1> a, int64_t lda,
+                   ::sycl::buffer<T, 1> b, int64_t ldb, T beta, ::sycl::buffer<T, 1> c, int64_t ldc, int64_t offset_a, int64_t offset_b,
                    int64_t offset_c);
 
     template <>
-    void innerGemm<double>(MKL_TRANSPOSE transa, MKL_TRANSPOSE transb, int64_t m, int64_t n, int64_t k, double alpha, cl::sycl::buffer<double, 1> a,
-                           int64_t lda, cl::sycl::buffer<double, 1> b, int64_t ldb, double beta, cl::sycl::buffer<double, 1> c, int64_t ldc,
+    void innerGemm<double>(MKL_TRANSPOSE transa, MKL_TRANSPOSE transb, int64_t m, int64_t n, int64_t k, double alpha, ::sycl::buffer<double, 1> a,
+                           int64_t lda, ::sycl::buffer<double, 1> b, int64_t ldb, double beta, ::sycl::buffer<double, 1> c, int64_t ldc,
                            int64_t offset_a, int64_t offset_b, int64_t offset_c)
     {
         ::oneapi::fpk::gpu::dgemm_sycl(&_queue, transa, transb, m, n, k, alpha, &a, lda, &b, ldb, beta, &c, ldc, offset_a, offset_b, offset_c);
     }
 
     template <>
-    void innerGemm<float>(MKL_TRANSPOSE transa, MKL_TRANSPOSE transb, int64_t m, int64_t n, int64_t k, float alpha, cl::sycl::buffer<float, 1> a,
-                          int64_t lda, cl::sycl::buffer<float, 1> b, int64_t ldb, float beta, cl::sycl::buffer<float, 1> c, int64_t ldc,
+    void innerGemm<float>(MKL_TRANSPOSE transa, MKL_TRANSPOSE transb, int64_t m, int64_t n, int64_t k, float alpha, ::sycl::buffer<float, 1> a,
+                          int64_t lda, ::sycl::buffer<float, 1> b, int64_t ldb, float beta, ::sycl::buffer<float, 1> c, int64_t ldc,
                           int64_t offset_a, int64_t offset_b, int64_t offset_c)
     {
         ::oneapi::fpk::gpu::sgemm_sycl(&_queue, transa, transb, m, n, k, alpha, &a, lda, &b, ldb, beta, &c, ldc, offset_a, offset_b, offset_c);
     }
 
-    cl::sycl::queue & _queue;
+    ::sycl::queue & _queue;
 };
 
 /**
@@ -117,7 +117,7 @@ private:
 template <typename algorithmFPType>
 struct MKLSyrk
 {
-    MKLSyrk(cl::sycl::queue & queue) : _queue(queue) {}
+    MKLSyrk(::sycl::queue & queue) : _queue(queue) {}
 
     Status operator()(const math::UpLo upper_lower, const math::Transpose trans, const size_t n, const size_t k, const algorithmFPType alpha,
                       const Buffer<algorithmFPType> & a_buffer, const size_t lda, const size_t offsetA, const algorithmFPType beta,
@@ -149,24 +149,24 @@ struct MKLSyrk
 
 private:
     template <typename T>
-    void innerSyrk(MKL_UPLO uplo, MKL_TRANSPOSE trans, int64_t n, int64_t k, T alpha, cl::sycl::buffer<T, 1> a, int64_t lda, T beta,
-                   cl::sycl::buffer<T, 1> c, int64_t ldc, int64_t offset_a, int64_t offset_c);
+    void innerSyrk(MKL_UPLO uplo, MKL_TRANSPOSE trans, int64_t n, int64_t k, T alpha, ::sycl::buffer<T, 1> a, int64_t lda, T beta,
+                   ::sycl::buffer<T, 1> c, int64_t ldc, int64_t offset_a, int64_t offset_c);
 
     template <>
-    void innerSyrk(MKL_UPLO uplo, MKL_TRANSPOSE trans, int64_t n, int64_t k, double alpha, cl::sycl::buffer<double, 1> a, int64_t lda, double beta,
-                   cl::sycl::buffer<double, 1> c, int64_t ldc, int64_t offset_a, int64_t offset_c)
+    void innerSyrk(MKL_UPLO uplo, MKL_TRANSPOSE trans, int64_t n, int64_t k, double alpha, ::sycl::buffer<double, 1> a, int64_t lda, double beta,
+                   ::sycl::buffer<double, 1> c, int64_t ldc, int64_t offset_a, int64_t offset_c)
     {
         ::oneapi::fpk::gpu::dsyrk_sycl(&_queue, uplo, trans, n, k, alpha, &a, lda, beta, &c, ldc, offset_a, offset_c);
     }
 
     template <>
-    void innerSyrk(MKL_UPLO uplo, MKL_TRANSPOSE trans, int64_t n, int64_t k, float alpha, cl::sycl::buffer<float, 1> a, int64_t lda, float beta,
-                   cl::sycl::buffer<float, 1> c, int64_t ldc, int64_t offset_a, int64_t offset_c)
+    void innerSyrk(MKL_UPLO uplo, MKL_TRANSPOSE trans, int64_t n, int64_t k, float alpha, ::sycl::buffer<float, 1> a, int64_t lda, float beta,
+                   ::sycl::buffer<float, 1> c, int64_t ldc, int64_t offset_a, int64_t offset_c)
     {
         ::oneapi::fpk::gpu::ssyrk_sycl(&_queue, uplo, trans, n, k, alpha, &a, lda, beta, &c, ldc, offset_a, offset_c);
     }
 
-    cl::sycl::queue & _queue;
+    ::sycl::queue & _queue;
 };
 
 /**
@@ -176,7 +176,7 @@ private:
 template <typename algorithmFPType>
 struct MKLAxpy
 {
-    MKLAxpy(cl::sycl::queue & queue) : _queue(queue) {}
+    MKLAxpy(::sycl::queue & queue) : _queue(queue) {}
 
     Status operator()(const int n, const algorithmFPType a, const Buffer<algorithmFPType> & x_buffer, const int incx,
                       Buffer<algorithmFPType> & y_buffer, const int incy)
@@ -201,7 +201,7 @@ struct MKLAxpy
     }
 
 private:
-    cl::sycl::queue & _queue;
+    ::sycl::queue & _queue;
 };
 
 /** @} */

--- a/cpp/daal/include/services/internal/sycl/math/mkl_lapack.h
+++ b/cpp/daal/include/services/internal/sycl/math/mkl_lapack.h
@@ -50,7 +50,7 @@ namespace interface1
 template <typename algorithmFPType>
 struct MKLPotrf
 {
-    MKLPotrf(cl::sycl::queue & queue) : _queue(queue) {}
+    MKLPotrf(::sycl::queue & queue) : _queue(queue) {}
 
     Status operator()(const math::UpLo uplo, const size_t n, Buffer<algorithmFPType> & a, const size_t lda)
     {
@@ -74,7 +74,7 @@ private:
         algorithmFPType * scratchpad = nullptr;
         if (scratchpadSize > 0)
         {
-            scratchpad = cl::sycl::malloc_device<algorithmFPType>(scratchpadSize, _queue);
+            scratchpad = ::sycl::malloc_device<algorithmFPType>(scratchpadSize, _queue);
             if (scratchpad == nullptr) return ErrorMemoryAllocationFailed;
         }
 
@@ -83,7 +83,7 @@ private:
             _queue.wait_and_throw();
         });
 
-        if (scratchpadSize > 0) cl::sycl::free(scratchpad, _queue);
+        if (scratchpadSize > 0) ::sycl::free(scratchpad, _queue);
 
         scratchpad = nullptr;
 #else
@@ -93,7 +93,7 @@ private:
     }
 
 private:
-    cl::sycl::queue & _queue;
+    ::sycl::queue & _queue;
 };
 
 /**
@@ -103,7 +103,7 @@ private:
 template <typename algorithmFPType>
 struct MKLPotrs
 {
-    MKLPotrs(cl::sycl::queue & queue) : _queue(queue) {}
+    MKLPotrs(::sycl::queue & queue) : _queue(queue) {}
 
     Status operator()(const math::UpLo uplo, const size_t n, const size_t ny, Buffer<algorithmFPType> & a, const size_t lda,
                       Buffer<algorithmFPType> & b, const size_t ldb)
@@ -132,7 +132,7 @@ private:
         algorithmFPType * scratchpad = nullptr;
         if (scratchpadSize > 0)
         {
-            scratchpad = cl::sycl::malloc_device<algorithmFPType>(scratchpadSize, _queue);
+            scratchpad = ::sycl::malloc_device<algorithmFPType>(scratchpadSize, _queue);
             if (scratchpad == nullptr) return ErrorMemoryAllocationFailed;
         }
 
@@ -141,7 +141,7 @@ private:
             _queue.wait_and_throw();
         });
 
-        if (scratchpadSize > 0) cl::sycl::free(scratchpad, _queue);
+        if (scratchpadSize > 0) ::sycl::free(scratchpad, _queue);
 
         scratchpad = nullptr;
 #else
@@ -151,7 +151,7 @@ private:
     }
 
 private:
-    cl::sycl::queue & _queue;
+    ::sycl::queue & _queue;
 };
 
 /** @} */

--- a/cpp/oneapi/dal/algo/basic_statistics/backend/gpu/compute_kernel_dense_impl_dpc.cpp
+++ b/cpp/oneapi/dal/algo/basic_statistics/backend/gpu/compute_kernel_dense_impl_dpc.cpp
@@ -634,7 +634,7 @@ compute_kernel_dense_impl<Float, List>::merge_blocks(local_buffer_list<Float, Li
     const sycl::nd_range<1> nd_range = bk::make_multiple_nd_range_1d(global_size, local_size);
 
     std::int64_t local_buffer_size = local_size;
-    auto last_event = q_.submit([&](cl::sycl::handler& cgh) {
+    auto last_event = q_.submit([&](sycl::handler& cgh) {
         cgh.depends_on(deps);
         local_accessor_rw_t<std::int64_t> lrc_buf(local_buffer_size, cgh);
         local_accessor_rw_t<Float> lmin_buf(local_buffer_size, cgh);
@@ -781,7 +781,7 @@ compute_kernel_dense_impl<Float, List>::merge_distr_blocks(
 
     const sycl::range<1> range{ de::integral_cast<std::size_t>(column_count) };
 
-    auto last_event = q_.submit([&](cl::sycl::handler& cgh) {
+    auto last_event = q_.submit([&](sycl::handler& cgh) {
         cgh.depends_on(deps);
         cgh.parallel_for(range, [=](sycl::id<1> id) {
             Float mrgsum = Float(0);

--- a/cpp/oneapi/dal/algo/dbscan/backend/gpu/data_keeper.hpp
+++ b/cpp/oneapi/dal/algo/dbscan/backend/gpu/data_keeper.hpp
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 #include "oneapi/dal/backend/common.hpp"
 #include "oneapi/dal/backend/primitives/ndarray.hpp"

--- a/cpp/oneapi/dal/algo/dbscan/backend/gpu/results.hpp
+++ b/cpp/oneapi/dal/algo/dbscan/backend/gpu/results.hpp
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 #include "oneapi/dal/backend/common.hpp"
 #include "oneapi/dal/backend/primitives/ndarray.hpp"

--- a/cpp/oneapi/dal/algo/decision_forest/backend/gpu/train_best_split_impl_dpc.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/gpu/train_best_split_impl_dpc.cpp
@@ -636,10 +636,10 @@ train_best_split_impl<Float, Bin, Index, Task, use_private_mem>::compute_best_sp
 
     sycl::event last_event;
 
-    last_event = queue.submit([&](cl::sycl::handler& cgh) {
+    last_event = queue.submit([&](sycl::handler& cgh) {
         cgh.depends_on(deps);
         local_accessor_rw_t<hist_type_t> local_hist_buf(local_hist_buf_size, cgh);
-        cgh.parallel_for(nd_range, [=](cl::sycl::nd_item<2> item) {
+        cgh.parallel_for(nd_range, [=](sycl::nd_item<2> item) {
             auto sbg = item.get_sub_group();
             if (sbg.get_group_id() > 0) {
                 return;
@@ -926,10 +926,10 @@ train_best_split_impl<Float, Bin, Index, Task, use_private_mem>::compute_best_sp
 
     constexpr Index buff_size = impl_const_t::private_hist_buff_size;
 
-    last_event = queue.submit([&](cl::sycl::handler& cgh) {
+    last_event = queue.submit([&](sycl::handler& cgh) {
         cgh.depends_on(deps);
         local_accessor_rw_t<hist_type_t> local_hist_buf(local_hist_buf_size, cgh);
-        cgh.parallel_for(nd_range, [=](cl::sycl::nd_item<2> item) {
+        cgh.parallel_for(nd_range, [=](sycl::nd_item<2> item) {
             auto sbg = item.get_sub_group();
             if (sbg.get_group_id() > 0) {
                 return;

--- a/cpp/oneapi/dal/algo/decision_forest/backend/gpu/train_best_split_sp_opt_impl_dpc.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/gpu/train_best_split_sp_opt_impl_dpc.cpp
@@ -169,7 +169,7 @@ sycl::event train_best_split_sp_opt_impl<Float, Bin, Index, Task, sbg_size>::
         const sycl::nd_range<2> nd_range =
             bk::make_multiple_nd_range_2d({ local_size, max_wg_count_ }, { local_size, 1 });
 
-        last_event = queue.submit([&](cl::sycl::handler& cgh) {
+        last_event = queue.submit([&](sycl::handler& cgh) {
             cgh.depends_on(deps);
             cgh.depends_on(fill_aux_ftr_event);
 
@@ -177,7 +177,7 @@ sycl::event train_best_split_sp_opt_impl<Float, Bin, Index, Task, sbg_size>::
 
             cgh.parallel_for(
                 nd_range,
-                [=](cl::sycl::nd_item<2> item) [[intel::reqd_sub_group_size(sbg_size)]] {
+                [=](sycl::nd_item<2> item) [[intel::reqd_sub_group_size(sbg_size)]] {
                     auto sbg = item.get_sub_group();
                     const Index group_id = item.get_group(1);
                     const Index ftr_group_id = group_id % ftr_worker_per_node_count;
@@ -489,13 +489,13 @@ sycl::event train_best_split_sp_opt_impl<Float, Bin, Index, Task, sbg_size>::
         const sycl::nd_range<2> nd_range =
             bk::make_multiple_nd_range_2d({ local_size, max_wg_count_ }, { local_size, 1 });
 
-        last_event = queue.submit([&](cl::sycl::handler& cgh) {
+        last_event = queue.submit([&](sycl::handler& cgh) {
             cgh.depends_on(deps);
             local_accessor_rw_t<byte_t> local_byte_buf(local_buf_byte_size, cgh);
 
             cgh.parallel_for(
                 nd_range,
-                [=](cl::sycl::nd_item<2> item) [[intel::reqd_sub_group_size(sbg_size)]] {
+                [=](sycl::nd_item<2> item) [[intel::reqd_sub_group_size(sbg_size)]] {
                     auto sbg = item.get_sub_group();
 
                     const Index node_idx = item.get_global_id(1);

--- a/cpp/oneapi/dal/algo/decision_forest/backend/gpu/train_impurity_data.hpp
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/gpu/train_impurity_data.hpp
@@ -31,7 +31,7 @@ namespace de = dal::detail;
 namespace bk = dal::backend;
 namespace pr = dal::backend::primitives;
 
-using alloc = cl::sycl::usm::alloc;
+using alloc = sycl::usm::alloc;
 
 template <typename Float, typename Index, typename Task>
 struct impurity_data;
@@ -45,7 +45,7 @@ struct impurity_data<Float, Index, task::classification> {
 
     impurity_data() = default;
     ~impurity_data() = default;
-    impurity_data(const cl::sycl::queue& q, Index node_count, Index class_count)
+    impurity_data(const sycl::queue& q, Index node_count, Index class_count)
             : imp_list_(
                   pr::ndarray<Float, 1>::empty(q,
                                                { node_count * impl_const_t::node_imp_prop_count_ },
@@ -53,7 +53,7 @@ struct impurity_data<Float, Index, task::classification> {
               class_hist_list_(
                   pr::ndarray<Index, 1>::empty(q, { node_count * class_count }, alloc::device)) {}
 
-    impurity_data(const cl::sycl::queue& q, const context_t& ctx, Index node_count)
+    impurity_data(const sycl::queue& q, const context_t& ctx, Index node_count)
             : imp_list_(
                   pr::ndarray<Float, 1>::empty(q,
                                                { node_count * impl_const_t::node_imp_prop_count_ },
@@ -62,7 +62,7 @@ struct impurity_data<Float, Index, task::classification> {
                                                             { node_count * ctx.class_count_ },
                                                             alloc::device)) {}
 
-    imp_data_t to_host(cl::sycl::queue& q, const dal::backend::event_vector& deps = {}) const {
+    imp_data_t to_host(sycl::queue& q, const dal::backend::event_vector& deps = {}) const {
         imp_data_t imp_data_host;
         imp_data_host.imp_list_ = imp_list_.to_host(q, deps);
         imp_data_host.class_hist_list_ = class_hist_list_.to_host(q);
@@ -82,19 +82,19 @@ struct impurity_data<Float, Index, task::regression> {
 
     impurity_data() = default;
     ~impurity_data() = default;
-    impurity_data(const cl::sycl::queue& q, Index node_count)
+    impurity_data(const sycl::queue& q, Index node_count)
             : imp_list_(
                   pr::ndarray<Float, 1>::empty(q,
                                                { node_count * impl_const_t::node_imp_prop_count_ },
                                                alloc::device)) {}
 
-    impurity_data(const cl::sycl::queue& q, const context_t& ctx, Index node_count)
+    impurity_data(const sycl::queue& q, const context_t& ctx, Index node_count)
             : imp_list_(
                   pr::ndarray<Float, 1>::empty(q,
                                                { node_count * impl_const_t::node_imp_prop_count_ },
                                                alloc::device)) {}
 
-    imp_data_t to_host(cl::sycl::queue& q, const dal::backend::event_vector& deps = {}) const {
+    imp_data_t to_host(sycl::queue& q, const dal::backend::event_vector& deps = {}) const {
         imp_data_t imp_data_host;
         imp_data_host.imp_list_ = imp_list_.to_host(q, deps);
         return imp_data_host;
@@ -169,7 +169,7 @@ struct impurity_data_manager<Float, Index, task::classification> {
     using imp_data_t = impurity_data<Float, Index, task_t>;
     using context_t = train_context<Float, Index, task_t>;
 
-    impurity_data_manager(const cl::sycl::queue& q, const context_t& ctx)
+    impurity_data_manager(const sycl::queue& q, const context_t& ctx)
             : queue_(q),
               class_count_(ctx.class_count_) {}
     ~impurity_data_manager() = default;
@@ -189,7 +189,7 @@ struct impurity_data_manager<Float, Index, task::classification> {
         return level_node_imp_list_[level];
     }
 
-    const cl::sycl::queue& queue_;
+    const sycl::queue& queue_;
     Index class_count_ = 0;
     std::vector<imp_data_t> level_node_imp_list_;
 };
@@ -200,7 +200,7 @@ struct impurity_data_manager<Float, Index, task::regression> {
     using imp_data_t = impurity_data<Float, Index, task_t>;
     using context_t = train_context<Float, Index, task_t>;
 
-    impurity_data_manager(const cl::sycl::queue& q, const context_t& ctx) : queue_(q) {}
+    impurity_data_manager(const sycl::queue& q, const context_t& ctx) : queue_(q) {}
     ~impurity_data_manager() = default;
 
     void init_new_level(Index node_count) {
@@ -218,7 +218,7 @@ struct impurity_data_manager<Float, Index, task::regression> {
         return level_node_imp_list_[level];
     }
 
-    const cl::sycl::queue& queue_;
+    const sycl::queue& queue_;
     std::vector<imp_data_t> level_node_imp_list_;
 };
 

--- a/cpp/oneapi/dal/algo/decision_forest/backend/gpu/train_kernel_hist_impl_dpc.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/gpu/train_kernel_hist_impl_dpc.cpp
@@ -749,7 +749,7 @@ sycl::event train_kernel_hist_impl<Float, Bin, Index, Task>::compute_initial_imp
             }
 
             node_ptr[impl_const_t::ind_win] = win_cls;
-            node_imp_ptr[0] = cl::sycl::max(imp, Float(0));
+            node_imp_ptr[0] = sycl::max(imp, Float(0));
         }
         imp_data_list.imp_list_.assign_from_host(queue_, imp_list_host).wait_and_throw();
         node_list.assign_from_host(queue_, node_list_host).wait_and_throw();

--- a/cpp/oneapi/dal/algo/decision_forest/backend/gpu/train_model_manager.hpp
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/gpu/train_model_manager.hpp
@@ -55,7 +55,7 @@ class tree_level_record {
     using imp_data_t = impurity_data<Float, Index, Task>;
 
 public:
-    tree_level_record(cl::sycl::queue& queue,
+    tree_level_record(sycl::queue& queue,
                       dal::backend::primitives::ndarray<Index, 1> node_list,
                       const imp_data_t& imp_data_list,
                       Index node_count,

--- a/cpp/oneapi/dal/backend/atomic.hpp
+++ b/cpp/oneapi/dal/backend/atomic.hpp
@@ -17,7 +17,7 @@
 #pragma once
 
 #ifdef ONEDAL_DATA_PARALLEL
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #endif
 
 #ifdef ONEDAL_DATA_PARALLEL
@@ -31,7 +31,7 @@ inline T atomic_global_add(T* ptr, T operand) {
     sycl::atomic_ref<T,
                      mem_order,
                      mem_scope,
-                     cl::sycl::access::address_space::ext_intel_global_device_space>
+                     sycl::access::address_space::ext_intel_global_device_space>
         atomic_var(*ptr);
     return atomic_var.fetch_add(operand);
 }
@@ -43,7 +43,7 @@ inline T atomic_global_sum(T* ptr, T operand) {
     sycl::atomic_ref<T,
                      mem_order,
                      mem_scope,
-                     cl::sycl::access::address_space::ext_intel_global_device_space>
+                     sycl::access::address_space::ext_intel_global_device_space>
         atomic_var(*ptr);
     auto old = atomic_var.fetch_add(operand);
     return old + operand;
@@ -56,7 +56,7 @@ inline T atomic_global_min(T* ptr, T operand) {
     sycl::atomic_ref<T,
                      mem_order,
                      mem_scope,
-                     cl::sycl::access::address_space::ext_intel_global_device_space>
+                     sycl::access::address_space::ext_intel_global_device_space>
         atomic_var(*ptr);
     return atomic_var.fetch_min(operand);
 }
@@ -68,7 +68,7 @@ inline T atomic_global_max(T* ptr, T operand) {
     sycl::atomic_ref<T,
                      mem_order,
                      mem_scope,
-                     cl::sycl::access::address_space::ext_intel_global_device_space>
+                     sycl::access::address_space::ext_intel_global_device_space>
         atomic_var(*ptr);
     return atomic_var.fetch_max(operand);
 }
@@ -81,7 +81,7 @@ inline T atomic_global_cmpxchg(T* ptr, T expected, T desired) {
     sycl::atomic_ref<T,
                      mem_order,
                      mem_scope,
-                     cl::sycl::access::address_space::ext_intel_global_device_space>
+                     sycl::access::address_space::ext_intel_global_device_space>
         atomic_var(*ptr);
     atomic_var.compare_exchange_weak(expected_, desired, mem_order, mem_scope);
     return expected_;
@@ -91,7 +91,7 @@ template <typename T,
           sycl::memory_order mem_order = sycl::memory_order::relaxed,
           sycl::memory_scope mem_scope = sycl::memory_scope::device>
 inline T atomic_local_add(T* ptr, T operand) {
-    sycl::atomic_ref<T, mem_order, mem_scope, cl::sycl::access::address_space::local_space>
+    sycl::atomic_ref<T, mem_order, mem_scope, sycl::access::address_space::local_space>
         atomic_var(*ptr);
     return atomic_var.fetch_add(operand);
 }
@@ -100,7 +100,7 @@ template <typename T,
           sycl::memory_order mem_order = sycl::memory_order::relaxed,
           sycl::memory_scope mem_scope = sycl::memory_scope::device>
 inline T atomic_local_sum(T* ptr, T operand) {
-    sycl::atomic_ref<T, mem_order, mem_scope, cl::sycl::access::address_space::local_space>
+    sycl::atomic_ref<T, mem_order, mem_scope, sycl::access::address_space::local_space>
         atomic_var(*ptr);
     auto old = atomic_var.fetch_add(operand);
     return old + operand;
@@ -110,7 +110,7 @@ template <typename T,
           sycl::memory_order mem_order = sycl::memory_order::relaxed,
           sycl::memory_scope mem_scope = sycl::memory_scope::device>
 inline T atomic_local_min(T* ptr, T operand) {
-    sycl::atomic_ref<T, mem_order, mem_scope, cl::sycl::access::address_space::local_space>
+    sycl::atomic_ref<T, mem_order, mem_scope, sycl::access::address_space::local_space>
         atomic_var(*ptr);
     return atomic_var.fetch_min(operand);
 }
@@ -119,7 +119,7 @@ template <typename T,
           sycl::memory_order mem_order = sycl::memory_order::relaxed,
           sycl::memory_scope mem_scope = sycl::memory_scope::device>
 inline T atomic_local_max(T* ptr, T operand) {
-    sycl::atomic_ref<T, mem_order, mem_scope, cl::sycl::access::address_space::local_space>
+    sycl::atomic_ref<T, mem_order, mem_scope, sycl::access::address_space::local_space>
         atomic_var(*ptr);
     return atomic_var.fetch_max(operand);
 }
@@ -129,7 +129,7 @@ template <typename T,
           sycl::memory_scope mem_scope = sycl::memory_scope::device>
 inline T atomic_local_cmpxchg(T* ptr, T expected, T desired) {
     T expected_temp = expected;
-    sycl::atomic_ref<T, mem_order, mem_scope, cl::sycl::access::address_space::local_space>
+    sycl::atomic_ref<T, mem_order, mem_scope, sycl::access::address_space::local_space>
         atomic_var(*ptr);
     atomic_var.compare_exchange_weak(expected_temp, desired, mem_order, mem_scope);
     return expected_temp;

--- a/cpp/oneapi/dal/backend/common.hpp
+++ b/cpp/oneapi/dal/backend/common.hpp
@@ -17,7 +17,7 @@
 #pragma once
 
 #ifdef ONEDAL_DATA_PARALLEL
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #endif
 
 #include "oneapi/dal/array.hpp"

--- a/cpp/oneapi/dal/detail/common.hpp
+++ b/cpp/oneapi/dal/detail/common.hpp
@@ -17,7 +17,7 @@
 #pragma once
 
 #ifdef ONEDAL_DATA_PARALLEL
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #endif
 
 #include <memory>

--- a/cpp/oneapi/dal/detail/communicator.hpp
+++ b/cpp/oneapi/dal/detail/communicator.hpp
@@ -17,7 +17,7 @@
 #pragma once
 
 #ifdef ONEDAL_DATA_PARALLEL
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #endif
 
 #include "oneapi/dal/spmd/communicator.hpp"

--- a/cpp/oneapi/dal/detail/policy.hpp
+++ b/cpp/oneapi/dal/detail/policy.hpp
@@ -18,7 +18,7 @@
 
 #include <type_traits>
 #ifdef ONEDAL_DATA_PARALLEL
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #endif
 
 #include "oneapi/dal/detail/common.hpp"

--- a/cpp/oneapi/dal/detail/profiler.hpp
+++ b/cpp/oneapi/dal/detail/profiler.hpp
@@ -17,7 +17,7 @@
 #pragma once
 
 #ifdef ONEDAL_DATA_PARALLEL
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #endif
 
 #define ONEDAL_PROFILER_CONCAT2(x, y) x##y

--- a/cpp/oneapi/dal/spmd/communicator.hpp
+++ b/cpp/oneapi/dal/spmd/communicator.hpp
@@ -17,7 +17,7 @@
 #pragma once
 
 #ifdef ONEDAL_DATA_PARALLEL
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #endif
 
 #include "oneapi/dal/detail/common.hpp"

--- a/docs/source/includes/data-management/array-usage-example.rst
+++ b/docs/source/includes/data-management/array-usage-example.rst
@@ -19,7 +19,7 @@
 
 ::
 
-   #include <CL/sycl.hpp>
+   #include <sycl/sycl.hpp>
    #include <iostream>
    #include <string>
    #include "oneapi/dal/array.hpp"

--- a/docs/source/includes/data-management/column-accessor-usage-example.rst
+++ b/docs/source/includes/data-management/column-accessor-usage-example.rst
@@ -18,7 +18,7 @@
 
 ::
 
-   #include <CL/sycl.hpp>
+   #include <sycl/sycl.hpp>
    #include <iostream>
 
    #include "oneapi/dal/table/homogen.hpp"

--- a/docs/source/includes/data-management/row-accessor-usage-example.rst
+++ b/docs/source/includes/data-management/row-accessor-usage-example.rst
@@ -18,7 +18,7 @@
 
 ::
 
-   #include <CL/sycl.hpp>
+   #include <sycl/sycl.hpp>
    #include <iostream>
 
    #include "oneapi/dal/table/homogen.hpp"

--- a/examples/daal/cpp_sycl/source/covariance/cor_dense_batch.cpp
+++ b/examples/daal/cpp_sycl/source/covariance/cor_dense_batch.cpp
@@ -46,7 +46,7 @@ int main(int argc, char* argv[]) {
     for (const auto& deviceSelector : getListOfDevices()) {
         const auto& nameDevice = deviceSelector.first;
         const auto& device = deviceSelector.second;
-        cl::sycl::queue queue(device);
+        sycl::queue queue(device);
         std::cout << "Running on " << nameDevice << "\n\n";
 
         SyclExecutionContext ctx(queue);

--- a/examples/daal/cpp_sycl/source/covariance/cor_dense_distr.cpp
+++ b/examples/daal/cpp_sycl/source/covariance/cor_dense_distr.cpp
@@ -61,7 +61,7 @@ int main(int argc, char* argv[]) {
     for (const auto& deviceSelector : getListOfDevices()) {
         const auto& nameDevice = deviceSelector.first;
         const auto& device = deviceSelector.second;
-        cl::sycl::queue queue(device);
+        sycl::queue queue(device);
         std::cout << "Running on " << nameDevice << "\n\n";
 
         daal::services::SyclExecutionContext ctx(queue);

--- a/examples/daal/cpp_sycl/source/covariance/cor_dense_online.cpp
+++ b/examples/daal/cpp_sycl/source/covariance/cor_dense_online.cpp
@@ -47,7 +47,7 @@ int main(int argc, char* argv[]) {
     for (const auto& deviceSelector : getListOfDevices()) {
         const auto& nameDevice = deviceSelector.first;
         const auto& device = deviceSelector.second;
-        cl::sycl::queue queue(device);
+        sycl::queue queue(device);
         std::cout << "Running on " << nameDevice << "\n\n";
 
         SyclExecutionContext ctx(queue);

--- a/examples/daal/cpp_sycl/source/datasource/datastructures_csr.cpp
+++ b/examples/daal/cpp_sycl/source/datasource/datastructures_csr.cpp
@@ -48,13 +48,13 @@ int main() {
     for (const auto& deviceSelector : getListOfDevices()) {
         const auto& nameDevice = deviceSelector.first;
         const auto& device = deviceSelector.second;
-        cl::sycl::queue queue(device);
+        sycl::queue queue(device);
         std::cout << "Running on " << nameDevice << "\n\n";
 
         SyclCSRNumericTablePtr dataTable = SyclCSRNumericTable::create<float>(
-            cl::sycl::buffer<float>(values, nNotZeroes),
-            cl::sycl::buffer<size_t>(colIndices, nNotZeroes),
-            cl::sycl::buffer<size_t>(rowOffsets, nObservations + 1),
+            sycl::buffer<float>(values, nNotZeroes),
+            sycl::buffer<size_t>(colIndices, nNotZeroes),
+            sycl::buffer<size_t>(rowOffsets, nObservations + 1),
             nFeatures,
             nObservations);
         checkPtr(dataTable.get());

--- a/examples/daal/cpp_sycl/source/datasource/datastructures_soa.cpp
+++ b/examples/daal/cpp_sycl/source/datasource/datastructures_soa.cpp
@@ -52,7 +52,7 @@ int main() {
     for (const auto& deviceSelector : getListOfDevices()) {
         const auto& nameDevice = deviceSelector.first;
         const auto& device = deviceSelector.second;
-        cl::sycl::queue queue(device);
+        sycl::queue queue(device);
         std::cout << "Running on " << nameDevice << "\n\n";
 
         SyclExecutionContext ctx(queue);
@@ -66,15 +66,15 @@ int main() {
         SyclSOANumericTablePtr dataTable = SyclSOANumericTable::create(nFeatures, nObservations);
 
         checkPtr(dataTable.get());
-        dataTable->setArray<int>(cl::sycl::buffer<int>(cDataSOA, cl::sycl::range<1>(nObservations)),
+        dataTable->setArray<int>(sycl::buffer<int>(cDataSOA, sycl::range<1>(nObservations)),
                                  0);
         dataTable->setArray<float>(
-            cl::sycl::buffer<float>(fDataSOA, cl::sycl::range<1>(nObservations)),
+            sycl::buffer<float>(fDataSOA, sycl::range<1>(nObservations)),
             1);
         dataTable->setArray<double>(
-            cl::sycl::buffer<double>(dDataSOA, cl::sycl::range<1>(nObservations)),
+            sycl::buffer<double>(dDataSOA, sycl::range<1>(nObservations)),
             2);
-        dataTable->setArray<int>(cl::sycl::buffer<int>(iDataSOA, cl::sycl::range<1>(nObservations)),
+        dataTable->setArray<int>(sycl::buffer<int>(iDataSOA, sycl::range<1>(nObservations)),
                                  3);
 
         /* Read a block of rows */

--- a/examples/daal/cpp_sycl/source/datasource/datastructures_usm.cpp
+++ b/examples/daal/cpp_sycl/source/datasource/datastructures_usm.cpp
@@ -63,7 +63,7 @@ NumericTablePtr computeCorrelationMatrix(const NumericTablePtr &table) {
 #ifdef IS_USM_SUPPORTED
 
 /* Fill the buffer with pseudo random numbers generated with MinStd engine */
-cl::sycl::event generateData(cl::sycl::queue &q, float *deviceData, size_t nRows, size_t nCols) {
+sycl::event generateData(sycl::queue &q, float *deviceData, size_t nRows, size_t nCols) {
     using namespace cl::sycl;
     return q.submit([&](handler &cgh) {
         cgh.parallel_for<class FillTable>(range<1>(nRows), [=](id<1> idx) {
@@ -90,13 +90,13 @@ int main(int argc, char *argv[]) {
         std::cout << "Running on " << deviceName << std::endl << std::endl;
 
         /* Crate SYCL* queue with desired device */
-        cl::sycl::queue queue{ device };
+        sycl::queue queue{ device };
 
         /* Set the queue to default execution context */
         Environment::getInstance()->setDefaultExecutionContext(SyclExecutionContext{ queue });
 
         /* Allocate shared memory to store input data */
-        float *dataDevice = (float *)cl::sycl::malloc_shared(sizeof(float) * nRows * nCols,
+        float *dataDevice = (float *)sycl::malloc_shared(sizeof(float) * nRows * nCols,
                                                              queue.get_device(),
                                                              queue.get_context());
         if (!dataDevice) {
@@ -118,7 +118,7 @@ int main(int argc, char *argv[]) {
         printNumericTable(covariance, "Covariance matrix:");
 
         /* Free USM data */
-        cl::sycl::free(dataDevice, queue.get_context());
+        sycl::free(dataDevice, queue.get_context());
     }
 
     return 0;

--- a/examples/daal/cpp_sycl/source/datasource/row_merged_to_sycl_homogen.cpp
+++ b/examples/daal/cpp_sycl/source/datasource/row_merged_to_sycl_homogen.cpp
@@ -101,7 +101,7 @@ int main(int argc, char *argv[]) {
         std::cout << "Running on " << deviceName << std::endl << std::endl;
 
         /* Create SYCL* queue with desired device */
-        cl::sycl::queue queue{ device };
+        sycl::queue queue{ device };
 
         /* Set the queue to default execution context */
         Environment::getInstance()->setDefaultExecutionContext(SyclExecutionContext{ queue });

--- a/examples/daal/cpp_sycl/source/dbscan/dbscan_dense_batch.cpp
+++ b/examples/daal/cpp_sycl/source/dbscan/dbscan_dense_batch.cpp
@@ -48,7 +48,7 @@ int main(int argc, char* argv[]) {
     for (const auto& deviceSelector : getListOfDevices()) {
         const auto& nameDevice = deviceSelector.first;
         const auto& device = deviceSelector.second;
-        cl::sycl::queue queue(device);
+        sycl::queue queue(device);
         std::cout << "Running on " << nameDevice << "\n\n";
 
         SyclExecutionContext ctx(queue);

--- a/examples/daal/cpp_sycl/source/decision_forest/df_cls_dense_batch.cpp
+++ b/examples/daal/cpp_sycl/source/decision_forest/df_cls_dense_batch.cpp
@@ -62,7 +62,7 @@ int main(int argc, char* argv[]) {
     for (const auto& deviceSelector : getListOfDevices()) {
         const auto& nameDevice = deviceSelector.first;
         const auto& device = deviceSelector.second;
-        cl::sycl::queue queue(device);
+        sycl::queue queue(device);
         std::cout << "Running on " << nameDevice << "\n\n";
 
         SyclExecutionContext ctx(queue);

--- a/examples/daal/cpp_sycl/source/decision_forest/df_reg_dense_batch.cpp
+++ b/examples/daal/cpp_sycl/source/decision_forest/df_reg_dense_batch.cpp
@@ -58,7 +58,7 @@ int main(int argc, char* argv[]) {
     for (const auto& deviceSelector : getListOfDevices()) {
         const auto& nameDevice = deviceSelector.first;
         const auto& device = deviceSelector.second;
-        cl::sycl::queue queue(device);
+        sycl::queue queue(device);
         std::cout << "Running on " << nameDevice << "\n\n";
 
         SyclExecutionContext ctx(queue);

--- a/examples/daal/cpp_sycl/source/gradient_boosted_trees/gbt_reg_dense_batch.cpp
+++ b/examples/daal/cpp_sycl/source/gradient_boosted_trees/gbt_reg_dense_batch.cpp
@@ -58,7 +58,7 @@ int main(int argc, char* argv[]) {
     for (const auto& deviceSelector : getListOfDevices()) {
         const auto& nameDevice = deviceSelector.first;
         const auto& device = deviceSelector.second;
-        cl::sycl::queue queue(device);
+        sycl::queue queue(device);
         std::cout << "Running on " << nameDevice << "\n\n";
 
         SyclExecutionContext ctx(queue);

--- a/examples/daal/cpp_sycl/source/k_nearest_neighbors/bf_knn_dense_batch.cpp
+++ b/examples/daal/cpp_sycl/source/k_nearest_neighbors/bf_knn_dense_batch.cpp
@@ -56,7 +56,7 @@ int main(int argc, char* argv[]) {
     for (const auto& deviceSelector : getListOfDevices()) {
         const auto& nameDevice = deviceSelector.first;
         const auto& device = deviceSelector.second;
-        cl::sycl::queue queue(device);
+        sycl::queue queue(device);
         std::cout << "Running on " << nameDevice << "\n\n";
 
         SyclExecutionContext ctx(queue);

--- a/examples/daal/cpp_sycl/source/k_nearest_neighbors/bf_knn_dense_regression_batch.cpp
+++ b/examples/daal/cpp_sycl/source/k_nearest_neighbors/bf_knn_dense_regression_batch.cpp
@@ -52,7 +52,7 @@ void trainModel(NumericTablePtr& trainSamples,
 void testModel(bf_knn_classification::training::ResultPtr& trainingResult,
                NumericTablePtr& testSamples,
                bf_knn_classification::prediction::ResultPtr& searchResult);
-void doRegression(cl::sycl::queue& q,
+void doRegression(sycl::queue& q,
                   bf_knn_classification::prediction::ResultPtr& searchResult,
                   NumericTablePtr& trainResponses,
                   NumericTablePtr& testResponses);
@@ -65,7 +65,7 @@ int main(int argc, char* argv[]) {
         const auto& nameDevice = deviceSelector.first;
         const auto& device = deviceSelector.second;
 
-        cl::sycl::queue queue(device);
+        sycl::queue queue(device);
         std::cout << "Running on " << nameDevice << "\n\n";
 
         SyclExecutionContext ctx(queue);
@@ -143,7 +143,7 @@ void testModel(bf_knn_classification::training::ResultPtr& trainingResult,
     searchResult = algorithm.getResult();
 }
 
-void doRegression(cl::sycl::queue& q,
+void doRegression(sycl::queue& q,
                   bf_knn_classification::prediction::ResultPtr& searchResult,
                   NumericTablePtr& trainResponses,
                   NumericTablePtr& testResponses) {
@@ -167,13 +167,13 @@ void doRegression(cl::sycl::queue& q,
         auto trainResponsesSharedPtr =
             trainResponsesBlock.getBuffer().toUSM(q, data_management::readOnly);
         const float kn = static_cast<float>(kNeighbors);
-        q.submit([&](cl::sycl::handler& h) {
+        q.submit([&](sycl::handler& h) {
             auto neighborsIndicesPtr = neighborsIndicesSharedPtr.get();
             auto testResponsesPtr = testResponsesSharedPtr.get();
             auto trainResponsesPtr = trainResponsesSharedPtr.get();
             h.parallel_for<class regressor>(
-                cl::sycl::range<2>(nTestSamples, nResponses),
-                [=](cl::sycl::id<2> idx) {
+                sycl::range<2>(nTestSamples, nResponses),
+                [=](sycl::id<2> idx) {
                     float acc(0);
                     int trIndex;
                     for (size_t i = 0; i < kNeighbors; ++i) {

--- a/examples/daal/cpp_sycl/source/k_nearest_neighbors/bf_knn_dense_search_batch.cpp
+++ b/examples/daal/cpp_sycl/source/k_nearest_neighbors/bf_knn_dense_search_batch.cpp
@@ -69,7 +69,7 @@ int main(int argc, char* argv[]) {
     for (const auto& deviceSelector : getListOfDevices()) {
         const auto& nameDevice = deviceSelector.first;
         const auto& device = deviceSelector.second;
-        cl::sycl::queue queue(device);
+        sycl::queue queue(device);
         std::cout << "Running on " << nameDevice << "\n\n";
 
         SyclExecutionContext ctx(queue);

--- a/examples/daal/cpp_sycl/source/kernel_function/kernel_func_lin_csr_batch.cpp
+++ b/examples/daal/cpp_sycl/source/kernel_function/kernel_func_lin_csr_batch.cpp
@@ -48,7 +48,7 @@ int main(int argc, char* argv[]) {
     for (const auto& deviceSelector : getListOfDevices()) {
         const auto& nameDevice = deviceSelector.first;
         const auto& device = deviceSelector.second;
-        cl::sycl::queue queue(device);
+        sycl::queue queue(device);
         std::cout << "Running on " << nameDevice << "\n\n";
 
         services::SyclExecutionContext ctx(queue);

--- a/examples/daal/cpp_sycl/source/kernel_function/kernel_func_lin_dense_batch.cpp
+++ b/examples/daal/cpp_sycl/source/kernel_function/kernel_func_lin_dense_batch.cpp
@@ -53,7 +53,7 @@ int main(int argc, char* argv[]) {
     for (const auto& deviceSelector : getListOfDevices()) {
         const auto& nameDevice = deviceSelector.first;
         const auto& device = deviceSelector.second;
-        cl::sycl::queue queue(device);
+        sycl::queue queue(device);
         std::cout << "Running on " << nameDevice << "\n\n";
 
         SyclExecutionContext ctx(queue);

--- a/examples/daal/cpp_sycl/source/kernel_function/kernel_func_rbf_csr_batch.cpp
+++ b/examples/daal/cpp_sycl/source/kernel_function/kernel_func_rbf_csr_batch.cpp
@@ -51,7 +51,7 @@ int main(int argc, char* argv[]) {
     for (const auto& deviceSelector : getListOfDevices()) {
         const auto& nameDevice = deviceSelector.first;
         const auto& device = deviceSelector.second;
-        cl::sycl::queue queue(device);
+        sycl::queue queue(device);
         std::cout << "Running on " << nameDevice << "\n\n";
 
         SyclExecutionContext ctx(queue);

--- a/examples/daal/cpp_sycl/source/kernel_function/kernel_func_rbf_dense_batch.cpp
+++ b/examples/daal/cpp_sycl/source/kernel_function/kernel_func_rbf_dense_batch.cpp
@@ -52,7 +52,7 @@ int main(int argc, char* argv[]) {
     for (const auto& deviceSelector : getListOfDevices()) {
         const auto& nameDevice = deviceSelector.first;
         const auto& device = deviceSelector.second;
-        cl::sycl::queue queue(device);
+        sycl::queue queue(device);
         std::cout << "Running on " << nameDevice << "\n\n";
 
         SyclExecutionContext ctx(queue);

--- a/examples/daal/cpp_sycl/source/kmeans/kmeans_dense_batch.cpp
+++ b/examples/daal/cpp_sycl/source/kmeans/kmeans_dense_batch.cpp
@@ -50,7 +50,7 @@ int main(int argc, char* argv[]) {
     for (const auto& deviceSelector : getListOfDevices()) {
         const auto& nameDevice = deviceSelector.first;
         const auto& device = deviceSelector.second;
-        cl::sycl::queue queue(device);
+        sycl::queue queue(device);
         std::cout << "Running on " << nameDevice << "\n\n";
 
         SyclExecutionContext ctx(queue);

--- a/examples/daal/cpp_sycl/source/kmeans/kmeans_dense_distr.cpp
+++ b/examples/daal/cpp_sycl/source/kmeans/kmeans_dense_distr.cpp
@@ -60,7 +60,7 @@ int main(int argc, char* argv[]) {
     for (const auto& deviceSelector : getListOfDevices()) {
         const auto& nameDevice = deviceSelector.first;
         const auto& device = deviceSelector.second;
-        cl::sycl::queue queue(device);
+        sycl::queue queue(device);
         std::cout << "Running on " << nameDevice << "\n\n";
 
         SyclExecutionContext ctx(queue);

--- a/examples/daal/cpp_sycl/source/kmeans/kmeans_init_dense_batch.cpp
+++ b/examples/daal/cpp_sycl/source/kmeans/kmeans_init_dense_batch.cpp
@@ -97,7 +97,7 @@ int main(int argc, char* argv[]) {
     for (const auto& deviceSelector : getListOfDevices()) {
         const auto& nameDevice = deviceSelector.first;
         const auto& device = deviceSelector.second;
-        cl::sycl::queue queue(device);
+        sycl::queue queue(device);
         std::cout << "Running on " << nameDevice << "\n\n";
 
         SyclExecutionContext ctx(queue);

--- a/examples/daal/cpp_sycl/source/linear_regression/lin_reg_norm_eq_dense_batch.cpp
+++ b/examples/daal/cpp_sycl/source/linear_regression/lin_reg_norm_eq_dense_batch.cpp
@@ -59,7 +59,7 @@ int main(int argc, char* argv[]) {
     for (const auto& deviceSelector : getListOfDevices()) {
         const auto& nameDevice = deviceSelector.first;
         const auto& device = deviceSelector.second;
-        cl::sycl::queue queue(device);
+        sycl::queue queue(device);
         std::cout << "Running on " << nameDevice << "\n\n";
 
         SyclExecutionContext ctx(queue);

--- a/examples/daal/cpp_sycl/source/linear_regression/lin_reg_norm_eq_dense_online.cpp
+++ b/examples/daal/cpp_sycl/source/linear_regression/lin_reg_norm_eq_dense_online.cpp
@@ -57,7 +57,7 @@ int main(int argc, char* argv[]) {
     for (const auto& deviceSelector : getListOfDevices()) {
         const auto& nameDevice = deviceSelector.first;
         const auto& device = deviceSelector.second;
-        cl::sycl::queue queue(device);
+        sycl::queue queue(device);
         std::cout << "Running on " << nameDevice << "\n\n";
 
         SyclExecutionContext ctx(queue);

--- a/examples/daal/cpp_sycl/source/logistic_regression/log_reg_binary_dense_batch.cpp
+++ b/examples/daal/cpp_sycl/source/logistic_regression/log_reg_binary_dense_batch.cpp
@@ -61,7 +61,7 @@ int main(int argc, char* argv[]) {
     for (const auto& deviceSelector : getListOfDevices()) {
         const auto& nameDevice = deviceSelector.first;
         const auto& device = deviceSelector.second;
-        cl::sycl::queue queue(device);
+        sycl::queue queue(device);
         std::cout << "Running on " << nameDevice << "\n\n";
 
         SyclExecutionContext ctx(queue);

--- a/examples/daal/cpp_sycl/source/logistic_regression/log_reg_binary_dense_online.cpp
+++ b/examples/daal/cpp_sycl/source/logistic_regression/log_reg_binary_dense_online.cpp
@@ -53,7 +53,7 @@ int main(int argc, char* argv[]) {
     for (const auto& deviceSelector : getListOfDevices()) {
         const auto& nameDevice = deviceSelector.first;
         const auto& device = deviceSelector.second;
-        cl::sycl::queue queue(device);
+        sycl::queue queue(device);
         std::cout << "Running on " << nameDevice << "\n\n";
 
         services::SyclExecutionContext ctx(queue);

--- a/examples/daal/cpp_sycl/source/logistic_regression/log_reg_dense_batch.cpp
+++ b/examples/daal/cpp_sycl/source/logistic_regression/log_reg_dense_batch.cpp
@@ -59,7 +59,7 @@ int main(int argc, char* argv[]) {
     for (const auto& deviceSelector : getListOfDevices()) {
         const auto& nameDevice = deviceSelector.first;
         const auto& device = deviceSelector.second;
-        cl::sycl::queue queue(device);
+        sycl::queue queue(device);
         std::cout << "Running on " << nameDevice << "\n\n";
 
         SyclExecutionContext ctx(queue);

--- a/examples/daal/cpp_sycl/source/logistic_regression/log_reg_dense_online.cpp
+++ b/examples/daal/cpp_sycl/source/logistic_regression/log_reg_dense_online.cpp
@@ -53,7 +53,7 @@ int main(int argc, char* argv[]) {
     for (const auto& deviceSelector : getListOfDevices()) {
         const auto& nameDevice = deviceSelector.first;
         const auto& device = deviceSelector.second;
-        cl::sycl::queue queue(device);
+        sycl::queue queue(device);
         std::cout << "Running on " << nameDevice << "\n\n";
 
         services::SyclExecutionContext ctx(queue);

--- a/examples/daal/cpp_sycl/source/moments/low_order_moms_dense_batch.cpp
+++ b/examples/daal/cpp_sycl/source/moments/low_order_moms_dense_batch.cpp
@@ -47,7 +47,7 @@ int main(int argc, char* argv[]) {
     for (const auto& deviceSelector : getListOfDevices()) {
         const auto& nameDevice = deviceSelector.first;
         const auto& device = deviceSelector.second;
-        cl::sycl::queue queue(device);
+        sycl::queue queue(device);
         std::cout << "Running on " << nameDevice << "\n\n";
 
         SyclExecutionContext ctx(queue);

--- a/examples/daal/cpp_sycl/source/moments/low_order_moms_dense_distr.cpp
+++ b/examples/daal/cpp_sycl/source/moments/low_order_moms_dense_distr.cpp
@@ -61,7 +61,7 @@ int main(int argc, char* argv[]) {
     for (const auto& deviceSelector : getListOfDevices()) {
         const auto& nameDevice = deviceSelector.first;
         const auto& device = deviceSelector.second;
-        cl::sycl::queue queue(device);
+        sycl::queue queue(device);
         std::cout << "Running on " << nameDevice << "\n\n";
 
         daal::services::SyclExecutionContext ctx(queue);

--- a/examples/daal/cpp_sycl/source/moments/low_order_moms_dense_online.cpp
+++ b/examples/daal/cpp_sycl/source/moments/low_order_moms_dense_online.cpp
@@ -46,7 +46,7 @@ int main(int argc, char* argv[]) {
     for (const auto& deviceSelector : getListOfDevices()) {
         const auto& nameDevice = deviceSelector.first;
         const auto& device = deviceSelector.second;
-        cl::sycl::queue queue(device);
+        sycl::queue queue(device);
         std::cout << "Running on " << nameDevice << "\n\n";
 
         SyclExecutionContext ctx(queue);

--- a/examples/daal/cpp_sycl/source/optimization_solvers/sgd_mini_log_loss_dense_batch.cpp
+++ b/examples/daal/cpp_sycl/source/optimization_solvers/sgd_mini_log_loss_dense_batch.cpp
@@ -56,7 +56,7 @@ int main(int argc, char* argv[]) {
     for (const auto& deviceSelector : getListOfDevices()) {
         const auto& nameDevice = deviceSelector.first;
         const auto& device = deviceSelector.second;
-        cl::sycl::queue queue(device);
+        sycl::queue queue(device);
         std::cout << "Running on " << nameDevice << "\n\n";
         SyclExecutionContext ctx(queue);
         services::Environment::getInstance()->setDefaultExecutionContext(ctx);
@@ -90,8 +90,8 @@ int main(int argc, char* argv[]) {
             logLoss);
 
         /* Set input objects for the the Stochastic gradient descent algorithm */
-        cl::sycl::buffer<float, 1> initialPointBuff(initialPoint,
-                                                    cl::sycl::range<1>(nFeatures + 1));
+        sycl::buffer<float, 1> initialPointBuff(initialPoint,
+                                                    sycl::range<1>(nFeatures + 1));
         sgdAlgorithm.input.set(
             optimization_solver::iterative_solver::inputArgument,
             SyclHomogenNumericTable<>::create(initialPointBuff, 1, nFeatures + 1, &s));

--- a/examples/daal/cpp_sycl/source/pca/pca_cor_dense_batch.cpp
+++ b/examples/daal/cpp_sycl/source/pca/pca_cor_dense_batch.cpp
@@ -46,7 +46,7 @@ int main(int argc, char* argv[]) {
     for (const auto& deviceSelector : getListOfDevices()) {
         const auto& nameDevice = deviceSelector.first;
         const auto& device = deviceSelector.second;
-        cl::sycl::queue queue(device);
+        sycl::queue queue(device);
         std::cout << "Running on " << nameDevice << "\n\n";
 
         SyclExecutionContext ctx(queue);

--- a/examples/daal/cpp_sycl/source/pca/pca_cor_dense_distr.cpp
+++ b/examples/daal/cpp_sycl/source/pca/pca_cor_dense_distr.cpp
@@ -56,7 +56,7 @@ int main(int argc, char* argv[]) {
     for (const auto& deviceSelector : getListOfDevices()) {
         const auto& nameDevice = deviceSelector.first;
         const auto& device = deviceSelector.second;
-        cl::sycl::queue queue(device);
+        sycl::queue queue(device);
         std::cout << "Running on " << nameDevice << "\n\n";
 
         daal::services::SyclExecutionContext ctx(queue);

--- a/examples/daal/cpp_sycl/source/pca/pca_cor_dense_online.cpp
+++ b/examples/daal/cpp_sycl/source/pca/pca_cor_dense_online.cpp
@@ -47,7 +47,7 @@ int main(int argc, char* argv[]) {
     for (const auto& deviceSelector : getListOfDevices()) {
         const auto& nameDevice = deviceSelector.first;
         const auto& device = deviceSelector.second;
-        cl::sycl::queue queue(device);
+        sycl::queue queue(device);
         std::cout << "Running on " << nameDevice << "\n\n";
 
         SyclExecutionContext ctx(queue);

--- a/examples/daal/cpp_sycl/source/pca_transform/pca_transform_dense_batch.cpp
+++ b/examples/daal/cpp_sycl/source/pca_transform/pca_transform_dense_batch.cpp
@@ -48,7 +48,7 @@ int main(int argc, char* argv[]) {
     for (const auto& deviceSelector : getListOfDevices()) {
         const auto& nameDevice = deviceSelector.first;
         const auto& device = deviceSelector.second;
-        cl::sycl::queue queue(device);
+        sycl::queue queue(device);
         std::cout << "Running on " << nameDevice << "\n\n";
 
         SyclExecutionContext ctx(queue);

--- a/examples/daal/cpp_sycl/source/svm/svm_two_class_thunder_csr_batch.cpp
+++ b/examples/daal/cpp_sycl/source/svm/svm_two_class_thunder_csr_batch.cpp
@@ -64,7 +64,7 @@ int main(int argc, char* argv[]) {
         const auto& nameDevice = deviceSelector.first;
         const auto& device = deviceSelector.second;
 
-        cl::sycl::queue queue(device);
+        sycl::queue queue(device);
         std::cout << "Running on " << nameDevice << "\n\n";
 
         SyclExecutionContext ctx(queue);

--- a/examples/daal/cpp_sycl/source/svm/svm_two_class_thunder_dense_batch.cpp
+++ b/examples/daal/cpp_sycl/source/svm/svm_two_class_thunder_dense_batch.cpp
@@ -62,7 +62,7 @@ int main(int argc, char* argv[]) {
         const auto& nameDevice = deviceSelector.first;
         const auto& device = deviceSelector.second;
 
-        cl::sycl::queue queue(device);
+        sycl::queue queue(device);
         std::cout << "Running on " << nameDevice << "\n\n";
 
         SyclExecutionContext ctx(queue);

--- a/examples/daal/cpp_sycl/source/utils/service_sycl.h
+++ b/examples/daal/cpp_sycl/source/utils/service_sycl.h
@@ -27,28 +27,28 @@
 #include <memory>
 
 #include <CL/cl.h>
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 #include "service.h"
 
-std::unique_ptr<cl::sycl::device> makeDevice(int (*selector)(const sycl::device&)) {
+std::unique_ptr<sycl::device> makeDevice(int (*selector)(const sycl::device&)) {
     try {
-        return std::unique_ptr<cl::sycl::device>(new cl::sycl::device(selector));
+        return std::unique_ptr<sycl::device>(new sycl::device(selector));
     }
     catch (...) {
-        return std::unique_ptr<cl::sycl::device>();
+        return std::unique_ptr<sycl::device>();
     }
 }
 
-std::list<std::pair<std::string, cl::sycl::device> > getListOfDevices() {
-    std::list<std::pair<std::string, cl::sycl::device> > selects;
-    std::unique_ptr<cl::sycl::device> device;
+std::list<std::pair<std::string, sycl::device> > getListOfDevices() {
+    std::list<std::pair<std::string, sycl::device> > selects;
+    std::unique_ptr<sycl::device> device;
 
-    device = makeDevice(&cl::sycl::gpu_selector_v);
+    device = makeDevice(&sycl::gpu_selector_v);
     if (device)
         selects.emplace_back("GPU", *device);
 
-    device = makeDevice(&cl::sycl::cpu_selector_v);
+    device = makeDevice(&sycl::cpu_selector_v);
     if (device)
         selects.emplace_back("CPU", *device);
 
@@ -65,10 +65,10 @@ daal::data_management::SyclCSRNumericTablePtr createSyclSparseTable(
     size_t* rowOffsets = nullptr;
     numericTable->getArrays(&data, &colIndices, &rowOffsets);
 
-    auto dataBuff = cl::sycl::buffer<DataType, 1>(data, numericTable->getDataSize());
-    auto colIndicesBuff = cl::sycl::buffer<size_t, 1>(colIndices, numericTable->getDataSize());
+    auto dataBuff = sycl::buffer<DataType, 1>(data, numericTable->getDataSize());
+    auto colIndicesBuff = sycl::buffer<size_t, 1>(colIndices, numericTable->getDataSize());
     auto rowOffsetsBuff =
-        cl::sycl::buffer<size_t, 1>(rowOffsets, numericTable->getNumberOfRows() + 1);
+        sycl::buffer<size_t, 1>(rowOffsets, numericTable->getNumberOfRows() + 1);
 
     auto syclNumericTable = daal::data_management::SyclCSRNumericTable::create<DataType>(
         dataBuff,

--- a/examples/oneapi/dpc/source/basic_statistics/basic_statistics_dense_batch.cpp
+++ b/examples/oneapi/dpc/source/basic_statistics/basic_statistics_dense_batch.cpp
@@ -14,7 +14,7 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 #ifndef ONEDAL_DATA_PARALLEL
 #define ONEDAL_DATA_PARALLEL

--- a/examples/oneapi/dpc/source/covariance/cor_dense_batch.cpp
+++ b/examples/oneapi/dpc/source/covariance/cor_dense_batch.cpp
@@ -14,7 +14,7 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 #ifndef ONEDAL_DATA_PARALLEL
 #define ONEDAL_DATA_PARALLEL

--- a/examples/oneapi/dpc/source/covariance/cov_dense_batch.cpp
+++ b/examples/oneapi/dpc/source/covariance/cov_dense_batch.cpp
@@ -14,7 +14,7 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 #ifndef ONEDAL_DATA_PARALLEL
 #define ONEDAL_DATA_PARALLEL

--- a/examples/oneapi/dpc/source/dbscan/dbscan_brute_force_batch.cpp
+++ b/examples/oneapi/dpc/source/dbscan/dbscan_brute_force_batch.cpp
@@ -14,7 +14,7 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iomanip>
 #include <iostream>
 

--- a/examples/oneapi/dpc/source/example_util/dpc_helpers.hpp
+++ b/examples/oneapi/dpc/source/example_util/dpc_helpers.hpp
@@ -17,7 +17,7 @@
 #pragma once
 
 #include <vector>
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 void try_add_device(std::vector<sycl::device>& devices, int (*selector)(const sycl::device&)) {
     try {

--- a/examples/oneapi/dpc/source/kmeans/kmeans_lloyd_dense_batch.cpp
+++ b/examples/oneapi/dpc/source/kmeans/kmeans_lloyd_dense_batch.cpp
@@ -14,7 +14,7 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iomanip>
 #include <iostream>
 

--- a/examples/oneapi/dpc/source/kmeans_init/kmeans_init_dense.cpp
+++ b/examples/oneapi/dpc/source/kmeans_init/kmeans_init_dense.cpp
@@ -14,7 +14,7 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iomanip>
 #include <iostream>
 

--- a/examples/oneapi/dpc/source/linear_kernel/linear_kernel_dense_batch.cpp
+++ b/examples/oneapi/dpc/source/linear_kernel/linear_kernel_dense_batch.cpp
@@ -14,7 +14,7 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 #ifndef ONEDAL_DATA_PARALLEL
 #define ONEDAL_DATA_PARALLEL

--- a/examples/oneapi/dpc/source/pca/pca_cor_dense_batch.cpp
+++ b/examples/oneapi/dpc/source/pca/pca_cor_dense_batch.cpp
@@ -16,7 +16,7 @@
 
 #include <iomanip>
 #include <iostream>
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 #ifndef ONEDAL_DATA_PARALLEL
 #define ONEDAL_DATA_PARALLEL

--- a/examples/oneapi/dpc/source/pca/pca_precomputed_cor_dense_batch.cpp
+++ b/examples/oneapi/dpc/source/pca/pca_precomputed_cor_dense_batch.cpp
@@ -16,7 +16,7 @@
 
 #include <iomanip>
 #include <iostream>
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 #ifndef ONEDAL_DATA_PARALLEL
 #define ONEDAL_DATA_PARALLEL

--- a/examples/oneapi/dpc/source/pca/pca_precomputed_cov_dense_batch.cpp
+++ b/examples/oneapi/dpc/source/pca/pca_precomputed_cov_dense_batch.cpp
@@ -16,7 +16,7 @@
 
 #include <iomanip>
 #include <iostream>
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 #ifndef ONEDAL_DATA_PARALLEL
 #define ONEDAL_DATA_PARALLEL

--- a/examples/oneapi/dpc/source/rbf_kernel/rbf_kernel_dense_batch.cpp
+++ b/examples/oneapi/dpc/source/rbf_kernel/rbf_kernel_dense_batch.cpp
@@ -14,7 +14,7 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 #ifndef ONEDAL_DATA_PARALLEL
 #define ONEDAL_DATA_PARALLEL

--- a/examples/oneapi/dpc/source/svm/svm_two_class_thunder_dense_batch.cpp
+++ b/examples/oneapi/dpc/source/svm/svm_two_class_thunder_dense_batch.cpp
@@ -14,7 +14,7 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 #ifndef ONEDAL_DATA_PARALLEL
 #define ONEDAL_DATA_PARALLEL

--- a/examples/oneapi/dpc/source/table/column_accessor_homogen.cpp
+++ b/examples/oneapi/dpc/source/table/column_accessor_homogen.cpp
@@ -14,7 +14,7 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iostream>
 
 #ifndef ONEDAL_DATA_PARALLEL

--- a/samples/daal/cpp/oneccl/sources/covariance_dense_batch_distributed_oneccl.cpp
+++ b/samples/daal/cpp/oneccl/sources/covariance_dense_batch_distributed_oneccl.cpp
@@ -118,7 +118,7 @@ int main(int argc, char *argv[]) {
     auto local_rank = getLocalRank(comm, size, rank);
     auto gpus = get_gpus();
     auto rank_gpu = gpus[local_rank % gpus.size()];
-    cl::sycl::queue queue(rank_gpu);
+    sycl::queue queue(rank_gpu);
     daal::services::SyclExecutionContext ctx(queue);
     services::Environment::getInstance()->setDefaultExecutionContext(ctx);
 

--- a/samples/daal/cpp/oneccl/sources/covariance_dense_online_distributed_oneccl.cpp
+++ b/samples/daal/cpp/oneccl/sources/covariance_dense_online_distributed_oneccl.cpp
@@ -121,7 +121,7 @@ int main(int argc, char *argv[]) {
     auto local_rank = getLocalRank(comm, size, rank);
     auto gpus = get_gpus();
     auto rank_gpu = gpus[local_rank % gpus.size()];
-    cl::sycl::queue queue(rank_gpu);
+    sycl::queue queue(rank_gpu);
     daal::services::SyclExecutionContext ctx(queue);
     services::Environment::getInstance()->setDefaultExecutionContext(ctx);
 

--- a/samples/daal/cpp/oneccl/sources/kmeans_dense_distributed_oneccl.cpp
+++ b/samples/daal/cpp/oneccl/sources/kmeans_dense_distributed_oneccl.cpp
@@ -121,7 +121,7 @@ int main(int argc, char *argv[]) {
     auto local_rank = getLocalRank(comm, size, rank);
     auto gpus = get_gpus();
     auto rank_gpu = gpus[local_rank % gpus.size()];
-    cl::sycl::queue queue(rank_gpu);
+    sycl::queue queue(rank_gpu);
     daal::services::SyclExecutionContext ctx(queue);
     services::Environment::getInstance()->setDefaultExecutionContext(ctx);
 

--- a/samples/daal/cpp/oneccl/sources/low_order_moments_dense_batch_distributed_oneccl.cpp
+++ b/samples/daal/cpp/oneccl/sources/low_order_moments_dense_batch_distributed_oneccl.cpp
@@ -127,7 +127,7 @@ int main(int argc, char *argv[]) {
     auto gpus = get_gpus();
 
     auto rank_gpu = gpus[local_rank % gpus.size()];
-    cl::sycl::queue queue(rank_gpu);
+    sycl::queue queue(rank_gpu);
     daal::services::SyclExecutionContext ctx(queue);
     services::Environment::getInstance()->setDefaultExecutionContext(ctx);
 

--- a/samples/daal/cpp/oneccl/sources/low_order_moments_dense_online_distributed_oneccl.cpp
+++ b/samples/daal/cpp/oneccl/sources/low_order_moments_dense_online_distributed_oneccl.cpp
@@ -126,7 +126,7 @@ int main(int argc, char *argv[]) {
     auto gpus = get_gpus();
 
     auto rank_gpu = gpus[local_rank % gpus.size()];
-    cl::sycl::queue queue(rank_gpu);
+    sycl::queue queue(rank_gpu);
     daal::services::SyclExecutionContext ctx(queue);
     services::Environment::getInstance()->setDefaultExecutionContext(ctx);
 

--- a/samples/daal/cpp/oneccl/sources/pca_dense_batch_distributed_oneccl.cpp
+++ b/samples/daal/cpp/oneccl/sources/pca_dense_batch_distributed_oneccl.cpp
@@ -115,7 +115,7 @@ int main(int argc, char *argv[]) {
     auto local_rank = getLocalRank(comm, size, rank);
     auto gpus = get_gpus();
     auto rank_gpu = gpus[local_rank % gpus.size()];
-    cl::sycl::queue queue(rank_gpu);
+    sycl::queue queue(rank_gpu);
     daal::services::SyclExecutionContext ctx(queue);
     services::Environment::getInstance()->setDefaultExecutionContext(ctx);
 

--- a/samples/daal/cpp/oneccl/sources/pca_dense_online_distributed_oneccl.cpp
+++ b/samples/daal/cpp/oneccl/sources/pca_dense_online_distributed_oneccl.cpp
@@ -116,7 +116,7 @@ int main(int argc, char *argv[]) {
     auto local_rank = getLocalRank(comm, size, rank);
     auto gpus = get_gpus();
     auto rank_gpu = gpus[local_rank % gpus.size()];
-    cl::sycl::queue queue(rank_gpu);
+    sycl::queue queue(rank_gpu);
     daal::services::SyclExecutionContext ctx(queue);
     services::Environment::getInstance()->setDefaultExecutionContext(ctx);
 

--- a/samples/daal/cpp/oneccl/sources/service_sycl.h
+++ b/samples/daal/cpp/oneccl/sources/service_sycl.h
@@ -27,7 +27,7 @@
 #include <memory>
 
 #include <CL/cl.h>
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 #include "service.h"
 

--- a/samples/oneapi/dpc/ccl/sources/basic_statistics_distr_ccl.cpp
+++ b/samples/oneapi/dpc/ccl/sources/basic_statistics_distr_ccl.cpp
@@ -14,7 +14,7 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iomanip>
 #include <iostream>
 

--- a/samples/oneapi/dpc/ccl/sources/comm_helpers.hpp
+++ b/samples/oneapi/dpc/ccl/sources/comm_helpers.hpp
@@ -18,7 +18,7 @@
 
 #ifdef ONEDAL_DATA_PARALLEL
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include "oneapi/dal/table/row_accessor.hpp"
 
 template <typename Comm, typename D = float>

--- a/samples/oneapi/dpc/ccl/sources/cor_distr_ccl.cpp
+++ b/samples/oneapi/dpc/ccl/sources/cor_distr_ccl.cpp
@@ -14,7 +14,7 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iomanip>
 #include <iostream>
 #include <mpi.h>

--- a/samples/oneapi/dpc/ccl/sources/cov_distr_ccl.cpp
+++ b/samples/oneapi/dpc/ccl/sources/cov_distr_ccl.cpp
@@ -14,7 +14,7 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iomanip>
 #include <iostream>
 #include <mpi.h>

--- a/samples/oneapi/dpc/ccl/sources/dbscan_distr_ccl.cpp
+++ b/samples/oneapi/dpc/ccl/sources/dbscan_distr_ccl.cpp
@@ -14,7 +14,7 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iomanip>
 #include <iostream>
 

--- a/samples/oneapi/dpc/ccl/sources/decision_forest_cls_hist_distr_ccl.cpp
+++ b/samples/oneapi/dpc/ccl/sources/decision_forest_cls_hist_distr_ccl.cpp
@@ -14,7 +14,7 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iomanip>
 #include <iostream>
 

--- a/samples/oneapi/dpc/ccl/sources/decision_forest_reg_hist_distr_ccl.cpp
+++ b/samples/oneapi/dpc/ccl/sources/decision_forest_reg_hist_distr_ccl.cpp
@@ -14,7 +14,7 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iomanip>
 #include <iostream>
 

--- a/samples/oneapi/dpc/ccl/sources/input_helpers.hpp
+++ b/samples/oneapi/dpc/ccl/sources/input_helpers.hpp
@@ -20,7 +20,7 @@
 #include <string>
 #include <fstream>
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include "oneapi/dal/table/row_accessor.hpp"
 
 namespace dal = oneapi::dal;

--- a/samples/oneapi/dpc/ccl/sources/kmeans_distr_ccl.cpp
+++ b/samples/oneapi/dpc/ccl/sources/kmeans_distr_ccl.cpp
@@ -14,7 +14,7 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iomanip>
 #include <iostream>
 

--- a/samples/oneapi/dpc/ccl/sources/linear_regression_distr_ccl.cpp
+++ b/samples/oneapi/dpc/ccl/sources/linear_regression_distr_ccl.cpp
@@ -14,7 +14,7 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iomanip>
 #include <iostream>
 

--- a/samples/oneapi/dpc/ccl/sources/pca_distr_ccl.cpp
+++ b/samples/oneapi/dpc/ccl/sources/pca_distr_ccl.cpp
@@ -14,7 +14,7 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iomanip>
 #include <iostream>
 #include <mpi.h>

--- a/samples/oneapi/dpc/mpi/sources/basic_statistics_distr_mpi.cpp
+++ b/samples/oneapi/dpc/mpi/sources/basic_statistics_distr_mpi.cpp
@@ -14,7 +14,7 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iomanip>
 #include <iostream>
 

--- a/samples/oneapi/dpc/mpi/sources/comm_helpers.hpp
+++ b/samples/oneapi/dpc/mpi/sources/comm_helpers.hpp
@@ -18,7 +18,7 @@
 
 #ifdef ONEDAL_DATA_PARALLEL
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include "oneapi/dal/table/row_accessor.hpp"
 
 template <typename Comm, typename D = float>

--- a/samples/oneapi/dpc/mpi/sources/cor_distr_mpi.cpp
+++ b/samples/oneapi/dpc/mpi/sources/cor_distr_mpi.cpp
@@ -14,7 +14,7 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iomanip>
 #include <iostream>
 #include <mpi.h>

--- a/samples/oneapi/dpc/mpi/sources/cov_distr_mpi.cpp
+++ b/samples/oneapi/dpc/mpi/sources/cov_distr_mpi.cpp
@@ -14,7 +14,7 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iomanip>
 #include <iostream>
 #include <mpi.h>

--- a/samples/oneapi/dpc/mpi/sources/dbscan_distr_mpi.cpp
+++ b/samples/oneapi/dpc/mpi/sources/dbscan_distr_mpi.cpp
@@ -14,7 +14,7 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iomanip>
 #include <iostream>
 

--- a/samples/oneapi/dpc/mpi/sources/decision_forest_cls_hist_distr_mpi.cpp
+++ b/samples/oneapi/dpc/mpi/sources/decision_forest_cls_hist_distr_mpi.cpp
@@ -14,7 +14,7 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iomanip>
 #include <iostream>
 

--- a/samples/oneapi/dpc/mpi/sources/decision_forest_reg_hist_distr_mpi.cpp
+++ b/samples/oneapi/dpc/mpi/sources/decision_forest_reg_hist_distr_mpi.cpp
@@ -14,7 +14,7 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iomanip>
 #include <iostream>
 

--- a/samples/oneapi/dpc/mpi/sources/input_helpers.hpp
+++ b/samples/oneapi/dpc/mpi/sources/input_helpers.hpp
@@ -20,7 +20,7 @@
 #include <string>
 #include <fstream>
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include "oneapi/dal/table/row_accessor.hpp"
 
 namespace dal = oneapi::dal;

--- a/samples/oneapi/dpc/mpi/sources/kmeans_distr_mpi.cpp
+++ b/samples/oneapi/dpc/mpi/sources/kmeans_distr_mpi.cpp
@@ -14,7 +14,7 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iomanip>
 #include <iostream>
 

--- a/samples/oneapi/dpc/mpi/sources/linear_regression_distr_mpi.cpp
+++ b/samples/oneapi/dpc/mpi/sources/linear_regression_distr_mpi.cpp
@@ -14,7 +14,7 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iomanip>
 #include <iostream>
 

--- a/samples/oneapi/dpc/mpi/sources/pca_distr_mpi.cpp
+++ b/samples/oneapi/dpc/mpi/sources/pca_distr_mpi.cpp
@@ -14,7 +14,7 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iomanip>
 #include <iostream>
 #include <mpi.h>


### PR DESCRIPTION
The cl::sycl namespace is depreciated for the SYCL2020 specification.  This update moves most of the code to the sycl namespace, except where explicitly required to avoid namespace collision (namely in defining daal::services::internal). In that case it enforces the root using ::sycl. 