### PR TITLE
[bug] fix numerical instability in right-most node in ensemble algorithms

### DIFF
--- a/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_train_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_train_dense_default_impl.i
@@ -594,7 +594,7 @@ public:
     void finalizeBestSplit(const IndexType * aIdx, const BinIndexType * binIndex, size_t n, IndexType iFeature, size_t idxFeatureValueBestSplit,
                            TSplitData & bestSplit, IndexType * bestSplitIdx) const;
     void simpleSplit(const algorithmFPType * featureVal, const IndexType * aIdx, TSplitData & split) const;
-    void simpleSwap(const algorithmFPType featureVal, const IndexType aIdx, TSplitData & split) const;
+    void simpleSwap(const IndexType aIdx, TSplitData & split) const;
 
     TResponse predict(const dtrees::internal::Tree & t, const algorithmFPType * x) const
     {
@@ -752,12 +752,10 @@ void RespHelperBase<algorithmFPType, cpu, crtp>::simpleSplit(const algorithmFPTy
 }
 
 template <typename algorithmFPType, CpuType cpu, typename crtp>
-void RespHelperBase<algorithmFPType, cpu, crtp>::simpleSwap(const algorithmFPType featureVal, const IndexType aIdx, TSplitData & split) const
+void RespHelperBase<algorithmFPType, cpu, crtp>::simpleSwap(const IndexType aIdx, TSplitData & split) const
 {
     split.left.init(this->_nClasses);
     const ClassIndexType iClass = this->_aResponse[aIdx].val;
-    split.featureValue          = featureVal;
-    split.iStart                = 0;
     split.left.hist[iClass]     = this->_aWeights[aIdx].val;
     split.nLeft                 = 1;
     split.leftWeights           = this->_aWeights[aIdx].val;

--- a/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_train_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_train_dense_default_impl.i
@@ -594,6 +594,7 @@ public:
     void finalizeBestSplit(const IndexType * aIdx, const BinIndexType * binIndex, size_t n, IndexType iFeature, size_t idxFeatureValueBestSplit,
                            TSplitData & bestSplit, IndexType * bestSplitIdx) const;
     void simpleSplit(const algorithmFPType * featureVal, const IndexType * aIdx, TSplitData & split) const;
+    void simpleSwap(const algorithmFPType featureVal, const IndexType aIdx, TSplitData & split) const;
 
     TResponse predict(const dtrees::internal::Tree & t, const algorithmFPType * x) const
     {
@@ -748,6 +749,18 @@ void RespHelperBase<algorithmFPType, cpu, crtp>::simpleSplit(const algorithmFPTy
     split.nLeft                 = 1;
     split.leftWeights           = this->_aWeights[aIdx[0]].val;
     split.totalWeights          = this->_aWeights[aIdx[0]].val + this->_aWeights[aIdx[1]].val;
+}
+
+template <typename algorithmFPType, CpuType cpu, typename crtp>
+void RespHelperBase<algorithmFPType, cpu, crtp>::simpleSwap(const algorithmFPType featureVal, const IndexType aIdx, TSplitData & split) const
+{
+    split.left.init(this->_nClasses);
+    const ClassIndexType iClass = this->_aResponse[aIdx].val;
+    split.featureValue          = featureVal;
+    split.iStart                = 0;
+    split.left.hist[iClass]     = this->_aWeights[aIdx].val;
+    split.nLeft                 = 1;
+    split.leftWeights           = this->_aWeights[aIdx].val;
 }
 
 template <typename algorithmFPType, CpuType cpu, typename crtp>

--- a/cpp/daal/src/algorithms/dtrees/forest/df_train_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/df_train_dense_default_impl.i
@@ -818,7 +818,15 @@ typename DataHelper::NodeType::Base * TrainBatchTaskBase<algorithmFPType, BinInd
         if (_par.varImportance == training::MDI) addImpurityDecrease(iFeature, n, curImpurity, split);
         typename DataHelper::NodeType::Base * left =
             buildDepthFirst(s, iStart, split.nLeft, level + 1, split.left, bUnorderedFeaturesUsed, nClasses, split.leftWeights);
-        _helper.convertLeftImpToRight(n, curImpurity, split);
+        if(n - split.nLeft != 1)
+        {
+            _helper.convertLeftImpToRight(n, curImpurity, split);
+        }
+        else
+        {
+            _helper.simpleSwap(_aSample.get()[iStart + nLeft], split);
+        }
+
         if (!_memorySavingMode && !_useConstFeatures)
         {
             for (size_t i = _nConstFeature; i > 0; --i)

--- a/cpp/daal/src/algorithms/dtrees/forest/regression/df_regression_train_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/regression/df_regression_train_dense_default_impl.i
@@ -489,6 +489,7 @@ public:
     void finalizeBestSplit(const IndexType * aIdx, const BinIndexType * binIndex, size_t n, IndexType iFeature, size_t idxFeatureValueBestSplit,
                            TSplitData & bestSplit, IndexType * bestSplitIdx) const;
     void simpleSplit(const algorithmFPType * featureVal, const IndexType * aIdx, TSplitData & split) const;
+    void simpleSwap(const algorithmFPType featureVal, const IndexType aIdx, TSplitData & split) const;
     bool terminateCriteria(ImpurityData & imp, algorithmFPType impurityThreshold, size_t nSamples) const { return imp.value() < impurityThreshold; }
 
     TResponse predict(const dtrees::internal::Tree & t, const algorithmFPType * x) const
@@ -593,6 +594,17 @@ void RespHelperBase<algorithmFPType, cpu, crtp>::simpleSplit(const algorithmFPTy
     split.iStart       = 0;
     split.totalWeights = this->_aWeights[aIdx[0]].val + this->_aWeights[aIdx[1]].val;
     split.leftWeights  = this->_aWeights[aIdx[0]].val;
+}
+
+template <typename algorithmFPType, CpuType cpu, typename crtp>
+void RespHelperBase<algorithmFPType, cpu, crtp>::simpleSwap(const algorithmFPType featureVal, const IndexType aIdx, TSplitData & split) const
+{
+    split.featureValue = featureVal;
+    split.left.var     = 0;
+    split.left.mean    = this->_aResponse[aIdx].val;
+    split.nLeft        = 1;
+    split.iStart       = 0;
+    split.leftWeights  = this->_aWeights[aIdx].val;
 }
 
 template <typename algorithmFPType, CpuType cpu, typename crtp>

--- a/cpp/daal/src/algorithms/dtrees/forest/regression/df_regression_train_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/regression/df_regression_train_dense_default_impl.i
@@ -489,7 +489,7 @@ public:
     void finalizeBestSplit(const IndexType * aIdx, const BinIndexType * binIndex, size_t n, IndexType iFeature, size_t idxFeatureValueBestSplit,
                            TSplitData & bestSplit, IndexType * bestSplitIdx) const;
     void simpleSplit(const algorithmFPType * featureVal, const IndexType * aIdx, TSplitData & split) const;
-    void simpleSwap(const algorithmFPType featureVal, const IndexType aIdx, TSplitData & split) const;
+    void simpleSwap(const IndexType aIdx, TSplitData & split) const;
     bool terminateCriteria(ImpurityData & imp, algorithmFPType impurityThreshold, size_t nSamples) const { return imp.value() < impurityThreshold; }
 
     TResponse predict(const dtrees::internal::Tree & t, const algorithmFPType * x) const
@@ -597,13 +597,11 @@ void RespHelperBase<algorithmFPType, cpu, crtp>::simpleSplit(const algorithmFPTy
 }
 
 template <typename algorithmFPType, CpuType cpu, typename crtp>
-void RespHelperBase<algorithmFPType, cpu, crtp>::simpleSwap(const algorithmFPType featureVal, const IndexType aIdx, TSplitData & split) const
+void RespHelperBase<algorithmFPType, cpu, crtp>::simpleSwap(const IndexType aIdx, TSplitData & split) const
 {
-    split.featureValue = featureVal;
     split.left.var     = 0;
     split.left.mean    = this->_aResponse[aIdx].val;
     split.nLeft        = 1;
-    split.iStart       = 0;
     split.leftWeights  = this->_aWeights[aIdx].val;
 }
 


### PR DESCRIPTION
# Description
DAAL random forest and extra trees implementations use the depthFirstSearch function to help build the trees. It generates right nodes of the trees via left nodes, parents nodes and math tricks of the cost functions. This causes float type error accumulation in the value of the right-most deepest node. When a right node has a single element, these tricks aren't necessary.  By directly assigning the value of the single element, it removes the numerical error and allows for (in some cases) perfect recall of the data (which matches sklearn).  This is the cause of some test failures moving code out of preview in scikit-learn-intelex.

Changes proposed in this pull request:
- Add simpleSwap function for classification, and a check for a single node element