### PR TITLE
fix: nColumns in AOSNumericTable constructor

### DIFF
--- a/cpp/daal/src/algorithms/dtrees/dtrees_model_impl.h
+++ b/cpp/daal/src/algorithms/dtrees/dtrees_model_impl.h
@@ -60,7 +60,7 @@ struct DecisionTreeNode
 class DecisionTreeTable : public data_management::AOSNumericTable
 {
 public:
-    DecisionTreeTable(size_t rowCount = 0) : data_management::AOSNumericTable(sizeof(DecisionTreeNode), 3, rowCount)
+    DecisionTreeTable(size_t rowCount = 0) : data_management::AOSNumericTable(sizeof(DecisionTreeNode), 4, rowCount)
     {
         setFeature<int>(0, DAAL_STRUCT_MEMBER_OFFSET(DecisionTreeNode, featureIndex));
         setFeature<ClassIndexType>(1, DAAL_STRUCT_MEMBER_OFFSET(DecisionTreeNode, leftIndexOrClass));


### PR DESCRIPTION
https://github.com/oneapi-src/oneDAL/pull/2345 introduced a new feature (`defaultLeft`) to the `DecisionTreeTable` without requesting space for it in the base `AOSNumericTable`. This results in an `ErrorIncorrectDataRange` thrown here
https://github.com/oneapi-src/oneDAL/blob/c98b1cf9ea7ee6b267c7d8dabafbd2ad60a4be5b/cpp/daal/include/data_management/data/aos_numeric_table.h#L208
when called from the `DecisionTreeTable` constructor here
https://github.com/oneapi-src/oneDAL/blob/c98b1cf9ea7ee6b267c7d8dabafbd2ad60a4be5b/cpp/daal/src/algorithms/dtrees/dtrees_model_impl.h#L68