### PR TITLE
fixup: skip tests on unsupported device/CPU

### DIFF
--- a/cpp/oneapi/dal/backend/primitives/objective_function/test/logloss_dpc.cpp
+++ b/cpp/oneapi/dal/backend/primitives/objective_function/test/logloss_dpc.cpp
@@ -529,35 +529,42 @@ private:
 
 TEMPLATE_TEST_M(logloss_test, "gold input test - double", "[logloss]", double) {
     SKIP_IF(this->not_float64_friendly());
+    SKIP_IF(this->get_policy().is_cpu());
     this->test_gold_input();
 }
 
 TEMPLATE_TEST_M(logloss_test, "gold input test - double - no fit_intercept", "[logloss]", double) {
     SKIP_IF(this->not_float64_friendly());
+    SKIP_IF(this->get_policy().is_cpu());
     this->test_gold_input(false);
 }
 
 TEMPLATE_TEST_M(logloss_test, "gold input test - float", "[logloss]", float) {
+    SKIP_IF(this->get_policy().is_cpu());
     this->test_gold_input();
 }
 
 TEMPLATE_TEST_M(logloss_test, "gold input test - float - no fit intercept", "[logloss]", float) {
+    SKIP_IF(this->get_policy().is_cpu());
     this->test_gold_input(false);
 }
 
 TEMPLATE_TEST_M(logloss_test, "test random input - double without L1", "[logloss]", double) {
     SKIP_IF(this->not_float64_friendly());
+    SKIP_IF(this->get_policy().is_cpu());
     this->generate_input();
     this->run_test(0.0, 1.3);
 }
 
 TEMPLATE_TEST_M(logloss_test, "test random input - double with L1", "[logloss]", double) {
     SKIP_IF(this->not_float64_friendly());
+    SKIP_IF(this->get_policy().is_cpu());
     this->generate_input();
     this->run_test(0.4, 1.3);
 }
 
 TEMPLATE_TEST_M(logloss_test, "test random input - float", "[logloss]", float) {
+    SKIP_IF(this->get_policy().is_cpu());
     this->generate_input();
     this->run_test(0.4, 1.3);
 }


### PR DESCRIPTION
The algorithm is not implemented for CPU therefore we cannot test it