### PR TITLE
Intel_LLVM compiler macros

### DIFF
--- a/cpp/daal/include/services/daal_defines.h
+++ b/cpp/daal/include/services/daal_defines.h
@@ -28,6 +28,10 @@
 
 #include <cstddef> // for size_t
 
+#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
+    #define DAAL_INTEL_CPP_COMPILER
+#endif
+
 #if !(defined(_MSC_VER) || defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER))
     #define __int32 int
     #define __int64 long long int

--- a/cpp/daal/include/services/daal_defines.h
+++ b/cpp/daal/include/services/daal_defines.h
@@ -50,7 +50,7 @@
 #endif
 
 /* Intel(R) oneDAL 64-bit integer types */
-#if (!defined(__INTEL_COMPILER)|| !defined(__INTEL_LLVM_COMPILER)) & defined(_MSC_VER)
+#if (!defined(__INTEL_COMPILER) || !defined(__INTEL_LLVM_COMPILER)) & defined(_MSC_VER)
     #define DAAL_INT64  __int64
     #define DAAL_UINT64 unsigned __int64
 #else

--- a/cpp/daal/include/services/daal_defines.h
+++ b/cpp/daal/include/services/daal_defines.h
@@ -28,7 +28,7 @@
 
 #include <cstddef> // for size_t
 
-#if !(defined(_MSC_VER) || defined(__INTEL_COMPILER))
+#if !(defined(_MSC_VER) || defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER))
     #define __int32 int
     #define __int64 long long int
 #endif
@@ -50,7 +50,7 @@
 #endif
 
 /* Intel(R) oneDAL 64-bit integer types */
-#if (!defined(__INTEL_COMPILER)) & defined(_MSC_VER)
+#if (!defined(__INTEL_COMPILER)|| !defined(__INTEL_LLVM_COMPILER)) & defined(_MSC_VER)
     #define DAAL_INT64  __int64
     #define DAAL_UINT64 unsigned __int64
 #else

--- a/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_predict_dense_default_batch_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_predict_dense_default_batch_impl.i
@@ -438,7 +438,7 @@ void PredictClassificationTask<algorithmFPType, cpu>::predictByTree(const algori
     predictByTreeCommon(x, sizeOfBlock, nCols, tFI, tLC, tFV, prob, iTree);
 }
 
-#if defined(__INTEL_COMPILER)
+#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
 
 template <>
 void PredictClassificationTask<float, avx512>::predictByTree(const float * const x, const size_t sizeOfBlock, const size_t nCols,
@@ -694,7 +694,7 @@ Status PredictClassificationTask<algorithmFPType, cpu>::predictOneRowByAllTrees(
     return safeStat.detach();
 }
 
-#if defined(__INTEL_COMPILER)
+#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
 template <>
 Status PredictClassificationTask<float, avx512>::predictOneRowByAllTrees(size_t nTreesTotal)
 {

--- a/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_predict_dense_default_batch_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_predict_dense_default_batch_impl.i
@@ -438,7 +438,7 @@ void PredictClassificationTask<algorithmFPType, cpu>::predictByTree(const algori
     predictByTreeCommon(x, sizeOfBlock, nCols, tFI, tLC, tFV, prob, iTree);
 }
 
-#if defined(DAAL_INTEL_CPP_COMPILER)
+#if defined(__AVX512F__) && defined(DAAL_INTEL_CPP_COMPILER)
 
 template <>
 void PredictClassificationTask<float, avx512>::predictByTree(const float * const x, const size_t sizeOfBlock, const size_t nCols,
@@ -694,7 +694,7 @@ Status PredictClassificationTask<algorithmFPType, cpu>::predictOneRowByAllTrees(
     return safeStat.detach();
 }
 
-#if defined(DAAL_INTEL_CPP_COMPILER)
+#if defined(__AVX512F__) && defined(DAAL_INTEL_CPP_COMPILER)
 template <>
 Status PredictClassificationTask<float, avx512>::predictOneRowByAllTrees(size_t nTreesTotal)
 {

--- a/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_predict_dense_default_batch_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_predict_dense_default_batch_impl.i
@@ -438,7 +438,7 @@ void PredictClassificationTask<algorithmFPType, cpu>::predictByTree(const algori
     predictByTreeCommon(x, sizeOfBlock, nCols, tFI, tLC, tFV, prob, iTree);
 }
 
-#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
+#if defined(DAAL_INTEL_CPP_COMPILER)
 
 template <>
 void PredictClassificationTask<float, avx512>::predictByTree(const float * const x, const size_t sizeOfBlock, const size_t nCols,
@@ -694,7 +694,7 @@ Status PredictClassificationTask<algorithmFPType, cpu>::predictOneRowByAllTrees(
     return safeStat.detach();
 }
 
-#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
+#if defined(DAAL_INTEL_CPP_COMPILER)
 template <>
 Status PredictClassificationTask<float, avx512>::predictOneRowByAllTrees(size_t nTreesTotal)
 {

--- a/cpp/daal/src/algorithms/dtrees/gbt/gbt_train_hist_kernel.i
+++ b/cpp/daal/src/algorithms/dtrees/gbt/gbt_train_hist_kernel.i
@@ -25,7 +25,7 @@
 #ifndef __GBT_TRAIN_SPLIT_HIST_KERNEL_I__
 #define __GBT_TRAIN_SPLIT_HIST_KERNEL_I__
 
-#if defined(__INTEL_COMPILER)
+#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
     #include <immintrin.h>
 #endif
 
@@ -307,7 +307,7 @@ struct MergeGHSums
     }
 };
 
-#if defined(__INTEL_COMPILER)
+#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
     #if __CPUID__(DAAL_CPU) >= __sse42__
         #define SSE42_ALL DAAL_CPU
     #else

--- a/cpp/daal/src/algorithms/dtrees/gbt/gbt_train_hist_kernel.i
+++ b/cpp/daal/src/algorithms/dtrees/gbt/gbt_train_hist_kernel.i
@@ -25,7 +25,7 @@
 #ifndef __GBT_TRAIN_SPLIT_HIST_KERNEL_I__
 #define __GBT_TRAIN_SPLIT_HIST_KERNEL_I__
 
-#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
+#if defined(DAAL_INTEL_CPP_COMPILER)
     #include <immintrin.h>
 #endif
 
@@ -307,7 +307,7 @@ struct MergeGHSums
     }
 };
 
-#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
+#if defined(DAAL_INTEL_CPP_COMPILER)
     #if __CPUID__(DAAL_CPU) >= __sse42__
         #define SSE42_ALL DAAL_CPU
     #else

--- a/cpp/daal/src/algorithms/k_nearest_neighbors/kdtree_knn_classification_train_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/k_nearest_neighbors/kdtree_knn_classification_train_dense_default_impl.i
@@ -39,7 +39,7 @@
 #include "src/algorithms/k_nearest_neighbors/kdtree_knn_impl.i"
 #include "src/algorithms/engines/engine_batch_impl.h"
 
-#if defined(__INTEL_COMPILER_BUILD_DATE)
+#if defined(__INTEL_COMPILER_BUILD_DATE) || defined(__INTEL_LLVM_COMPILER)
     #include <immintrin.h>
 #endif
 
@@ -610,7 +610,7 @@ size_t KNNClassificationTrainBatchKernel<algorithmFpType, training::defaultDense
                                                                                                         size_t subSampleCount16,
                                                                                                         algorithmFpType value)
 {
-#if (__CPUID__(DAAL_CPU) >= __avx__) && (__FPTYPE__(DAAL_FPTYPE) == __float__) && defined(__INTEL_COMPILER_BUILD_DATE)
+#if (__CPUID__(DAAL_CPU) >= __avx__) && (__FPTYPE__(DAAL_FPTYPE) == __float__) && (defined(__INTEL_COMPILER_BUILD_DATE)|| defined(__INTEL_LLVM_COMPILER))
 
     __m256 vValue = _mm256_set1_ps(value);
     size_t k      = 0;
@@ -653,7 +653,7 @@ size_t KNNClassificationTrainBatchKernel<algorithmFpType, training::defaultDense
 
     return i;
 
-#else // #if (__CPUID__(DAAL_CPU) >= __avx__) && (__FPTYPE__(DAAL_FPTYPE) == __float__) && defined(__INTEL_COMPILER_BUILD_DATE)
+#else // #if (__CPUID__(DAAL_CPU) >= __avx__) && (__FPTYPE__(DAAL_FPTYPE) == __float__) && (defined(__INTEL_COMPILER_BUILD_DATE)|| defined(__INTEL_LLVM_COMPILER))
 
     size_t k = 0;
     for (; k < subSampleCount; ++k)
@@ -676,7 +676,7 @@ size_t KNNClassificationTrainBatchKernel<algorithmFpType, training::defaultDense
     }
     return i;
 
-#endif // #if (__CPUID__(DAAL_CPU) >= __avx__) && (__FPTYPE__(DAAL_FPTYPE) == __float__) && defined(__INTEL_COMPILER_BUILD_DATE)
+#endif // #if (__CPUID__(DAAL_CPU) >= __avx__) && (__FPTYPE__(DAAL_FPTYPE) == __float__) && (defined(__INTEL_COMPILER_BUILD_DATE)|| defined(__INTEL_LLVM_COMPILER))
 }
 
 template <CpuType cpu, typename ForwardIterator1, typename ForwardIterator2>

