### PR TITLE
resolving knn classification distance voting issue

### DIFF
--- a/cpp/oneapi/dal/algo/knn/backend/gpu/infer_kernel_impl_dpc.hpp
+++ b/cpp/oneapi/dal/algo/knn/backend/gpu/infer_kernel_impl_dpc.hpp
@@ -418,6 +418,7 @@ sycl::event bf_kernel(sycl::queue& queue,
         ONEDAL_ASSERT(qcount == distances.get_dimension(0));
         ONEDAL_ASSERT(kcount == distances.get_dimension(1));
     }
+    const auto ccount = desc.get_class_count();
 
     // Callback preparation
     const auto qbcount = pr::propose_query_block<Float>(queue, fcount);
@@ -439,7 +440,7 @@ sycl::event bf_kernel(sycl::queue& queue,
         if (desc.get_result_options().test(result_options::responses) &&
             (desc.get_voting_mode() == voting_mode::distance)) {
             callback.set_distance_voting(
-                std::move(pr::make_distance_voting<Float>(queue, qbcount, kcount)));
+                std::move(pr::make_distance_voting<Float>(queue, qbcount, ccount)));
         }
     }
 

--- a/cpp/oneapi/dal/algo/knn/backend/gpu/infer_kernel_impl_dpc_distr.hpp
+++ b/cpp/oneapi/dal/algo/knn/backend/gpu/infer_kernel_impl_dpc_distr.hpp
@@ -538,6 +538,7 @@ sycl::event bf_kernel_distr(sycl::queue& queue,
         ONEDAL_ASSERT(qcount == part_distances.get_dimension(0));
         ONEDAL_ASSERT(2 * kcount == part_distances.get_dimension(1));
     }
+    const auto ccount = desc.get_class_count();
 
     auto block_size = pr::get_block_size<Float>();
     auto rank_count = comm.get_rank_count();
@@ -586,7 +587,7 @@ sycl::event bf_kernel_distr(sycl::queue& queue,
         if (desc.get_result_options().test(result_options::responses) &&
             (desc.get_voting_mode() == voting_mode::distance)) {
             callback.set_distance_voting(
-                std::move(pr::make_distance_voting<Float>(queue, qbcount, kcount)));
+                std::move(pr::make_distance_voting<Float>(queue, qbcount, ccount)));
         }
     }
 


### PR DESCRIPTION
Pass class count to distance voting primitive instead of k value. This resolves incorrect knn classification using distance voting on single gpu and distributed implementations. (ie examples/oneapi/dpc/knn_cls_brute_force_dense_batch)