### PR TITLE
icx compiler and avx2 optimization level for CI

### DIFF
--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -131,15 +131,19 @@ jobs:
     displayName: 'Upload build artifacts'
     continueOnError: true
   - script: |
+      source /opt/intel/oneapi/compiler/latest/env/vars.sh
       .ci/scripts/test.sh --test-kind examples --build-dir $(release.dir) --compiler clang --interface daal/java --conda-env ci-env
     displayName: 'daal/java examples'
   - script: |
+      source /opt/intel/oneapi/compiler/latest/env/vars.sh
       .ci/scripts/test.sh --test-kind examples --build-dir $(release.dir) --compiler clang --interface daal/cpp --build_system cmake
     displayName: 'daal/cpp examples'
   - script: |
+      source /opt/intel/oneapi/compiler/latest/env/vars.sh
       .ci/scripts/test.sh --test-kind examples --build-dir $(release.dir) --compiler clang --interface oneapi/cpp --build_system cmake
     displayName: 'oneapi/cpp examples'
   - script: |
+      source /opt/intel/oneapi/compiler/latest/env/vars.sh
       .ci/scripts/test.sh --test-kind samples --build-dir $(release.dir) --compiler gnu --interface daal/cpp/mpi --conda-env ci-env --build_system make
     displayName: 'daal/cpp/mpi samples'
   - task: PublishPipelineArtifact@1

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -53,10 +53,10 @@ jobs:
       .ci/scripts/describe_system.sh
     displayName: 'System info'
   - script: |
-      .ci/scripts/build.sh --compiler gnu --target daal --conda-env ci-env
+      .ci/scripts/build.sh --compiler gnu --optimizations avx2 --target daal --conda-env ci-env
     displayName: 'make daal'
   - script: |
-      .ci/scripts/build.sh --compiler gnu --target oneapi_c
+      .ci/scripts/build.sh --compiler gnu --optimizations avx2 --target oneapi_c
     displayName: 'make oneapi_c'
   - task: PublishPipelineArtifact@1
     inputs:
@@ -92,7 +92,7 @@ jobs:
 - job: 'LinuxMakeDPCPP'
   timeoutInMinutes: 0
   variables:
-    release.dir: '__release_lnx_clang'
+    release.dir: '__release_lnx_icx'
     platform.type : 'lnx32e'
   pool:
     vmImage: 'ubuntu-22.04'
@@ -117,11 +117,11 @@ jobs:
       .ci/scripts/describe_system.sh
     displayName: 'System info'
   - script: |
-      .ci/scripts/build.sh --compiler clang --target daal --conda-env ci-env
+      .ci/scripts/build.sh --compiler icx  --optimizations avx2 --target daal --conda-env ci-env
     displayName: 'make daal'
   - script: |
       source /opt/intel/oneapi/compiler/latest/env/vars.sh
-      .ci/scripts/build.sh --compiler clang --target onedal_dpc
+      .ci/scripts/build.sh --compiler icx  --optimizations avx2 --target onedal_dpc
     displayName: 'make onedal_dpc'
   - task: PublishPipelineArtifact@1
     inputs:

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -117,6 +117,7 @@ jobs:
       .ci/scripts/describe_system.sh
     displayName: 'System info'
   - script: |
+      source /opt/intel/oneapi/compiler/latest/env/vars.sh
       .ci/scripts/build.sh --compiler icx  --optimizations avx2 --target daal --conda-env ci-env
     displayName: 'make daal'
   - script: |

--- a/cpp/daal/include/data_management/data/internal/finiteness_checker.h
+++ b/cpp/daal/include/data_management/data/internal/finiteness_checker.h
@@ -30,6 +30,12 @@ namespace internal
 template <typename DataType>
 DAAL_EXPORT bool allValuesAreFinite(NumericTable & table, bool allowNaN);
 
+template <typename DataType>
+bool checkFinitenessByComparison(DataType value)
+{
+    return value != value;
+}
+
 } // namespace internal
 } // namespace data_management
 } // namespace daal

--- a/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_predict_dense_default_batch_fpt_cpu.cpp
+++ b/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_predict_dense_default_batch_fpt_cpu.cpp
@@ -22,6 +22,7 @@
 */
 
 #include "src/algorithms/dtrees/forest/classification/df_classification_predict_dense_default_batch.h"
+#include "src/algorithms/dtrees/forest/classification/df_classification_predict_dense_default_batch_impl.i"
 #include "src/algorithms/dtrees/forest/classification/df_classification_predict_dense_default_batch_container.h"
 
 namespace daal

--- a/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_predict_dense_default_batch_fpt_cpu.cpp
+++ b/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_predict_dense_default_batch_fpt_cpu.cpp
@@ -22,7 +22,6 @@
 */
 
 #include "src/algorithms/dtrees/forest/classification/df_classification_predict_dense_default_batch.h"
-#include "src/algorithms/dtrees/forest/classification/df_classification_predict_dense_default_batch_impl.i"
 #include "src/algorithms/dtrees/forest/classification/df_classification_predict_dense_default_batch_container.h"
 
 namespace daal

