### PR TITLE
fix: fix deduction of min template in newton cg

### DIFF
--- a/cpp/oneapi/dal/backend/primitives/optimizers/newton_cg_dpc.cpp
+++ b/cpp/oneapi/dal/backend/primitives/optimizers/newton_cg_dpc.cpp
@@ -60,7 +60,7 @@ sycl::event newton_cg(sycl::queue& queue,
 
         Float grad_norm = 0;
         l1_norm(queue, gradient, tmp_gpu, &grad_norm, update_event_vec).wait_and_throw();
-        Float tol_k = std::min(sqrt(grad_norm), 0.5);
+        Float tol_k = std::min<Float>(sqrt(grad_norm), 0.5);
 
         auto prepare_grad_event =
             element_wise(queue, kernel_minus, gradient, nullptr, gradient, update_event_vec);


### PR DESCRIPTION
# Description
Replacing of https://github.com/oneapi-src/oneDAL/pull/2449

https://github.com/oneapi-src/oneDAL/pull/2437 can lead to compile error here https://github.com/oneapi-src/oneDAL/blob/199d4a56ab1913d5f39b561212d5952b06e7a844/cpp/oneapi/dal/backend/primitives/optimizers/newton_cg_dpc.cpp#L63
