### PR TITLE
DAAL random splitter bugfix histogram size_t underflow

### DIFF
--- a/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_train_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_train_dense_default_impl.i
@@ -996,7 +996,7 @@ size_t UnorderedRespHelperRandom<algorithmFPType, cpu>::genRandomBinIdx(const In
 {
     //randomly select a histogram split index
     algorithmFPType fidx   = 0;
-    algorithmFPType minval = minidx ? this->indexedFeatures().min(iFeature) : this->indexedFeatures().binRightBorder(iFeature, minidx - 1);
+    algorithmFPType minval = minidx ? this->indexedFeatures().binRightBorder(iFeature, minidx - 1) : this->indexedFeatures().min(iFeature);
     algorithmFPType maxval = this->indexedFeatures().binRightBorder(iFeature, maxidx);
     size_t mid;
     size_t l   = minidx;

--- a/cpp/daal/src/algorithms/dtrees/forest/regression/df_regression_train_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/regression/df_regression_train_dense_default_impl.i
@@ -844,7 +844,7 @@ size_t OrderedRespHelperRandom<algorithmFPType, cpu>::genRandomBinIdx(const Inde
 {
     //randomly select a histogram split index
     algorithmFPType fidx   = 0;
-    algorithmFPType minval = minidx ? this->indexedFeatures().min(iFeature) : this->indexedFeatures().binRightBorder(iFeature, minidx - 1);
+    algorithmFPType minval = minidx ? this->indexedFeatures().binRightBorder(iFeature, minidx - 1) : this->indexedFeatures().min(iFeature);
     algorithmFPType maxval = this->indexedFeatures().binRightBorder(iFeature, maxidx);
     size_t mid;
     size_t l   = minidx;


### PR DESCRIPTION
# Description
Corrects an error with random histogram selection when the minidx =0, it causes minidx to underflow size_t.

Changes proposed in this pull request:
- Swaps the order for proper logic in the ternary operator, this is in training df_regression and df_classification. The ternary checks if minidx is 0 by using the fact that (bool) of 0 is False, and then doesn't do the subtraction and instead uses other logic.
-
-