### PR TITLE
Fix for kernels selector sed command on macOS

### DIFF
--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -382,10 +382,10 @@ jobs:
       .ci/scripts/describe_system.sh
     displayName: 'System info'
   - script: |
-      .ci/scripts/build.sh --compiler clang --target daal --optimizations "sse2 sse42 avx2 avx512" --conda-env ci-env
+      .ci/scripts/build.sh --compiler clang --target daal --optimizations "sse2 avx2" --conda-env ci-env
     displayName: 'make daal'
   - script: |
-      .ci/scripts/build.sh --compiler clang --target oneapi_c --optimizations "sse2 sse42 avx2 avx512"
+      .ci/scripts/build.sh --compiler clang --target oneapi_c --optimizations "sse2 avx2"
     displayName: 'make oneapi_c'
   - task: PublishPipelineArtifact@1
     inputs:

--- a/dev/make/common.mk
+++ b/dev/make/common.mk
@@ -175,6 +175,13 @@ sed.eol.mac =
 sed.eol.win = \r
 sed.eol.lnx =
 
+# sed's end of word
+sed.eow = $(sed.eol.$(_OS))
+# macOS default sed doesn't support it
+sed.eow.mac =
+sed.eow.win = \b
+sed.eow.lnx = \b
+
 # sed
 PATCHBIN = $(patchbin.cmd)
 patchbin.cmd = cp $< $@.patchbin.tmp && $(patchbin.workaround.$(_OS)) sed -n $(sed.-i) $(sed.-b) -e $(PATCHBIN.OPTS) -e "w $@" $@.patchbin.tmp && rm -f $@.patchbin.tmp || { rm -f $@ $@.patchbin.tmp; false; }

--- a/makefile
+++ b/makefile
@@ -133,10 +133,10 @@ USECPUS.files := $(subst sse2,nrh,$(subst ssse3,,$(subst sse42,neh,$(subst avx,,
 USECPUS.out := $(filter-out $(USECPUS),$(CPUs))
 USECPUS.out.for.grep.filter := $(addprefix _,$(addsuffix _,$(subst $(space),_|_,$(USECPUS.out))))
 USECPUS.out.grep.filter := $(if $(USECPUS.out),| grep -v -E '$(USECPUS.out.for.grep.filter)')
-USECPUS.out.defs := $(subst sse2,^\#define DAAL_KERNEL_SSE2\b,$(subst ssse3,^\#define DAAL_KERNEL_SSSE3\b,\
-                    $(subst sse42,^\#define DAAL_KERNEL_SSE42\b,$(subst avx,^\#define DAAL_KERNEL_AVX\b,\
-                    $(subst avx2,^\#define DAAL_KERNEL_AVX2\b,$(subst avx512,^\#define DAAL_KERNEL_AVX512\b,\
-                    $(subst avx512_mic,^\#define DAAL_KERNEL_AVX512_MIC\b,$(USECPUS.out))))))))
+USECPUS.out.defs := $(subst sse2,^\#define DAAL_KERNEL_SSE2$(sed.eow),$(subst ssse3,^\#define DAAL_KERNEL_SSSE3$(sed.eow),\
+                    $(subst sse42,^\#define DAAL_KERNEL_SSE42$(sed.eow),$(subst avx,^\#define DAAL_KERNEL_AVX$(sed.eow),\
+                    $(subst avx2,^\#define DAAL_KERNEL_AVX2$(sed.eow),$(subst avx512,^\#define DAAL_KERNEL_AVX512$(sed.eow),\
+                    $(subst avx512_mic,^\#define DAAL_KERNEL_AVX512_MIC$(sed.eow),$(USECPUS.out))))))))
 USECPUS.out.defs := $(subst $(space)^,|^,$(strip $(USECPUS.out.defs)))
 USECPUS.out.defs.filter := $(if $(USECPUS.out.defs),sed $(sed.-b) $(sed.-i) -E -e 's/$(USECPUS.out.defs)/$(sed.eol)/')
 


### PR DESCRIPTION
Remove '\b' symbol from sed command on macOS to fix selection of kernels.