### PR TITLE
chore: remove fn decl from header after it was deleted

### DIFF
--- a/cpp/daal/src/algorithms/dtrees/gbt/treeshap.h
+++ b/cpp/daal/src/algorithms/dtrees/gbt/treeshap.h
@@ -59,13 +59,6 @@ using gbt::internal::ModelFPType;
 using FeatureTypes = algorithms::dtrees::internal::FeatureTypes;
 
 /**
- * Determine the requested version of the TreeSHAP algorithm set in the
- * environment variable SHAP_VERSION.
- * Returns fallback if SHAP_VERSION is not set.
-*/
-uint8_t getRequestedAlgorithmVersion(uint8_t fallback);
-
-/**
  * Decision Path context
 */
 struct PathElement


### PR DESCRIPTION
#2460 forgot to remove a fn declaration from `treeshap.h` - `getRequestedAlgorithmVersion()` no longer exists.