### PR TITLE
Fix 'no type named 'uint32_t'' failure in ICX build

### DIFF
--- a/cpp/daal/include/algorithms/algorithm_types.h
+++ b/cpp/daal/include/algorithms/algorithm_types.h
@@ -81,7 +81,7 @@ struct DAAL_EXPORT HyperparameterIface
      * \param[in] value The value of the hyperparameter
      * \return Execution status
      */
-    virtual services::Status set(std::uint32_t id, std::int64_t value) = 0;
+    virtual services::Status set(unsigned int id, int64_t value) = 0;
 
     /**
      * Sets double precision hyperparameter into this structure
@@ -89,7 +89,7 @@ struct DAAL_EXPORT HyperparameterIface
      * \param[in] value The value of the hyperparameter
      * \return Execution status
      */
-    virtual services::Status set(std::uint32_t id, double value) = 0;
+    virtual services::Status set(unsigned int id, double value) = 0;
 
     /**
      * Finds integer hyperparameter in this structure
@@ -99,7 +99,7 @@ struct DAAL_EXPORT HyperparameterIface
      *         ErrorHyperparameterNotFound is returned if the 'id' of the hyperparameter cannot be foun
      *         in the structure.
      */
-    virtual services::Status find(std::uint32_t id, std::int64_t & value) const = 0;
+    virtual services::Status find(unsigned int id, int64_t & value) const = 0;
 
     /**
      * Finds double precision hyperparameter in this structure
@@ -109,7 +109,7 @@ struct DAAL_EXPORT HyperparameterIface
      *         ErrorHyperparameterNotFound is returned if the 'id' of the hyperparameter cannot be foun
      *         in the structure.
      */
-    virtual services::Status find(std::uint32_t id, double & value) const = 0;
+    virtual services::Status find(unsigned int id, double & value) const = 0;
 
     virtual ~HyperparameterIface() {}
 };
@@ -146,7 +146,7 @@ protected:
      * \param[in] value The value of the hyperparameter
      * \return Execution status
      */
-    services::Status set(std::uint32_t id, std::int64_t value) final;
+    services::Status set(unsigned int id, int64_t value) final;
 
     /**
      * Sets double precision hyperparameter into this structure
@@ -154,7 +154,7 @@ protected:
      * \param[in] value The value of the hyperparameter
      * \return Execution status
      */
-    services::Status set(std::uint32_t id, double value) final;
+    services::Status set(unsigned int id, double value) final;
 
     /**
      * Finds integer hyperparameter in this structure
@@ -164,7 +164,7 @@ protected:
      *         ErrorHyperparameterNotFound is returned if the 'id' of the hyperparameter cannot be foun
      *         in the structure.
      */
-    services::Status find(std::uint32_t id, std::int64_t & value) const final;
+    services::Status find(unsigned int id, int64_t & value) const final;
 
     /**
      * Finds double precision hyperparameter in this structure
@@ -174,7 +174,7 @@ protected:
      *         ErrorHyperparameterNotFound is returned if the 'id' of the hyperparameter cannot be foun
      *         in the structure.
      */
-    services::Status find(std::uint32_t id, double & value) const final;
+    services::Status find(unsigned int id, double & value) const final;
 
     /** Pointer to the implementation */
     services::SharedPtr<HyperparameterBaseImpl> _pimpl;

--- a/cpp/daal/include/algorithms/algorithm_types.h
+++ b/cpp/daal/include/algorithms/algorithm_types.h
@@ -81,7 +81,7 @@ struct DAAL_EXPORT HyperparameterIface
      * \param[in] value The value of the hyperparameter
      * \return Execution status
      */
-    virtual services::Status set(unsigned int id, int64_t value) = 0;
+    virtual services::Status set(unsigned int id, DAAL_INT64 value) = 0;
 
     /**
      * Sets double precision hyperparameter into this structure
@@ -99,7 +99,7 @@ struct DAAL_EXPORT HyperparameterIface
      *         ErrorHyperparameterNotFound is returned if the 'id' of the hyperparameter cannot be foun
      *         in the structure.
      */
