### PR TITLE
coverity fixes 2024.0.1

### DIFF
--- a/cpp/daal/src/algorithms/dtrees/gbt/classification/gbt_classification_model_impl.h
+++ b/cpp/daal/src/algorithms/dtrees/gbt/classification/gbt_classification_model_impl.h
@@ -48,7 +48,7 @@ public:
     typedef gbt::internal::ModelImpl ImplType;
     typedef algorithms::classifier::internal::ModelInternal ClassificationImplType;
 
-    ModelImpl(size_t nFeatures = 0) : ClassificationImplType(nFeatures) {}
+    ModelImpl(size_t nFeatures = 0) : ClassificationImplType(nFeatures), _predictionBias(0.) {}
     ~ModelImpl() DAAL_C11_OVERRIDE {}
 
     virtual size_t getNumberOfFeatures() const DAAL_C11_OVERRIDE { return ClassificationImplType::getNumberOfFeatures(); }

--- a/cpp/daal/src/algorithms/dtrees/gbt/classification/gbt_classification_model_impl.h
+++ b/cpp/daal/src/algorithms/dtrees/gbt/classification/gbt_classification_model_impl.h
@@ -48,7 +48,7 @@ public:
     typedef gbt::internal::ModelImpl ImplType;
     typedef algorithms::classifier::internal::ModelInternal ClassificationImplType;
 
-    ModelImpl(size_t nFeatures = 0) : ClassificationImplType(nFeatures), _predictionBias(0.) {}
+    ModelImpl(size_t nFeatures = 0) : ClassificationImplType(nFeatures), _predictionBias(0.0f) {}
     ~ModelImpl() DAAL_C11_OVERRIDE {}
 
     virtual size_t getNumberOfFeatures() const DAAL_C11_OVERRIDE { return ClassificationImplType::getNumberOfFeatures(); }

--- a/cpp/daal/src/algorithms/dtrees/gbt/regression/gbt_regression_model_impl.h
+++ b/cpp/daal/src/algorithms/dtrees/gbt/regression/gbt_regression_model_impl.h
@@ -48,7 +48,7 @@ public:
     typedef gbt::internal::ModelImpl ImplType;
     typedef algorithms::regression::internal::ModelInternal RegressionImplType;
 
-    ModelImpl(size_t nFeatures = 0) : RegressionImplType(nFeatures), _predictionBias(0.) {}
+    ModelImpl(size_t nFeatures = 0) : RegressionImplType(nFeatures), _predictionBias(0.0f) {}
     ~ModelImpl() DAAL_C11_OVERRIDE {}
 
     virtual size_t getNumberOfFeatures() const DAAL_C11_OVERRIDE { return RegressionImplType::getNumberOfFeatures(); }

--- a/cpp/daal/src/algorithms/dtrees/gbt/regression/gbt_regression_model_impl.h
+++ b/cpp/daal/src/algorithms/dtrees/gbt/regression/gbt_regression_model_impl.h
@@ -48,7 +48,7 @@ public:
     typedef gbt::internal::ModelImpl ImplType;
     typedef algorithms::regression::internal::ModelInternal RegressionImplType;
 
-    ModelImpl(size_t nFeatures = 0) : RegressionImplType(nFeatures) {}
+    ModelImpl(size_t nFeatures = 0) : RegressionImplType(nFeatures), _predictionBias(0.) {}
     ~ModelImpl() DAAL_C11_OVERRIDE {}
 
     virtual size_t getNumberOfFeatures() const DAAL_C11_OVERRIDE { return RegressionImplType::getNumberOfFeatures(); }


### PR DESCRIPTION
# Description
Fixing a default value hit for gbt classification and regression

Changes proposed in this pull request:
- add default value to gbt classification ModelImpl
- add default value to gbt regression ModelImpl