### PR TITLE
Add docs for 'csr_accessor' class 

### DIFF
--- a/docs/source/api/data-management/accessor/csr.rst
+++ b/docs/source/api/data-management/accessor/csr.rst
@@ -1,5 +1,5 @@
 .. ******************************************************************************
-.. * Copyright 2020 Intel Corporation
+.. * Copyright 2023 Intel Corporation
 .. *
 .. * Licensed under the Apache License, Version 2.0 (the "License");
 .. * you may not use this file except in compliance with the License.
@@ -17,17 +17,27 @@
 .. highlight:: cpp
 .. default-domain:: cpp
 
-.. _api_accessors:
+.. _api_csr_accessor:
 
-=========
-Accessors
-=========
+===============
+Compressed Sparse Rows (CSR) accessor
+===============
 
-The requirements for accessors and accessor types are defined in
-:ref:`Developer Guide: Accessors <dm_accessors>`.
+The ``csr_accessor`` class provides a read-only access to the rows of the
+:txtref:`csr_table` as data arrays in :capterm:`CSR <CSR data>` storage format.
 
-.. toctree::
+-------------
+Usage example
+-------------
 
-   accessor/column.rst
-   accessor/csr.rst
-   accessor/row.rst
+.. include:: ../../../includes/data-management/csr-accessor-usage-example.rst
+
+---------------------
+Programming interface
+---------------------
+
+All types and functions in this section are declared in the
+``oneapi::dal`` namespace and be available via inclusion of the
+``oneapi/dal/table/csr_accessor.hpp`` header file.
+
+.. onedal_class:: oneapi::dal::csr_accessor

--- a/docs/source/includes/data-management/column-accessor-usage-example.rst
+++ b/docs/source/includes/data-management/column-accessor-usage-example.rst
@@ -41,7 +41,7 @@
 
       auto shared_data = sycl::malloc_shared<float>(row_count * column_count, queue);
       auto event = queue.memcpy(shared_data, host_data, sizeof(float) * row_count * column_count);
-      auto t = dal::homogen_table::wrap(queue, data, row_count, column_count, { event });
+      auto t = dal::homogen_table::wrap(queue, shared_data, row_count, column_count, { event });
 
       // Accessing whole elements in a first column
       dal::column_accessor<const float> acc { t };

