### PR TITLE
Fix remaining coverity hits

### DIFF
--- a/cpp/oneapi/dal/detail/chunked_array_impl.cpp
+++ b/cpp/oneapi/dal/detail/chunked_array_impl.cpp
@@ -81,7 +81,7 @@ public:
     }
 
     explicit chunked_array_impl(std::int64_t chunk_count) {
-        auto raw = detail::integral_cast_debug<std::size_t>(chunk_count);
+        auto raw = detail::integral_cast<std::size_t>(chunk_count);
         const auto empty_chunk = detail::array_impl<byte_t>{};
         chunks = std::vector<array_impl_t>(raw, empty_chunk);
         [[maybe_unused]] auto res = update_offsets();


### PR DESCRIPTION
# Description
Substitute integral_cast_debug check with integral_cast check in constructor to validate parameter and throw exception if it is incorrect