### PR TITLE
Fix GPU test failures: PCA

### DIFF
--- a/cpp/oneapi/dal/algo/pca/backend/cpu/train_kernel_precomputed.cpp
+++ b/cpp/oneapi/dal/algo/pca/backend/cpu/train_kernel_precomputed.cpp
@@ -79,6 +79,9 @@ static result_t call_daal_kernel(const context_cpu& ctx,
         *daal_means,
         *daal_variances));
 
+    if (desc.get_result_options().test(result_options::vars)) {
+        result.set_variances(homogen_table::wrap(arr_vars, 1, column_count));
+    }
     if (desc.get_result_options().test(result_options::eigenvectors)) {
         const auto mdl = model_t{}.set_eigenvectors(
             homogen_table::wrap(arr_eigvec, component_count, column_count));

--- a/cpp/oneapi/dal/algo/pca/backend/gpu/train_kernel_cov_impl_dpc.cpp
+++ b/cpp/oneapi/dal/algo/pca/backend/gpu/train_kernel_cov_impl_dpc.cpp
@@ -154,7 +154,6 @@ template <typename Float>
 result_t train_kernel_cov_impl<Float>::operator()(const descriptor_t& desc, const input_t& input) {
     ONEDAL_ASSERT(input.get_data().has_data());
     const auto data = input.get_data();
-
     std::int64_t row_count = data.get_row_count();
     auto rows_count_global = row_count;
     ONEDAL_ASSERT(data.get_column_count() > 0);
@@ -194,7 +193,8 @@ result_t train_kernel_cov_impl<Float>::operator()(const descriptor_t& desc, cons
 
     auto [cov, cov_event] = compute_covariance(q_, rows_count_global, xtx, sums, { gemm_event });
     if (desc.get_result_options().test(result_options::vars)) {
-        auto [vars, vars_event] = compute_variances(q_, cov, { gemm_event });
+        auto [vars, vars_event] = compute_variances(q_, cov, { cov_event });
+        vars_event.wait_and_throw();
         result.set_variances(homogen_table::wrap(vars.flatten(q_), 1, column_count));
     }
     if (desc.get_result_options().test(result_options::eigenvectors |

--- a/cpp/oneapi/dal/algo/pca/backend/gpu/train_kernel_precomputed_impl_dpc.cpp
+++ b/cpp/oneapi/dal/algo/pca/backend/gpu/train_kernel_precomputed_impl_dpc.cpp
@@ -80,7 +80,6 @@ auto compute_eigenvectors_on_host(sycl::queue& q,
 template <typename Float>
 result_t train_kernel_precomputed_impl<Float>::operator()(const descriptor_t& desc,
                                                           const input_t& input) {
-
     ONEDAL_ASSERT(input.get_data().has_data());
     const auto data = input.get_data();
     ONEDAL_ASSERT(data.get_column_count() > 0);

--- a/cpp/oneapi/dal/algo/pca/backend/gpu/train_kernel_precomputed_impl_dpc.cpp
+++ b/cpp/oneapi/dal/algo/pca/backend/gpu/train_kernel_precomputed_impl_dpc.cpp
@@ -63,7 +63,6 @@ auto compute_eigenvectors_on_host(sycl::queue& q,
                                   std::int64_t component_count,
                                   const dal::backend::event_vector& deps = {}) {
     ONEDAL_PROFILER_TASK(compute_eigenvectors_on_host);
-    ONEDAL_ASSERT(corr.has_mutable_data());
     ONEDAL_ASSERT(corr.get_dimension(0) == corr.get_dimension(1),
                   "Correlation matrix must be square");
     ONEDAL_ASSERT(corr.get_dimension(0) > 0);
@@ -81,6 +80,7 @@ auto compute_eigenvectors_on_host(sycl::queue& q,
 template <typename Float>
 result_t train_kernel_precomputed_impl<Float>::operator()(const descriptor_t& desc,
                                                           const input_t& input) {
+
     ONEDAL_ASSERT(input.get_data().has_data());
     const auto data = input.get_data();
     ONEDAL_ASSERT(data.get_column_count() > 0);


### PR DESCRIPTION
# Description
Fix PCA test failures: 
- Wrong ASSERT(has_mutable_data()) for this kernel no need to have data being mutable.
- set_variances() to result. 
- Wrong order for sycl::event and wait_and_throw() before setting.