--- a/cpp/daal/src/algorithms/k_nearest_neighbors/kdtree_knn_classification_train_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/k_nearest_neighbors/kdtree_knn_classification_train_dense_default_impl.i
@@ -610,8 +610,7 @@ size_t KNNClassificationTrainBatchKernel<algorithmFpType, training::defaultDense
                                                                                                         size_t subSampleCount16,
                                                                                                         algorithmFpType value)
 {
-#if (__CPUID__(DAAL_CPU) >= __avx__) && (__FPTYPE__(DAAL_FPTYPE) == __float__) \
-    && (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) \
+#if (__CPUID__(DAAL_CPU) >= __avx__) && (__FPTYPE__(DAAL_FPTYPE) == __float__) && (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) \
     && !defined(SYCL_LANGUAGE_VERSION)
 
     __m256 vValue = _mm256_set1_ps(value);

--- a/cpp/daal/src/algorithms/k_nearest_neighbors/kdtree_knn_classification_train_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/k_nearest_neighbors/kdtree_knn_classification_train_dense_default_impl.i
@@ -39,7 +39,7 @@
 #include "src/algorithms/k_nearest_neighbors/kdtree_knn_impl.i"
 #include "src/algorithms/engines/engine_batch_impl.h"
 
-#if defined(__INTEL_COMPILER_BUILD_DATE) || defined(__INTEL_LLVM_COMPILER)
+#if defined(DAAL_INTEL_CPP_COMPILER)
     #include <immintrin.h>
 #endif
 
@@ -610,8 +610,7 @@ size_t KNNClassificationTrainBatchKernel<algorithmFpType, training::defaultDense
                                                                                                         size_t subSampleCount16,
                                                                                                         algorithmFpType value)
 {
-#if (__CPUID__(DAAL_CPU) >= __avx__) && (__FPTYPE__(DAAL_FPTYPE) == __float__) && (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) \
-    && !defined(SYCL_LANGUAGE_VERSION)
+#if (__CPUID__(DAAL_CPU) >= __avx__) && (__FPTYPE__(DAAL_FPTYPE) == __float__) && defined(DAAL_INTEL_CPP_COMPILER)
 
     __m256 vValue = _mm256_set1_ps(value);
     size_t k      = 0;
@@ -654,7 +653,7 @@ size_t KNNClassificationTrainBatchKernel<algorithmFpType, training::defaultDense
 
     return i;
 
-#else // #if (__CPUID__(DAAL_CPU) >= __avx__) && (__FPTYPE__(DAAL_FPTYPE) == __float__) && (defined(__INTEL_COMPILER_BUILD_DATE)|| defined(__INTEL_LLVM_COMPILER))
+#else // #if (__CPUID__(DAAL_CPU) >= __avx__) && (__FPTYPE__(DAAL_FPTYPE) == __float__) && defined(DAAL_INTEL_CPP_COMPILER)
 
     size_t k = 0;
     for (; k < subSampleCount; ++k)
@@ -677,7 +676,7 @@ size_t KNNClassificationTrainBatchKernel<algorithmFpType, training::defaultDense
     }
     return i;
 
-#endif // #if (__CPUID__(DAAL_CPU) >= __avx__) && (__FPTYPE__(DAAL_FPTYPE) == __float__) && (defined(__INTEL_COMPILER_BUILD_DATE)|| defined(__INTEL_LLVM_COMPILER))
+#endif // #if (__CPUID__(DAAL_CPU) >= __avx__) && (__FPTYPE__(DAAL_FPTYPE) == __float__) && defined(DAAL_INTEL_CPP_COMPILER)
 }
 
 template <CpuType cpu, typename ForwardIterator1, typename ForwardIterator2>

--- a/cpp/daal/src/algorithms/k_nearest_neighbors/kdtree_knn_classification_train_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/k_nearest_neighbors/kdtree_knn_classification_train_dense_default_impl.i
@@ -611,7 +611,8 @@ size_t KNNClassificationTrainBatchKernel<algorithmFpType, training::defaultDense
                                                                                                         algorithmFpType value)
 {
 #if (__CPUID__(DAAL_CPU) >= __avx__) && (__FPTYPE__(DAAL_FPTYPE) == __float__) \
-    && (defined(__INTEL_COMPILER_BUILD_DATE) || defined(__INTEL_LLVM_COMPILER))
+    && (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) \
+    && !defined(SYCL_LANGUAGE_VERSION)
 
     __m256 vValue = _mm256_set1_ps(value);
     size_t k      = 0;

--- a/cpp/daal/src/algorithms/k_nearest_neighbors/kdtree_knn_classification_train_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/k_nearest_neighbors/kdtree_knn_classification_train_dense_default_impl.i
@@ -610,7 +610,8 @@ size_t KNNClassificationTrainBatchKernel<algorithmFpType, training::defaultDense
                                                                                                         size_t subSampleCount16,
                                                                                                         algorithmFpType value)
 {
-#if (__CPUID__(DAAL_CPU) >= __avx__) && (__FPTYPE__(DAAL_FPTYPE) == __float__) && (defined(__INTEL_COMPILER_BUILD_DATE)|| defined(__INTEL_LLVM_COMPILER))
+#if (__CPUID__(DAAL_CPU) >= __avx__) && (__FPTYPE__(DAAL_FPTYPE) == __float__) \
+    && (defined(__INTEL_COMPILER_BUILD_DATE) || defined(__INTEL_LLVM_COMPILER))
 
     __m256 vValue = _mm256_set1_ps(value);
     size_t k      = 0;

--- a/cpp/daal/src/algorithms/k_nearest_neighbors/kdtree_knn_impl.i
+++ b/cpp/daal/src/algorithms/k_nearest_neighbors/kdtree_knn_impl.i
@@ -24,7 +24,7 @@
 #ifndef __KDTREE_KNN_IMPL_I__
 #define __KDTREE_KNN_IMPL_I__
 
-#if defined(_MSC_VER) || defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
+#if defined(_MSC_VER) || defined(DAAL_INTEL_CPP_COMPILER)
     #include <immintrin.h>
 #endif
 

--- a/cpp/daal/src/algorithms/k_nearest_neighbors/kdtree_knn_impl.i
+++ b/cpp/daal/src/algorithms/k_nearest_neighbors/kdtree_knn_impl.i
@@ -24,7 +24,7 @@
 #ifndef __KDTREE_KNN_IMPL_I__
 #define __KDTREE_KNN_IMPL_I__
 
-#if defined(_MSC_VER) || defined(__INTEL_COMPILER)
+#if defined(_MSC_VER) || defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
     #include <immintrin.h>
 #endif
 

--- a/cpp/daal/src/algorithms/kernel_function/kernel_function_csr_impl.i
+++ b/cpp/daal/src/algorithms/kernel_function/kernel_function_csr_impl.i
@@ -74,7 +74,7 @@ algorithmFPType KernelCSRImplBase<algorithmFPType, cpu>::computeDotProduct(const
     return computeDotProductBaseline<algorithmFPType, cpu>(startIndexA, endIndexA, valuesA, indicesA, startIndexB, endIndexB, valuesB, indicesB);
 }
 
-#if defined(DAAL_INTEL_CPP_COMPILER)
+#if defined(__AVX512F__) && defined(DAAL_INTEL_CPP_COMPILER)
 
     #undef __DAAL_IA32e
 

--- a/cpp/daal/src/algorithms/kernel_function/kernel_function_csr_impl.i
+++ b/cpp/daal/src/algorithms/kernel_function/kernel_function_csr_impl.i
@@ -24,7 +24,7 @@
 #ifndef __KERNEL_FUNCTION_CSR_IMPL_I__
 #define __KERNEL_FUNCTION_CSR_IMPL_I__
 
-#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
+#if defined(DAAL_INTEL_CPP_COMPILER)
     #include <immintrin.h>
 #endif
 
@@ -74,7 +74,7 @@ algorithmFPType KernelCSRImplBase<algorithmFPType, cpu>::computeDotProduct(const
     return computeDotProductBaseline<algorithmFPType, cpu>(startIndexA, endIndexA, valuesA, indicesA, startIndexB, endIndexB, valuesB, indicesB);
 }
 
-#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
+#if defined(DAAL_INTEL_CPP_COMPILER)
 
     #undef __DAAL_IA32e
 

--- a/cpp/daal/src/algorithms/kernel_function/kernel_function_csr_impl.i
+++ b/cpp/daal/src/algorithms/kernel_function/kernel_function_csr_impl.i
@@ -24,7 +24,7 @@
 #ifndef __KERNEL_FUNCTION_CSR_IMPL_I__
 #define __KERNEL_FUNCTION_CSR_IMPL_I__
 
-#if defined(__INTEL_COMPILER)
+#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
     #include <immintrin.h>
 #endif
 
@@ -74,7 +74,7 @@ algorithmFPType KernelCSRImplBase<algorithmFPType, cpu>::computeDotProduct(const
     return computeDotProductBaseline<algorithmFPType, cpu>(startIndexA, endIndexA, valuesA, indicesA, startIndexB, endIndexB, valuesB, indicesB);
 }
 
-#if defined(__INTEL_COMPILER)
+#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
 
     #undef __DAAL_IA32e
 

--- a/cpp/daal/src/algorithms/kernel_function/kernel_function_csr_impl.i
+++ b/cpp/daal/src/algorithms/kernel_function/kernel_function_csr_impl.i
@@ -24,7 +24,7 @@
 #ifndef __KERNEL_FUNCTION_CSR_IMPL_I__
 #define __KERNEL_FUNCTION_CSR_IMPL_I__
 
-#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
+#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
     #include <immintrin.h>
 #endif
 
@@ -74,7 +74,7 @@ algorithmFPType KernelCSRImplBase<algorithmFPType, cpu>::computeDotProduct(const
     return computeDotProductBaseline<algorithmFPType, cpu>(startIndexA, endIndexA, valuesA, indicesA, startIndexB, endIndexB, valuesB, indicesB);
 }
 
-#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
+#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
 
     #undef __DAAL_IA32e
 

--- a/cpp/daal/src/algorithms/kernel_function/kernel_function_rbf_helper.h
+++ b/cpp/daal/src/algorithms/kernel_function/kernel_function_rbf_helper.h
@@ -88,7 +88,7 @@ services::Status HelperKernelRBF<algorithmFPType, cpu>::postGemmPart(algorithmFP
     return services::Status();
 }
 
-#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
+#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
 
 template <>
 services::Status HelperKernelRBF<double, avx512>::postGemmPart(double * const mklBuff, const double * const sqrA1i, const double sqrA2i,

--- a/cpp/daal/src/algorithms/kernel_function/kernel_function_rbf_helper.h
+++ b/cpp/daal/src/algorithms/kernel_function/kernel_function_rbf_helper.h
@@ -88,7 +88,7 @@ services::Status HelperKernelRBF<algorithmFPType, cpu>::postGemmPart(algorithmFP
     return services::Status();
 }
 
-#if defined(__INTEL_COMPILER)
+#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
 
 template <>
 services::Status HelperKernelRBF<double, avx512>::postGemmPart(double * const mklBuff, const double * const sqrA1i, const double sqrA2i,

--- a/cpp/daal/src/algorithms/kernel_function/kernel_function_rbf_helper.h
+++ b/cpp/daal/src/algorithms/kernel_function/kernel_function_rbf_helper.h
@@ -88,7 +88,7 @@ services::Status HelperKernelRBF<algorithmFPType, cpu>::postGemmPart(algorithmFP
     return services::Status();
 }
 
-#if defined(DAAL_INTEL_CPP_COMPILER)
+#if defined(__AVX512F__) && defined(DAAL_INTEL_CPP_COMPILER)
 
 template <>
 services::Status HelperKernelRBF<double, avx512>::postGemmPart(double * const mklBuff, const double * const sqrA1i, const double sqrA2i,

--- a/cpp/daal/src/algorithms/kernel_function/kernel_function_rbf_helper.h
+++ b/cpp/daal/src/algorithms/kernel_function/kernel_function_rbf_helper.h
@@ -88,7 +88,7 @@ services::Status HelperKernelRBF<algorithmFPType, cpu>::postGemmPart(algorithmFP
     return services::Status();
 }
 
-#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
+#if defined(DAAL_INTEL_CPP_COMPILER)
 
 template <>
 services::Status HelperKernelRBF<double, avx512>::postGemmPart(double * const mklBuff, const double * const sqrA1i, const double sqrA2i,

--- a/cpp/daal/src/algorithms/qr/qr_dense_default_pcl_impl.i
+++ b/cpp/daal/src/algorithms/qr/qr_dense_default_pcl_impl.i
@@ -24,7 +24,7 @@
 #ifndef __QR_KERNEL_DEFAULT_PCL_IMPL_I__
 #define __QR_KERNEL_DEFAULT_PCL_IMPL_I__
 
-#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
+#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
 
     #include "immintrin.h"
 

--- a/cpp/daal/src/algorithms/qr/qr_dense_default_pcl_impl.i
+++ b/cpp/daal/src/algorithms/qr/qr_dense_default_pcl_impl.i
@@ -24,7 +24,7 @@
 #ifndef __QR_KERNEL_DEFAULT_PCL_IMPL_I__
 #define __QR_KERNEL_DEFAULT_PCL_IMPL_I__
 
-#if defined __INTEL_COMPILER
+#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
 
     #include "immintrin.h"
 

--- a/cpp/daal/src/algorithms/qr/qr_dense_default_pcl_impl.i
+++ b/cpp/daal/src/algorithms/qr/qr_dense_default_pcl_impl.i
@@ -24,7 +24,7 @@
 #ifndef __QR_KERNEL_DEFAULT_PCL_IMPL_I__
 #define __QR_KERNEL_DEFAULT_PCL_IMPL_I__
 
-#if defined(DAAL_INTEL_CPP_COMPILER)
+#if defined(__AVX512F__) && defined(DAAL_INTEL_CPP_COMPILER)
 
     #include "immintrin.h"
 

--- a/cpp/daal/src/algorithms/qr/qr_dense_default_pcl_impl.i
+++ b/cpp/daal/src/algorithms/qr/qr_dense_default_pcl_impl.i
@@ -24,7 +24,7 @@
 #ifndef __QR_KERNEL_DEFAULT_PCL_IMPL_I__
 #define __QR_KERNEL_DEFAULT_PCL_IMPL_I__
 
-#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
+#if defined(DAAL_INTEL_CPP_COMPILER)
 
     #include "immintrin.h"
 

--- a/cpp/daal/src/algorithms/service_kernel_math.h
+++ b/cpp/daal/src/algorithms/service_kernel_math.h
@@ -532,7 +532,7 @@ private:
     const NumericTable & _b;
 };
 
-#if defined(__AVX512F__)
+#if defined(__AVX512F__) && defined(DAAL_INTEL_CPP_COMPILER)
 
 template <>
 float MinkowskiDistances<float, avx512>::computeDistance(const float * x, const float * y, const size_t n)

--- a/cpp/daal/src/algorithms/service_kernel_math.h
+++ b/cpp/daal/src/algorithms/service_kernel_math.h
@@ -532,7 +532,7 @@ private:
     const NumericTable & _b;
 };
 
-#if defined(__INTEL_COMPILER)
+#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
 
 template <>
 float MinkowskiDistances<float, avx512>::computeDistance(const float * x, const float * y, const size_t n)

--- a/cpp/daal/src/algorithms/service_kernel_math.h
+++ b/cpp/daal/src/algorithms/service_kernel_math.h
@@ -532,7 +532,7 @@ private:
     const NumericTable & _b;
 };
 
-#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
+#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) & !defined(SYCL_LANGUAGE_VERSION)
 
 template <>
 float MinkowskiDistances<float, avx512>::computeDistance(const float * x, const float * y, const size_t n)

--- a/cpp/daal/src/algorithms/service_kernel_math.h
+++ b/cpp/daal/src/algorithms/service_kernel_math.h
@@ -532,7 +532,7 @@ private:
     const NumericTable & _b;
 };
 
-#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) & !defined(SYCL_LANGUAGE_VERSION)
+#if defined(__AVX512F__)
 
 template <>
 float MinkowskiDistances<float, avx512>::computeDistance(const float * x, const float * y, const size_t n)

--- a/cpp/daal/src/algorithms/service_sort.h
+++ b/cpp/daal/src/algorithms/service_sort.h
@@ -28,7 +28,7 @@
 #include "src/algorithms/service_heap.h"
 #include "services/collection.h"
 
-#if defined(__INTEL_COMPILER_BUILD_DATE)
+#if defined(__INTEL_COMPILER_BUILD_DATE) || defined(__INTEL_LLVM_COMPILER)
     #include <immintrin.h>
 #endif
 
@@ -571,7 +571,7 @@ void indexBubbleSortDesc(services::Collection<algorithmFPtype> & x, services::Co
     }
 }
 
