### PR TITLE
Fix for compiler defines

### DIFF
--- a/cpp/daal/src/data_management/data_conversion_cpu.cpp
+++ b/cpp/daal/src/data_management/data_conversion_cpu.cpp
@@ -26,7 +26,7 @@ namespace data_management
 namespace internal
 {
 /* only for AVX512 architecture with using intrinsics */
-#if defined(__AVX512F__) && defined(DAAL_INTEL_CPP_COMPILER)
+#if defined(__INTEL_COMPILER)
 template <typename T>
 void vectorCopyInternal()
 {

--- a/cpp/daal/src/data_management/finiteness_checker.cpp
+++ b/cpp/daal/src/data_management/finiteness_checker.cpp
@@ -163,7 +163,7 @@ bool checkFinitenessSOA(NumericTable & table, bool allowNaN, services::Status & 
     return valuesAreFinite;
 }
 
-#if defined(__AVX512F__) && defined(DAAL_INTEL_CPP_COMPILER)
+#if defined(__INTEL_COMPILER)
 
 const size_t BLOCK_SIZE       = 8192;
 const size_t THREADING_BORDER = 262144;


### PR DESCRIPTION
Some of optimized code branches were disabled by `#if defined(__AVX512F__) && defined(DAAL_INTEL_CPP_COMPILER)` check for `icc` compiler.
This PR removes check for `__AVX512F__` define and changes check from `DAAL_INTEL_CPP_COMPILER` to `__INTEL_COMPILER`.