-    virtual services::Status find(unsigned int id, int64_t & value) const = 0;
+    virtual services::Status find(unsigned int id, DAAL_INT64 & value) const = 0;
 
     /**
      * Finds double precision hyperparameter in this structure
@@ -146,7 +146,7 @@ protected:
      * \param[in] value The value of the hyperparameter
      * \return Execution status
      */
-    services::Status set(unsigned int id, int64_t value) final;
+    services::Status set(unsigned int id, DAAL_INT64 value) final;
 
     /**
      * Sets double precision hyperparameter into this structure
@@ -164,7 +164,7 @@ protected:
      *         ErrorHyperparameterNotFound is returned if the 'id' of the hyperparameter cannot be foun
      *         in the structure.
      */
-    services::Status find(unsigned int id, int64_t & value) const final;
+    services::Status find(unsigned int id, DAAL_INT64 & value) const final;
 
     /**
      * Finds double precision hyperparameter in this structure

--- a/cpp/daal/include/algorithms/algorithm_types.h
+++ b/cpp/daal/include/algorithms/algorithm_types.h
@@ -30,7 +30,6 @@
 #include "data_management/data/data_collection.h"
 #include "services/error_handling.h"
 #include "services/daal_shared_ptr.h"
-#include <cstdint>
 
 namespace daal
 {

--- a/cpp/daal/src/algorithms/algorithm_hyperparameter.cpp
+++ b/cpp/daal/src/algorithms/algorithm_hyperparameter.cpp
@@ -40,7 +40,7 @@ struct HyperparameterImpl : public HyperparameterBaseImpl
 
     HyperparameterImpl(size_t intParamCount, size_t doubleParamCount) : _iHT(intParamCount), _dHT(doubleParamCount) {}
 
-    services::Status set(unsigned int id, int64_t value)
+    services::Status set(unsigned int id, DAAL_INT64 value)
     {
         _iHT.insert(id, value);
         return services::Status();
@@ -52,7 +52,7 @@ struct HyperparameterImpl : public HyperparameterBaseImpl
         return services::Status();
     }
 
-    services::Status find(unsigned int id, int64_t & value) const
+    services::Status find(unsigned int id, DAAL_INT64 & value) const
     {
         DAAL_CHECK_EX(_iHT.find(id, value), services::ErrorHyperparameterNotFound, services::Key, id);
         return services::Status();
@@ -80,7 +80,7 @@ Hyperparameter::Hyperparameter(size_t intParamCount, size_t doubleParamCount)
     : _pimpl(new internal::HyperparameterImpl(intParamCount, doubleParamCount))
 {}
 
-services::Status Hyperparameter::set(unsigned int id, int64_t value)
+services::Status Hyperparameter::set(unsigned int id, DAAL_INT64 value)
 {
     return _pimpl->set(id, value);
 }
@@ -90,7 +90,7 @@ services::Status Hyperparameter::set(unsigned int id, double value)
     return _pimpl->set(id, value);
 }
 
-services::Status Hyperparameter::find(unsigned int id, int64_t & value) const
+services::Status Hyperparameter::find(unsigned int id, DAAL_INT64 & value) const
 {
     return _pimpl->find(id, value);
 }

--- a/cpp/daal/src/algorithms/algorithm_hyperparameter.cpp
+++ b/cpp/daal/src/algorithms/algorithm_hyperparameter.cpp
@@ -40,25 +40,25 @@ struct HyperparameterImpl : public HyperparameterBaseImpl
 
     HyperparameterImpl(size_t intParamCount, size_t doubleParamCount) : _iHT(intParamCount), _dHT(doubleParamCount) {}
 
-    services::Status set(std::uint32_t id, std::int64_t value)
+    services::Status set(unsigned int id, int64_t value)
     {
         _iHT.insert(id, value);
         return services::Status();
     }
 
-    services::Status set(std::uint32_t id, double value)
+    services::Status set(unsigned int id, double value)
     {
         _dHT.insert(id, value);
         return services::Status();
     }
 
-    services::Status find(std::uint32_t id, std::int64_t & value) const
+    services::Status find(unsigned int id, int64_t & value) const
     {
         DAAL_CHECK_EX(_iHT.find(id, value), services::ErrorHyperparameterNotFound, services::Key, id);
         return services::Status();
     }
 
-    services::Status find(std::uint32_t id, double & value) const
+    services::Status find(unsigned int id, double & value) const
     {
         DAAL_CHECK_EX(_dHT.find(id, value), services::ErrorHyperparameterNotFound, services::Key, id);
         return services::Status();
@@ -66,10 +66,10 @@ struct HyperparameterImpl : public HyperparameterBaseImpl
 
 protected:
     /** Stores integer hyperparameters of the algorithm */