--- a/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_predict_dense_default_batch_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_predict_dense_default_batch_impl.i
@@ -430,10 +430,11 @@ void PredictClassificationTask<algorithmFPType, cpu>::predictByTreeCommon(const 
 }
 
 template <typename algorithmFPType, CpuType cpu>
-DAAL_FORCEINLINE void PredictClassificationTask<algorithmFPType, cpu>::predictByTree(const algorithmFPType * const x, const size_t sizeOfBlock, const size_t nCols,
-                                                                    const featureIndexType * const tFI, const leftOrClassType * const tLC,
-                                                                    const algorithmFPType * const tFV, algorithmFPType * const prob,
-                                                                    const size_t iTree)
+DAAL_FORCEINLINE void PredictClassificationTask<algorithmFPType, cpu>::predictByTree(const algorithmFPType * const x, const size_t sizeOfBlock,
+                                                                                     const size_t nCols, const featureIndexType * const tFI,
+                                                                                     const leftOrClassType * const tLC,
+                                                                                     const algorithmFPType * const tFV, algorithmFPType * const prob,
+                                                                                     const size_t iTree)
 {
     predictByTreeCommon(x, sizeOfBlock, nCols, tFI, tLC, tFV, prob, iTree);
 }
@@ -442,8 +443,9 @@ DAAL_FORCEINLINE void PredictClassificationTask<algorithmFPType, cpu>::predictBy
 
 template <>
 DAAL_FORCEINLINE void PredictClassificationTask<float, avx512>::predictByTree(const float * const x, const size_t sizeOfBlock, const size_t nCols,
-                                                             const featureIndexType * const feat_idx, const leftOrClassType * const left_son,
-                                                             const float * const split_point, float * const resPtr, const size_t iTree)
+                                                                              const featureIndexType * const feat_idx,
+                                                                              const leftOrClassType * const left_son, const float * const split_point,
+                                                                              float * const resPtr, const size_t iTree)
 {
     if (sizeOfBlock == _DEFAULT_BLOCK_SIZE)
     {
@@ -500,8 +502,10 @@ DAAL_FORCEINLINE void PredictClassificationTask<float, avx512>::predictByTree(co
 
 template <>
 DAAL_FORCEINLINE void PredictClassificationTask<double, avx512>::predictByTree(const double * const x, const size_t sizeOfBlock, const size_t nCols,
-                                                              const featureIndexType * const feat_idx, const leftOrClassType * const left_son,
-                                                              const double * const split_point, double * const resPtr, const size_t iTree)
+                                                                               const featureIndexType * const feat_idx,
+                                                                               const leftOrClassType * const left_son,
+                                                                               const double * const split_point, double * const resPtr,
+                                                                               const size_t iTree)
 {
     if (sizeOfBlock == _DEFAULT_BLOCK_SIZE)
     {

--- a/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_predict_dense_default_batch_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_predict_dense_default_batch_impl.i
@@ -430,7 +430,7 @@ void PredictClassificationTask<algorithmFPType, cpu>::predictByTreeCommon(const 
 }
 
 template <typename algorithmFPType, CpuType cpu>
-void PredictClassificationTask<algorithmFPType, cpu>::predictByTree(const algorithmFPType * const x, const size_t sizeOfBlock, const size_t nCols,
+DAAL_FORCEINLINE void PredictClassificationTask<algorithmFPType, cpu>::predictByTree(const algorithmFPType * const x, const size_t sizeOfBlock, const size_t nCols,
                                                                     const featureIndexType * const tFI, const leftOrClassType * const tLC,
                                                                     const algorithmFPType * const tFV, algorithmFPType * const prob,
                                                                     const size_t iTree)
@@ -441,7 +441,7 @@ void PredictClassificationTask<algorithmFPType, cpu>::predictByTree(const algori
 #if defined(__AVX512F__) && defined(DAAL_INTEL_CPP_COMPILER)
 
 template <>
-void PredictClassificationTask<float, avx512>::predictByTree(const float * const x, const size_t sizeOfBlock, const size_t nCols,
+DAAL_FORCEINLINE void PredictClassificationTask<float, avx512>::predictByTree(const float * const x, const size_t sizeOfBlock, const size_t nCols,
                                                              const featureIndexType * const feat_idx, const leftOrClassType * const left_son,
                                                              const float * const split_point, float * const resPtr, const size_t iTree)
 {
@@ -499,7 +499,7 @@ void PredictClassificationTask<float, avx512>::predictByTree(const float * const
 }
 
 template <>
-void PredictClassificationTask<double, avx512>::predictByTree(const double * const x, const size_t sizeOfBlock, const size_t nCols,
+DAAL_FORCEINLINE void PredictClassificationTask<double, avx512>::predictByTree(const double * const x, const size_t sizeOfBlock, const size_t nCols,
                                                               const featureIndexType * const feat_idx, const leftOrClassType * const left_son,
                                                               const double * const split_point, double * const resPtr, const size_t iTree)
 {
@@ -610,7 +610,7 @@ Status PredictClassificationTask<algorithmFPType, cpu>::predictByAllTrees(const 
 }
 
 template <typename algorithmFPType, CpuType cpu>
-Status PredictClassificationTask<algorithmFPType, cpu>::predictOneRowByAllTrees(const size_t nTreesTotal)
+DAAL_FORCEINLINE Status PredictClassificationTask<algorithmFPType, cpu>::predictOneRowByAllTrees(const size_t nTreesTotal)
 {
     if (_nClasses != _cachedNClasses)
     {
@@ -696,7 +696,7 @@ Status PredictClassificationTask<algorithmFPType, cpu>::predictOneRowByAllTrees(
 
 #if defined(__AVX512F__) && defined(DAAL_INTEL_CPP_COMPILER)
 template <>
-Status PredictClassificationTask<float, avx512>::predictOneRowByAllTrees(size_t nTreesTotal)
+DAAL_FORCEINLINE Status PredictClassificationTask<float, avx512>::predictOneRowByAllTrees(const size_t nTreesTotal)
 {
     if (_cachedModel != _model)
     {

--- a/cpp/daal/src/algorithms/dtrees/gbt/classification/gbt_classification_predict_dense_default_batch_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/gbt/classification/gbt_classification_predict_dense_default_batch_impl.i
@@ -228,7 +228,7 @@ protected:
         {
             for (size_t idx = 0; idx < nRows * nColumns; ++idx)
             {
-                if (isnan(x[idx])) return true;
+                if (checkFinitenessByComparison(x[idx])) return true;
             }
         }
         return false;

--- a/cpp/daal/src/algorithms/dtrees/gbt/gbt_predict_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/gbt/gbt_predict_dense_default_impl.i
@@ -30,6 +30,7 @@
 #include "src/algorithms/dtrees/dtrees_predict_dense_default_impl.i"
 #include "src/algorithms/dtrees/dtrees_feature_type_helper.h"
 #include "src/algorithms/dtrees/gbt/gbt_internal.h"
+#include "data_management/data/internal/finiteness_checker.h"
 
 namespace daal
 {
@@ -69,7 +70,7 @@ template <typename algorithmFPType>
 inline FeatureIndexType updateIndex(FeatureIndexType idx, algorithmFPType valueFromDataSet, const ModelFPType * splitPoints, const int * defaultLeft,
                                     const FeatureTypes & featTypes, FeatureIndexType splitFeature, const PredictDispatcher<false, true> & dispatcher)
 {
-    if (isnan(valueFromDataSet))
+    if (checkFinitenessByComparison(valueFromDataSet))
     {
         return idx * 2 + (defaultLeft[idx] != 1);
     }
@@ -83,7 +84,7 @@ template <typename algorithmFPType>
 inline FeatureIndexType updateIndex(FeatureIndexType idx, algorithmFPType valueFromDataSet, const ModelFPType * splitPoints, const int * defaultLeft,
                                     const FeatureTypes & featTypes, FeatureIndexType splitFeature, const PredictDispatcher<true, true> & dispatcher)
 {
-    if (isnan(valueFromDataSet))
+    if (checkFinitenessByComparison(valueFromDataSet))
     {
         return idx * 2 + (defaultLeft[idx] != 1);
     }

--- a/cpp/daal/src/algorithms/dtrees/gbt/regression/gbt_regression_predict_dense_default_batch_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/gbt/regression/gbt_regression_predict_dense_default_batch_impl.i
@@ -92,7 +92,7 @@ protected:
         {
             for (size_t idx = 0; idx < nRows * nColumns; ++idx)
             {
-                if (isnan(x[idx])) return true;
+                if (checkFinitenessByComparison(x[idx])) return true;
             }
         }
         return false;

--- a/cpp/oneapi/dal/algo/triangle_counting/backend/cpu/intersection_tc.hpp
+++ b/cpp/oneapi/dal/algo/triangle_counting/backend/cpu/intersection_tc.hpp
@@ -78,7 +78,7 @@ struct intersection_local_tc<dal::backend::cpu_dispatch_avx512> {
                                                std::int64_t tc_size) {
         std::int64_t total = 0;
         std::int32_t i_u = 0, i_v = 0;
-#if defined(DAAL_INTEL_CPP_COMPILER)
+#if defined(__AVX512F__) && defined(DAAL_INTEL_CPP_COMPILER)
         while (i_u < (n_u / 16) * 16 && i_v < (n_v / 16) * 16) { // not in last n%16 elements
             // assumes neighbor list is ordered
             std::int32_t min_neigh_u = neigh_u[i_u];


### PR DESCRIPTION
Changes:
- Set compiler to `icx` for `LinuxMakeDPCPP` job
- Set optimization level to avx2 for `LinuxMake*` jobs
- Fix `icx` compilation errors:
  - Force inline for some of decision forest classification `PredictClassificationTask` methods
  - Replace std::isnan with `x != x` comparison (orevents icx error: `explicit comparison with NaN in fast floating point mode`)
  - Explicit ifdef(AVX512F) in intersection_tc.hpp