### PR TITLE
FIX:newton_cg_dpc.cpp

### DIFF
--- a/cpp/oneapi/dal/backend/primitives/optimizers/newton_cg_dpc.cpp
+++ b/cpp/oneapi/dal/backend/primitives/optimizers/newton_cg_dpc.cpp
@@ -59,8 +59,9 @@ sycl::event newton_cg(sycl::queue& queue,
         auto gradient = f.get_gradient();
 
         Float grad_norm = 0;
+        constexpr Float half = 0.5;
         l1_norm(queue, gradient, tmp_gpu, &grad_norm, update_event_vec).wait_and_throw();
-        Float tol_k = std::min(sqrt(grad_norm), 0.5);
+        Float tol_k = std::min(sqrt(grad_norm), half);
 
         auto prepare_grad_event =
             element_wise(queue, kernel_minus, gradient, nullptr, gradient, update_event_vec);


### PR DESCRIPTION
# Description

https://github.com/oneapi-src/oneDAL/pull/2437 can lead to compile error here https://github.com/oneapi-src/oneDAL/blob/199d4a56ab1913d5f39b561212d5952b06e7a844/cpp/oneapi/dal/backend/primitives/optimizers/newton_cg_dpc.cpp#L63 in case Float is single precision.
