### PR TITLE
Add hessian product function to logloss primitve

### DIFF
--- a/cpp/oneapi/dal/backend/primitives/objective_function/BUILD
+++ b/cpp/oneapi/dal/backend/primitives/objective_function/BUILD
@@ -10,7 +10,6 @@ dal_module(
     dal_deps = [
         "@onedal//cpp/oneapi/dal/backend/primitives:common",
         "@onedal//cpp/oneapi/dal/backend/primitives:blas",
-        "@onedal//cpp/oneapi/dal/backend/primitives:rng"
     ],
 )
 
@@ -26,6 +25,7 @@ dal_test_suite(
     ]),
     dal_deps = [
         ":objective_function",
+        "@onedal//cpp/oneapi/dal/backend/primitives:rng",
     ],
 )
 

--- a/cpp/oneapi/dal/backend/primitives/objective_function/BUILD
+++ b/cpp/oneapi/dal/backend/primitives/objective_function/BUILD
@@ -9,7 +9,8 @@ dal_module(
     auto = True,
     dal_deps = [
         "@onedal//cpp/oneapi/dal/backend/primitives:common",
-        "@onedal//cpp/oneapi/dal/backend/primitives:blas"
+        "@onedal//cpp/oneapi/dal/backend/primitives:blas",
+        "@onedal//cpp/oneapi/dal/backend/primitives:rng"
     ],
 )
 

--- a/cpp/oneapi/dal/backend/primitives/objective_function/logloss.hpp
+++ b/cpp/oneapi/dal/backend/primitives/objective_function/logloss.hpp
@@ -104,11 +104,20 @@ public:
 
     sycl::event set_raw_hessian(const ndview<Float, 1>& raw_hessian, const event_vector& deps = {});
 
+    ndview<Float, 1>& get_raw_hessian();
+
     sycl::event operator()(const ndview<Float, 1>& vec,
                            ndview<Float, 1>& out,
                            const event_vector& deps = {});
 
 private:
+    sycl::event compute_with_fit_intercept(const ndview<Float, 1>& vec,
+                                           ndview<Float, 1>& out,
+                                           const event_vector& deps);
+    sycl::event compute_without_fit_intercept(const ndview<Float, 1>& vec,
+                                              ndview<Float, 1>& out,
+                                              const event_vector& deps);
+
     sycl::queue q_;
     ndarray<Float, 1> raw_hessian_;
     const ndview<Float, 2> data_;

--- a/cpp/oneapi/dal/backend/primitives/objective_function/logloss.hpp
+++ b/cpp/oneapi/dal/backend/primitives/objective_function/logloss.hpp
@@ -88,4 +88,35 @@ sycl::event compute_hessian(sycl::queue& q,
                             bool fit_intercept = true,
                             const event_vector& deps = {});
 
+template <typename Float>
+sycl::event compute_raw_hessian(sycl::queue& q,
+                                const ndview<Float, 1>& probabilities,
+                                ndview<Float, 1>& out_hessian,
+                                const event_vector& deps = {});
+
+template <typename Float>
+class logloss_hessp {
+public:
+    logloss_hessp(sycl::queue& q,
+                  const ndview<Float, 2>& data,
+                  const Float L2 = Float(0),
+                  const bool fit_intercept = true);
+
+    sycl::event set_raw_hessian(const ndview<Float, 1>& raw_hessian, const event_vector& deps = {});
+
+    sycl::event operator()(const ndview<Float, 1>& vec,
+                           ndview<Float, 1>& out,
+                           const event_vector& deps = {});
+
+private:
+    sycl::queue q_;
+    ndarray<Float, 1> raw_hessian_;
+    const ndview<Float, 2> data_;
+    ndarray<Float, 1> buffer_;
+    const Float L2_;
+    const bool fit_intercept_;
+    const std::int64_t n_;
+    const std::int64_t p_;
+};
+
 } // namespace oneapi::dal::backend::primitives

--- a/cpp/oneapi/dal/backend/primitives/objective_function/logloss.hpp
+++ b/cpp/oneapi/dal/backend/primitives/objective_function/logloss.hpp
@@ -95,17 +95,16 @@ sycl::event compute_raw_hessian(sycl::queue& q,
                                 const event_vector& deps = {});
 
 template <typename Float>