-#if defined(__INTEL_COMPILER_BUILD_DATE)
+#if defined(__INTEL_COMPILER_BUILD_DATE) || defined(__INTEL_LLVM_COMPILER)
     #define __RADIX_SORT_CAST32(x) (_castf32_u32(x))
     #define __RADIX_SORT_CAST64(x) (_castf64_u64(x))
 #else

--- a/cpp/daal/src/algorithms/service_sort.h
+++ b/cpp/daal/src/algorithms/service_sort.h
@@ -28,7 +28,7 @@
 #include "src/algorithms/service_heap.h"
 #include "services/collection.h"
 
-#if defined(__INTEL_COMPILER_BUILD_DATE) || defined(__INTEL_LLVM_COMPILER)
+#if defined(DAAL_INTEL_CPP_COMPILER)
     #include <immintrin.h>
 #endif
 
@@ -571,7 +571,7 @@ void indexBubbleSortDesc(services::Collection<algorithmFPtype> & x, services::Co
     }
 }
 
-#if defined(__INTEL_COMPILER_BUILD_DATE) || defined(__INTEL_LLVM_COMPILER)
+#if defined(DAAL_INTEL_CPP_COMPILER)
     #define __RADIX_SORT_CAST32(x) (_castf32_u32(x))
     #define __RADIX_SORT_CAST64(x) (_castf64_u64(x))
 #else

--- a/cpp/daal/src/algorithms/svm/svm_train_common_impl.i
+++ b/cpp/daal/src/algorithms/svm/svm_train_common_impl.i
@@ -32,7 +32,7 @@
 #include "src/algorithms/svm/svm_train_result.h"
 #include "src/algorithms/svm/svm_train_common.h"
 
-#if defined(__INTEL_COMPILER)
+#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
     #if defined(_M_AMD64) || defined(__amd64) || defined(__x86_64) || defined(__x86_64__)
         #if (__CPUID__(DAAL_CPU) == __avx512__)
 

--- a/cpp/daal/src/algorithms/svm/svm_train_common_impl.i
+++ b/cpp/daal/src/algorithms/svm/svm_train_common_impl.i
@@ -32,7 +32,7 @@
 #include "src/algorithms/svm/svm_train_result.h"
 #include "src/algorithms/svm/svm_train_common.h"
 
-#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
+#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
     #if defined(_M_AMD64) || defined(__amd64) || defined(__x86_64) || defined(__x86_64__)
         #if (__CPUID__(DAAL_CPU) == __avx512__)
 

--- a/cpp/daal/src/algorithms/svm/svm_train_common_impl.i
+++ b/cpp/daal/src/algorithms/svm/svm_train_common_impl.i
@@ -32,7 +32,7 @@
 #include "src/algorithms/svm/svm_train_result.h"
 #include "src/algorithms/svm/svm_train_common.h"
 
-#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
+#if defined(DAAL_INTEL_CPP_COMPILER)
     #if defined(_M_AMD64) || defined(__amd64) || defined(__x86_64) || defined(__x86_64__)
         #if (__CPUID__(DAAL_CPU) == __avx512__)
 

--- a/cpp/daal/src/algorithms/tsne/tsne_gradient_descent_fpt_cpu.cpp
+++ b/cpp/daal/src/algorithms/tsne/tsne_gradient_descent_fpt_cpu.cpp
@@ -24,7 +24,7 @@
 #include "tsne_gradient_descent_kernel.h"
 #include "tsne_gradient_descent_impl.i"
 
-#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
+#if defined(DAAL_INTEL_CPP_COMPILER)
     #if (__CPUID__(DAAL_CPU) == __avx512__)
 
         #include <immintrin.h>

--- a/cpp/daal/src/algorithms/tsne/tsne_gradient_descent_fpt_cpu.cpp
+++ b/cpp/daal/src/algorithms/tsne/tsne_gradient_descent_fpt_cpu.cpp
@@ -24,7 +24,7 @@
 #include "tsne_gradient_descent_kernel.h"
 #include "tsne_gradient_descent_impl.i"
 
-#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
+#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
     #if (__CPUID__(DAAL_CPU) == __avx512__)
 
         #include <immintrin.h>

