### PR TITLE
Fix typo in K-Means docs

### DIFF
--- a/docs/source/onedal/algorithms/clustering/kmeans.rst
+++ b/docs/source/onedal/algorithms/clustering/kmeans.rst
@@ -86,7 +86,7 @@ to each cluster.
    c_j^{(t + 1)} = \frac{1}{|S_j^{(t)}|} \sum_{x \in S_j^{(t)}} x, \quad 1 \leq j \leq k.
 
 If any of :math:`S_j^{(t)}` are empty, start the empty clusters handling procedure.
-In this case, you can set the value of :math:c_j^{(t+1)} as the farthest point from 
+In this case, you can set the value of :math:`c_j^{(t+1)}` as the farthest point from 
 the previously calculated centroids for each empty cluster. This procedure makes sure 
 that the number of clusters remains the same.
 


### PR DESCRIPTION
Fix typo in math syntax in K-Means algorithm description