-class logloss_hessp {
+class logloss_hessian_product {
 public:
-    logloss_hessp(sycl::queue& q,
-                  const ndview<Float, 2>& data,
-                  const Float L2 = Float(0),
-                  const bool fit_intercept = true);
+    logloss_hessian_product(sycl::queue& q,
+                            const ndview<Float, 2>& data,
+                            const Float L2 = Float(0),
+                            const bool fit_intercept = true);
 
     sycl::event set_raw_hessian(const ndview<Float, 1>& raw_hessian, const event_vector& deps = {});
 
     ndview<Float, 1>& get_raw_hessian();
-
     sycl::event operator()(const ndview<Float, 1>& vec,
                            ndview<Float, 1>& out,
                            const event_vector& deps = {});

--- a/cpp/oneapi/dal/backend/primitives/objective_function/logloss_dpc.cpp
+++ b/cpp/oneapi/dal/backend/primitives/objective_function/logloss_dpc.cpp
@@ -16,6 +16,7 @@
 
 #include "oneapi/dal/backend/primitives/objective_function/logloss.hpp"
 #include "oneapi/dal/backend/primitives/blas/gemv.hpp"
+#include "oneapi/dal/backend/primitives/element_wise.hpp"
 
 namespace oneapi::dal::backend::primitives {
 
@@ -473,16 +474,12 @@ sycl::event compute_raw_hessian(sycl::queue& q,
     ONEDAL_ASSERT(probabilities.has_data());
     ONEDAL_ASSERT(out_hessian.has_mutable_data());
 
-    auto* const hes_ptr = out_hessian.get_mutable_data();
-    const auto* const proba_ptr = probabilities.get_data();
+    const auto kernel = [=](const Float& val, Float*) -> Float {
+        constexpr Float one(1);
+        return val * (one - val);
+    };
 
-    return q.submit([&](sycl::handler& cgh) {
-        cgh.depends_on(deps);
-        const auto range = make_range_1d(n);
-        cgh.parallel_for(range, [=](sycl::id<1> idx) {
-            hes_ptr[idx] = proba_ptr[idx] * (1 - proba_ptr[idx]);
-        });
-    });
+    return element_wise(q, kernel, probabilities, nullptr, out_hessian, deps);
 }
 
 template <typename Float>
@@ -508,68 +505,75 @@ sycl::event logloss_hessp<Float>::set_raw_hessian(const ndview<Float, 1>& raw_he
 }
 
 template <typename Float>
-sycl::event logloss_hessp<Float>::operator()(const ndview<Float, 1>& vec,
-                                             ndview<Float, 1>& out,
-                                             const event_vector& deps) {
+ndview<Float, 1>& logloss_hessp<Float>::get_raw_hessian() {
+    return raw_hessian_;
+}
+
+template <typename Float>
+sycl::event logloss_hessp<Float>::compute_with_fit_intercept(const ndview<Float, 1>& vec,
+                                                             ndview<Float, 1>& out,
+                                                             const event_vector& deps) {
     auto* const buffer_ptr = buffer_.get_mutable_data();
     const auto* const hess_ptr = raw_hessian_.get_data();
     auto* const out_ptr = out.get_mutable_data();
-    auto* const vec_ptr = vec.get_data();
+    ONEDAL_ASSERT(vec.get_dimension(0) == p_ + 1);
+    ONEDAL_ASSERT(out.get_dimension(0) == p_ + 1);
+    auto fill_buffer_event = fill<Float>(q_, buffer_, Float(1), deps);
+    auto out_suf = out.get_slice(1, p_ + 1);
+    auto out_bias = out.get_slice(0, 1);
+    auto vec_suf = vec.get_slice(1, p_ + 1);
 
+    sycl::event fill_out_event = copy(q_, out_suf, vec_suf, deps);
+    sycl::event fill_out0_event = fill<Float>(q_, out_bias, Float(0), deps);
+
+    Float v0 = vec.at_device(q_, 0, deps);
+    sycl::event event_xv = gemv(q_, data_, vec_suf, buffer_, Float(1), v0, { fill_buffer_event });
+
+    sycl::event event_dxv = q_.submit([&](sycl::handler& cgh) {
+        cgh.depends_on({ event_xv, fill_out_event, fill_out0_event });
+        const auto range = make_range_1d(n_);
+        auto sum_reduction = sycl::reduction(out_ptr, sycl::plus<>());
+        cgh.parallel_for(range, sum_reduction, [=](sycl::id<1> idx, auto& sum_v0) {
+            buffer_ptr[idx] = buffer_ptr[idx] * hess_ptr[idx];
+            sum_v0 += buffer_ptr[idx];
+        });
+    });
+    auto event_xtdxv =
+        gemv(q_, data_.t(), buffer_, out_suf, Float(1), L2_ * 2, { event_dxv, fill_out_event });
+    return event_xtdxv;
+}
+
+template <typename Float>
+sycl::event logloss_hessp<Float>::compute_without_fit_intercept(const ndview<Float, 1>& vec,
+                                                                ndview<Float, 1>& out,
+                                                                const event_vector& deps) {
+    ONEDAL_ASSERT(vec.get_dimension(0) == p_);
+    ONEDAL_ASSERT(out.get_dimension(0) == p_);
+
+    sycl::event fill_out_event = copy(q_, out, vec, deps);
+
+    auto event_xv = gemv(q_, data_, vec, buffer_, Float(1), Float(0), deps);
+
+    auto buf_ndview = static_cast<ndview<Float, 1>&>(buffer_);
+    auto hess_ndview = static_cast<ndview<Float, 1>&>(raw_hessian_);
+    constexpr sycl::multiplies<Float> kernel_mul{};
+    auto event_dxv =
+        element_wise(q_, kernel_mul, buf_ndview, hess_ndview, buf_ndview, { event_xv });
+
+    auto event_xtdxv =
+        gemv(q_, data_.t(), buffer_, out, Float(1), L2_ * 2, { event_dxv, fill_out_event });
+    return event_xtdxv;
+}
+
+template <typename Float>
+sycl::event logloss_hessp<Float>::operator()(const ndview<Float, 1>& vec,
+                                             ndview<Float, 1>& out,
+                                             const event_vector& deps) {
     if (fit_intercept_) {
-        ONEDAL_ASSERT(vec.get_dimension(0) == p_ + 1);
-        ONEDAL_ASSERT(out.get_dimension(0) == p_ + 1);
-        auto fill_buffer_event = fill<Float>(q_, buffer_, Float(1), deps);
-        auto out_suf = out.get_slice(1, p_ + 1);
-        auto vec_suf = vec.get_slice(1, p_ + 1);
-
-        sycl::event fill_out_event = q_.submit([&](sycl::handler& cgh) {
-            cgh.depends_on(deps);
-            const auto range = make_range_1d(p_ + 1);
-            cgh.parallel_for(range, [=](sycl::id<1> idx) {
-                out_ptr[idx] = idx > 0 ? vec_ptr[idx] : 0;
-            });
-        });
-
-        Float v0 = vec.get_slice(0, 1).to_host(q_, deps).at(0);
-
-        sycl::event event_xv =
-            gemv(q_, data_, vec_suf, buffer_, Float(1), v0, { fill_buffer_event });
-
-        sycl::event event_dxv = q_.submit([&](sycl::handler& cgh) {
-            cgh.depends_on({ event_xv, fill_out_event });
-            const auto range = make_range_1d(n_);
-            auto sum_reduction = sycl::reduction(out_ptr, sycl::plus<>());
-            cgh.parallel_for(range, sum_reduction, [=](sycl::id<1> idx, auto& sum_v0) {
-                buffer_ptr[idx] = buffer_ptr[idx] * hess_ptr[idx];
-                sum_v0 += buffer_ptr[idx];
-            });
-        });
-        auto event_xtdxv =
-            gemv(q_, data_.t(), buffer_, out_suf, Float(1), L2_ * 2, { event_dxv, fill_out_event });
-        return event_xtdxv;
+        return compute_with_fit_intercept(vec, out, deps);
     }
     else {
-        ONEDAL_ASSERT(vec.get_dimension(0) == p_);
-        ONEDAL_ASSERT(out.get_dimension(0) == p_);
-        sycl::event fill_out_event = q_.submit([&](sycl::handler& cgh) {
-            cgh.depends_on(deps);
-            const auto range = make_range_1d(p_);
-            cgh.parallel_for(range, [=](sycl::id<1> idx) {
-                out_ptr[idx] = vec_ptr[idx];
-            });
-        });
-        auto event_xv = gemv(q_, data_, vec, buffer_, Float(1), Float(0), deps);
-        auto event_dxv = q_.submit([&](sycl::handler& cgh) {
-            cgh.depends_on({ event_xv });
-            const auto range = make_range_1d(n_);
-            cgh.parallel_for(range, [=](sycl::id<1> idx) {
-                buffer_ptr[idx] = buffer_ptr[idx] * hess_ptr[idx];
-            });
-        });
-        auto event_xtdxv =
-            gemv(q_, data_.t(), buffer_, out, Float(1), L2_ * 2, { event_dxv, fill_out_event });
-        return event_xtdxv;
+        return compute_without_fit_intercept(vec, out, deps);
     }
 }
 

--- a/cpp/oneapi/dal/backend/primitives/objective_function/logloss_dpc.cpp
+++ b/cpp/oneapi/dal/backend/primitives/objective_function/logloss_dpc.cpp
@@ -462,6 +462,117 @@ sycl::event compute_hessian(sycl::queue& q,
     return make_symmetric;
 }
 
+template <typename Float>
+sycl::event compute_raw_hessian(sycl::queue& q,
+                                const ndview<Float, 1>& probabilities,
+                                ndview<Float, 1>& out_hessian,
+                                const event_vector& deps) {
+    const std::int64_t n = probabilities.get_dimension(0);
+
+    ONEDAL_ASSERT(out_hessian.get_dimension(0) == n);
+    ONEDAL_ASSERT(probabilities.has_data());
+    ONEDAL_ASSERT(out_hessian.has_mutable_data());
+
+    auto* const hes_ptr = out_hessian.get_mutable_data();
+    const auto* const proba_ptr = probabilities.get_data();
+
+    return q.submit([&](sycl::handler& cgh) {
+        cgh.depends_on(deps);
+        const auto range = make_range_1d(n);
+        cgh.parallel_for(range, [=](sycl::id<1> idx) {
+            hes_ptr[idx] = proba_ptr[idx] * (1 - proba_ptr[idx]);
+        });
+    });
+}
+
+template <typename Float>
+logloss_hessp<Float>::logloss_hessp(sycl::queue& q,
+                                    const ndview<Float, 2>& data,
+                                    const Float L2,
+                                    const bool fit_intercept)
+        : q_(q),
+          data_(data),
+          L2_{ L2 },
+          fit_intercept_{ fit_intercept },
+          n_{ data.get_dimension(0) },
+          p_{ data.get_dimension(1) } {
+    raw_hessian_ = ndarray<Float, 1>::empty(q_, { n_ });
+    buffer_ = ndarray<Float, 1>::empty(q_, { n_ });
+}
+
+template <typename Float>
+sycl::event logloss_hessp<Float>::set_raw_hessian(const ndview<Float, 1>& raw_hessian,
+                                                  const event_vector& deps) {
+    ONEDAL_ASSERT(raw_hessian.get_dimension(0) == n_);
+    return copy(q_, raw_hessian_, raw_hessian, deps);
+}
+
+template <typename Float>
+sycl::event logloss_hessp<Float>::operator()(const ndview<Float, 1>& vec,
+                                             ndview<Float, 1>& out,
+                                             const event_vector& deps) {
+    auto* const buffer_ptr = buffer_.get_mutable_data();
+    const auto* const hess_ptr = raw_hessian_.get_data();
+    auto* const out_ptr = out.get_mutable_data();
+    auto* const vec_ptr = vec.get_data();
+
+    if (fit_intercept_) {
+        ONEDAL_ASSERT(vec.get_dimension(0) == p_ + 1);
+        ONEDAL_ASSERT(out.get_dimension(0) == p_ + 1);
+        auto fill_buffer_event = fill<Float>(q_, buffer_, Float(1), deps);
+        auto out_suf = out.get_slice(1, p_ + 1);
+        auto vec_suf = vec.get_slice(1, p_ + 1);
+
+        sycl::event fill_out_event = q_.submit([&](sycl::handler& cgh) {
+            cgh.depends_on(deps);
+            const auto range = make_range_1d(p_ + 1);
+            cgh.parallel_for(range, [=](sycl::id<1> idx) {
+                out_ptr[idx] = idx > 0 ? vec_ptr[idx] : 0;
+            });
+        });
+
+        Float v0 = vec.get_slice(0, 1).to_host(q_, deps).at(0);
+
+        sycl::event event_xv =
+            gemv(q_, data_, vec_suf, buffer_, Float(1), v0, { fill_buffer_event });
+
+        sycl::event event_dxv = q_.submit([&](sycl::handler& cgh) {
+            cgh.depends_on({ event_xv, fill_out_event });
+            const auto range = make_range_1d(n_);
+            auto sum_reduction = sycl::reduction(out_ptr, sycl::plus<>());
+            cgh.parallel_for(range, sum_reduction, [=](sycl::id<1> idx, auto& sum_v0) {
+                buffer_ptr[idx] = buffer_ptr[idx] * hess_ptr[idx];
+                sum_v0 += buffer_ptr[idx];
+            });
+        });
+        auto event_xtdxv =
+            gemv(q_, data_.t(), buffer_, out_suf, Float(1), L2_ * 2, { event_dxv, fill_out_event });
+        return event_xtdxv;
+    }
+    else {
+        ONEDAL_ASSERT(vec.get_dimension(0) == p_);
+        ONEDAL_ASSERT(out.get_dimension(0) == p_);
+        sycl::event fill_out_event = q_.submit([&](sycl::handler& cgh) {
+            cgh.depends_on(deps);
+            const auto range = make_range_1d(p_);
+            cgh.parallel_for(range, [=](sycl::id<1> idx) {
+                out_ptr[idx] = vec_ptr[idx];
+            });
+        });
+        auto event_xv = gemv(q_, data_, vec, buffer_, Float(1), Float(0), deps);
+        auto event_dxv = q_.submit([&](sycl::handler& cgh) {
+            cgh.depends_on({ event_xv });
+            const auto range = make_range_1d(n_);
+            cgh.parallel_for(range, [=](sycl::id<1> idx) {
+                buffer_ptr[idx] = buffer_ptr[idx] * hess_ptr[idx];
+            });
+        });
+        auto event_xtdxv =
+            gemv(q_, data_.t(), buffer_, out, Float(1), L2_ * 2, { event_dxv, fill_out_event });
+        return event_xtdxv;
+    }
+}
+
 #define INSTANTIATE(F)                                                               \
     template sycl::event compute_probabilities<F>(sycl::queue&,                      \
                                                   const ndview<F, 1>&,               \
@@ -518,7 +629,12 @@ sycl::event compute_hessian(sycl::queue& q,
                                             const F,                                 \
                                             const F,                                 \
                                             const bool,                              \
-                                            const event_vector&);
+                                            const event_vector&);                    \
+    template sycl::event compute_raw_hessian<F>(sycl::queue&,                        \
+                                                const ndview<F, 1>&,                 \
+                                                ndview<F, 1>&,                       \
+                                                const event_vector&);                \
+    template class logloss_hessp<F>;
 
 INSTANTIATE(float);
 INSTANTIATE(double);

--- a/cpp/oneapi/dal/backend/primitives/objective_function/logloss_dpc.cpp
+++ b/cpp/oneapi/dal/backend/primitives/objective_function/logloss_dpc.cpp
@@ -554,8 +554,8 @@ sycl::event logloss_hessp<Float>::compute_without_fit_intercept(const ndview<Flo
 
     auto event_xv = gemv(q_, data_, vec, buffer_, Float(1), Float(0), deps);
 
-    auto buf_ndview = static_cast<ndview<Float, 1>&>(buffer_);
-    auto hess_ndview = static_cast<ndview<Float, 1>&>(raw_hessian_);
+    auto& buf_ndview = static_cast<ndview<Float, 1>&>(buffer_);
+    auto& hess_ndview = static_cast<ndview<Float, 1>&>(raw_hessian_);
     constexpr sycl::multiplies<Float> kernel_mul{};
     auto event_dxv =
         element_wise(q_, kernel_mul, buf_ndview, hess_ndview, buf_ndview, { event_xv });

--- a/cpp/oneapi/dal/backend/primitives/objective_function/logloss_dpc.cpp
+++ b/cpp/oneapi/dal/backend/primitives/objective_function/logloss_dpc.cpp
@@ -483,10 +483,10 @@ sycl::event compute_raw_hessian(sycl::queue& q,
 }
 
 template <typename Float>
-logloss_hessp<Float>::logloss_hessp(sycl::queue& q,
-                                    const ndview<Float, 2>& data,
-                                    const Float L2,
-                                    const bool fit_intercept)
+logloss_hessian_product<Float>::logloss_hessian_product(sycl::queue& q,
+                                                        const ndview<Float, 2>& data,
+                                                        const Float L2,
+                                                        const bool fit_intercept)
         : q_(q),
           data_(data),
           L2_{ L2 },
@@ -498,21 +498,21 @@ logloss_hessp<Float>::logloss_hessp(sycl::queue& q,
 }
 
 template <typename Float>
-sycl::event logloss_hessp<Float>::set_raw_hessian(const ndview<Float, 1>& raw_hessian,
-                                                  const event_vector& deps) {
+sycl::event logloss_hessian_product<Float>::set_raw_hessian(const ndview<Float, 1>& raw_hessian,
+                                                            const event_vector& deps) {
     ONEDAL_ASSERT(raw_hessian.get_dimension(0) == n_);
     return copy(q_, raw_hessian_, raw_hessian, deps);
 }
 
 template <typename Float>
-ndview<Float, 1>& logloss_hessp<Float>::get_raw_hessian() {
+ndview<Float, 1>& logloss_hessian_product<Float>::get_raw_hessian() {
     return raw_hessian_;
 }
 
 template <typename Float>
-sycl::event logloss_hessp<Float>::compute_with_fit_intercept(const ndview<Float, 1>& vec,
-                                                             ndview<Float, 1>& out,
-                                                             const event_vector& deps) {
+sycl::event logloss_hessian_product<Float>::compute_with_fit_intercept(const ndview<Float, 1>& vec,
+                                                                       ndview<Float, 1>& out,
+                                                                       const event_vector& deps) {
     auto* const buffer_ptr = buffer_.get_mutable_data();
     const auto* const hess_ptr = raw_hessian_.get_data();
     auto* const out_ptr = out.get_mutable_data();
@@ -544,9 +544,10 @@ sycl::event logloss_hessp<Float>::compute_with_fit_intercept(const ndview<Float,
 }
 
 template <typename Float>
-sycl::event logloss_hessp<Float>::compute_without_fit_intercept(const ndview<Float, 1>& vec,
-                                                                ndview<Float, 1>& out,
-                                                                const event_vector& deps) {
+sycl::event logloss_hessian_product<Float>::compute_without_fit_intercept(
+    const ndview<Float, 1>& vec,
+    ndview<Float, 1>& out,
+    const event_vector& deps) {
     ONEDAL_ASSERT(vec.get_dimension(0) == p_);
     ONEDAL_ASSERT(out.get_dimension(0) == p_);
 
@@ -566,9 +567,9 @@ sycl::event logloss_hessp<Float>::compute_without_fit_intercept(const ndview<Flo
 }
 
 template <typename Float>
-sycl::event logloss_hessp<Float>::operator()(const ndview<Float, 1>& vec,
-                                             ndview<Float, 1>& out,
-                                             const event_vector& deps) {
+sycl::event logloss_hessian_product<Float>::operator()(const ndview<Float, 1>& vec,
+                                                       ndview<Float, 1>& out,
+                                                       const event_vector& deps) {
     if (fit_intercept_) {
         return compute_with_fit_intercept(vec, out, deps);
     }
@@ -638,7 +639,7 @@ sycl::event logloss_hessp<Float>::operator()(const ndview<Float, 1>& vec,
                                                 const ndview<F, 1>&,                 \
                                                 ndview<F, 1>&,                       \
                                                 const event_vector&);                \
-    template class logloss_hessp<F>;
+    template class logloss_hessian_product<F>;
 
 INSTANTIATE(float);
 INSTANTIATE(double);

--- a/cpp/oneapi/dal/backend/primitives/objective_function/test/logloss_dpc.cpp
+++ b/cpp/oneapi/dal/backend/primitives/objective_function/test/logloss_dpc.cpp
@@ -212,7 +212,7 @@ public:
         auto out_raw_hessian =
             ndarray<float_t, 1>::empty(this->get_queue(), { n }, sycl::usm::alloc::device);
 
-        auto hessp = logloss_hessp(this->get_queue(), data_gpu, L2, fit_intercept);
+        auto hessp = logloss_hessian_product(this->get_queue(), data_gpu, L2, fit_intercept);
 
         auto raw_hess_event =
             compute_raw_hessian(this->get_queue(), out_predictions, hessp.get_raw_hessian(), {});
@@ -535,7 +535,7 @@ public:
     }
 
     void test_hessian_product(const ndview<float_t, 2>& hessian_host,
-                              logloss_hessp<float_t>& hessp,
+                              logloss_hessian_product<float_t>& hessp,
                               bool fit_intercept,
                               double L2,
                               const float_t rtol = 1e-3,


### PR DESCRIPTION
# Description=
To use logloss objective in newton-cg optimizer it should provide hessian-product callable object.

In this PR I implemented class logloss_hessp<Float> with overloaded operator() to calculate hessian product and implemented a function that calculated raw hessian