### PR TITLE
Fix AddressSanitizer error: alloc-dealloc-mismatch

### DIFF
--- a/cpp/daal/src/threading/threading.h
+++ b/cpp/daal/src/threading/threading.h
@@ -429,7 +429,7 @@ public:
             _deleter->del(_creater);
         }
         delete _deleter;
-        delete _storage;
+        delete[] _storage;
     }
 
     F local(size_t tid)


### PR DESCRIPTION
When compiling w/ [AddressSanitizer](https://github.com/google/sanitizers/wiki/AddressSanitizer) we are getting
```
ERROR: AddressSanitizer: alloc-dealloc-mismatch (operator new [] vs operator delete)
```
presumably due to the mismatch between
https://github.com/oneapi-src/oneDAL/blob/63681e65828995164ea4986fb2174e61f63cd647/cpp/daal/src/threading/threading.h#L399
and
https://github.com/oneapi-src/oneDAL/blob/63681e65828995164ea4986fb2174e61f63cd647/cpp/daal/src/threading/threading.h#L432
It appears that the latter should be
```
delete[] _storage;
```