--- a/cpp/daal/src/data_management/data_conversion.cpp
+++ b/cpp/daal/src/data_management/data_conversion.cpp
@@ -33,7 +33,7 @@ namespace data_management
 namespace internal
 {
 /* only for AVX512 architecture with using intrinsics */
-#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
+#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
 template <typename T>
 static bool tryToCopyFuncAVX512(const size_t nrows, const size_t ncols, void * dst, void const * ptrMin, DAAL_INT64 const * arrOffsets)
 {

--- a/cpp/daal/src/data_management/data_conversion.cpp
+++ b/cpp/daal/src/data_management/data_conversion.cpp
@@ -33,7 +33,7 @@ namespace data_management
 namespace internal
 {
 /* only for AVX512 architecture with using intrinsics */
-#if defined(__INTEL_COMPILER)
+#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
 template <typename T>
 static bool tryToCopyFuncAVX512(const size_t nrows, const size_t ncols, void * dst, void const * ptrMin, DAAL_INT64 const * arrOffsets)
 {

--- a/cpp/daal/src/data_management/data_conversion.cpp
+++ b/cpp/daal/src/data_management/data_conversion.cpp
@@ -33,7 +33,7 @@ namespace data_management
 namespace internal
 {
 /* only for AVX512 architecture with using intrinsics */
-#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
+#if defined(DAAL_INTEL_CPP_COMPILER)
 template <typename T>
 static bool tryToCopyFuncAVX512(const size_t nrows, const size_t ncols, void * dst, void const * ptrMin, DAAL_INT64 const * arrOffsets)
 {

--- a/cpp/daal/src/data_management/data_conversion_cpu.cpp
+++ b/cpp/daal/src/data_management/data_conversion_cpu.cpp
@@ -26,7 +26,7 @@ namespace data_management
 namespace internal
 {
 /* only for AVX512 architecture with using intrinsics */
-#if defined(__INTEL_COMPILER)
+#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
 template <typename T>
 void vectorCopyInternal()
 {

--- a/cpp/daal/src/data_management/data_conversion_cpu.cpp
+++ b/cpp/daal/src/data_management/data_conversion_cpu.cpp
@@ -26,7 +26,7 @@ namespace data_management
 namespace internal
 {
 /* only for AVX512 architecture with using intrinsics */
-#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
+#if defined(DAAL_INTEL_CPP_COMPILER)
 template <typename T>
 void vectorCopyInternal()
 {

--- a/cpp/daal/src/data_management/data_conversion_cpu.cpp
+++ b/cpp/daal/src/data_management/data_conversion_cpu.cpp
@@ -26,7 +26,7 @@ namespace data_management
 namespace internal
 {
 /* only for AVX512 architecture with using intrinsics */
-#if defined(DAAL_INTEL_CPP_COMPILER)
+#if defined(__AVX512F__) && defined(DAAL_INTEL_CPP_COMPILER)
 template <typename T>
 void vectorCopyInternal()
 {

--- a/cpp/daal/src/data_management/data_conversion_cpu.cpp
+++ b/cpp/daal/src/data_management/data_conversion_cpu.cpp
@@ -26,7 +26,7 @@ namespace data_management
 namespace internal
 {
 /* only for AVX512 architecture with using intrinsics */
-#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) & !defined(SYCL_LANGUAGE_VERSION)
+#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
 template <typename T>
 void vectorCopyInternal()
 {

--- a/cpp/daal/src/data_management/data_conversion_cpu.cpp
+++ b/cpp/daal/src/data_management/data_conversion_cpu.cpp
@@ -26,7 +26,7 @@ namespace data_management
 namespace internal
 {
 /* only for AVX512 architecture with using intrinsics */
-#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
+#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) & !defined(SYCL_LANGUAGE_VERSION)
 template <typename T>
 void vectorCopyInternal()
 {

--- a/cpp/daal/src/data_management/data_conversion_cpu.h
+++ b/cpp/daal/src/data_management/data_conversion_cpu.h
@@ -27,7 +27,7 @@ namespace data_management
 namespace internal
 {
 /* only for AVX512 architecture with using intrinsics */
-#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
+#if defined(DAAL_INTEL_CPP_COMPILER)
 template <typename T, CpuType cpu>
 void vectorCopy(const size_t nrows, const size_t ncols, void * dst, void const * ptrMin, DAAL_INT64 const * arrOffsets);
 

--- a/cpp/daal/src/data_management/data_conversion_cpu.h
+++ b/cpp/daal/src/data_management/data_conversion_cpu.h
@@ -27,7 +27,7 @@ namespace data_management
 namespace internal
 {
 /* only for AVX512 architecture with using intrinsics */
-#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
+#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
 template <typename T, CpuType cpu>
 void vectorCopy(const size_t nrows, const size_t ncols, void * dst, void const * ptrMin, DAAL_INT64 const * arrOffsets);
 

--- a/cpp/daal/src/data_management/data_conversion_cpu.h
+++ b/cpp/daal/src/data_management/data_conversion_cpu.h
@@ -27,7 +27,7 @@ namespace data_management
 namespace internal
 {
 /* only for AVX512 architecture with using intrinsics */
-#if defined(__INTEL_COMPILER)
+#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
 template <typename T, CpuType cpu>
 void vectorCopy(const size_t nrows, const size_t ncols, void * dst, void const * ptrMin, DAAL_INT64 const * arrOffsets);
 

--- a/cpp/daal/src/data_management/finiteness_checker.cpp
+++ b/cpp/daal/src/data_management/finiteness_checker.cpp
@@ -163,7 +163,7 @@ bool checkFinitenessSOA(NumericTable & table, bool allowNaN, services::Status & 
     return valuesAreFinite;
 }
 
-#if defined(__INTEL_COMPILER)
+#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
 
 const size_t BLOCK_SIZE       = 8192;
 const size_t THREADING_BORDER = 262144;

--- a/cpp/daal/src/data_management/finiteness_checker.cpp
+++ b/cpp/daal/src/data_management/finiteness_checker.cpp
@@ -163,7 +163,7 @@ bool checkFinitenessSOA(NumericTable & table, bool allowNaN, services::Status & 
     return valuesAreFinite;
 }
 
-#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
+#if defined(DAAL_INTEL_CPP_COMPILER)
 
 const size_t BLOCK_SIZE       = 8192;
 const size_t THREADING_BORDER = 262144;

--- a/cpp/daal/src/data_management/finiteness_checker.cpp
+++ b/cpp/daal/src/data_management/finiteness_checker.cpp
@@ -163,7 +163,7 @@ bool checkFinitenessSOA(NumericTable & table, bool allowNaN, services::Status & 
     return valuesAreFinite;
 }
 
-#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
+#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
 
 const size_t BLOCK_SIZE       = 8192;
 const size_t THREADING_BORDER = 262144;

--- a/cpp/daal/src/data_management/finiteness_checker.cpp
+++ b/cpp/daal/src/data_management/finiteness_checker.cpp
@@ -163,7 +163,7 @@ bool checkFinitenessSOA(NumericTable & table, bool allowNaN, services::Status & 
     return valuesAreFinite;
 }
 
-#if defined(DAAL_INTEL_CPP_COMPILER)
+#if defined(__AVX512F__) && defined(DAAL_INTEL_CPP_COMPILER)
 
 const size_t BLOCK_SIZE       = 8192;
 const size_t THREADING_BORDER = 262144;

--- a/cpp/daal/src/externals/service_blas.h
+++ b/cpp/daal/src/externals/service_blas.h
@@ -50,7 +50,7 @@ void Helper<fpType, cpu>::copy(fpType * dsc, const fpType * src, const size_t n)
     }
 }
 
-#if defined(__INTEL_COMPILER)
+#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
 
 template <>
 void Helper<float, avx512>::copy(float * dsc, const float * src, const size_t n)

--- a/cpp/daal/src/externals/service_blas.h
+++ b/cpp/daal/src/externals/service_blas.h
@@ -50,7 +50,7 @@ void Helper<fpType, cpu>::copy(fpType * dsc, const fpType * src, const size_t n)
     }
 }
 
-#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) & !defined(SYCL_LANGUAGE_VERSION)
+#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
 
 template <>
 void Helper<float, avx512>::copy(float * dsc, const float * src, const size_t n)

--- a/cpp/daal/src/externals/service_blas.h
+++ b/cpp/daal/src/externals/service_blas.h
@@ -50,7 +50,7 @@ void Helper<fpType, cpu>::copy(fpType * dsc, const fpType * src, const size_t n)
     }
 }
 
-#if defined(__AVX512F__)
+#if defined(__AVX512F__) && defined(DAAL_INTEL_CPP_COMPILER)
 
 template <>
 void Helper<float, avx512>::copy(float * dsc, const float * src, const size_t n)

--- a/cpp/daal/src/externals/service_blas.h
+++ b/cpp/daal/src/externals/service_blas.h
@@ -50,7 +50,7 @@ void Helper<fpType, cpu>::copy(fpType * dsc, const fpType * src, const size_t n)
     }
 }
 
-#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
+#if defined(__AVX512F__)
 
 template <>
 void Helper<float, avx512>::copy(float * dsc, const float * src, const size_t n)

--- a/cpp/daal/src/externals/service_blas.h
+++ b/cpp/daal/src/externals/service_blas.h
@@ -50,7 +50,7 @@ void Helper<fpType, cpu>::copy(fpType * dsc, const fpType * src, const size_t n)
     }
 }
 
-#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
+#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) & !defined(SYCL_LANGUAGE_VERSION)
 
 template <>
 void Helper<float, avx512>::copy(float * dsc, const float * src, const size_t n)

--- a/cpp/daal/src/services/service_defines.h
+++ b/cpp/daal/src/services/service_defines.h
@@ -35,7 +35,7 @@ bool daal_check_is_intel_cpu();
 
 #define DAAL_CHECK_CPU_ENVIRONMENT (daal_check_is_intel_cpu())
 
-#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
+#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
     #define PRAGMA_IVDEP            _Pragma("ivdep")
     #define PRAGMA_NOVECTOR         _Pragma("novector")
     #define PRAGMA_VECTOR_ALIGNED   _Pragma("vector aligned")

--- a/cpp/daal/src/services/service_defines.h
+++ b/cpp/daal/src/services/service_defines.h
@@ -35,7 +35,7 @@ bool daal_check_is_intel_cpu();
 
 #define DAAL_CHECK_CPU_ENVIRONMENT (daal_check_is_intel_cpu())
 
-#if defined(DAAL_INTEL_CPP_COMPILER)
+#if defined(__INTEL_COMPILER)
     #define PRAGMA_IVDEP            _Pragma("ivdep")
     #define PRAGMA_NOVECTOR         _Pragma("novector")
     #define PRAGMA_VECTOR_ALIGNED   _Pragma("vector aligned")

--- a/cpp/daal/src/services/service_defines.h
+++ b/cpp/daal/src/services/service_defines.h
@@ -35,7 +35,7 @@ bool daal_check_is_intel_cpu();
 
 #define DAAL_CHECK_CPU_ENVIRONMENT (daal_check_is_intel_cpu())
 
-#if defined(__INTEL_COMPILER)
+#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
     #define PRAGMA_IVDEP            _Pragma("ivdep")
     #define PRAGMA_NOVECTOR         _Pragma("novector")
     #define PRAGMA_VECTOR_ALIGNED   _Pragma("vector aligned")

--- a/cpp/daal/src/services/service_defines.h
+++ b/cpp/daal/src/services/service_defines.h
@@ -35,7 +35,7 @@ bool daal_check_is_intel_cpu();
 
 #define DAAL_CHECK_CPU_ENVIRONMENT (daal_check_is_intel_cpu())
 
-#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
+#if defined(DAAL_INTEL_CPP_COMPILER)
     #define PRAGMA_IVDEP            _Pragma("ivdep")
     #define PRAGMA_NOVECTOR         _Pragma("novector")
     #define PRAGMA_VECTOR_ALIGNED   _Pragma("vector aligned")
@@ -319,7 +319,7 @@ typedef union
 
 #define COMPUTE_DAAL_VERSION(majorVersion, minorVersion, updateVersion) (majorVersion * 10000 + minorVersion * 100 + updateVersion)
 
-#if defined(_MSC_VER) || defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
+#if defined(_MSC_VER) || defined(DAAL_INTEL_CPP_COMPILER)
     #include <immintrin.h>
     #define DAAL_PREFETCH_READ_T0(addr) _mm_prefetch((char *)addr, _MM_HINT_T0)
 #else

--- a/cpp/oneapi/dal/algo/jaccard/backend/cpu/vertex_similarity_default_kernel_avx512.hpp
+++ b/cpp/oneapi/dal/algo/jaccard/backend/cpu/vertex_similarity_default_kernel_avx512.hpp
@@ -59,7 +59,7 @@ vertex_similarity_result<task::all_vertex_pairs> jaccard_avx512(
 
     std::int64_t nnz = 0;
     std::int32_t j = column_begin;
-#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
+#if defined(__AVX512F__)
     __m512i j_vertices_tmp1 =
         _mm512_set_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
     GRAPH_STACK_ALING(64) std::int32_t stack16_j_vertex[16] = { 0 };
@@ -72,7 +72,7 @@ vertex_similarity_result<task::all_vertex_pairs> jaccard_avx512(
         const auto i_neigbhors = cols + rows_vertex[i];
         const auto diagonal = detail::min(i, column_end);
 
-#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
+#if defined(__AVX512F__)
         __m512i n_i_start_v = _mm512_set1_epi32(i_neigbhors[0]);
         __m512i n_i_end_v = _mm512_set1_epi32(i_neigbhors[i_neighbor_size - 1]);
         __m512i i_vertex = _mm512_set1_epi32(i);
@@ -234,7 +234,7 @@ vertex_similarity_result<task::all_vertex_pairs> jaccard_avx512(
                     }
                 }
             }
-#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
+#if defined(__AVX512F__)
         }
 #endif
 
@@ -249,7 +249,7 @@ vertex_similarity_result<task::all_vertex_pairs> jaccard_avx512(
         }
         j = tmp_idx;
 
-#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
+#if defined(__AVX512F__)
         if (j < tmp_idx + ((column_end - tmp_idx) / 16) * 16) {
             //load_data(0)
             __m512i start_indices_j_v = _mm512_load_epi32(rows_vertex + j);
@@ -407,7 +407,7 @@ vertex_similarity_result<task::all_vertex_pairs> jaccard_avx512(
                     }
                 }
             }
-#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
+#if defined(__AVX512F__)
         }
 #endif
     }

--- a/cpp/oneapi/dal/algo/jaccard/backend/cpu/vertex_similarity_default_kernel_avx512.hpp
+++ b/cpp/oneapi/dal/algo/jaccard/backend/cpu/vertex_similarity_default_kernel_avx512.hpp
@@ -59,7 +59,7 @@ vertex_similarity_result<task::all_vertex_pairs> jaccard_avx512(
 
     std::int64_t nnz = 0;
     std::int32_t j = column_begin;
-#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
+#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) & !defined(SYCL_LANGUAGE_VERSION)
     __m512i j_vertices_tmp1 =
         _mm512_set_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
     GRAPH_STACK_ALING(64) std::int32_t stack16_j_vertex[16] = { 0 };
@@ -72,7 +72,7 @@ vertex_similarity_result<task::all_vertex_pairs> jaccard_avx512(
         const auto i_neigbhors = cols + rows_vertex[i];
         const auto diagonal = detail::min(i, column_end);
 
-#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
+#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) & !defined(SYCL_LANGUAGE_VERSION)
         __m512i n_i_start_v = _mm512_set1_epi32(i_neigbhors[0]);
         __m512i n_i_end_v = _mm512_set1_epi32(i_neigbhors[i_neighbor_size - 1]);
         __m512i i_vertex = _mm512_set1_epi32(i);
@@ -234,7 +234,7 @@ vertex_similarity_result<task::all_vertex_pairs> jaccard_avx512(
                     }
                 }
             }
-#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
+#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) & !defined(SYCL_LANGUAGE_VERSION)
         }
 #endif
 
@@ -249,7 +249,7 @@ vertex_similarity_result<task::all_vertex_pairs> jaccard_avx512(
         }
         j = tmp_idx;
 
-#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
+#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) & !defined(SYCL_LANGUAGE_VERSION)
         if (j < tmp_idx + ((column_end - tmp_idx) / 16) * 16) {
             //load_data(0)
             __m512i start_indices_j_v = _mm512_load_epi32(rows_vertex + j);
@@ -407,7 +407,7 @@ vertex_similarity_result<task::all_vertex_pairs> jaccard_avx512(
                     }
                 }
             }
-#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
+#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) & !defined(SYCL_LANGUAGE_VERSION)
         }
 #endif
     }

--- a/cpp/oneapi/dal/algo/jaccard/backend/cpu/vertex_similarity_default_kernel_avx512.hpp
+++ b/cpp/oneapi/dal/algo/jaccard/backend/cpu/vertex_similarity_default_kernel_avx512.hpp
@@ -59,7 +59,7 @@ vertex_similarity_result<task::all_vertex_pairs> jaccard_avx512(
 
     std::int64_t nnz = 0;
     std::int32_t j = column_begin;
-#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) & !defined(SYCL_LANGUAGE_VERSION)
+#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
     __m512i j_vertices_tmp1 =
         _mm512_set_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
     GRAPH_STACK_ALING(64) std::int32_t stack16_j_vertex[16] = { 0 };
@@ -72,7 +72,7 @@ vertex_similarity_result<task::all_vertex_pairs> jaccard_avx512(
         const auto i_neigbhors = cols + rows_vertex[i];
         const auto diagonal = detail::min(i, column_end);
 
-#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) & !defined(SYCL_LANGUAGE_VERSION)
+#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
         __m512i n_i_start_v = _mm512_set1_epi32(i_neigbhors[0]);
         __m512i n_i_end_v = _mm512_set1_epi32(i_neigbhors[i_neighbor_size - 1]);
         __m512i i_vertex = _mm512_set1_epi32(i);
@@ -234,7 +234,7 @@ vertex_similarity_result<task::all_vertex_pairs> jaccard_avx512(
                     }
                 }
             }
-#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) & !defined(SYCL_LANGUAGE_VERSION)
+#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
         }
 #endif
 
