### PR TITLE
FIX: void function return in csr table

### DIFF
--- a/cpp/oneapi/dal/table/csr.hpp
+++ b/cpp/oneapi/dal/table/csr.hpp
@@ -296,13 +296,13 @@ private:
         row_count = (row_count ? row_count - 1 : std::int64_t(0));
         check_indices(row_offsets.get_data(), row_count, column_count, indexing);
 
-        return init_impl(detail::default_host_policy{},
-                         detail::reinterpret_array_cast<byte_t>(data),
-                         column_indices,
-                         row_offsets,
-                         column_count,
-                         detail::make_data_type<Data>(),
-                         indexing);
+        init_impl(detail::default_host_policy{},
+                  detail::reinterpret_array_cast<byte_t>(data),
+                  column_indices,
+                  row_offsets,
+                  column_count,
+                  detail::make_data_type<Data>(),
+                  indexing);
     }
 
     template <typename Policy>


### PR DESCRIPTION
# Description
Fix static scanner hints