--- a/docs/source/includes/data-management/csr-accessor-usage-example.rst
+++ b/docs/source/includes/data-management/csr-accessor-usage-example.rst
@@ -1,0 +1,88 @@
+.. ******************************************************************************
+.. * Copyright 2023 Intel Corporation
+.. *
+.. * Licensed under the Apache License, Version 2.0 (the "License");
+.. * you may not use this file except in compliance with the License.
+.. * You may obtain a copy of the License at
+.. *
+.. *     http://www.apache.org/licenses/LICENSE-2.0
+.. *
+.. * Unless required by applicable law or agreed to in writing, software
+.. * distributed under the License is distributed on an "AS IS" BASIS,
+.. * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+.. * See the License for the specific language governing permissions and
+.. * limitations under the License.
+.. *******************************************************************************/
+
+.. highlight:: cpp
+
+::
+
+   #include <sycl/sycl.hpp>
+   #include <iostream>
+
+   #include "oneapi/dal/table/csr.hpp"
+   #include "oneapi/dal/table/csr_accessor.hpp"
+
+   namespace dal = oneapi::dal;
+
+   int main() {
+      sycl::queue queue { sycl::default_selector() };
+
+      // Create arrays of data, column indices and row offsets of the table
+      // in sparse CSR storage format with one-based indexing on host
+      const float host_data[] = { 1.0f, 2.0f, 3.0f, 4.0f, 1.0f, 11.0f, 8.0f };
+      const std::int64_t host_column_indices[] = { 1, 2, 4, 3, 2, 4, 2 };
+      const std::int64_t host_row_offsets[] = { 1, 4, 5, 7, 8 };
+
+      constexpr std::int64_t row_count = 4;
+      constexpr std::int64_t column_count = 4;
+      constexpr std::int64_t element_count = 7;
+
+      // Allocate SYCL shared memory for storing data, column indices and row offsets arrays
+      auto shared_data = sycl::malloc_shared<float>(element_count, queue);
+      auto shared_column_indices = sycl::malloc_shared<std::int64_t>(element_count, queue);
+      auto shared_row_offsets = sycl::malloc_shared<std::int64_t>(row_count + 1, queue);
+
+      // Copy data, column indices and row offsets arrays from host to SYCL shared memory
+      auto data_event = queue.memcpy(shared_data, host_data, sizeof(float) * element_count);
+      auto column_indices_event = queue.memcpy(shared_column_indices,
+                                               host_column_indices,
+                                               sizeof(std::int64_t) * element_count);
+      auto row_offsets_event =
+         queue.memcpy(shared_row_offsets, host_row_offsets, sizeof(std::int64_t) * (row_count + 1));
+
+      auto table = dal::csr_table::wrap(queue,
+                                        shared_data,
+                                        shared_column_indices,
+                                        shared_row_offsets,
+                                        row_count,
+                                        column_count,
+                                        dal::sparse_indexing::one_based,
+                                        { data_event, column_indices_event, row_offsets_event });
+
+      // Accessing second and third rows of the table
+      dal::csr_accessor<const float> acc{ table };
+
+      const auto [block_data, block_column_indices, block_row_offsets] = acc.pull(queue, { 1, 3 });
+
+      for (std::int64_t i = 0; i < block_data.get_count(); i++) {
+         std::cout << block_data[i] << ", ";
+      }
+      std::cout << std::endl;
+
+      for (std::int64_t i = 0; i < block_column_indices.get_count(); i++) {
+         std::cout << block_column_indices[i] << ", ";
+      }
+      std::cout << std::endl;
+
+      for (std::int64_t i = 0; i < block_row_offsets.get_count(); i++) {
+         std::cout << block_row_offsets[i] << ", ";
+      }
+      std::cout << std::endl;
+
+      sycl::free(shared_data, queue);
+      sycl::free(shared_column_indices, queue);
+      sycl::free(shared_row_offsets, queue);
+      return 0;
+   }

--- a/docs/source/includes/data-management/row-accessor-usage-example.rst
+++ b/docs/source/includes/data-management/row-accessor-usage-example.rst
@@ -41,7 +41,7 @@
 
       auto shared_data = sycl::malloc_shared<float>(row_count * column_count, queue);
       auto event = queue.memcpy(shared_data, host_data, sizeof(float) * row_count * column_count);
-      auto t = dal::homogen_table::wrap(queue, data, row_count, column_count, { event });
+      auto t = dal::homogen_table::wrap(queue, shared_data, row_count, column_count, { event });
 
       // Accessing second and third rows of the table
       dal::row_accessor<const float> acc { t };

--- a/docs/source/onedal/glossary.rst
+++ b/docs/source/onedal/glossary.rst
@@ -232,13 +232,13 @@ Graph analytics terms
     Component
         A :capterm:`connected<Connected graph>` :capterm:`subgraph<Subgraph>` :math:`H` of graph :math:`G` such that no subgraph
         of :math:`G` that properly contains :math:`H` is connected [Gross2014]_.
-    
+
     Connected graph
         A :capterm:`graph` is connected if there is a :capterm:`walk` between every pair of its vertices [Gross2014]_.
 
     Edge index
         The index :math:`i` of an edge :math:`e_i` in an edge set :math:`E=\{e_1, e_2,  ..., e_m\}`
-        of :capterm:`graph` :math:`G`. Can be an integer value.         
+        of :capterm:`graph` :math:`G`. Can be an integer value.
 
     Directed graph
         A :capterm:`graph` where each edge is an ordered pair :math:`(u, v)`
@@ -249,23 +249,23 @@ Graph analytics terms
         An object :math:`G=(V;E)` that consists of two sets, :math:`V` and :math:`E`,
         where :math:`V` is a finite nonempty set, :math:`E` is a finite set that may
         be empty, and the elements of :math:`E` are two-element subsets of :math:`V`.
-        :math:`V` is called a set of vertices, :math:`E` is called a set of edges [Gross2014]_. 
+        :math:`V` is called a set of vertices, :math:`E` is called a set of edges [Gross2014]_.
 
     Subgraph
