### PR TITLE
move genRandomBinIdx to parent class

### DIFF
--- a/cpp/daal/src/algorithms/dtrees/dtrees_train_data_helper.i
+++ b/cpp/daal/src/algorithms/dtrees/dtrees_train_data_helper.i
@@ -399,6 +399,34 @@ protected:
         DAAL_ASSERT(i < _aResponse.size());
         return _aResponse.get()[i].idx;
     }
+    
+    size_t genRandomBinIdx(const IndexType iFeature, const size_t minidx, const size_t maxidx) const
+    {
+        //randomly select a histogram split index
+        algorithmFPType fidx   = 0;
+        algorithmFPType minval = minidx ? this->indexedFeatures().binRightBorder(iFeature, minidx - 1) : this->indexedFeatures().min(iFeature);
+        algorithmFPType maxval = this->indexedFeatures().binRightBorder(iFeature, maxidx);
+        size_t mid;
+        size_t l   = minidx;
+        size_t idx = maxidx;
+        RNGs<algorithmFPType, cpu> rng;
+        rng.uniform(1, &fidx, this->engineImpl->getState(), minval, maxval); //find random index between minidx and maxidx
+
+        while (l < idx)
+        {
+            mid = l + (idx - l) / 2;
+            if (this->indexedFeatures().binRightBorder(iFeature, idx) > fidx)
+            {
+                idx = mid;
+            }
+            else
+            {
+                l = mid + 1;
+            }
+        }
+        return idx;
+    }
+    
 
 protected:
     TArray<Response, cpu> _aResponse;

--- a/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_train_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_train_dense_default_impl.i
@@ -992,34 +992,6 @@ public:
 };
 
 template <typename algorithmFPType, CpuType cpu>
-size_t UnorderedRespHelperRandom<algorithmFPType, cpu>::genRandomBinIdx(const IndexType iFeature, const size_t minidx, const size_t maxidx) const
-{
-    //randomly select a histogram split index
-    algorithmFPType fidx   = 0;
-    algorithmFPType minval = minidx ? this->indexedFeatures().binRightBorder(iFeature, minidx - 1) : this->indexedFeatures().min(iFeature);
-    algorithmFPType maxval = this->indexedFeatures().binRightBorder(iFeature, maxidx);
-    size_t mid;
-    size_t l   = minidx;
-    size_t idx = maxidx;
-    RNGs<algorithmFPType, cpu> rng;
-    rng.uniform(1, &fidx, this->engineImpl->getState(), minval, maxval); //find random index between minidx and maxidx
-
-    while (l < idx)
-    {
-        mid = l + (idx - l) / 2;
-        if (this->indexedFeatures().binRightBorder(iFeature, idx) > fidx)
-        {
-            idx = mid;
-        }
-        else
-        {
-            l = mid + 1;
-        }
-    }
-    return idx;
-}
-
-template <typename algorithmFPType, CpuType cpu>
 int UnorderedRespHelperRandom<algorithmFPType, cpu>::findSplitbyHistDefault(int nDiffFeatMax, size_t n, size_t nMinSplitPart,
                                                                             const ImpurityData & curImpurity, TSplitData & split,
                                                                             const algorithmFPType minWeightLeaf, const algorithmFPType totalWeights,

--- a/cpp/daal/src/algorithms/dtrees/forest/regression/df_regression_train_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/regression/df_regression_train_dense_default_impl.i
@@ -840,34 +840,6 @@ public:
 };
 
 template <typename algorithmFPType, CpuType cpu>
-size_t OrderedRespHelperRandom<algorithmFPType, cpu>::genRandomBinIdx(const IndexType iFeature, const size_t minidx, const size_t maxidx) const
-{
-    //randomly select a histogram split index
-    algorithmFPType fidx   = 0;
-    algorithmFPType minval = minidx ? this->indexedFeatures().binRightBorder(iFeature, minidx - 1) : this->indexedFeatures().min(iFeature);
-    algorithmFPType maxval = this->indexedFeatures().binRightBorder(iFeature, maxidx);
-    size_t mid;
-    size_t l   = minidx;
-    size_t idx = maxidx;
-    RNGs<algorithmFPType, cpu> rng;
-    rng.uniform(1, &fidx, this->engineImpl->getState(), minval, maxval); //find random index between minidx and maxidx
-
-    while (l < idx)
-    {
-        mid = l + (idx - l) / 2;
-        if (this->indexedFeatures().binRightBorder(iFeature, idx) > fidx)
-        {
-            idx = mid;
-        }
-        else
-        {
-            l = mid + 1;
-        }
-    }
-    return idx;
-}
-
-template <typename algorithmFPType, CpuType cpu>
 template <bool noWeights, bool featureUnordered>
 int OrderedRespHelperRandom<algorithmFPType, cpu>::findBestSplitByHist(size_t nDiffFeatMax, intermSummFPType sumTotal, algorithmFPType * buf,
                                                                        size_t n, size_t nMinSplitPart, const ImpurityData & curImpurity,


### PR DESCRIPTION
# Description
There is an unnecessary duplication of the same function in regression and classification. This PR will unify and reduce the size of the code

Changes proposed in this pull request:
- remove genRandomBinIdx from UnorderedRespHelperRandom
- remove genRandomBinIdx from OrderedRespHelperRandom
- add genRandomBinIdx to DataHelperBase