### PR TITLE
Fix return type of get_class_count_method

### DIFF
--- a/cpp/oneapi/dal/algo/logistic_regression/common.hpp
+++ b/cpp/oneapi/dal/algo/logistic_regression/common.hpp
@@ -208,7 +208,7 @@ public:
     }
 
     /// Defines number of classes.
-    double get_class_count() const {
+    std::int64_t get_class_count() const {
         return base_t::get_class_count();
     }
 


### PR DESCRIPTION
# Description
The return type was incorrect, we need to fix it from double to std::int64_t