-        A graph :math:`H = (V'; E')` is called a subgraph of graph :math:`G = (V; E)` if 
-        :math:`V' \subseteq V; E' \subseteq E` and :math:`V'` contains all the endpoints of all the 
+        A graph :math:`H = (V'; E')` is called a subgraph of graph :math:`G = (V; E)` if
+        :math:`V' \subseteq V; E' \subseteq E` and :math:`V'` contains all the endpoints of all the
         edges in :math:`E'` [Gross2014]_.
 
     Induced subgraph on the edge set
-        Each subset :math:`E' \subseteq E` defines a unique :capterm:`subgraph <Subgraph>` :math:`H' = (V'; E')` of graph 
+        Each subset :math:`E' \subseteq E` defines a unique :capterm:`subgraph <Subgraph>` :math:`H' = (V'; E')` of graph
         :math:`G = (V; E)`, where :math:`V'` consists of only those vertices that are the endpoints of the
         edges in :math:`E'`. The subgraph :math:`H` is called an induced subgraph of :math:`G` on the
         edge set :math:`E'` [Gross2014]_.
 
     Induced subgraph on the vertex set
         Each subset :math:`V' \subseteq V` defines a unique :capterm:`subgraph <Subgraph>`
-        :math:`H = (V'; E')` of graph :math:`G = (V; E)`, where :math:`E'` consists of those edges 
-        whose endpoints are in :math:`V'`. The subgraph :math:`H` is called an induced subgraph of :math:`G` on the vertex 
+        :math:`H = (V'; E')` of graph :math:`G = (V; E)`, where :math:`E'` consists of those edges
+        whose endpoints are in :math:`V'`. The subgraph :math:`H` is called an induced subgraph of :math:`G` on the vertex
         set :math:`V'` [Gross2014]_.
 
     Self-loop
@@ -282,10 +282,10 @@ Graph analytics terms
 
     Vertex index
         The index :math:`i` of a vertex :math:`v_i` in a vertex set :math:`V=\{v_1, v_2,  ..., v_n\}`
-        of :capterm:`graph` :math:`G`. Can be an integer value. 
+        of :capterm:`graph` :math:`G`. Can be an integer value.
 
     Walk
-        An alternating sequence of vertices and edges such that for each edge, 
+        An alternating sequence of vertices and edges such that for each edge,
         one endpoint precedes and the other succeeds that edge in the sequence [Gross2014]_.
 
     Weight
@@ -319,7 +319,7 @@ Graph analytics terms
     Contiguous data
         Data that are stored as one contiguous memory block. One of the
         characteristics of a :capterm:`data format`.
-    
+
     CSR data
         A Compressed Sparse Row (CSR) data is the sparse matrix representation.
         Data with values of a single :capterm:`data type` and the same set of
@@ -361,8 +361,8 @@ Graph analytics terms
         **Examples:** ``int32_t``, ``float``, ``double``
 
     Dataset
-        A collection of data in a specific data format. 
-        
+        A collection of data in a specific data format.
+
         **Examples:** a collection of observations, a :capterm:`graph`
 
     Flat data
@@ -487,7 +487,7 @@ Distributed computational mode terms
 .. glossary::
     :sorted:
 
-    SPMD 
+    SPMD
         Single Program, Multiple Data (SPMD) is a technique employed to achieve parallelism.
         In SPMD model, multiple autonomous processors simultaneously execute the same program at independent points.
 
@@ -497,6 +497,6 @@ Distributed computational mode terms
 
     Communicator backend
         A particular library providing collective operations.
-        
+
         **Examples:** oneCCL, oneMPI
 

