### PR TITLE
Support building reference backend with clang

### DIFF
--- a/dev/make/cmplr.clang.ref.mk
+++ b/dev/make/cmplr.clang.ref.mk
@@ -29,9 +29,9 @@ CORE.SERV.COMPILER.clang = generic
 -DEBC.clang = -g
 
 COMPILER.mac.clang = clang++ -m64 -fgnu-runtime -stdlib=libc++ -mmacosx-version-min=10.15 -fwrapv \
-                     -DDAAL_REF -Werror -Wreturn-type
+                     -DDAAL_REF -DONEDAL_REF -Werror -Wreturn-type
 COMPILER.lnx.clang = clang++ -m64 \
-                     -DDAAL_REF -Werror -Wreturn-type
+                     -DDAAL_REF -DONEDAL_REF -Werror -Wreturn-type
 
 link.dynamic.mac.clang = clang++ -m64
 link.dynamic.lnx.clang = clang++ -m64

--- a/makefile
+++ b/makefile
@@ -217,7 +217,7 @@ TBBDIR := $(if $(wildcard $(DIR)/__deps/tbb/$(_OS)/*),$(DIR)/__deps/tbb/$(_OS)$(
 TBBDIR.2 := $(if $(TBBDIR),$(TBBDIR),$(call topf,$$TBBROOT))
 TBBDIR.2 := $(if $(TBBDIR.2),$(TBBDIR.2),$(error Can`t find TBB neither in $(DIR)/__deps/tbb not in $$TBBROOT))
 
-TBBDIR.include := $(if $(TBBDIR),$(TBBDIR)/include/tbb $(TBBDIR)/include)
+TBBDIR.include := $(if $(TBBDIR.2),$(TBBDIR.2)/include/tbb $(TBBDIR.2)/include)
 
 TBBDIR.libia.prefix := $(TBBDIR.2)/lib
 


### PR DESCRIPTION
# Description
Make some small changes to the makefiles, to support building the reference backend, and for using a custom-built TBB

Changes proposed in this pull request:
- Makefile for clang reference backend needs to specify the same defines as the GCC build
- When oneTBB is not in the __deps folder, allow for it to be identified from the TBBROOT environment variable