-    HashTable<sse2, std::uint32_t, std::int64_t> _iHT;
+    HashTable<sse2, uint32_t, int64_t> _iHT;
 
     /** Stores floating point hyperparameters of the algorithm */
-    HashTable<sse2, std::uint32_t, double> _dHT;
+    HashTable<sse2, uint32_t, double> _dHT;
 };
 
 } // namespace internal
@@ -80,22 +80,22 @@ Hyperparameter::Hyperparameter(size_t intParamCount, size_t doubleParamCount)
     : _pimpl(new internal::HyperparameterImpl(intParamCount, doubleParamCount))
 {}
 
-services::Status Hyperparameter::set(std::uint32_t id, std::int64_t value)
+services::Status Hyperparameter::set(unsigned int id, int64_t value)
 {
     return _pimpl->set(id, value);
 }
 
-services::Status Hyperparameter::set(std::uint32_t id, double value)
+services::Status Hyperparameter::set(unsigned int id, double value)
 {
     return _pimpl->set(id, value);
 }
 
-services::Status Hyperparameter::find(std::uint32_t id, std::int64_t & value) const
+services::Status Hyperparameter::find(unsigned int id, int64_t & value) const
 {
     return _pimpl->find(id, value);
 }
 
-services::Status Hyperparameter::find(std::uint32_t id, double & value) const
+services::Status Hyperparameter::find(unsigned int id, double & value) const
 {
     return _pimpl->find(id, value);
 }

--- a/cpp/daal/src/algorithms/algorithm_hyperparameter.cpp
+++ b/cpp/daal/src/algorithms/algorithm_hyperparameter.cpp
@@ -66,7 +66,7 @@ struct HyperparameterImpl : public HyperparameterBaseImpl
 
 protected:
     /** Stores integer hyperparameters of the algorithm */
-    HashTable<sse2, uint32_t, int64_t> _iHT;
+    HashTable<sse2, uint32_t, DAAL_INT64> _iHT;
 
     /** Stores floating point hyperparameters of the algorithm */
     HashTable<sse2, uint32_t, double> _dHT;