@@ -249,7 +249,7 @@ vertex_similarity_result<task::all_vertex_pairs> jaccard_avx512(
         }
         j = tmp_idx;
 
-#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) & !defined(SYCL_LANGUAGE_VERSION)
+#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
         if (j < tmp_idx + ((column_end - tmp_idx) / 16) * 16) {
             //load_data(0)
             __m512i start_indices_j_v = _mm512_load_epi32(rows_vertex + j);
@@ -407,7 +407,7 @@ vertex_similarity_result<task::all_vertex_pairs> jaccard_avx512(
                     }
                 }
             }
-#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) & !defined(SYCL_LANGUAGE_VERSION)
+#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
         }
 #endif
     }

--- a/cpp/oneapi/dal/algo/jaccard/backend/cpu/vertex_similarity_default_kernel_avx512.hpp
+++ b/cpp/oneapi/dal/algo/jaccard/backend/cpu/vertex_similarity_default_kernel_avx512.hpp
@@ -59,7 +59,7 @@ vertex_similarity_result<task::all_vertex_pairs> jaccard_avx512(
 
     std::int64_t nnz = 0;
     std::int32_t j = column_begin;
-#if defined(__INTEL_COMPILER)
+#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
     __m512i j_vertices_tmp1 =
         _mm512_set_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
     GRAPH_STACK_ALING(64) std::int32_t stack16_j_vertex[16] = { 0 };
@@ -72,7 +72,7 @@ vertex_similarity_result<task::all_vertex_pairs> jaccard_avx512(
         const auto i_neigbhors = cols + rows_vertex[i];
         const auto diagonal = detail::min(i, column_end);
 
-#if defined(__INTEL_COMPILER)
+#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
         __m512i n_i_start_v = _mm512_set1_epi32(i_neigbhors[0]);
         __m512i n_i_end_v = _mm512_set1_epi32(i_neigbhors[i_neighbor_size - 1]);
         __m512i i_vertex = _mm512_set1_epi32(i);
@@ -234,7 +234,7 @@ vertex_similarity_result<task::all_vertex_pairs> jaccard_avx512(
                     }
                 }
             }
-#if defined(__INTEL_COMPILER)
+#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
         }
 #endif
 
@@ -249,7 +249,7 @@ vertex_similarity_result<task::all_vertex_pairs> jaccard_avx512(
         }
         j = tmp_idx;
 
-#if defined(__INTEL_COMPILER)
+#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
         if (j < tmp_idx + ((column_end - tmp_idx) / 16) * 16) {
             //load_data(0)
             __m512i start_indices_j_v = _mm512_load_epi32(rows_vertex + j);
@@ -407,7 +407,7 @@ vertex_similarity_result<task::all_vertex_pairs> jaccard_avx512(
                     }
                 }
             }
-#if defined(__INTEL_COMPILER)
+#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
         }
 #endif
     }

