### PR TITLE
Add RNG engine support to oneDAL Decision_forest descriptor

### DIFF
--- a/cpp/oneapi/dal/algo/decision_forest/backend/cpu/train_kernel_cls.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/cpu/train_kernel_cls.cpp
@@ -78,7 +78,7 @@ static result_t call_daal_kernel(const context_cpu& ctx,
         dal::detail::integral_cast<std::size_t>(desc.get_max_tree_depth());
     daal_parameter.minObservationsInLeafNode =
         dal::detail::integral_cast<std::size_t>(desc.get_min_observations_in_leaf_node());
-    
+
     daal_parameter.engine = desc.get_engine().get_enginePtr();
     daal_parameter.impurityThreshold = desc.get_impurity_threshold();
     daal_parameter.memorySavingMode = desc.get_memory_saving_mode();

--- a/cpp/oneapi/dal/algo/decision_forest/backend/cpu/train_kernel_cls.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/cpu/train_kernel_cls.cpp
@@ -78,8 +78,8 @@ static result_t call_daal_kernel(const context_cpu& ctx,
         dal::detail::integral_cast<std::size_t>(desc.get_max_tree_depth());
     daal_parameter.minObservationsInLeafNode =
         dal::detail::integral_cast<std::size_t>(desc.get_min_observations_in_leaf_node());
-    // TODO take engines from desc
-    daal_parameter.engine = daal::algorithms::engines::mt2203::Batch<>::create();
+    
+    daal_parameter.engine = desc.get_engine().get_enginePtr();
     daal_parameter.impurityThreshold = desc.get_impurity_threshold();
     daal_parameter.memorySavingMode = desc.get_memory_saving_mode();
     daal_parameter.bootstrap = desc.get_bootstrap();

--- a/cpp/oneapi/dal/algo/decision_forest/backend/cpu/train_kernel_reg.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/cpu/train_kernel_reg.cpp
@@ -77,7 +77,7 @@ static result_t call_daal_kernel(const context_cpu& ctx,
         dal::detail::integral_cast<std::size_t>(desc.get_max_tree_depth());
     daal_parameter.minObservationsInLeafNode =
         dal::detail::integral_cast<std::size_t>(desc.get_min_observations_in_leaf_node());
-    
+
     daal_parameter.engine = desc.get_engine().get_enginePtr();
     daal_parameter.impurityThreshold = desc.get_impurity_threshold();
     daal_parameter.memorySavingMode = desc.get_memory_saving_mode();

--- a/cpp/oneapi/dal/algo/decision_forest/backend/cpu/train_kernel_reg.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/cpu/train_kernel_reg.cpp
@@ -77,8 +77,8 @@ static result_t call_daal_kernel(const context_cpu& ctx,
         dal::detail::integral_cast<std::size_t>(desc.get_max_tree_depth());
     daal_parameter.minObservationsInLeafNode =
         dal::detail::integral_cast<std::size_t>(desc.get_min_observations_in_leaf_node());
-    // TODO take engines from desc
-    daal_parameter.engine = daal::algorithms::engines::mt2203::Batch<>::create();
+    
+    daal_parameter.engine = desc.get_engine().get_enginePtr();
     daal_parameter.impurityThreshold = desc.get_impurity_threshold();
     daal_parameter.memorySavingMode = desc.get_memory_saving_mode();
     daal_parameter.bootstrap = desc.get_bootstrap();

--- a/cpp/oneapi/dal/algo/decision_forest/backend/gpu/train_kernel_hist_impl_dpc.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/gpu/train_kernel_hist_impl_dpc.cpp
@@ -2889,7 +2889,7 @@ train_result<Task> train_kernel_hist_impl<Float, Bin, Index, Task>::operator()(
 
     de::check_mul_overflow<std::size_t>((ctx.tree_count_ - 1), skip_num);
 
-    pr::engine_collection collection(ctx.tree_count_, desc.get_seed());
+    pr::engine_collection collection(ctx.tree_count_, desc.get_engine());
     rng_engine_list_t engine_arr = collection([&](std::size_t i, std::size_t& skip) {
         skip = i * skip_num;
     });

--- a/cpp/oneapi/dal/algo/decision_forest/common.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/common.cpp
@@ -274,7 +274,7 @@ void descriptor_base<Task>::set_memory_saving_mode_impl(bool value) {
     impl_->memory_saving_mode = value;
 }
 
-template <typename Task>h
+template <typename Task>
 void descriptor_base<Task>::set_bootstrap_impl(bool value) {
     impl_->bootstrap = value;
 }

--- a/cpp/oneapi/dal/algo/decision_forest/common.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/common.cpp
@@ -69,7 +69,7 @@ public:
     voting_mode voting_mode_value = voting_mode::weighted;
 
     std::int64_t seed = 777;
-    oneapi::dal::backend::primitives::engine engine(seed);
+    oneapi::dal::backend::primitives::engine eng;
 };
 
 template <typename Task>
@@ -181,8 +181,8 @@ std::int64_t descriptor_base<Task>::get_seed() const {
 }
 
 template <typename Task>
-std::int64_t descriptor_base<Task>::get_engine() const {
-    return impl_->engine;
+oneapi::dal::backend::primitives::engine descriptor_base<Task>::get_engine() const {
+    return impl_->eng;
 }
 
 template <typename Task>
@@ -307,7 +307,7 @@ void descriptor_base<Task>::set_seed_impl(std::int64_t value) {
 
 template <typename Task>
 void descriptor_base<Task>::set_engine_impl(oneapi::dal::backend::primitives::engine value) {
-    impl_->engine = value;
+    impl_->eng = value;
 }
 
 template class ONEDAL_EXPORT descriptor_base<task::classification>;

--- a/cpp/oneapi/dal/algo/decision_forest/common.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/common.cpp
@@ -69,6 +69,7 @@ public:
     voting_mode voting_mode_value = voting_mode::weighted;
 
     std::int64_t seed = 777;
+    oneapi::dal::backend::primitives::engine engine(seed);
 };
 
 template <typename Task>
@@ -180,6 +181,11 @@ std::int64_t descriptor_base<Task>::get_seed() const {
 }
 
 template <typename Task>
+std::int64_t descriptor_base<Task>::get_engine() const {
+    return impl_->engine;
+}
+
+template <typename Task>
 void descriptor_base<Task>::set_observations_per_tree_fraction_impl(double value) {
     check_domain_cond((value > 0.0 && value <= 1.0),
                       "observations_per_tree_fraction should be > 0.0 and <= 1.0");
@@ -268,7 +274,7 @@ void descriptor_base<Task>::set_memory_saving_mode_impl(bool value) {
     impl_->memory_saving_mode = value;
 }
 
-template <typename Task>
+template <typename Task>h
 void descriptor_base<Task>::set_bootstrap_impl(bool value) {
     impl_->bootstrap = value;
 }
@@ -297,6 +303,11 @@ void descriptor_base<Task>::set_voting_mode_impl(voting_mode value) {
 template <typename Task>
 void descriptor_base<Task>::set_seed_impl(std::int64_t value) {
     impl_->seed = value;
+}
+
+template <typename Task>
+void descriptor_base<Task>::set_engine_impl(oneapi::dal::backend::primitives::engine value) {
+    impl_->engine = value;
 }
 
 template class ONEDAL_EXPORT descriptor_base<task::classification>;

--- a/cpp/oneapi/dal/algo/decision_forest/common.hpp
+++ b/cpp/oneapi/dal/algo/decision_forest/common.hpp
@@ -251,7 +251,6 @@ public:
 
     std::int64_t get_seed() const;
     oneapi::dal::backend::primitives::engine get_engine() const;
-    
 
 protected:
     void set_observations_per_tree_fraction_impl(double value);
@@ -607,7 +606,7 @@ public:
         base_t::set_seed_impl(value);
         return *this;
     }
-    
+
     oneapi::dal::backend::primitives::engine get_engine() const {
         return base_t::get_engine();
     }

--- a/cpp/oneapi/dal/algo/decision_forest/common.hpp
+++ b/cpp/oneapi/dal/algo/decision_forest/common.hpp
@@ -616,7 +616,6 @@ public:
         base_t::set_engine_impl(value);
         return *this;
     }
-    
 };
 
 /// @tparam Task   Tag-type that specifies the type of the problem to solve. Can

--- a/cpp/oneapi/dal/algo/decision_forest/common.hpp
+++ b/cpp/oneapi/dal/algo/decision_forest/common.hpp
@@ -21,6 +21,7 @@
 #include "oneapi/dal/util/common.hpp"
 #include "oneapi/dal/algo/decision_tree/detail/node_visitor.hpp"
 #include "oneapi/dal/detail/serialization.hpp"
+#include "oneapi/dal/backend/primitives/rng/rng_engine.hpp"
 
 namespace oneapi::dal::decision_forest {
 
@@ -249,6 +250,8 @@ public:
     }
 
     std::int64_t get_seed() const;
+    oneapi::dal::backend::primitives::engine get_engine() const;
+    
 
 protected:
     void set_observations_per_tree_fraction_impl(double value);
@@ -277,6 +280,7 @@ protected:
     voting_mode get_voting_mode_impl() const;
 
     void set_seed_impl(std::int64_t value);
+    void set_engine_impl(oneapi::dal::backend::primitves::engine value);
 
 private:
     dal::detail::pimpl<descriptor_impl<Task>> impl_;
@@ -603,6 +607,16 @@ public:
         base_t::set_seed_impl(value);
         return *this;
     }
+    
+    oneapi::dal::backend::primitives::engine get_engine() const {
+        return base_t::get_engine();
+    }
+
+    auto& set_engine(oneapi::dal::backend::primitives::engine value) {
+        base_t::set_engine_impl(value);
+        return *this;
+    }
+    
 };
 
 /// @tparam Task   Tag-type that specifies the type of the problem to solve. Can

--- a/cpp/oneapi/dal/algo/decision_forest/common.hpp
+++ b/cpp/oneapi/dal/algo/decision_forest/common.hpp
@@ -280,7 +280,7 @@ protected:
     voting_mode get_voting_mode_impl() const;
 
     void set_seed_impl(std::int64_t value);
-    void set_engine_impl(oneapi::dal::backend::primitves::engine value);
+    void set_engine_impl(oneapi::dal::backend::primitives::engine value);
 
 private:
     dal::detail::pimpl<descriptor_impl<Task>> impl_;

--- a/cpp/oneapi/dal/backend/primitives/rng/rng_engine.hpp
+++ b/cpp/oneapi/dal/backend/primitives/rng/rng_engine.hpp
@@ -92,7 +92,7 @@ public:
     void* get_state() const {
         return impl_->getState();
     }
-    
+
     daal::algorithms::engines::EnginePtr get_enginePtr() const {
         return engine_;
     }

--- a/cpp/oneapi/dal/backend/primitives/rng/rng_engine.hpp
+++ b/cpp/oneapi/dal/backend/primitives/rng/rng_engine.hpp
@@ -92,6 +92,10 @@ public:
     void* get_state() const {
         return impl_->getState();
     }
+    
+    daal::algorithms::engines::EnginePtr get_enginePtr() const {
+        return engine_;
+    }
 
 private:
     daal::algorithms::engines::EnginePtr engine_;

--- a/cpp/oneapi/dal/backend/primitives/rng/rng_engine_collection.hpp
+++ b/cpp/oneapi/dal/backend/primitives/rng/rng_engine_collection.hpp
@@ -31,6 +31,13 @@ public:
               params_(count),
               technique_(daal::algorithms::engines::internal::family),
               daal_engine_list_(count) {}
+    
+    explicit engine_collection(Size count, const daal::algorithms::engines::EnginePtr& eng)
+            : count_(count),
+              engine_(eng),
+              params_(count),
+              technique_(daal::algorithms::engines::internal::family),
+              daal_engine_list_(count) {}
 
     template <typename Op>
     std::vector<engine> operator()(Op&& op) {

--- a/cpp/oneapi/dal/backend/primitives/rng/rng_engine_collection.hpp
+++ b/cpp/oneapi/dal/backend/primitives/rng/rng_engine_collection.hpp
@@ -31,7 +31,7 @@ public:
               params_(count),
               technique_(daal::algorithms::engines::internal::family),
               daal_engine_list_(count) {}
-    
+
     explicit engine_collection(Size count, const daal::algorithms::engines::EnginePtr& eng)
             : count_(count),
               engine_(eng),

--- a/cpp/oneapi/dal/backend/primitives/rng/rng_engine_collection.hpp
+++ b/cpp/oneapi/dal/backend/primitives/rng/rng_engine_collection.hpp
@@ -39,6 +39,13 @@ public:
               technique_(daal::algorithms::engines::internal::family),
               daal_engine_list_(count) {}
 
+    explicit engine_collection(Size count, oneapi::dal::backend::primitives::engine eng)
+            : count_(count),
+              engine_(eng.get_enginePtr()),
+              params_(count),
+              technique_(daal::algorithms::engines::internal::family),
+              daal_engine_list_(count) {}
+
     template <typename Op>
     std::vector<engine> operator()(Op&& op) {
         daal::services::Status status;


### PR DESCRIPTION
# Add RNG engine support to DF in oneDAL
This allows for modification of the decision forest descriptor to change aspects of the RNG engine.  This will enable the use of random state by properly setting the seed on DF for CPU, and for other engines to be used for CPU and GPU (like MT19937). This will enable better determinism for testing and operation.

Changes proposed in this pull request:
- Add desc.engine using the oneapi::dal::backend::primitive::engine class, as using daal engines explicitly is bad abstraction
- Modify CPU and GPU backends to work with oneapi::dal::backend::primitive::engine
- Add another constructor for engine_collection to take an engine class, which allows for better interoperability.

THIS IS A DRAFT, I knowingly see that there is a conflict between setting desc.seed and desc.engine.  I will need to modify the get_seed and set_seed to regenerate the desc.engine with the new seed, but I need to talk to someone first as to the correct way to do this, especially when the state has been updated.

Secondly, I need to make sure that by returning the enginePtr in some cases that maybe I need to be returning the engine state instead since it updates. I need someone to walk through this with me as to the correct procedure. I may be misusing the engines. 