--- a/cpp/daal/src/algorithms/covariance/covariance_container.h
+++ b/cpp/daal/src/algorithms/covariance/covariance_container.h
@@ -277,7 +277,7 @@
     template <typename algorithmFPType, CpuType cpu>                                                                                         \
     DistributedContainer<step2Master, algorithmFPType, ComputeMethod, cpu>::DistributedContainer(daal::services::Environment::env * daalEnv) \
     {                                                                                                                                        \
-        auto & context    = services::Environment::getInstance() -> getDefaultExecutionContext();                                            \
+        auto & context    = services::Environment::getInstance()->getDefaultExecutionContext();                                              \
         auto & deviceInfo = context.getInfoDevice();                                                                                         \
                                                                                                                                              \
         if (deviceInfo.isCpu)                                                                                                                \
@@ -336,7 +336,7 @@
         Parameter * parameter                  = static_cast<Parameter *>(_par);                                                                \
         daal::services::Environment::env & env = *_env;                                                                                         \
                                                                                                                                                 \
-        auto & context    = services::Environment::getInstance() -> getDefaultExecutionContext();                                               \
+        auto & context    = services::Environment::getInstance()->getDefaultExecutionContext();                                                 \
         auto & deviceInfo = context.getInfoDevice();                                                                                            \
                                                                                                                                                 \
         if (deviceInfo.isCpu)                                                                                                                   \
@@ -392,7 +392,7 @@
         Parameter * parameter                  = static_cast<Parameter *>(_par);                                                                     \
         daal::services::Environment::env & env = *_env;                                                                                              \
                                                                                                                                                      \
-        auto & context    = services::Environment::getInstance() -> getDefaultExecutionContext();                                                    \
+        auto & context    = services::Environment::getInstance()->getDefaultExecutionContext();                                                      \
         auto & deviceInfo = context.getInfoDevice();                                                                                                 \
                                                                                                                                                      \
         if (deviceInfo.isCpu)                                                                                                                        \

--- a/cpp/daal/src/algorithms/covariance/covariance_container.h
+++ b/cpp/daal/src/algorithms/covariance/covariance_container.h
@@ -277,7 +277,7 @@
     template <typename algorithmFPType, CpuType cpu>                                                                                         \
     DistributedContainer<step2Master, algorithmFPType, ComputeMethod, cpu>::DistributedContainer(daal::services::Environment::env * daalEnv) \
     {                                                                                                                                        \
-        auto & context    = services::Environment::getInstance()->getDefaultExecutionContext();                                              \
+        auto & context    = services::Environment::getInstance() -> getDefaultExecutionContext();                                            \
         auto & deviceInfo = context.getInfoDevice();                                                                                         \
                                                                                                                                              \
         if (deviceInfo.isCpu)                                                                                                                \
@@ -336,7 +336,7 @@
         Parameter * parameter                  = static_cast<Parameter *>(_par);                                                                \
         daal::services::Environment::env & env = *_env;                                                                                         \
                                                                                                                                                 \
-        auto & context    = services::Environment::getInstance()->getDefaultExecutionContext();                                                 \
+        auto & context    = services::Environment::getInstance() -> getDefaultExecutionContext();                                               \
         auto & deviceInfo = context.getInfoDevice();                                                                                            \
                                                                                                                                                 \
         if (deviceInfo.isCpu)                                                                                                                   \
@@ -392,7 +392,7 @@
         Parameter * parameter                  = static_cast<Parameter *>(_par);                                                                     \
         daal::services::Environment::env & env = *_env;                                                                                              \
                                                                                                                                                      \
-        auto & context    = services::Environment::getInstance()->getDefaultExecutionContext();                                                      \
+        auto & context    = services::Environment::getInstance() -> getDefaultExecutionContext();                                                    \
         auto & deviceInfo = context.getInfoDevice();                                                                                                 \
                                                                                                                                                      \
         if (deviceInfo.isCpu)                                                                                                                        \

--- a/cpp/daal/src/algorithms/covariance/covariance_hyperparameter.cpp
+++ b/cpp/daal/src/algorithms/covariance/covariance_hyperparameter.cpp
@@ -21,6 +21,7 @@
 //--
 */
 
+#include <stdint.h>
 #include "src/algorithms/covariance/covariance_hyperparameter_impl.h"
 
 namespace daal

--- a/cpp/daal/src/algorithms/covariance/covariance_hyperparameter.cpp
+++ b/cpp/daal/src/algorithms/covariance/covariance_hyperparameter.cpp
@@ -34,24 +34,24 @@ namespace internal
 
 Hyperparameter::Hyperparameter() : algorithms::Hyperparameter(hyperparameterIdCount, doubleHyperparameterIdCount) {}
 
-services::Status Hyperparameter::set(HyperparameterId id, std::int64_t value)
+services::Status Hyperparameter::set(HyperparameterId id, DAAL_INT64 value)
 {
-    return this->algorithms::Hyperparameter::set(std::uint32_t(id), value);
+    return this->algorithms::Hyperparameter::set(unsigned int(id), value);
 }
 
 services::Status Hyperparameter::set(DoubleHyperparameterId id, double value)
 {
-    return this->algorithms::Hyperparameter::set(std::uint32_t(id), value);
+    return this->algorithms::Hyperparameter::set(unsigned int(id), value);
 }
 
-services::Status Hyperparameter::find(HyperparameterId id, std::int64_t & value) const
+services::Status Hyperparameter::find(HyperparameterId id, DAAL_INT64 & value) const
 {
-    return this->algorithms::Hyperparameter::find(std::uint32_t(id), value);
+    return this->algorithms::Hyperparameter::find(unsigned int(id), value);
 }
 
 services::Status Hyperparameter::find(DoubleHyperparameterId id, double & value) const
 {
-    return this->algorithms::Hyperparameter::find(std::uint32_t(id), value);
+    return this->algorithms::Hyperparameter::find(unsigned int(id), value);
 }
 
 } // namespace internal

--- a/cpp/daal/src/algorithms/covariance/covariance_hyperparameter.cpp
+++ b/cpp/daal/src/algorithms/covariance/covariance_hyperparameter.cpp
@@ -36,22 +36,22 @@ Hyperparameter::Hyperparameter() : algorithms::Hyperparameter(hyperparameterIdCo
 
 services::Status Hyperparameter::set(HyperparameterId id, DAAL_INT64 value)
 {
-    return this->algorithms::Hyperparameter::set(unsigned int(id), value);
+    return this->algorithms::Hyperparameter::set(uint32_t(id), value);
 }
 
 services::Status Hyperparameter::set(DoubleHyperparameterId id, double value)
 {
-    return this->algorithms::Hyperparameter::set(unsigned int(id), value);
+    return this->algorithms::Hyperparameter::set(uint32_t(id), value);
 }
 
 services::Status Hyperparameter::find(HyperparameterId id, DAAL_INT64 & value) const
 {
-    return this->algorithms::Hyperparameter::find(unsigned int(id), value);
+    return this->algorithms::Hyperparameter::find(uint32_t(id), value);
 }
 
 services::Status Hyperparameter::find(DoubleHyperparameterId id, double & value) const
 {
-    return this->algorithms::Hyperparameter::find(unsigned int(id), value);
+    return this->algorithms::Hyperparameter::find(uint32_t(id), value);
 }
 
 } // namespace internal

--- a/cpp/daal/src/algorithms/covariance/covariance_hyperparameter_impl.h
+++ b/cpp/daal/src/algorithms/covariance/covariance_hyperparameter_impl.h
@@ -67,7 +67,7 @@ struct DAAL_EXPORT Hyperparameter : public daal::algorithms::Hyperparameter
      * \param[in] id        Identifier of the hyperparameter
      * \param[in] value     The value of the hyperparameter
      */
-    services::Status set(HyperparameterId id, std::int64_t value);
+    services::Status set(HyperparameterId id, DAAL_INT64 value);
 
     /**
      * Sets double precision hyperparameter of the correlation or variance-covariance matrix algorithm
@@ -81,7 +81,7 @@ struct DAAL_EXPORT Hyperparameter : public daal::algorithms::Hyperparameter
      * \param[in]  id       Identifier of the hyperparameter
      * \param[out] value    Value of the found hyperparameter
      */
-    services::Status find(HyperparameterId id, std::int64_t & value) const;
+    services::Status find(HyperparameterId id, DAAL_INT64 & value) const;
 
     /**
      * Finds double precision hyperparameter of the correlation or variance-covariance matrix algorithm by its identifier

--- a/cpp/daal/src/algorithms/covariance/covariance_hyperparameter_impl.h
+++ b/cpp/daal/src/algorithms/covariance/covariance_hyperparameter_impl.h
@@ -56,9 +56,8 @@ enum DoubleHyperparameterId
 struct DAAL_EXPORT Hyperparameter : public daal::algorithms::Hyperparameter
 {
     using algorithms::Hyperparameter::set;
-    //using algorithms::Hyperparameter::set(std::uint32_t id, double value);
     using algorithms::Hyperparameter::find;
-    //using algorithms::Hyperparameter::find(std::uint32_t id, double & value) const;
+
     /** Default constructor */
     Hyperparameter();
 

--- a/cpp/daal/src/algorithms/covariance/covariance_impl.i
+++ b/cpp/daal/src/algorithms/covariance/covariance_impl.i
@@ -154,7 +154,7 @@ services::Status updateDenseCrossProductAndSums(bool isNormalized, size_t nFeatu
         algorithmFPType nVectorsInv = 1.0 / (double)(nVectors);
 
         /* Split rows by blocks */
-        std::int64_t numRowsInBlock = getBlockSize<cpu>(nVectors);
+        DAAL_INT64 numRowsInBlock = getBlockSize<cpu>(nVectors);
         if (hyperparameter)
         {
             services::Status status = hyperparameter->find(denseUpdateStepBlockSize, numRowsInBlock);

--- a/cpp/daal/src/algorithms/linear_model/linear_model_hyperparameter.cpp
+++ b/cpp/daal/src/algorithms/linear_model/linear_model_hyperparameter.cpp
@@ -34,24 +34,24 @@ namespace internal
 
 Hyperparameter::Hyperparameter() : algorithms::Hyperparameter(hyperparameterIdCount, doubleHyperparameterIdCount) {}
 
-services::Status Hyperparameter::set(HyperparameterId id, std::int64_t value)
+services::Status Hyperparameter::set(HyperparameterId id, DAAL_INT64 value)
 {
-    return this->algorithms::Hyperparameter::set(std::uint32_t(id), value);
+    return this->algorithms::Hyperparameter::set(unsigned int(id), value);
 }
 
 services::Status Hyperparameter::set(DoubleHyperparameterId id, double value)
 {
-    return this->algorithms::Hyperparameter::set(std::uint32_t(id), value);
+    return this->algorithms::Hyperparameter::set(unsigned int(id), value);
 }
 
-services::Status Hyperparameter::find(HyperparameterId id, std::int64_t & value) const
+services::Status Hyperparameter::find(HyperparameterId id, DAAL_INT64 & value) const
 {
-    return this->algorithms::Hyperparameter::find(std::uint32_t(id), value);
+    return this->algorithms::Hyperparameter::find(unsigned int(id), value);
 }
 
 services::Status Hyperparameter::find(DoubleHyperparameterId id, double & value) const
 {
-    return this->algorithms::Hyperparameter::find(std::uint32_t(id), value);
+    return this->algorithms::Hyperparameter::find(unsigned int(id), value);
 }
 
 } // namespace internal

--- a/cpp/daal/src/algorithms/linear_model/linear_model_hyperparameter.cpp
+++ b/cpp/daal/src/algorithms/linear_model/linear_model_hyperparameter.cpp
@@ -21,6 +21,7 @@
 //--
 */
 
+#include <stdint.h>
 #include "src/algorithms/linear_model/linear_model_hyperparameter_impl.h"
 
 namespace daal

--- a/cpp/daal/src/algorithms/linear_model/linear_model_hyperparameter.cpp
+++ b/cpp/daal/src/algorithms/linear_model/linear_model_hyperparameter.cpp
@@ -36,22 +36,22 @@ Hyperparameter::Hyperparameter() : algorithms::Hyperparameter(hyperparameterIdCo
 
 services::Status Hyperparameter::set(HyperparameterId id, DAAL_INT64 value)
 {
-    return this->algorithms::Hyperparameter::set(unsigned int(id), value);
+    return this->algorithms::Hyperparameter::set(uint32_t(id), value);
 }
 
 services::Status Hyperparameter::set(DoubleHyperparameterId id, double value)
 {
-    return this->algorithms::Hyperparameter::set(unsigned int(id), value);
+    return this->algorithms::Hyperparameter::set(uint32_t(id), value);
 }
 
 services::Status Hyperparameter::find(HyperparameterId id, DAAL_INT64 & value) const
 {
-    return this->algorithms::Hyperparameter::find(unsigned int(id), value);
+    return this->algorithms::Hyperparameter::find(uint32_t(id), value);
 }
 
 services::Status Hyperparameter::find(DoubleHyperparameterId id, double & value) const
 {
-    return this->algorithms::Hyperparameter::find(unsigned int(id), value);
+    return this->algorithms::Hyperparameter::find(uint32_t(id), value);
 }
 
 } // namespace internal

--- a/cpp/daal/src/algorithms/linear_model/linear_model_hyperparameter_impl.h
+++ b/cpp/daal/src/algorithms/linear_model/linear_model_hyperparameter_impl.h
@@ -66,7 +66,7 @@ struct DAAL_EXPORT Hyperparameter : public daal::algorithms::Hyperparameter
      * \param[in] id        Identifier of the hyperparameter
      * \param[in] value     The value of the hyperparameter
      */
-    services::Status set(HyperparameterId id, std::int64_t value);
+    services::Status set(HyperparameterId id, DAAL_INT64 value);
 
     /**
      * Sets double precision hyperparameter of the linear model algorithm
@@ -80,7 +80,7 @@ struct DAAL_EXPORT Hyperparameter : public daal::algorithms::Hyperparameter
      * \param[in]  id       Identifier of the hyperparameter
      * \param[out] value    Value of the found hyperparameter
      */
-    services::Status find(HyperparameterId id, std::int64_t & value) const;
+    services::Status find(HyperparameterId id, DAAL_INT64 & value) const;
 
     /**
      * Finds double precision hyperparameter of the linear model algorithm by its identifier

--- a/cpp/daal/src/algorithms/linear_model/linear_model_train_normeq_update_impl.i
+++ b/cpp/daal/src/algorithms/linear_model/linear_model_train_normeq_update_impl.i
@@ -205,7 +205,7 @@ Status UpdateKernel<algorithmFPType, cpu>::compute(const NumericTable & xTable, 
     if (hyperparameter != nullptr)
     {
         DAAL_INT64 nRowsInBlockInt64 = 0l;
-        services::Status status        = hyperparameter->find(denseUpdateStepBlockSize, nRowsInBlockInt64);
+        services::Status status      = hyperparameter->find(denseUpdateStepBlockSize, nRowsInBlockInt64);
         DAAL_CHECK(0l < nRowsInBlockInt64, services::ErrorIncorrectDataRange);
         DAAL_CHECK_STATUS_VAR(status);
 

--- a/cpp/daal/src/algorithms/linear_model/linear_model_train_normeq_update_impl.i
+++ b/cpp/daal/src/algorithms/linear_model/linear_model_train_normeq_update_impl.i
@@ -204,7 +204,7 @@ Status UpdateKernel<algorithmFPType, cpu>::compute(const NumericTable & xTable, 
     size_t nRowsInBlock = 128;
     if (hyperparameter != nullptr)
     {
-        std::int64_t nRowsInBlockInt64 = 0l;
+        DAAL_INT64 nRowsInBlockInt64 = 0l;
         services::Status status        = hyperparameter->find(denseUpdateStepBlockSize, nRowsInBlockInt64);
         DAAL_CHECK(0l < nRowsInBlockInt64, services::ErrorIncorrectDataRange);
         DAAL_CHECK_STATUS_VAR(status);

--- a/cpp/daal/src/algorithms/linear_regression/linear_regression_hyperparameter.cpp
+++ b/cpp/daal/src/algorithms/linear_regression/linear_regression_hyperparameter.cpp
@@ -35,24 +35,24 @@ namespace internal
 
 Hyperparameter::Hyperparameter() : algorithms::Hyperparameter(hyperparameterIdCount, doubleHyperparameterIdCount) {}
 
-services::Status Hyperparameter::set(HyperparameterId id, std::int64_t value)
+services::Status Hyperparameter::set(HyperparameterId id, DAAL_INT64 value)
 {
-    return this->algorithms::Hyperparameter::set(std::uint32_t(id), value);
+    return this->algorithms::Hyperparameter::set(unsigned int(id), value);
 }
 
 services::Status Hyperparameter::set(DoubleHyperparameterId id, double value)
 {
-    return this->algorithms::Hyperparameter::set(std::uint32_t(id), value);
+    return this->algorithms::Hyperparameter::set(unsigned int(id), value);
 }
 
-services::Status Hyperparameter::find(HyperparameterId id, std::int64_t & value) const
+services::Status Hyperparameter::find(HyperparameterId id, DAAL_INT64 & value) const
 {
-    return this->algorithms::Hyperparameter::find(std::uint32_t(id), value);
+    return this->algorithms::Hyperparameter::find(unsigned int(id), value);
 }
 
 services::Status Hyperparameter::find(DoubleHyperparameterId id, double & value) const
 {
-    return this->algorithms::Hyperparameter::find(std::uint32_t(id), value);
+    return this->algorithms::Hyperparameter::find(unsigned int(id), value);
 }
 
 services::Status convert(const Hyperparameter * params, services::SharedPtr<LinearModelHyperparameter> & result)

--- a/cpp/daal/src/algorithms/linear_regression/linear_regression_hyperparameter.cpp
+++ b/cpp/daal/src/algorithms/linear_regression/linear_regression_hyperparameter.cpp
@@ -37,22 +37,22 @@ Hyperparameter::Hyperparameter() : algorithms::Hyperparameter(hyperparameterIdCo
 
 services::Status Hyperparameter::set(HyperparameterId id, DAAL_INT64 value)
 {
-    return this->algorithms::Hyperparameter::set(unsigned int(id), value);
+    return this->algorithms::Hyperparameter::set(uint32_t(id), value);
 }
 
 services::Status Hyperparameter::set(DoubleHyperparameterId id, double value)
 {
-    return this->algorithms::Hyperparameter::set(unsigned int(id), value);
+    return this->algorithms::Hyperparameter::set(uint32_t(id), value);
 }
 
 services::Status Hyperparameter::find(HyperparameterId id, DAAL_INT64 & value) const
 {
-    return this->algorithms::Hyperparameter::find(unsigned int(id), value);
+    return this->algorithms::Hyperparameter::find(uint32_t(id), value);
 }
 
 services::Status Hyperparameter::find(DoubleHyperparameterId id, double & value) const
 {
-    return this->algorithms::Hyperparameter::find(unsigned int(id), value);
+    return this->algorithms::Hyperparameter::find(uint32_t(id), value);
 }
 
 services::Status convert(const Hyperparameter * params, services::SharedPtr<LinearModelHyperparameter> & result)
@@ -63,7 +63,7 @@ services::Status convert(const Hyperparameter * params, services::SharedPtr<Line
 
     if (params != nullptr)
     {
-        std::int64_t denseUpdateStepBlockSize = 0l;
+        DAAL_INT64 denseUpdateStepBlockSize = 0l;
 
         auto * const resultPtr = new LinearModelHyperparameter();
         DAAL_CHECK_MALLOC(resultPtr);

--- a/cpp/daal/src/algorithms/linear_regression/linear_regression_hyperparameter.cpp
+++ b/cpp/daal/src/algorithms/linear_regression/linear_regression_hyperparameter.cpp
@@ -21,6 +21,7 @@
 //--
 */
 
+#include <stdint.h>
 #include "src/algorithms/linear_model/linear_model_hyperparameter_impl.h"
 #include "src/algorithms/linear_regression/linear_regression_hyperparameter_impl.h"
 

--- a/cpp/daal/src/algorithms/linear_regression/linear_regression_hyperparameter_impl.h
+++ b/cpp/daal/src/algorithms/linear_regression/linear_regression_hyperparameter_impl.h
@@ -70,7 +70,7 @@ struct DAAL_EXPORT Hyperparameter : public daal::algorithms::Hyperparameter
      * \param[in] id        Identifier of the hyperparameter
      * \param[in] value     The value of the hyperparameter
      */
-    services::Status set(HyperparameterId id, std::int64_t value);
+    services::Status set(HyperparameterId id, DAAL_INT64 value);
 
     /**
      * Sets double precision hyperparameter of the linear regression algorithm
@@ -84,7 +84,7 @@ struct DAAL_EXPORT Hyperparameter : public daal::algorithms::Hyperparameter
      * \param[in]  id       Identifier of the hyperparameter
      * \param[out] value    Value of the found hyperparameter
      */
-    services::Status find(HyperparameterId id, std::int64_t & value) const;
+    services::Status find(HyperparameterId id, DAAL_INT64 & value) const;
 
     /**
      * Finds double precision hyperparameter of the linear regression algorithm by its identifier


### PR DESCRIPTION
Removed unnecessary #include <cstdint> from "algorithm_types.h" file.

By design we are trying not to include additional standard or third-party files into DAAL user-facing headers.
This is done so as not to clutter up end user's code with additional declarations.

Following changes were made in the code of `algorithms::Hyperparameter` and the derived classes to get rid of data types defined in <cstdint>:
- `std::unit32_t` type was changed to `unsigned int` in interface part of the code and to `uint32_t` in kernel part of the code
- `std::int64_t` types was changed to `DAAL_INT64`
