### PR TITLE
Less strict input check for linear models

### DIFF
--- a/cpp/daal/src/algorithms/linear_regression/linear_regression_training_input.cpp
+++ b/cpp/daal/src/algorithms/linear_regression/linear_regression_training_input.cpp
@@ -88,14 +88,9 @@ services::Status Input::check(const daal::algorithms::Parameter * par, int metho
     NumericTablePtr dataTable = get(data);
     size_t nRowsInData        = dataTable->getNumberOfRows();
     size_t nColumnsInData     = dataTable->getNumberOfColumns();
-    if (method == normEqDense)
-    {
-        DAAL_CHECK(nRowsInData >= nColumnsInData, ErrorIncorrectNumberOfRows);
-    }
-    else
-    {
-        DAAL_CHECK(nRowsInData > 0, ErrorIncorrectNumberOfRows);
-    }
+
+    DAAL_CHECK(nRowsInData > 0, ErrorIncorrectNumberOfObservations);
+    DAAL_CHECK(nColumnsInData > 0, ErrorIncorrectNumberOfFeatures);
     return s;
 }
 

--- a/cpp/daal/src/algorithms/ridge_regression/ridge_regression_training_input.cpp
+++ b/cpp/daal/src/algorithms/ridge_regression/ridge_regression_training_input.cpp
@@ -93,7 +93,8 @@ services::Status Input::check(const daal::algorithms::Parameter * par, int metho
     size_t nRowsInData              = dataTable->getNumberOfRows();
     size_t nColumnsInData           = dataTable->getNumberOfColumns();
 
-    DAAL_CHECK(nRowsInData >= nColumnsInData, ErrorIncorrectNumberOfObservations);
+    DAAL_CHECK(nRowsInData > 0, ErrorIncorrectNumberOfObservations);
+    DAAL_CHECK(nColumnsInData > 0, ErrorIncorrectNumberOfFeatures);
 
     const NumericTablePtr dependentVariableTable = get(dependentVariables);
     const size_t nColumnsInDepVariable           = dependentVariableTable->getNumberOfColumns();


### PR DESCRIPTION
# Description
Ridge and linear regressions in batch/online mode might work for some cases where n_samples < n_features and especially for online mode where total n_samples > n_features.
According to that, input check should be less strict to allow users compute linear models for these cases.
Solves https://github.com/intel/scikit-learn-intelex/issues/1025