--- a/cpp/oneapi/dal/algo/jaccard/backend/cpu/vertex_similarity_default_kernel_avx512.hpp
+++ b/cpp/oneapi/dal/algo/jaccard/backend/cpu/vertex_similarity_default_kernel_avx512.hpp
@@ -59,7 +59,7 @@ vertex_similarity_result<task::all_vertex_pairs> jaccard_avx512(
 
     std::int64_t nnz = 0;
     std::int32_t j = column_begin;
-#if defined(__AVX512F__)
+#if defined(__AVX512F__) && defined(DAAL_INTEL_CPP_COMPILER)
     __m512i j_vertices_tmp1 =
         _mm512_set_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
     GRAPH_STACK_ALING(64) std::int32_t stack16_j_vertex[16] = { 0 };
@@ -72,7 +72,7 @@ vertex_similarity_result<task::all_vertex_pairs> jaccard_avx512(
         const auto i_neigbhors = cols + rows_vertex[i];
         const auto diagonal = detail::min(i, column_end);
 
-#if defined(__AVX512F__)
+#if defined(__AVX512F__) && defined(DAAL_INTEL_CPP_COMPILER)
         __m512i n_i_start_v = _mm512_set1_epi32(i_neigbhors[0]);
         __m512i n_i_end_v = _mm512_set1_epi32(i_neigbhors[i_neighbor_size - 1]);
         __m512i i_vertex = _mm512_set1_epi32(i);
@@ -234,7 +234,7 @@ vertex_similarity_result<task::all_vertex_pairs> jaccard_avx512(
                     }
                 }
             }
-#if defined(__AVX512F__)
+#if defined(__AVX512F__) && defined(DAAL_INTEL_CPP_COMPILER)
         }
 #endif
 
@@ -249,7 +249,7 @@ vertex_similarity_result<task::all_vertex_pairs> jaccard_avx512(
         }
         j = tmp_idx;
 
-#if defined(__AVX512F__)
+#if defined(__AVX512F__) && defined(DAAL_INTEL_CPP_COMPILER)
         if (j < tmp_idx + ((column_end - tmp_idx) / 16) * 16) {
             //load_data(0)
             __m512i start_indices_j_v = _mm512_load_epi32(rows_vertex + j);
@@ -407,7 +407,7 @@ vertex_similarity_result<task::all_vertex_pairs> jaccard_avx512(
                     }
                 }
             }
-#if defined(__AVX512F__)
+#if defined(__AVX512F__) && defined(DAAL_INTEL_CPP_COMPILER)
         }
 #endif
     }

