### PR TITLE
Update EOLed links in documentation

### DIFF
--- a/docs/source/get-started/build-and-run-examples.rst
+++ b/docs/source/get-started/build-and-run-examples.rst
@@ -15,7 +15,7 @@
 .. *******************************************************************************/
 
 .. |dpcpp_gsg| replace:: Get Started with Intel\ |reg|\  oneAPI DPC++/C++ Compiler
-.. _dpcpp_gsg: https://software.intel.com/content/www/us/en/develop/documentation/get-started-with-dpcpp-compiler/top.html
+.. _dpcpp_gsg: https://www.intel.com/content/www/us/en/docs/dpcpp-cpp-compiler/get-started-guide/current/overview.html
 
 Build and Run Examples
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/get-started/prerequisites.rst
+++ b/docs/source/get-started/prerequisites.rst
@@ -15,7 +15,7 @@
 .. *******************************************************************************/
 
 .. |dpcpp_comp| replace:: Intel\ |reg|\  oneAPI DPC++/C++ Compiler
-.. _dpcpp_comp: https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/dpc-compiler.html
+.. _dpcpp_comp: https://www.intel.com/content/www/us/en/developer/tools/oneapi/dpc-compiler.html#gs.wymymc
 
 .. _before_you_begin:
 


### PR DESCRIPTION
# Description
The software.intel.com domain will be removed at the end of Q2, so any redirected links that currently point to it will turn into broken links at that time.

Changes proposed in this pull request:
- Update those links with the correct ones. 

Signed-off-by: Alexandra Epanchinzeva alexandra.epanchinzeva@intel.com 