### PR TITLE
Fix the include in service_hash_table.h

### DIFF
--- a/cpp/daal/src/algorithms/classifier/classifier_predict_fpt.cpp
+++ b/cpp/daal/src/algorithms/classifier/classifier_predict_fpt.cpp
@@ -32,7 +32,8 @@ namespace classifier
 {
 namespace prediction
 {
-using namespace daal::data_management;
+namespace dm = daal::data_management;
+namespace dmi = daal::data_management::internal;
 
 namespace interface2
 {
@@ -58,31 +59,31 @@ DAAL_EXPORT services::Status Result::allocate(const daal::algorithms::Input * in
 
     if (par->resultsToEvaluate & computeClassLabels)
     {
-        data_management::NumericTablePtr nt;
+        dm::NumericTablePtr nt;
         if (deviceInfo.isCpu)
-            nt = HomogenNumericTable<algorithmFPType>::create(1, nRows, NumericTableIface::doAllocate, &st);
+            nt = dm::HomogenNumericTable<algorithmFPType>::create(1, nRows, dm::NumericTableIface::doAllocate, &st);
         else
-            nt = internal::SyclHomogenNumericTable<algorithmFPType>::create(1, nRows, NumericTableIface::doAllocate, &st);
+            nt = dmi::SyclHomogenNumericTable<algorithmFPType>::create(1, nRows, dm::NumericTableIface::doAllocate, &st);
 
         set(prediction, nt);
     }
     if (par->resultsToEvaluate & computeClassProbabilities)
     {
-        data_management::NumericTablePtr nt;
+        dm::NumericTablePtr nt;
         if (deviceInfo.isCpu)
-            nt = HomogenNumericTable<algorithmFPType>::create(nClasses, nRows, NumericTableIface::doAllocate, &st);
+            nt = dm::HomogenNumericTable<algorithmFPType>::create(nClasses, nRows, dm::NumericTableIface::doAllocate, &st);
         else
-            nt = internal::SyclHomogenNumericTable<algorithmFPType>::create(nClasses, nRows, NumericTableIface::doAllocate, &st);
+            nt = dmi::SyclHomogenNumericTable<algorithmFPType>::create(nClasses, nRows, dm::NumericTableIface::doAllocate, &st);
 
         set(probabilities, nt);
     }
     if (par->resultsToEvaluate & computeClassLogProbabilities)
     {
-        data_management::NumericTablePtr nt;
+        dm::NumericTablePtr nt;
         if (deviceInfo.isCpu)
-            nt = HomogenNumericTable<algorithmFPType>::create(nClasses, nRows, NumericTableIface::doAllocate, &st);
+            nt = dm::HomogenNumericTable<algorithmFPType>::create(nClasses, nRows, dm::NumericTableIface::doAllocate, &st);
         else
-            nt = internal::SyclHomogenNumericTable<algorithmFPType>::create(nClasses, nRows, NumericTableIface::doAllocate, &st);
+            nt = dmi::SyclHomogenNumericTable<algorithmFPType>::create(nClasses, nRows, dm::NumericTableIface::doAllocate, &st);
 
         set(logProbabilities, nt);
     }

--- a/cpp/daal/src/algorithms/classifier/classifier_predict_fpt.cpp
+++ b/cpp/daal/src/algorithms/classifier/classifier_predict_fpt.cpp
@@ -32,7 +32,7 @@ namespace classifier
 {
 namespace prediction
 {
-namespace dm = daal::data_management;
+namespace dm  = daal::data_management;
 namespace dmi = daal::data_management::internal;
 
 namespace interface2

--- a/cpp/daal/src/algorithms/kmeans/kmeans_result.h
+++ b/cpp/daal/src/algorithms/kmeans/kmeans_result.h
@@ -29,15 +29,16 @@
 #include "services/internal/sycl/types.h"
 #include "data_management/data/internal/numeric_table_sycl_homogen.h"
 
-using namespace daal::data_management;
-using namespace daal::services::internal::sycl;
-
 namespace daal
 {
 namespace algorithms
 {
 namespace kmeans
 {
+namespace dm = daal::data_management;
+namespace dmi = daal::data_management::internal;
+namespace si_sycl = daal::services::internal::sycl;
+
 /**
  * Allocates memory to store the results of the K-Means algorithm
  * \param[in] input     Pointer to the structure of the input objects
@@ -64,24 +65,24 @@ DAAL_EXPORT services::Status Result::allocate(const daal::algorithms::Input * in
 
         if (deviceInfo.isCpu)
         {
-            set(objectiveFunction, HomogenNumericTable<algorithmFPType>::create(1, 1, NumericTable::doAllocate, &status));
-            set(nIterations, HomogenNumericTable<int>::create(1, 1, NumericTable::doAllocate, &status));
+            set(objectiveFunction, dm::HomogenNumericTable<algorithmFPType>::create(1, 1, dm::NumericTable::doAllocate, &status));
+            set(nIterations, dm::HomogenNumericTable<int>::create(1, 1, dm::NumericTable::doAllocate, &status));
 
             if (kmPar2->resultsToEvaluate & computeCentroids)
             {
-                set(centroids, HomogenNumericTable<algorithmFPType>::create(nFeatures, nClusters, NumericTable::doAllocate, &status));
+                set(centroids, dm::HomogenNumericTable<algorithmFPType>::create(nFeatures, nClusters, dm::NumericTable::doAllocate, &status));
             }
             if (kmPar2->resultsToEvaluate & computeAssignments || kmPar2->assignFlag)
             {
-                set(assignments, HomogenNumericTable<int>::create(1, nRows, NumericTable::doAllocate, &status));
+                set(assignments, dm::HomogenNumericTable<int>::create(1, nRows, dm::NumericTable::doAllocate, &status));
             }
         }
         else
         {
-            set(centroids, internal::SyclHomogenNumericTable<algorithmFPType>::create(nFeatures, nClusters, NumericTable::doAllocate, &status));
-            set(objectiveFunction, HomogenNumericTable<algorithmFPType>::create(1, 1, NumericTable::doAllocate, &status));
-            set(nIterations, HomogenNumericTable<int>::create(1, 1, NumericTable::doAllocate, &status));
-            set(assignments, internal::SyclHomogenNumericTable<int>::create(1, nRows, NumericTable::doAllocate, &status));
+            set(centroids, dmi::SyclHomogenNumericTable<algorithmFPType>::create(nFeatures, nClusters, dm::NumericTable::doAllocate, &status));
+            set(objectiveFunction, dm::HomogenNumericTable<algorithmFPType>::create(1, 1, dm::NumericTable::doAllocate, &status));
+            set(nIterations, dm::HomogenNumericTable<int>::create(1, 1, dm::NumericTable::doAllocate, &status));
+            set(assignments, dmi::SyclHomogenNumericTable<int>::create(1, nRows, dm::NumericTable::doAllocate, &status));
         }
     }
 
@@ -101,9 +102,9 @@ DAAL_EXPORT services::Status Result::allocate(const daal::algorithms::PartialRes
     size_t nFeatures = (static_cast<const PartialResult *>(partialResult))->getNumberOfFeatures();
 
     services::Status status;
-    set(centroids, HomogenNumericTable<algorithmFPType>::create(nFeatures, nClusters, NumericTable::doAllocate, &status));
-    set(objectiveFunction, HomogenNumericTable<algorithmFPType>::create(1, 1, NumericTable::doAllocate, &status));
-    set(nIterations, HomogenNumericTable<int>::create(1, 1, NumericTable::doAllocate, &status));
+    set(centroids, dm::HomogenNumericTable<algorithmFPType>::create(nFeatures, nClusters, dm::NumericTable::doAllocate, &status));
+    set(objectiveFunction, dm::HomogenNumericTable<algorithmFPType>::create(1, 1, dm::NumericTable::doAllocate, &status));
+    set(nIterations, dm::HomogenNumericTable<int>::create(1, 1, dm::NumericTable::doAllocate, &status));
     return status;
 }
 

--- a/cpp/daal/src/algorithms/kmeans/kmeans_result.h
+++ b/cpp/daal/src/algorithms/kmeans/kmeans_result.h
@@ -35,8 +35,8 @@ namespace algorithms
 {
 namespace kmeans
 {
-namespace dm = daal::data_management;
-namespace dmi = daal::data_management::internal;
+namespace dm      = daal::data_management;
+namespace dmi     = daal::data_management::internal;
 namespace si_sycl = daal::services::internal::sycl;
 
 /**

--- a/cpp/daal/src/algorithms/optimization_solver/iterative_solver_types.cpp
+++ b/cpp/daal/src/algorithms/optimization_solver/iterative_solver_types.cpp
@@ -26,9 +26,6 @@
 #include "src/services/serialization_utils.h"
 #include "src/services/daal_strings.h"
 
-using namespace daal::data_management;
-using namespace daal::services;
-
 namespace daal
 {
 namespace algorithms
@@ -39,6 +36,9 @@ namespace iterative_solver
 {
 namespace interface2
 {
+using namespace daal::data_management;
+using namespace daal::services;
+
 __DAAL_REGISTER_SERIALIZATION_CLASS(Result, SERIALIZATION_ITERATIVE_SOLVER_RESULT_ID);
 
 Parameter::Parameter(const sum_of_functions::BatchPtr & function_, const size_t nIterations_, const double accuracyThreshold_, bool optionalResultReq,

--- a/cpp/daal/src/algorithms/optimization_solver/iterative_solver_types_fpt.cpp
+++ b/cpp/daal/src/algorithms/optimization_solver/iterative_solver_types_fpt.cpp
@@ -35,7 +35,7 @@ namespace iterative_solver
 namespace interface2
 {
 
-namespace dm = daal::data_management;
+namespace dm  = daal::data_management;
 namespace dmi = daal::data_management::internal;
 /**
  * Allocates memory to store the results of the iterative solver algorithm

--- a/cpp/daal/src/algorithms/optimization_solver/iterative_solver_types_fpt.cpp
+++ b/cpp/daal/src/algorithms/optimization_solver/iterative_solver_types_fpt.cpp
@@ -34,6 +34,9 @@ namespace iterative_solver
 {
 namespace interface2
 {
+
+namespace dm = daal::data_management;
+namespace dmi = daal::data_management::internal;
 /**
  * Allocates memory to store the results of the iterative solver algorithm
  * \param[in] input  Pointer to the input structure
@@ -43,7 +46,6 @@ namespace interface2
 template <typename algorithmFPType>
 DAAL_EXPORT services::Status Result::allocate(const daal::algorithms::Input * input, const daal::algorithms::Parameter * par, const int method)
 {
-    using namespace daal::data_management;
     const Input * algInput = static_cast<const Input *>(input);
     size_t nRows           = algInput->get(inputArgument)->getNumberOfRows();
 
@@ -54,20 +56,20 @@ DAAL_EXPORT services::Status Result::allocate(const daal::algorithms::Input * in
 
     if (!get(minimum))
     {
-        NumericTablePtr nt;
+        dm::NumericTablePtr nt;
         if (deviceInfo.isCpu)
         {
-            nt = HomogenNumericTable<algorithmFPType>::create(1, nRows, NumericTable::doAllocate, &status);
+            nt = dm::HomogenNumericTable<algorithmFPType>::create(1, nRows, dm::NumericTable::doAllocate, &status);
         }
         else
         {
-            nt = internal::SyclHomogenNumericTable<algorithmFPType>::create(1, nRows, NumericTable::doAllocate, &status);
+            nt = dmi::SyclHomogenNumericTable<algorithmFPType>::create(1, nRows, dm::NumericTable::doAllocate, &status);
         }
         set(minimum, nt);
     }
     if (!get(nIterations))
     {
-        NumericTablePtr nt = HomogenNumericTable<int>::create(1, 1, NumericTable::doAllocate, int(0));
+        dm::NumericTablePtr nt = dm::HomogenNumericTable<int>::create(1, 1, dm::NumericTable::doAllocate, int(0));
         set(nIterations, nt);
     }
     return status;

--- a/cpp/daal/src/algorithms/service_hash_table.h
+++ b/cpp/daal/src/algorithms/service_hash_table.h
@@ -24,7 +24,7 @@
 #ifndef __SERVICE_HASH_TABLE_H__
 #define __SERVICE_HASH_TABLE_H__
 
-#include "src/services/service_utils.h"
+#include "src/services/service_arrays.h"
 
 namespace daal
 {
@@ -83,7 +83,7 @@ public:
         }
     }
 
-    bool find(const KeyType & key, ValueType & value)
+    bool find(const KeyType & key, ValueType & value) const
     {
         const size_t id = _hashFunc(key) % _size;
         if (_table[id].isFree)
@@ -230,4 +230,4 @@ private:
 } // namespace algorithms
 } // namespace daal
 
-#endif //__SERVICE_HASH_MAP_H__
+#endif //__SERVICE_HASH_TABLE_H__

--- a/cpp/daal/src/algorithms/svm/svm_model_fpt.cpp
+++ b/cpp/daal/src/algorithms/svm/svm_model_fpt.cpp
@@ -33,7 +33,7 @@ namespace svm
 {
 namespace interface1
 {
-namespace dm = daal::data_management;
+namespace dm  = daal::data_management;
 namespace dmi = daal::data_management::internal;
 template <typename modelFPType>
 services::SharedPtr<Model> Model::create(size_t nColumns, data_management::NumericTableIface::StorageLayout layout, services::Status * stat)
@@ -52,8 +52,8 @@ Model::Model(modelFPType dummy, size_t nColumns, data_management::NumericTableIf
         if (layout == dm::NumericTableIface::csrArray)
         {
             _SV = dmi::SyclCSRNumericTable::create<modelFPType>(services::internal::Buffer<modelFPType>(), services::internal::Buffer<size_t>(),
-                                                                     services::internal::Buffer<size_t>(), nColumns, size_t(0),
-                                                                     dm::CSRNumericTable::oneBased, &st);
+                                                                services::internal::Buffer<size_t>(), nColumns, size_t(0),
+                                                                dm::CSRNumericTable::oneBased, &st);
         }
         else
         {

--- a/cpp/daal/src/algorithms/svm/svm_model_fpt.cpp
+++ b/cpp/daal/src/algorithms/svm/svm_model_fpt.cpp
@@ -33,6 +33,8 @@ namespace svm
 {
 namespace interface1
 {
+namespace dm = daal::data_management;
+namespace dmi = daal::data_management::internal;
 template <typename modelFPType>
 services::SharedPtr<Model> Model::create(size_t nColumns, data_management::NumericTableIface::StorageLayout layout, services::Status * stat)
 {
@@ -42,40 +44,38 @@ services::SharedPtr<Model> Model::create(size_t nColumns, data_management::Numer
 template <typename modelFPType>
 Model::Model(modelFPType dummy, size_t nColumns, data_management::NumericTableIface::StorageLayout layout, services::Status & st) : _bias(0.0)
 {
-    using namespace data_management;
-
     auto & context    = services::internal::getDefaultContext();
     auto & deviceInfo = context.getInfoDevice();
 
     if (!deviceInfo.isCpu)
     {
-        if (layout == NumericTableIface::csrArray)
+        if (layout == dm::NumericTableIface::csrArray)
         {
-            _SV = internal::SyclCSRNumericTable::create<modelFPType>(services::internal::Buffer<modelFPType>(), services::internal::Buffer<size_t>(),
+            _SV = dmi::SyclCSRNumericTable::create<modelFPType>(services::internal::Buffer<modelFPType>(), services::internal::Buffer<size_t>(),
                                                                      services::internal::Buffer<size_t>(), nColumns, size_t(0),
-                                                                     CSRNumericTable::oneBased, &st);
+                                                                     dm::CSRNumericTable::oneBased, &st);
         }
         else
         {
-            _SV = internal::SyclHomogenNumericTable<modelFPType>::create(nColumns, 0, NumericTable::doNotAllocate, &st);
+            _SV = dmi::SyclHomogenNumericTable<modelFPType>::create(nColumns, 0, dm::NumericTable::doNotAllocate, &st);
         }
-        _SVCoeff = internal::SyclHomogenNumericTable<modelFPType>::create(1, 0, NumericTable::doNotAllocate, &st);
+        _SVCoeff = dmi::SyclHomogenNumericTable<modelFPType>::create(1, 0, dm::NumericTable::doNotAllocate, &st);
         if (!st) return;
-        _SVIndices = internal::SyclHomogenNumericTable<int>::create(1, 0, NumericTable::doNotAllocate, &st);
+        _SVIndices = dmi::SyclHomogenNumericTable<int>::create(1, 0, dm::NumericTable::doNotAllocate, &st);
     }
     else
     {
-        if (layout == NumericTableIface::csrArray)
+        if (layout == dm::NumericTableIface::csrArray)
         {
-            _SV = CSRNumericTable::create<modelFPType>(NULL, NULL, NULL, nColumns, 0, CSRNumericTable::oneBased, &st);
+            _SV = dm::CSRNumericTable::create<modelFPType>(NULL, NULL, NULL, nColumns, 0, dm::CSRNumericTable::oneBased, &st);
         }
         else
         {
-            _SV = HomogenNumericTable<modelFPType>::create(NULL, nColumns, 0, &st);
+            _SV = dm::HomogenNumericTable<modelFPType>::create(NULL, nColumns, 0, &st);
         }
-        _SVCoeff = HomogenNumericTable<modelFPType>::create(NULL, 1, 0, &st);
+        _SVCoeff = dm::HomogenNumericTable<modelFPType>::create(NULL, 1, 0, &st);
         if (!st) return;
-        _SVIndices = HomogenNumericTable<int>::create(NULL, 1, 0, &st);
+        _SVIndices = dm::HomogenNumericTable<int>::create(NULL, 1, 0, &st);
     }
 
     return;
@@ -84,7 +84,7 @@ Model::Model(modelFPType dummy, size_t nColumns, data_management::NumericTableIf
 template DAAL_EXPORT services::SharedPtr<Model> Model::create<DAAL_FPTYPE>(size_t nColumns, data_management::NumericTableIface::StorageLayout layout,
                                                                            services::Status * stat);
 
-template DAAL_EXPORT Model::Model(DAAL_FPTYPE, size_t, data_management::NumericTableIface::StorageLayout, services::Status &);
+template DAAL_EXPORT Model::Model(DAAL_FPTYPE, size_t, dm::NumericTableIface::StorageLayout, services::Status &);
 
 } // namespace interface1
 } // namespace svm


### PR DESCRIPTION
* Change the #include "service_utils.h" to the #include "service_arrays.h" in service_hash_table.h. The change is necessary due to the use of TArray template defined in service_arrays.h
* Fix build errors that appeared after the include change