--- a/cpp/oneapi/dal/algo/subgraph_isomorphism/backend/cpu/bit_vector.hpp
+++ b/cpp/oneapi/dal/algo/subgraph_isomorphism/backend/cpu/bit_vector.hpp
@@ -116,7 +116,7 @@ void or_equal(std::uint8_t* vec, const std::int64_t* bit_index, const std::int64
 
 template <typename Cpu>
 void set(std::uint8_t* vec, std::int64_t size, const std::uint8_t byte_val = 0x0) {
-    ONEDAL_VECTOR_ALWAYS
+    ONEDAL_IVDEP
     for (std::int64_t i = 0; i < size; i++) {
         vec[i] = byte_val;
     }

--- a/cpp/oneapi/dal/algo/subgraph_isomorphism/backend/cpu/bit_vector.hpp
+++ b/cpp/oneapi/dal/algo/subgraph_isomorphism/backend/cpu/bit_vector.hpp
@@ -116,7 +116,7 @@ void or_equal(std::uint8_t* vec, const std::int64_t* bit_index, const std::int64
 
 template <typename Cpu>
 void set(std::uint8_t* vec, std::int64_t size, const std::uint8_t byte_val = 0x0) {
-    ONEDAL_IVDEP
+    ONEDAL_VECTOR_ALWAYS
     for (std::int64_t i = 0; i < size; i++) {
         vec[i] = byte_val;
     }

--- a/cpp/oneapi/dal/algo/subgraph_isomorphism/backend/cpu/compiler_adapt.hpp
+++ b/cpp/oneapi/dal/algo/subgraph_isomorphism/backend/cpu/compiler_adapt.hpp
@@ -49,7 +49,7 @@ ONEDAL_FORCEINLINE std::int32_t ONEDAL_lzcnt_u32(std::uint32_t a) {
 
 template <typename Cpu>
 ONEDAL_FORCEINLINE std::int32_t ONEDAL_lzcnt_u64(std::uint64_t a) {
-#if defined(DAAL_INTEL_CPP_COMPILER)
+#if defined(__AVX__) && defined(DAAL_INTEL_CPP_COMPILER)
     return _lzcnt_u64(a);
 #else
     if (a == 0)
@@ -66,7 +66,7 @@ ONEDAL_FORCEINLINE std::int32_t ONEDAL_lzcnt_u64(std::uint64_t a) {
 
 template <typename Cpu>
 ONEDAL_FORCEINLINE std::int32_t ONEDAL_popcnt64(std::uint64_t a) {
-#if defined(DAAL_INTEL_CPP_COMPILER)
+#if defined(__AVX__) && defined(DAAL_INTEL_CPP_COMPILER)
     return _popcnt64(a);
 #else
     if (a == 0)

--- a/cpp/oneapi/dal/algo/subgraph_isomorphism/backend/cpu/compiler_adapt.hpp
+++ b/cpp/oneapi/dal/algo/subgraph_isomorphism/backend/cpu/compiler_adapt.hpp
@@ -22,7 +22,7 @@
 
 namespace oneapi::dal::preview::subgraph_isomorphism::backend {
 
-#if defined(__INTEL_COMPILER)
+#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
 #define ONEDAL_IVDEP         _Pragma("ivdep")
 #define ONEDAL_VECTOR_ALWAYS _Pragma("vector always")
 #else
@@ -32,7 +32,7 @@ namespace oneapi::dal::preview::subgraph_isomorphism::backend {
 
 template <typename Cpu>
 ONEDAL_FORCEINLINE std::int32_t ONEDAL_lzcnt_u32(std::uint32_t a) {
-#if defined(__INTEL_COMPILER)
+#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
     return _lzcnt_u32(a);
 #else
     if (a == 0)
@@ -49,7 +49,7 @@ ONEDAL_FORCEINLINE std::int32_t ONEDAL_lzcnt_u32(std::uint32_t a) {
 
 template <typename Cpu>
 ONEDAL_FORCEINLINE std::int32_t ONEDAL_lzcnt_u64(std::uint64_t a) {
-#if defined(__INTEL_COMPILER)
+#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
     return _lzcnt_u64(a);
 #else
     if (a == 0)
@@ -66,7 +66,7 @@ ONEDAL_FORCEINLINE std::int32_t ONEDAL_lzcnt_u64(std::uint64_t a) {
 
 template <typename Cpu>
 ONEDAL_FORCEINLINE std::int32_t ONEDAL_popcnt64(std::uint64_t a) {
-#if defined(__INTEL_COMPILER)
+#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
     return _popcnt64(a);
 #else
     if (a == 0)

--- a/cpp/oneapi/dal/algo/subgraph_isomorphism/backend/cpu/compiler_adapt.hpp
+++ b/cpp/oneapi/dal/algo/subgraph_isomorphism/backend/cpu/compiler_adapt.hpp
@@ -32,7 +32,7 @@ namespace oneapi::dal::preview::subgraph_isomorphism::backend {
 
 template <typename Cpu>
 ONEDAL_FORCEINLINE std::int32_t ONEDAL_lzcnt_u32(std::uint32_t a) {
-#if defined(DAAL_INTEL_CPP_COMPILER)
+#if defined(__AVX__) && defined(DAAL_INTEL_CPP_COMPILER)
     return _lzcnt_u32(a);
 #else
     if (a == 0)

--- a/cpp/oneapi/dal/algo/subgraph_isomorphism/backend/cpu/compiler_adapt.hpp
+++ b/cpp/oneapi/dal/algo/subgraph_isomorphism/backend/cpu/compiler_adapt.hpp
@@ -22,7 +22,7 @@
 
 namespace oneapi::dal::preview::subgraph_isomorphism::backend {
 
-#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) & !defined(SYCL_LANGUAGE_VERSION)
+#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
 #define ONEDAL_IVDEP         _Pragma("ivdep")
 #define ONEDAL_VECTOR_ALWAYS _Pragma("vector always")
 #else
@@ -32,7 +32,7 @@ namespace oneapi::dal::preview::subgraph_isomorphism::backend {
 
 template <typename Cpu>
 ONEDAL_FORCEINLINE std::int32_t ONEDAL_lzcnt_u32(std::uint32_t a) {
-#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) & !defined(SYCL_LANGUAGE_VERSION)
+#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
     return _lzcnt_u32(a);
 #else
     if (a == 0)
@@ -49,7 +49,7 @@ ONEDAL_FORCEINLINE std::int32_t ONEDAL_lzcnt_u32(std::uint32_t a) {
 
 template <typename Cpu>
 ONEDAL_FORCEINLINE std::int32_t ONEDAL_lzcnt_u64(std::uint64_t a) {
-#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) & !defined(SYCL_LANGUAGE_VERSION)
+#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
     return _lzcnt_u64(a);
 #else
     if (a == 0)
@@ -66,7 +66,7 @@ ONEDAL_FORCEINLINE std::int32_t ONEDAL_lzcnt_u64(std::uint64_t a) {
 
 template <typename Cpu>
 ONEDAL_FORCEINLINE std::int32_t ONEDAL_popcnt64(std::uint64_t a) {
-#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) & !defined(SYCL_LANGUAGE_VERSION)
+#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
     return _popcnt64(a);
 #else
     if (a == 0)

--- a/cpp/oneapi/dal/algo/subgraph_isomorphism/backend/cpu/compiler_adapt.hpp
+++ b/cpp/oneapi/dal/algo/subgraph_isomorphism/backend/cpu/compiler_adapt.hpp
@@ -22,7 +22,7 @@
 
 namespace oneapi::dal::preview::subgraph_isomorphism::backend {
 
-#if defined(DAAL_INTEL_CPP_COMPILER)
+#if defined(__INTEL_COMPILER)
 #define ONEDAL_IVDEP         _Pragma("ivdep")
 #define ONEDAL_VECTOR_ALWAYS _Pragma("vector always")
 #else
@@ -32,7 +32,7 @@ namespace oneapi::dal::preview::subgraph_isomorphism::backend {
 
 template <typename Cpu>
 ONEDAL_FORCEINLINE std::int32_t ONEDAL_lzcnt_u32(std::uint32_t a) {
-#if defined(__AVX__) && defined(DAAL_INTEL_CPP_COMPILER)
+#if defined(__AVX__) && defined(__INTEL_COMPILER)
     return _lzcnt_u32(a);
 #else
     if (a == 0)
@@ -49,7 +49,7 @@ ONEDAL_FORCEINLINE std::int32_t ONEDAL_lzcnt_u32(std::uint32_t a) {
 
 template <typename Cpu>
 ONEDAL_FORCEINLINE std::int32_t ONEDAL_lzcnt_u64(std::uint64_t a) {
-#if defined(__AVX__) && defined(DAAL_INTEL_CPP_COMPILER)
+#if defined(__AVX__) && defined(__INTEL_COMPILER)
     return _lzcnt_u64(a);
 #else
     if (a == 0)
@@ -66,7 +66,7 @@ ONEDAL_FORCEINLINE std::int32_t ONEDAL_lzcnt_u64(std::uint64_t a) {
 
 template <typename Cpu>
 ONEDAL_FORCEINLINE std::int32_t ONEDAL_popcnt64(std::uint64_t a) {
-#if defined(__AVX__) && defined(DAAL_INTEL_CPP_COMPILER)
+#if defined(__AVX__) && defined(__INTEL_COMPILER)
     return _popcnt64(a);
 #else
     if (a == 0)

--- a/cpp/oneapi/dal/algo/subgraph_isomorphism/backend/cpu/compiler_adapt.hpp
+++ b/cpp/oneapi/dal/algo/subgraph_isomorphism/backend/cpu/compiler_adapt.hpp
@@ -22,7 +22,7 @@
 
 namespace oneapi::dal::preview::subgraph_isomorphism::backend {
 
-#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
+#if defined(DAAL_INTEL_CPP_COMPILER)
 #define ONEDAL_IVDEP         _Pragma("ivdep")
 #define ONEDAL_VECTOR_ALWAYS _Pragma("vector always")
 #else
@@ -32,7 +32,7 @@ namespace oneapi::dal::preview::subgraph_isomorphism::backend {
 
 template <typename Cpu>
 ONEDAL_FORCEINLINE std::int32_t ONEDAL_lzcnt_u32(std::uint32_t a) {
-#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
+#if defined(DAAL_INTEL_CPP_COMPILER)
     return _lzcnt_u32(a);
 #else
     if (a == 0)
@@ -49,7 +49,7 @@ ONEDAL_FORCEINLINE std::int32_t ONEDAL_lzcnt_u32(std::uint32_t a) {
 
 template <typename Cpu>
 ONEDAL_FORCEINLINE std::int32_t ONEDAL_lzcnt_u64(std::uint64_t a) {
-#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
+#if defined(DAAL_INTEL_CPP_COMPILER)
     return _lzcnt_u64(a);
 #else
     if (a == 0)
@@ -66,7 +66,7 @@ ONEDAL_FORCEINLINE std::int32_t ONEDAL_lzcnt_u64(std::uint64_t a) {
 
 template <typename Cpu>
 ONEDAL_FORCEINLINE std::int32_t ONEDAL_popcnt64(std::uint64_t a) {
-#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
+#if defined(DAAL_INTEL_CPP_COMPILER)
     return _popcnt64(a);
 #else
     if (a == 0)

--- a/cpp/oneapi/dal/algo/subgraph_isomorphism/backend/cpu/compiler_adapt.hpp
+++ b/cpp/oneapi/dal/algo/subgraph_isomorphism/backend/cpu/compiler_adapt.hpp
@@ -22,7 +22,7 @@
 
 namespace oneapi::dal::preview::subgraph_isomorphism::backend {
 
-#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
+#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) & !defined(SYCL_LANGUAGE_VERSION)
 #define ONEDAL_IVDEP         _Pragma("ivdep")
 #define ONEDAL_VECTOR_ALWAYS _Pragma("vector always")
 #else
@@ -32,7 +32,7 @@ namespace oneapi::dal::preview::subgraph_isomorphism::backend {
 
 template <typename Cpu>
 ONEDAL_FORCEINLINE std::int32_t ONEDAL_lzcnt_u32(std::uint32_t a) {
-#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
+#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) & !defined(SYCL_LANGUAGE_VERSION)
     return _lzcnt_u32(a);
 #else
     if (a == 0)
@@ -49,7 +49,7 @@ ONEDAL_FORCEINLINE std::int32_t ONEDAL_lzcnt_u32(std::uint32_t a) {
 
 template <typename Cpu>
 ONEDAL_FORCEINLINE std::int32_t ONEDAL_lzcnt_u64(std::uint64_t a) {
-#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
+#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) & !defined(SYCL_LANGUAGE_VERSION)
     return _lzcnt_u64(a);
 #else
     if (a == 0)
@@ -66,7 +66,7 @@ ONEDAL_FORCEINLINE std::int32_t ONEDAL_lzcnt_u64(std::uint64_t a) {
 
 template <typename Cpu>
 ONEDAL_FORCEINLINE std::int32_t ONEDAL_popcnt64(std::uint64_t a) {
-#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
+#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) & !defined(SYCL_LANGUAGE_VERSION)
     return _popcnt64(a);
 #else
     if (a == 0)

--- a/cpp/oneapi/dal/algo/triangle_counting/backend/cpu/intersection_tc.hpp
+++ b/cpp/oneapi/dal/algo/triangle_counting/backend/cpu/intersection_tc.hpp
@@ -49,7 +49,7 @@ struct intersection_local_tc {
     }
 };
 
-#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
+#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) & !defined(SYCL_LANGUAGE_VERSION)
 ONEDAL_FORCEINLINE std::int32_t _popcnt32_redef(const std::int32_t& x) {
     return _popcnt32(x);
 }
@@ -78,7 +78,7 @@ struct intersection_local_tc<dal::backend::cpu_dispatch_avx512> {
                                                std::int64_t tc_size) {
         std::int64_t total = 0;
         std::int32_t i_u = 0, i_v = 0;
-#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
+#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) & !defined(SYCL_LANGUAGE_VERSION)
         while (i_u < (n_u / 16) * 16 && i_v < (n_v / 16) * 16) { // not in last n%16 elements
             // assumes neighbor list is ordered
             std::int32_t min_neigh_u = neigh_u[i_u];

--- a/cpp/oneapi/dal/algo/triangle_counting/backend/cpu/intersection_tc.hpp
+++ b/cpp/oneapi/dal/algo/triangle_counting/backend/cpu/intersection_tc.hpp
@@ -49,7 +49,7 @@ struct intersection_local_tc {
     }
 };
 
-#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) & !defined(SYCL_LANGUAGE_VERSION)
+#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
 ONEDAL_FORCEINLINE std::int32_t _popcnt32_redef(const std::int32_t& x) {
     return _popcnt32(x);
 }
@@ -78,7 +78,7 @@ struct intersection_local_tc<dal::backend::cpu_dispatch_avx512> {
                                                std::int64_t tc_size) {
         std::int64_t total = 0;
         std::int32_t i_u = 0, i_v = 0;
-#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) & !defined(SYCL_LANGUAGE_VERSION)
+#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
         while (i_u < (n_u / 16) * 16 && i_v < (n_v / 16) * 16) { // not in last n%16 elements
             // assumes neighbor list is ordered
             std::int32_t min_neigh_u = neigh_u[i_u];

--- a/cpp/oneapi/dal/algo/triangle_counting/backend/cpu/intersection_tc.hpp
+++ b/cpp/oneapi/dal/algo/triangle_counting/backend/cpu/intersection_tc.hpp
@@ -49,7 +49,7 @@ struct intersection_local_tc {
     }
 };
 
-#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
+#if defined(DAAL_INTEL_CPP_COMPILER)
 ONEDAL_FORCEINLINE std::int32_t _popcnt32_redef(const std::int32_t& x) {
     return _popcnt32(x);
 }
@@ -78,7 +78,7 @@ struct intersection_local_tc<dal::backend::cpu_dispatch_avx512> {
                                                std::int64_t tc_size) {
         std::int64_t total = 0;
         std::int32_t i_u = 0, i_v = 0;
-#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
+#if defined(DAAL_INTEL_CPP_COMPILER)
         while (i_u < (n_u / 16) * 16 && i_v < (n_v / 16) * 16) { // not in last n%16 elements
             // assumes neighbor list is ordered
             std::int32_t min_neigh_u = neigh_u[i_u];

--- a/cpp/oneapi/dal/algo/triangle_counting/backend/cpu/intersection_tc.hpp
+++ b/cpp/oneapi/dal/algo/triangle_counting/backend/cpu/intersection_tc.hpp
@@ -49,7 +49,7 @@ struct intersection_local_tc {
     }
 };
 
-#if defined(__INTEL_COMPILER)
+#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
 ONEDAL_FORCEINLINE std::int32_t _popcnt32_redef(const std::int32_t& x) {
     return _popcnt32(x);
 }
@@ -78,7 +78,7 @@ struct intersection_local_tc<dal::backend::cpu_dispatch_avx512> {
                                                std::int64_t tc_size) {
         std::int64_t total = 0;
         std::int32_t i_u = 0, i_v = 0;
-#if defined(__INTEL_COMPILER)
+#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
         while (i_u < (n_u / 16) * 16 && i_v < (n_v / 16) * 16) { // not in last n%16 elements
             // assumes neighbor list is ordered
             std::int32_t min_neigh_u = neigh_u[i_u];

--- a/cpp/oneapi/dal/backend/common.hpp
+++ b/cpp/oneapi/dal/backend/common.hpp
@@ -23,7 +23,7 @@
 #include "oneapi/dal/array.hpp"
 #include "oneapi/dal/detail/common.hpp"
 
-#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) & !defined(SYCL_LANGUAGE_VERSION)
+#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
 #define PRAGMA_IVDEP         _Pragma("ivdep")
 #define PRAGMA_VECTOR_ALWAYS _Pragma("vector always")
 #else

--- a/cpp/oneapi/dal/backend/common.hpp
+++ b/cpp/oneapi/dal/backend/common.hpp
@@ -23,7 +23,7 @@
 #include "oneapi/dal/array.hpp"
 #include "oneapi/dal/detail/common.hpp"
 
-#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
+#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) & !defined(SYCL_LANGUAGE_VERSION)
 #define PRAGMA_IVDEP         _Pragma("ivdep")
 #define PRAGMA_VECTOR_ALWAYS _Pragma("vector always")
 #else

--- a/cpp/oneapi/dal/backend/common.hpp
+++ b/cpp/oneapi/dal/backend/common.hpp
@@ -23,7 +23,7 @@
 #include "oneapi/dal/array.hpp"
 #include "oneapi/dal/detail/common.hpp"
 
-#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
+#if defined(DAAL_INTEL_CPP_COMPILER)
 #define PRAGMA_IVDEP         _Pragma("ivdep")
 #define PRAGMA_VECTOR_ALWAYS _Pragma("vector always")
 #else

--- a/cpp/oneapi/dal/backend/common.hpp
+++ b/cpp/oneapi/dal/backend/common.hpp
@@ -23,7 +23,7 @@
 #include "oneapi/dal/array.hpp"
 #include "oneapi/dal/detail/common.hpp"
 
-#if defined(__INTEL_COMPILER)
+#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
 #define PRAGMA_IVDEP         _Pragma("ivdep")
 #define PRAGMA_VECTOR_ALWAYS _Pragma("vector always")
 #else

--- a/cpp/oneapi/dal/backend/common.hpp
+++ b/cpp/oneapi/dal/backend/common.hpp
@@ -23,7 +23,7 @@
 #include "oneapi/dal/array.hpp"
 #include "oneapi/dal/detail/common.hpp"
 
-#if defined(DAAL_INTEL_CPP_COMPILER)
+#if defined(__INTEL_COMPILER)
 #define PRAGMA_IVDEP         _Pragma("ivdep")
 #define PRAGMA_VECTOR_ALWAYS _Pragma("vector always")
 #else

--- a/cpp/oneapi/dal/backend/primitives/intersection/intersection.hpp
+++ b/cpp/oneapi/dal/backend/primitives/intersection/intersection.hpp
@@ -43,7 +43,7 @@ ONEDAL_FORCEINLINE std::int64_t intersection(const std::int32_t *neigh_u,
     return total;
 }
 
-#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) & !defined(SYCL_LANGUAGE_VERSION)
+#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
 ONEDAL_FORCEINLINE std::int32_t _popcnt32_redef(const std::int32_t &x) {
     return _popcnt32(x);
 }
@@ -70,7 +70,7 @@ ONEDAL_FORCEINLINE std::int64_t intersection<dal::backend::cpu_dispatch_avx512>(
     std::int32_t n_v) {
     std::int64_t total = 0;
     std::int32_t i_u = 0, i_v = 0;
-#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) & !defined(SYCL_LANGUAGE_VERSION)
+#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
     while (i_u < (n_u / 16) * 16 && i_v < (n_v / 16) * 16) { // not in last n%16 elements
         // assumes neighbor list is ordered
         std::int32_t min_neigh_u = neigh_u[i_u];
@@ -362,7 +362,7 @@ ONEDAL_FORCEINLINE std::int64_t intersection<dal::backend::cpu_dispatch_avx2>(
     std::int32_t n_v) {
     std::int64_t total = 0;
     std::int32_t i_u = 0, i_v = 0;
-#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) & !defined(SYCL_LANGUAGE_VERSION)
+#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
     const std::int32_t n_u_8_end = n_u - 8;
     const std::int32_t n_v_8_end = n_v - 8;
     while (i_u <= n_u_8_end && i_v <= n_v_8_end) {

--- a/cpp/oneapi/dal/backend/primitives/intersection/intersection.hpp
+++ b/cpp/oneapi/dal/backend/primitives/intersection/intersection.hpp
@@ -43,7 +43,7 @@ ONEDAL_FORCEINLINE std::int64_t intersection(const std::int32_t *neigh_u,
     return total;
 }
 
-#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
+#if defined(DAAL_INTEL_CPP_COMPILER)
 ONEDAL_FORCEINLINE std::int32_t _popcnt32_redef(const std::int32_t &x) {
     return _popcnt32(x);
 }
@@ -70,7 +70,7 @@ ONEDAL_FORCEINLINE std::int64_t intersection<dal::backend::cpu_dispatch_avx512>(
     std::int32_t n_v) {
     std::int64_t total = 0;
     std::int32_t i_u = 0, i_v = 0;
-#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
+#if defined(DAAL_INTEL_CPP_COMPILER)
     while (i_u < (n_u / 16) * 16 && i_v < (n_v / 16) * 16) { // not in last n%16 elements
         // assumes neighbor list is ordered
         std::int32_t min_neigh_u = neigh_u[i_u];
@@ -362,7 +362,7 @@ ONEDAL_FORCEINLINE std::int64_t intersection<dal::backend::cpu_dispatch_avx2>(
     std::int32_t n_v) {
     std::int64_t total = 0;
     std::int32_t i_u = 0, i_v = 0;
-#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
+#if defined(DAAL_INTEL_CPP_COMPILER)
     const std::int32_t n_u_8_end = n_u - 8;
     const std::int32_t n_v_8_end = n_v - 8;
     while (i_u <= n_u_8_end && i_v <= n_v_8_end) {

--- a/cpp/oneapi/dal/backend/primitives/intersection/intersection.hpp
+++ b/cpp/oneapi/dal/backend/primitives/intersection/intersection.hpp
@@ -43,7 +43,7 @@ ONEDAL_FORCEINLINE std::int64_t intersection(const std::int32_t *neigh_u,
     return total;
 }
 
-#if defined(__INTEL_COMPILER)
+#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
 ONEDAL_FORCEINLINE std::int32_t _popcnt32_redef(const std::int32_t &x) {
     return _popcnt32(x);
 }
@@ -70,7 +70,7 @@ ONEDAL_FORCEINLINE std::int64_t intersection<dal::backend::cpu_dispatch_avx512>(
     std::int32_t n_v) {
     std::int64_t total = 0;
     std::int32_t i_u = 0, i_v = 0;
-#if defined(__INTEL_COMPILER)
+#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
     while (i_u < (n_u / 16) * 16 && i_v < (n_v / 16) * 16) { // not in last n%16 elements
         // assumes neighbor list is ordered
         std::int32_t min_neigh_u = neigh_u[i_u];
@@ -362,7 +362,7 @@ ONEDAL_FORCEINLINE std::int64_t intersection<dal::backend::cpu_dispatch_avx2>(
     std::int32_t n_v) {
     std::int64_t total = 0;
     std::int32_t i_u = 0, i_v = 0;
-#if defined(__INTEL_COMPILER)
+#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
     const std::int32_t n_u_8_end = n_u - 8;
     const std::int32_t n_v_8_end = n_v - 8;
     while (i_u <= n_u_8_end && i_v <= n_v_8_end) {

--- a/cpp/oneapi/dal/backend/primitives/intersection/intersection.hpp
+++ b/cpp/oneapi/dal/backend/primitives/intersection/intersection.hpp
@@ -43,7 +43,7 @@ ONEDAL_FORCEINLINE std::int64_t intersection(const std::int32_t *neigh_u,
     return total;
 }
 
-#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
+#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) & !defined(SYCL_LANGUAGE_VERSION)
 ONEDAL_FORCEINLINE std::int32_t _popcnt32_redef(const std::int32_t &x) {
     return _popcnt32(x);
 }

--- a/cpp/oneapi/dal/backend/primitives/intersection/intersection.hpp
+++ b/cpp/oneapi/dal/backend/primitives/intersection/intersection.hpp
@@ -70,7 +70,7 @@ ONEDAL_FORCEINLINE std::int64_t intersection<dal::backend::cpu_dispatch_avx512>(
     std::int32_t n_v) {
     std::int64_t total = 0;
     std::int32_t i_u = 0, i_v = 0;
-#if defined(DAAL_INTEL_CPP_COMPILER)
+#if defined(__AVX512F__) && defined(DAAL_INTEL_CPP_COMPILER)
     while (i_u < (n_u / 16) * 16 && i_v < (n_v / 16) * 16) { // not in last n%16 elements
         // assumes neighbor list is ordered
         std::int32_t min_neigh_u = neigh_u[i_u];
@@ -362,7 +362,7 @@ ONEDAL_FORCEINLINE std::int64_t intersection<dal::backend::cpu_dispatch_avx2>(
     std::int32_t n_v) {
     std::int64_t total = 0;
     std::int32_t i_u = 0, i_v = 0;
-#if defined(DAAL_INTEL_CPP_COMPILER)
+#if defined(__AVX__) && defined(DAAL_INTEL_CPP_COMPILER)
     const std::int32_t n_u_8_end = n_u - 8;
     const std::int32_t n_v_8_end = n_v - 8;
     while (i_u <= n_u_8_end && i_v <= n_v_8_end) {

--- a/cpp/oneapi/dal/backend/primitives/intersection/intersection.hpp
+++ b/cpp/oneapi/dal/backend/primitives/intersection/intersection.hpp
@@ -70,7 +70,7 @@ ONEDAL_FORCEINLINE std::int64_t intersection<dal::backend::cpu_dispatch_avx512>(
     std::int32_t n_v) {
     std::int64_t total = 0;
     std::int32_t i_u = 0, i_v = 0;
-#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
+#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) & !defined(SYCL_LANGUAGE_VERSION)
     while (i_u < (n_u / 16) * 16 && i_v < (n_v / 16) * 16) { // not in last n%16 elements
         // assumes neighbor list is ordered
         std::int32_t min_neigh_u = neigh_u[i_u];
@@ -362,7 +362,7 @@ ONEDAL_FORCEINLINE std::int64_t intersection<dal::backend::cpu_dispatch_avx2>(
     std::int32_t n_v) {
     std::int64_t total = 0;
     std::int32_t i_u = 0, i_v = 0;
-#if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
+#if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) & !defined(SYCL_LANGUAGE_VERSION)
     const std::int32_t n_u_8_end = n_u - 8;
     const std::int32_t n_v_8_end = n_v - 8;
     while (i_u <= n_u_8_end && i_v <= n_v_8_end) {

--- a/docs/source/contribution/coding_guide.rst
+++ b/docs/source/contribution/coding_guide.rst
@@ -335,6 +335,7 @@ Common definitions
   defined(__ICL) // defined for Intel compiler. Has numeric value.
   defined(__INTEL_COMPILER) // defined for Intel compiler. Has numeric value.
   defined(__INTEL_LLVM_COMPILER) // defined for Intel LLVM compiler
+  defined(DAAL_INTEL_CPP_COMPILER) // defined for all Intel C++ compilers
   defined(_MSC_VER) // defined for Intel and MS compilers. Has numeric value.
 
 Statements

--- a/docs/source/contribution/coding_guide.rst
+++ b/docs/source/contribution/coding_guide.rst
@@ -334,6 +334,7 @@ Common definitions
   defined(_WIN32) // defined for Winddows 32bit & Winddows 64bit
   defined(__ICL) // defined for Intel compiler. Has numeric value.
   defined(__INTEL_COMPILER) // defined for Intel compiler. Has numeric value.
+  defined(__INTEL_LLVM_COMPILER) // defined for Intel LLVM compiler
   defined(_MSC_VER) // defined for Intel and MS compilers. Has numeric value.
 
 Statements


### PR DESCRIPTION
# Description
Update intel compiler macros checks with Intel_LLVM case for migration to ICX compiler