--- a/examples/oneapi/dpc/source/table/csr_accessor.cpp
+++ b/examples/oneapi/dpc/source/table/csr_accessor.cpp
@@ -1,0 +1,132 @@
+/*******************************************************************************
+* Copyright 2023 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include <sycl/sycl.hpp>
+#include <iostream>
+
+#ifndef ONEDAL_DATA_PARALLEL
+#define ONEDAL_DATA_PARALLEL
+#endif
+
+#include "oneapi/dal/table/csr_accessor.hpp"
+#include "oneapi/dal/table/csr.hpp"
+
+#include "example_util/dpc_helpers.hpp"
+
+namespace dal = oneapi::dal;
+
+void run(sycl::queue &q) {
+    constexpr std::int64_t row_count = 4;
+    constexpr std::int64_t column_count = 4;
+    constexpr std::int64_t element_count = 7;
+
+    // create arrays of data, column indices and row offsets of the table
+    // in sparse CSR storage format on host
+    const float data_host[] = { 1.0f, 2.0f, 3.0f, 4.0f, 1.0f, 11.0f, 8.0f };
+    const std::int64_t column_indices_host[] = { 1, 2, 4, 3, 2, 4, 2 };
+    const std::int64_t row_offsets_host[] = { 1, 4, 5, 7, 8 };
+
+    // allocate SYCL shared memory for storing data, column indices and row offsets arrays
+    auto data = sycl::malloc_shared<float>(element_count, q);
+    auto column_indices = sycl::malloc_shared<std::int64_t>(element_count, q);
+    auto row_offsets = sycl::malloc_shared<std::int64_t>(row_count + 1, q);
+
+    // copy data, column indices and row offsets arrays from host to SYCL shared memory
+    q.memcpy(data, data_host, sizeof(float) * element_count).wait();
+    q.memcpy(column_indices, column_indices_host, sizeof(std::int64_t) * element_count).wait();
+    q.memcpy(row_offsets, row_offsets_host, sizeof(std::int64_t) * (row_count + 1)).wait();
+
+    // create sparse table in CSR format from arrays of data, column indices and row offsets
+    // that are allocated in SYCL shared memory
+    auto table = dal::csr_table{ q,
+                                 data,
+                                 column_indices,
+                                 row_offsets,
+                                 row_count,
+                                 column_count,
+                                 dal::detail::make_default_delete<const float>(q),
+                                 dal::detail::make_default_delete<const std::int64_t>(q),
+                                 dal::detail::make_default_delete<const std::int64_t>(q) };
+    dal::csr_accessor<const float> acc{ table };
+
+    // pull 2 rows, starting from row number 1, from the sparse table;
+    // the pulled rows will have one-based indicies by default
+    const auto [subtable_data, subtable_column_indices, subtable_row_offsets] =
+        acc.pull(q, { 1, 3 });
+
+    // allocate SYCL shared memory for storing data, column indices and row offsets arrays
+    std::unique_ptr<float[]> subtable_data_host(new float[subtable_data.get_count()]);
+    std::unique_ptr<std::int64_t[]> subtable_column_indices_host(
+        new std::int64_t[subtable_column_indices.get_count()]);
+    std::unique_ptr<std::int64_t[]> subtable_row_offsets_host(
+        new std::int64_t[subtable_row_offsets.get_count()]);
+
+    // copy data, column indices and row offsets arrays from host to SYCL shared memory
+    q.memcpy(subtable_data_host.get(),
+             subtable_data.get_data(),
+             sizeof(float) * subtable_data.get_count())
+        .wait();
+    q.memcpy(subtable_column_indices_host.get(),
+             subtable_column_indices.get_data(),
+             sizeof(std::int64_t) * subtable_column_indices.get_count())
+        .wait();
+    q.memcpy(subtable_row_offsets_host.get(),
+             subtable_row_offsets.get_data(),
+             sizeof(std::int64_t) * subtable_row_offsets.get_count())
+        .wait();
+
+    std::cout << "Print the original sparse data table as 3 arrays in CSR storage format:"
+              << std::endl;
+    std::cout << "Values of the table:" << std::endl;
+    for (std::int64_t i = 0; i < element_count; i++) {
+        std::cout << data_host[i] << ", ";
+    }
+    std::cout << std::endl << "Column indices of the table:" << std::endl;
+    for (std::int64_t i = 0; i < element_count; i++) {
+        std::cout << column_indices_host[i] << ", ";
+    }
+    std::cout << std::endl << "Row offsets of the table:" << std::endl;
+    for (std::int64_t i = 0; i < row_count + 1; i++) {
+        std::cout << row_offsets_host[i] << ", ";
+    }
+    std::cout << std::endl;
+
+    std::cout << std::endl << "Print 2 rows from CSR table as dense float arrays" << std::endl;
+    std::cout << "Values in 2 rows as dense float array:" << std::endl;
+    for (std::int64_t i = 0; i < subtable_data.get_count(); i++) {
+        std::cout << subtable_data_host[i] << ", ";
+    }
+    std::cout << std::endl << "Column indices in 2 rows from CSR table:" << std::endl;
+    for (std::int64_t i = 0; i < subtable_column_indices.get_count(); i++) {
+        std::cout << subtable_column_indices_host[i] << ", ";
+    }
+    std::cout << std::endl << "Row offsets in 2 rows from CSR table:" << std::endl;
+    for (std::int64_t i = 0; i < subtable_row_offsets.get_count(); i++) {
+        std::cout << subtable_row_offsets_host[i] << ", ";
+    }
+    std::cout << std::endl;
+}
+
+int main(int argc, char const *argv[]) {
+    for (auto d : list_devices()) {
+        std::cout << "Running on " << d.get_platform().get_info<sycl::info::platform::name>()
+                  << ", " << d.get_info<sycl::info::device::name>() << "\n"
+                  << std::endl;
+        auto q = sycl::queue{ d };
+        run(q);
+    }
+    return 0;
+}

--- a/examples/oneapi/dpc/source/table/csr_accessor.cpp
+++ b/examples/oneapi/dpc/source/table/csr_accessor.cpp
@@ -70,24 +70,6 @@ void run(sycl::queue &q) {
     // the pulled rows will have one-based indicies by default
     const auto [block_data, block_column_indices, block_row_offsets] = acc.pull(q, { 1, 3 });
 
-    // allocate SYCL shared memory for storing data, column indices and row offsets arrays
-    std::unique_ptr<float[]> block_data_host(new float[block_data.get_count()]);
-    std::unique_ptr<std::int64_t[]> block_column_indices_host(
-        new std::int64_t[block_column_indices.get_count()]);
-    std::unique_ptr<std::int64_t[]> block_row_offsets_host(
-        new std::int64_t[block_row_offsets.get_count()]);
-
-    // copy data, column indices and row offsets arrays from host to SYCL shared memory
-    data_event = q.memcpy(block_data_host.get(),
-                          block_data.get_data(),
-                          sizeof(float) * block_data.get_count());
-    column_indices_event = q.memcpy(block_column_indices_host.get(),
-                                    block_column_indices.get_data(),
-                                    sizeof(std::int64_t) * block_column_indices.get_count());
-    row_offsets_event = q.memcpy(block_row_offsets_host.get(),
-                                 block_row_offsets.get_data(),
-                                 sizeof(std::int64_t) * block_row_offsets.get_count());
-
     std::cout << "Print the original sparse data table as 3 arrays in CSR storage format:"
               << std::endl;
     std::cout << "Values of the table:" << std::endl;
@@ -104,24 +86,22 @@ void run(sycl::queue &q) {
     }
     std::cout << std::endl;
 
-    sycl::event::wait({ data_event, column_indices_event, row_offsets_event });
-
     std::cout << std::endl << "Print 2 rows from CSR table as dense float arrays" << std::endl;
     std::cout << "Values in the second and third rows of the table as dense float array:"
               << std::endl;
     for (std::int64_t i = 0; i < block_data.get_count(); i++) {
-        std::cout << block_data_host[i] << ", ";
+        std::cout << block_data[i] << ", ";
     }
     std::cout << std::endl
               << "Column indices of the data in the second and third rows from CSR table:"
               << std::endl;
     for (std::int64_t i = 0; i < block_column_indices.get_count(); i++) {
-        std::cout << block_column_indices_host[i] << ", ";
+        std::cout << block_column_indices[i] << ", ";
     }
     std::cout << std::endl
               << "Row offsets of the second and third rows from CSR table:" << std::endl;
     for (std::int64_t i = 0; i < block_row_offsets.get_count(); i++) {
-        std::cout << block_row_offsets_host[i] << ", ";
+        std::cout << block_row_offsets[i] << ", ";
     }
     std::cout << std::endl;
 }


### PR DESCRIPTION
Documentation and DPC++ example for 'csr_accessor' class added.
Minor fixes in the usage examples provided along with the documentation for 'row_accessor' and 'column_accessor' classes made.