### PR TITLE
Add RF clsf inference hyperparameters

### DIFF
--- a/cpp/daal/include/services/error_indexes.h
+++ b/cpp/daal/include/services/error_indexes.h
@@ -143,6 +143,7 @@ enum ErrorID
     ErrorBufferSizeIntegerOverflow                    = -80, /*!< Integer oveflow is occured during buffer size calculation */
     ErrorHyperparameterNotFound                       = -81, /*!< Cannot find a hyperparameter with a given id */
     ErrorHyperparameterCanNotBeSet                    = -82, /*!< Cannot set a hyperparameter with a specified id */
+    ErrorHyperparameterBadValue                       = -83, /*!< Provided a bad value for a hyperparameter */
 
     // Environment errors: -2000..-2999
     ErrorCpuNotSupported          = -2000, /*!< CPU not supported */

--- a/cpp/daal/src/algorithms/classifier/BUILD
+++ b/cpp/daal/src/algorithms/classifier/BUILD
@@ -4,7 +4,9 @@ load("@onedal//dev/bazel:daal.bzl", "daal_module")
 daal_module(
     name = "kernel",
     auto = True,
+    opencl = True,
     deps = [
         "@onedal//cpp/daal:core",
+        "@onedal//cpp/daal:sycl",
     ],
 )

--- a/cpp/daal/src/algorithms/dtrees/BUILD
+++ b/cpp/daal/src/algorithms/dtrees/BUILD
@@ -3,8 +3,7 @@ load("@onedal//dev/bazel:daal.bzl", "daal_module")
 
 daal_module(
     name = "kernel",
-    hdrs = glob(["**/*.h", "**/*.i", "**/*.cl"]),
-    srcs = glob(["*.cpp"]),
+    auto = True,
     deps = [
         "@onedal//cpp/daal:core",
     ],

--- a/cpp/daal/src/algorithms/dtrees/BUILD
+++ b/cpp/daal/src/algorithms/dtrees/BUILD
@@ -3,7 +3,8 @@ load("@onedal//dev/bazel:daal.bzl", "daal_module")
 
 daal_module(
     name = "kernel",
-    auto = True,
+    hdrs = glob(["**/*.h", "**/*.i", "**/*.cl"]),
+    srcs = glob(["*.cpp"]),
     deps = [
         "@onedal//cpp/daal:core",
     ],

--- a/cpp/daal/src/algorithms/dtrees/forest/classification/BUILD
+++ b/cpp/daal/src/algorithms/dtrees/forest/classification/BUILD
@@ -13,3 +13,8 @@ daal_module(
         "@onedal//cpp/daal/src/algorithms/dtrees/forest:kernel",
     ],
 )
+
+daal_module(
+    name = "model_impl",
+    hdrs = glob(["*.hpp"]),
+)

--- a/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_predict_dense_default_batch.h
+++ b/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_predict_dense_default_batch.h
@@ -26,6 +26,7 @@
 #define __DF_CLASSIFICATION_PREDICT_DENSE_DEFAULT_BATCH_H__
 
 #include "algorithms/decision_forest/decision_forest_classification_predict.h"
+#include "src/algorithms/dtrees/forest/df_hyperparameter_impl.h"
 #include "src/externals/service_memory.h"
 #include "src/algorithms/kernel.h"
 #include "data_management/data/numeric_table.h"
@@ -47,11 +48,12 @@ namespace internal
 {
 template <typename algorithmFPType, CpuType cpu>
 class PredictClassificationTask;
-
 template <typename algorithmFpType, prediction::Method method, CpuType cpu>
 class PredictKernel : public daal::algorithms::Kernel
 {
 public:
+    typedef decision_forest::internal::Hyperparameter HyperparameterType;
+
     PredictKernel() : _task(nullptr) {};
     ~PredictKernel();
     /**
@@ -63,7 +65,8 @@ public:
      *  \param par[in]  decision forest algorithm parameters
      */
     services::Status compute(services::HostAppIface * const pHostApp, const NumericTable * a, const decision_forest::classification::Model * const m,
-                             NumericTable * const r, NumericTable * const prob, const size_t nClasses, const VotingMethod votingMethod);
+                             NumericTable * const r, NumericTable * const prob, const size_t nClasses, const VotingMethod votingMethod,
+                             const HyperparameterType * hyperparameter = nullptr);
     PredictClassificationTask<algorithmFpType, cpu> * _task;
 
 private:

--- a/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_predict_dense_default_batch_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_predict_dense_default_batch_impl.i
@@ -1026,9 +1026,9 @@ Status PredictClassificationTask<algorithmFPType, cpu>::predictAllPointsByAllTre
             parallelPredict(aX, aNode, treeSize, nBlocks, nCols, _blockSize, residualSize, tlsData.local(tid), iTree);
         });
 
-        const size_t nThreads       = tlsData.nthreads();
+        const size_t nThreads  = tlsData.nthreads();
         const size_t blockSize = 256; // TODO: Why can't this be the class value _blockSize?
-        const size_t nBlocks        = nRowsOfRes / blockSize + !!(nRowsOfRes % blockSize);
+        const size_t nBlocks   = nRowsOfRes / blockSize + !!(nRowsOfRes % blockSize);
 
         daal::threader_for(nBlocks, nBlocks, [&](const size_t iBlock) {
             const size_t begin = iBlock * blockSize;
@@ -1092,7 +1092,7 @@ Status PredictClassificationTask<algorithmFPType, cpu>::predictAllPointsByAllTre
         if (prob != nullptr || res != nullptr)
         {
             const size_t blockSize = 256;
-            const size_t nBlocks    = nRowsOfRes / blockSize + !!(nRowsOfRes % blockSize);
+            const size_t nBlocks   = nRowsOfRes / blockSize + !!(nRowsOfRes % blockSize);
 
             daal::threader_for(nBlocks, nBlocks, [&, nCols](const size_t iBlock) {
                 const size_t begin = iBlock * blockSize;

--- a/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_predict_dense_default_batch_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_predict_dense_default_batch_impl.i
@@ -1133,10 +1133,7 @@ Status PredictClassificationTask<algorithmFPType, cpu>::predictAllPointsByAllTre
 template <typename algorithmFPType, CpuType cpu>
 Status PredictClassificationTask<algorithmFPType, cpu>::run(services::HostAppIface * const pHostApp)
 {
-    if (!assertHyperparameters())
-    {
-        return services::Status(services::ErrorIncorrectDataRange);
-    }
+    DAAL_CHECK(assertHyperparameters(), services::ErrorIncorrectDataRange);
 
     const auto nTreesTotal = _model->size();
     if (_cachedData != _data)

--- a/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_predict_dense_default_batch_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_predict_dense_default_batch_impl.i
@@ -1135,8 +1135,6 @@ Status PredictClassificationTask<algorithmFPType, cpu>::run(services::HostAppIfa
 {
     DAAL_CHECK(assertHyperparameters(), services::ErrorIncorrectDataRange);
 
-    printf("Running with hyperparameter blockSize = %lu\n", _blockSize);
-
     const auto nTreesTotal = _model->size();
     if (_cachedData != _data)
     {

--- a/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_predict_dense_default_batch_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_predict_dense_default_batch_impl.i
@@ -300,7 +300,7 @@ services::Status PredictKernel<algorithmFPType, method, cpu>::compute(services::
 
         double scaleFactorForVectParallelComputeValue = 0.0f;
         st = hyperparameter->find(scaleFactorForVectParallelCompute, scaleFactorForVectParallelComputeValue);
-        DAAL_CHECK(0l < scaleFactorForVectParallelComputeValue, services::ErrorIncorrectDataRange);
+        DAAL_CHECK(0.0f < scaleFactorForVectParallelComputeValue, services::ErrorIncorrectDataRange);
         DAAL_CHECK_STATUS_VAR(st);
 
         _task->setHyperparams(defaultBlockSizeValue, defaultBlockSizeCommonValue, minTreesForThreadingValue, minNumberOfRowsForVectSeqComputeValue,

--- a/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_predict_dense_default_batch_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_predict_dense_default_batch_impl.i
@@ -517,7 +517,8 @@ DAAL_FORCEINLINE Status PredictClassificationTask<float, avx512>::predictByTree(
 {
     if (sizeOfBlock == _blockSize)
     {
-        uint32_t idx[_blockSize];
+        TArray<uint32_t, avx512> idxArray(_blockSize);
+        auto idx = idxArray.get();
         services::internal::service_memset_seq<uint32_t, avx512>(idx, uint32_t(0), _blockSize);
 
         __mmask16 isSplit = 0xffff;
@@ -578,7 +579,8 @@ DAAL_FORCEINLINE Status PredictClassificationTask<double, avx512>::predictByTree
 {
     if (sizeOfBlock == _blockSize)
     {
-        uint32_t idx[_blockSize];
+        TArray<uint32_t, avx512> idxArray(_blockSize);
+        auto idx = idxArray.get();
         services::internal::service_memset_seq<uint32_t, avx512>(idx, uint32_t(0), _blockSize);
 
         __mmask8 isSplit = 1;

--- a/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_predict_dense_default_batch_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_predict_dense_default_batch_impl.i
@@ -560,7 +560,8 @@ DAAL_FORCEINLINE Status PredictClassificationTask<float, avx512>::predictByTree(
         }
         const double * probas = _model->getProbas(iTree);
 
-        return fillResults<float, avx512>(_nClasses, _votingMethod, _blockSize, probas, left_son, idx, resPtr);
+        fillResults<float, avx512>(_nClasses, _votingMethod, _blockSize, probas, left_son, idx, resPtr);
+        return Status();
     }
     else
     {
@@ -616,7 +617,8 @@ DAAL_FORCEINLINE Status PredictClassificationTask<double, avx512>::predictByTree
 
         const double * probas = _model->getProbas(iTree);
 
-        return fillResults<double, avx512>(_nClasses, _votingMethod, _blockSize, probas, left_son, idx, resPtr);
+        fillResults<double, avx512>(_nClasses, _votingMethod, _blockSize, probas, left_son, idx, resPtr);
+        return Status();
     }
     else
     {

--- a/cpp/daal/src/algorithms/dtrees/forest/df_hyperparameter.cpp
+++ b/cpp/daal/src/algorithms/dtrees/forest/df_hyperparameter.cpp
@@ -1,0 +1,61 @@
+/* file: df_hyperparameter.cpp */
+/*******************************************************************************
+* Copyright 2023 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+/*
+//++
+//  Implementation of performance-related hyperparameters of the decision_forest algorithm.
+//--
+*/
+
+#include <stdint.h>
+#include "src/algorithms/dtrees/forest/df_hyperparameter_impl.h"
+
+namespace daal
+{
+namespace algorithms
+{
+namespace decision_forest
+{
+namespace internal
+{
+
+Hyperparameter::Hyperparameter() : algorithms::Hyperparameter(hyperparameterIdCount, doubleHyperparameterIdCount) {}
+
+services::Status Hyperparameter::set(HyperparameterId id, DAAL_INT64 value)
+{
+    return this->algorithms::Hyperparameter::set(uint32_t(id), value);
+}
+
+services::Status Hyperparameter::set(DoubleHyperparameterId id, double value)
+{
+    return this->algorithms::Hyperparameter::set(uint32_t(id), value);
+}
+
+services::Status Hyperparameter::find(HyperparameterId id, DAAL_INT64 & value) const
+{
+    return this->algorithms::Hyperparameter::find(uint32_t(id), value);
+}
+
+services::Status Hyperparameter::find(DoubleHyperparameterId id, double & value) const
+{
+    return this->algorithms::Hyperparameter::find(uint32_t(id), value);
+}
+
+} // namespace internal
+} // namespace decision_forest
+} // namespace algorithms
+} // namespace daal

--- a/cpp/daal/src/algorithms/dtrees/forest/df_hyperparameter_impl.h
+++ b/cpp/daal/src/algorithms/dtrees/forest/df_hyperparameter_impl.h
@@ -1,6 +1,6 @@
 /* file: df_hyperparameter_impl.h */
 /*******************************************************************************
-* Copyright 2023 Intel Corporation
+* Copyright contributors to the oneDAL project
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -41,7 +41,8 @@ namespace internal
  */
 enum HyperparameterId
 {
-    blockSize = 0,
+    blockSizeMultiplier = 0,
+    blockSize,
     minTreesForThreading,
     minNumberOfRowsForVectSeqCompute,
     hyperparameterIdCount = minNumberOfRowsForVectSeqCompute + 1

--- a/cpp/daal/src/algorithms/dtrees/forest/df_hyperparameter_impl.h
+++ b/cpp/daal/src/algorithms/dtrees/forest/df_hyperparameter_impl.h
@@ -41,8 +41,7 @@ namespace internal
  */
 enum HyperparameterId
 {
-    defaultBlockSize = 0,
-    defaultBlockSizeCommon,
+    blockSize = 0,
     minTreesForThreading,
     minNumberOfRowsForVectSeqCompute,
     hyperparameterIdCount = minNumberOfRowsForVectSeqCompute + 1

--- a/cpp/daal/src/algorithms/dtrees/forest/df_hyperparameter_impl.h
+++ b/cpp/daal/src/algorithms/dtrees/forest/df_hyperparameter_impl.h
@@ -1,0 +1,103 @@
+/* file: df_hyperparameter_impl.h */
+/*******************************************************************************
+* Copyright 2023 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+/*
+//++
+//  Declaration of the class that implements performance-related hyperparameters
+//  of the decision forest algorithm.
+//--
+*/
+
+#ifndef DF_HYPERPARAMETER_IMPL
+#define DF_HYPERPARAMETER_IMPL
+
+#include "algorithms/algorithm_types.h"
+
+namespace daal
+{
+namespace algorithms
+{
+namespace decision_forest
+{
+namespace internal
+{
+
+/**
+ * Available identifiers of integer hyperparameters of the decision forest algorithm
+ */
+enum HyperparameterId
+{
+    defaultBlockSize = 0,
+    defaultBlockSizeCommon,
+    minTreesForThreading,
+    minNumberOfRowsForVectSeqCompute,
+    hyperparameterIdCount = minNumberOfRowsForVectSeqCompute + 1
+};
+
+enum DoubleHyperparameterId
+{
+
+    scaleFactorForVectParallelCompute = 0,
+    doubleHyperparameterIdCount       = scaleFactorForVectParallelCompute + 1
+};
+
+/**
+ * \brief Hyperparameters of the decision forest algorithm
+ */
+struct DAAL_EXPORT Hyperparameter : public daal::algorithms::Hyperparameter
+{
+    using algorithms::Hyperparameter::set;
+    using algorithms::Hyperparameter::find;
+
+    /** Default constructor */
+    Hyperparameter();
+
+    /**
+     * Sets integer hyperparameter of the decision forest algorithm
+     * \param[in] id        Identifier of the hyperparameter
+     * \param[in] value     The value of the hyperparameter
+     */
+    services::Status set(HyperparameterId id, DAAL_INT64 value);
+
+    /**
+     * Sets double precision hyperparameter of the decision forest algorithm
+     * \param[in] id        Identifier of the hyperparameter
+     * \param[in] value     Value of the hyperparameter
+     */
+    services::Status set(DoubleHyperparameterId id, double value);
+
+    /**
+     * Finds integer hyperparameter of the decision forest algorithm by its identifier
+     * \param[in]  id       Identifier of the hyperparameter
+     * \param[out] value    Value of the found hyperparameter
+     */
+    services::Status find(HyperparameterId id, DAAL_INT64 & value) const;
+
+    /**
+     * Finds double precision hyperparameter of the decision forest algorithm by its identifier
+     * \param[in]  id       Identifier of the hyperparameter
+     * \param[out] value    Value of the found hyperparameter
+     */
+    services::Status find(DoubleHyperparameterId id, double & value) const;
+};
+
+} // namespace internal
+} // namespace decision_forest
+} // namespace algorithms
+} // namespace daal
+
+#endif

--- a/cpp/daal/src/algorithms/dtrees/forest/regression/BUILD
+++ b/cpp/daal/src/algorithms/dtrees/forest/regression/BUILD
@@ -13,3 +13,8 @@ daal_module(
         "@onedal//cpp/daal/src/algorithms/dtrees/forest:kernel",
     ],
 )
+
+daal_module(
+    name = "model_impl",
+    hdrs = glob(["*.hpp"]),
+)

--- a/cpp/daal/src/algorithms/dtrees/gbt/regression/BUILD
+++ b/cpp/daal/src/algorithms/dtrees/gbt/regression/BUILD
@@ -7,11 +7,13 @@ daal_module(
     auto = False,
     hdrs = glob(["**/*.h", "**/*.i", "**/*.cl"]),
     srcs = glob(["*.cpp"]),
+    opencl = True,
     deps = [
         "@onedal//cpp/daal:core",
         "@onedal//cpp/daal:sycl",
+        "@onedal//cpp/daal/src/algorithms/dtrees/gbt:kernel",
         "@onedal//cpp/daal/src/algorithms/regression:kernel",
-        "@onedal//cpp/daal/src/algorithms/classifer:kernel",
+        "@onedal//cpp/daal/src/algorithms/classifier:kernel",
         "@onedal//cpp/daal/src/algorithms/dtrees:kernel",
     ],
 )

--- a/cpp/daal/src/algorithms/dtrees/gbt/regression/BUILD
+++ b/cpp/daal/src/algorithms/dtrees/gbt/regression/BUILD
@@ -11,7 +11,8 @@ daal_module(
         "@onedal//cpp/daal:core",
         "@onedal//cpp/daal:sycl",
         "@onedal//cpp/daal/src/algorithms/regression:kernel",
-        "@onedal//cpp/daal/src/algorithms/dtrees/gbt:kernel",
+        "@onedal//cpp/daal/src/algorithms/classifer:kernel",
+        "@onedal//cpp/daal/src/algorithms/dtrees:kernel",
     ],
 )
 

--- a/cpp/daal/src/services/error_handling.cpp
+++ b/cpp/daal/src/services/error_handling.cpp
@@ -718,7 +718,7 @@ void ErrorMessageCollection::parseResourceFile()
     add(ErrorNullByteInjection, "Null byte injection has been detected");
     add(ErrorBufferSizeIntegerOverflow, "Integer overflow is occured");
     add(ErrorHyperparameterNotFound, "Cannot find a hyperparameter");
-    add(ErrorHyperparameterBadValue, "Hyperparamter has bad value");
+    add(ErrorHyperparameterBadValue, "Hyperparameter has bad value");
 
     // Environment errors: -2000..-2999
     add(ErrorCpuNotSupported, "CPU not supported");

--- a/cpp/daal/src/services/error_handling.cpp
+++ b/cpp/daal/src/services/error_handling.cpp
@@ -718,6 +718,7 @@ void ErrorMessageCollection::parseResourceFile()
     add(ErrorNullByteInjection, "Null byte injection has been detected");
     add(ErrorBufferSizeIntegerOverflow, "Integer overflow is occured");
     add(ErrorHyperparameterNotFound, "Cannot find a hyperparameter");
+    add(ErrorHyperparameterBadValue, "Hyperparamter has bad value");
 
     // Environment errors: -2000..-2999
     add(ErrorCpuNotSupported, "CPU not supported");

--- a/cpp/oneapi/dal/algo/BUILD
+++ b/cpp/oneapi/dal/algo/BUILD
@@ -7,6 +7,7 @@ load("@onedal//dev/bazel:dal.bzl",
 
 PARAMETRIZED_ALGOS = [
     "covariance",
+    "decision_forest",
     "linear_regression",
 ]
 
@@ -16,7 +17,6 @@ ALGOS = [
     "connected_components",
     "cosine_distance",
     "dbscan",
-    "decision_forest",
     "decision_tree",
     "jaccard",
     "kmeans",

--- a/cpp/oneapi/dal/algo/decision_forest/BUILD
+++ b/cpp/oneapi/dal/algo/decision_forest/BUILD
@@ -31,8 +31,7 @@ dal_module(
         "@onedal//cpp/oneapi/dal/backend/primitives:rng",
     ],
     extra_deps = [
-        "@onedal//cpp/daal/src/algorithms/dtrees/forest/classification:kernel",
-        "@onedal//cpp/daal/src/algorithms/dtrees/forest/regression:kernel",
+        "@onedal//cpp/daal/src/algorithms/decision_tree:kernel",
     ]
 )
 

--- a/cpp/oneapi/dal/algo/decision_forest/BUILD
+++ b/cpp/oneapi/dal/algo/decision_forest/BUILD
@@ -14,6 +14,7 @@ dal_module(
 
 dal_module(
     name = "parameters",
+    auto = True,
     dal_deps = [
         "@onedal//cpp/oneapi/dal/algo/decision_forest/parameters",
     ],
@@ -24,8 +25,8 @@ dal_module(
     dal_deps = [
         ":core",
         ":parameters",
-        "@onedal//cpp/oneapi/dal/algo/decision_forest/detail",
-        "@onedal//cpp/oneapi/dal/algo/decision_forest/backend",
+        "@onedal//cpp/oneapi/dal/algo/decision_forest:detail",
+        "@onedal//cpp/oneapi/dal/algo/decision_forest:backend",
         "@onedal//cpp/oneapi/dal/backend/primitives:common",
         "@onedal//cpp/oneapi/dal/backend/primitives:sort",
         "@onedal//cpp/oneapi/dal/backend/primitives:rng",

--- a/cpp/oneapi/dal/algo/decision_forest/BUILD
+++ b/cpp/oneapi/dal/algo/decision_forest/BUILD
@@ -46,8 +46,6 @@ dal_test_suite(
         "test/*.cpp",
     ]),
     dal_deps = [
-        ":core",
-        ":parameters",
         ":decision_forest",
     ],
 )
@@ -55,9 +53,6 @@ dal_test_suite(
 dal_test_suite(
     name = "tests",
     tests = [
-        ":core",
-        ":parameters",
-        ":decision_forest",
         ":interface_tests",
     ],
 )

--- a/cpp/oneapi/dal/algo/decision_forest/BUILD
+++ b/cpp/oneapi/dal/algo/decision_forest/BUILD
@@ -9,12 +9,12 @@ dal_module(
     auto = True,
     dal_deps = [
         "@onedal//cpp/oneapi/dal:core",
+        "@onedal//cpp/oneapi/dal/algo/decision_forest/backend:model_impl",  
     ],
 )
 
 dal_module(
     name = "parameters",
-    auto = True,
     dal_deps = [
         "@onedal//cpp/oneapi/dal/algo/decision_forest/parameters",
     ],
@@ -25,8 +25,9 @@ dal_module(
     dal_deps = [
         ":core",
         ":parameters",
-        "@onedal//cpp/oneapi/dal/algo/decision_forest:detail",
-        "@onedal//cpp/oneapi/dal/algo/decision_forest:backend",
+        "@onedal//cpp/oneapi/dal/algo/decision_forest/detail",
+        "@onedal//cpp/oneapi/dal/algo/decision_forest/backend",
+        "@onedal//cpp/oneapi/dal/algo:decision_tree",
         "@onedal//cpp/oneapi/dal/backend/primitives:common",
         "@onedal//cpp/oneapi/dal/backend/primitives:sort",
         "@onedal//cpp/oneapi/dal/backend/primitives:rng",

--- a/cpp/oneapi/dal/algo/decision_forest/BUILD
+++ b/cpp/oneapi/dal/algo/decision_forest/BUILD
@@ -9,7 +9,7 @@ dal_module(
     auto = True,
     dal_deps = [
         "@onedal//cpp/oneapi/dal:core",
-        "@onedal//cpp/oneapi/dal/algo/decision_forest/backend:model_impl",  
+        "@onedal//cpp/oneapi/dal/algo/decision_forest/backend:model_impl",
     ],
 )
 
@@ -34,6 +34,8 @@ dal_module(
     ],
     extra_deps = [
         "@onedal//cpp/daal/src/algorithms/decision_tree:kernel",
+        "@onedal//cpp/daal/src/algorithms/dtrees/forest/classification:kernel",
+        "@onedal//cpp/daal/src/algorithms/dtrees/forest/regression:kernel",
     ]
 )
 

--- a/cpp/oneapi/dal/algo/decision_forest/BUILD
+++ b/cpp/oneapi/dal/algo/decision_forest/BUILD
@@ -5,11 +5,27 @@ load("@onedal//dev/bazel:dal.bzl",
 )
 
 dal_module(
-    name = "decision_forest",
+    name = "core",
     auto = True,
     dal_deps = [
         "@onedal//cpp/oneapi/dal:core",
-        "@onedal//cpp/oneapi/dal/algo:decision_tree",
+    ],
+)
+
+dal_module(
+    name = "parameters",
+    dal_deps = [
+        "@onedal//cpp/oneapi/dal/algo/covariance/parameters",
+    ],
+)
+
+dal_module(
+    name = "decision_forest",
+    dal_deps = [
+        ":core",
+        ":parameters",
+        "@onedal//cpp/oneapi/dal/algo/decision_forest/detail",
+        "@onedal//cpp/oneapi/dal/algo/decision_forest/backend",
         "@onedal//cpp/oneapi/dal/backend/primitives:common",
         "@onedal//cpp/oneapi/dal/backend/primitives:sort",
         "@onedal//cpp/oneapi/dal/backend/primitives:rng",
@@ -30,6 +46,8 @@ dal_test_suite(
         "test/*.cpp",
     ]),
     dal_deps = [
+        ":core",
+        ":parameters",
         ":decision_forest",
     ],
 )
@@ -37,6 +55,9 @@ dal_test_suite(
 dal_test_suite(
     name = "tests",
     tests = [
+        ":core",
+        ":parameters",
+        ":decision_forest",
         ":interface_tests",
     ],
 )

--- a/cpp/oneapi/dal/algo/decision_forest/BUILD
+++ b/cpp/oneapi/dal/algo/decision_forest/BUILD
@@ -15,7 +15,7 @@ dal_module(
 dal_module(
     name = "parameters",
     dal_deps = [
-        "@onedal//cpp/oneapi/dal/algo/covariance/parameters",
+        "@onedal//cpp/oneapi/dal/algo/decision_forest/parameters",
     ],
 )
 

--- a/cpp/oneapi/dal/algo/decision_forest/backend/BUILD
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/BUILD
@@ -1,0 +1,13 @@
+package(default_visibility = ["//visibility:public"])
+load("@onedal//dev/bazel:dal.bzl",
+    "dal_module",
+    "dal_test_suite",
+)
+
+dal_module(
+    name = "backend",
+    dal_deps = [
+        "@onedal//cpp/oneapi/dal/algo/decisino_forest/backend/cpu",
+        "@onedal//cpp/oneapi/dal/algo/decisino_forest/backend/gpu",
+    ],
+)

--- a/cpp/oneapi/dal/algo/decision_forest/backend/BUILD
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/BUILD
@@ -7,7 +7,7 @@ load("@onedal//dev/bazel:dal.bzl",
 dal_module(
     name = "backend",
     dal_deps = [
-        "@onedal//cpp/oneapi/dal/algo/decisino_forest/backend/cpu",
-        "@onedal//cpp/oneapi/dal/algo/decisino_forest/backend/gpu",
+        "@onedal//cpp/oneapi/dal/algo/decision_forest/backend/cpu",
+        "@onedal//cpp/oneapi/dal/algo/decision_forest/backend/gpu",
     ],
 )

--- a/cpp/oneapi/dal/algo/decision_forest/backend/BUILD
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/BUILD
@@ -12,3 +12,11 @@ dal_module(
         "@onedal//cpp/oneapi/dal/algo/decision_forest/backend/gpu",
     ],
 )
+
+dal_module(
+    name = "model_impl",
+    hdrs = glob(["*.hpp"]),
+    dal_deps = [
+        "@onedal//cpp/oneapi/dal/algo:decision_tree",
+    ]
+)

--- a/cpp/oneapi/dal/algo/decision_forest/backend/BUILD
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/BUILD
@@ -6,6 +6,7 @@ load("@onedal//dev/bazel:dal.bzl",
 
 dal_module(
     name = "backend",
+    auto=True,
     dal_deps = [
         "@onedal//cpp/oneapi/dal/algo/decision_forest/backend/cpu",
         "@onedal//cpp/oneapi/dal/algo/decision_forest/backend/gpu",

--- a/cpp/oneapi/dal/algo/decision_forest/backend/cpu/BUILD
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/cpu/BUILD
@@ -13,6 +13,6 @@ dal_module(
     ],
     extra_deps = [
         "@onedal//cpp/daal:core",
-        "@onedal//cpp/daal/src/algorithms/decision_forest:kernel",
+        "@onedal//cpp/daal/src/algorithms/decision_tree:kernel",
     ],
 )

--- a/cpp/oneapi/dal/algo/decision_forest/backend/cpu/BUILD
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/cpu/BUILD
@@ -14,5 +14,9 @@ dal_module(
     extra_deps = [
         "@onedal//cpp/daal:core",
         "@onedal//cpp/daal/src/algorithms/dtrees:kernel",
+        "@onedal//cpp/daal/src/algorithms/dtrees/forest/regression:kernel",
+        "@onedal//cpp/daal/src/algorithms/dtrees/forest/classification:kernel",
+        "@onedal//cpp/daal/src/algorithms/dtrees/forest/regression:model_impl",
+        "@onedal//cpp/daal/src/algorithms/dtrees/forest/classification:model_impl",
     ],
 )

--- a/cpp/oneapi/dal/algo/decision_forest/backend/cpu/BUILD
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/cpu/BUILD
@@ -1,0 +1,18 @@
+package(default_visibility = ["//visibility:public"])
+load("@onedal//dev/bazel:dal.bzl",
+    "dal_module",
+    "dal_test_suite",
+)
+
+dal_module(
+    name = "cpu",
+    auto = True,
+    dal_deps = [
+        "@onedal//cpp/oneapi/dal/algo/decision_forest:core",
+        "@onedal//cpp/oneapi/dal/backend/primitives:common",
+    ],
+    extra_deps = [
+        "@onedal//cpp/daal:core",
+        "@onedal//cpp/daal/src/algorithms/decision_forest:kernel",
+    ],
+)

--- a/cpp/oneapi/dal/algo/decision_forest/backend/cpu/BUILD
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/cpu/BUILD
@@ -13,6 +13,6 @@ dal_module(
     ],
     extra_deps = [
         "@onedal//cpp/daal:core",
-        "@onedal//cpp/daal/src/algorithms/decision_tree:kernel",
+        "@onedal//cpp/daal/src/algorithms/dtrees:kernel",
     ],
 )

--- a/cpp/oneapi/dal/algo/decision_forest/backend/cpu/infer_kernel.hpp
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/cpu/infer_kernel.hpp
@@ -24,7 +24,8 @@ namespace oneapi::dal::decision_forest::backend {
 template <typename Float, typename Method, typename Task>
 struct infer_kernel_cpu {
     infer_result<Task> operator()(const dal::backend::context_cpu& ctx,
-                                  const detail::descriptor_base<Task>& params,
+                                  const detail::descriptor_base<Task>& desc,
+                                  const detail::infer_parameters<Task>& params,
                                   const infer_input<Task>& input) const;
 };
 

--- a/cpp/oneapi/dal/algo/decision_forest/backend/cpu/infer_kernel_cls.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/cpu/infer_kernel_cls.cpp
@@ -33,6 +33,7 @@ using dal::backend::context_cpu;
 using model_t = model<task::classification>;
 using input_t = infer_input<task::classification>;
 using result_t = infer_result<task::classification>;
+using param_t = detail::infer_parameters<task::classification>;
 using descriptor_t = detail::descriptor_base<task::classification>;
 
 namespace daal_df = daal::algorithms::decision_forest;
@@ -59,6 +60,7 @@ static daal_df::classification::ModelPtr get_daal_model(const model_t& trained_m
 template <typename Float>
 static result_t call_daal_kernel(const context_cpu& ctx,
                                  const descriptor_t& desc,
+                                 const param_t& params,
                                  const model_t& trained_model,
                                  const table& data) {
     const std::int64_t row_count = data.get_row_count();
@@ -115,12 +117,15 @@ static result_t call_daal_kernel(const context_cpu& ctx,
 }
 
 template <typename Float>
-static result_t infer(const context_cpu& ctx, const descriptor_t& desc, const input_t& input) {
-    return call_daal_kernel<Float>(ctx, desc, input.get_model(), input.get_data());
+static result_t infer(const context_cpu& ctx,
+                      const descriptor_t& desc,
+                      const param_t& params,
+                      const input_t& input) {
+    return call_daal_kernel<Float>(ctx, desc, params, input.get_model(), input.get_data());
 }
 
-template <typename Float, typename Task>
-static daal_hyperparameters_t convert_parameters(const detail::infer_parameters<Task>& params) {
+template <typename Float>
+static daal_hyperparameters_t convert_parameters(const param_t& params) {
     using daal_df::internal::HyperparameterId;
     using daal_df::internal::DoubleHyperparameterId;
 
@@ -148,8 +153,9 @@ template <typename Float>
 struct infer_kernel_cpu<Float, method::by_default, task::classification> {
     result_t operator()(const context_cpu& ctx,
                         const descriptor_t& desc,
+                        const param_t& params,
                         const input_t& input) const {
-        return infer<Float>(ctx, desc, input);
+        return infer<Float>(ctx, desc, params, input);
     }
 };
 

--- a/cpp/oneapi/dal/algo/decision_forest/backend/cpu/infer_kernel_cls.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/cpu/infer_kernel_cls.cpp
@@ -22,6 +22,7 @@
 #include "oneapi/dal/algo/decision_forest/backend/cpu/infer_kernel.hpp"
 
 #include "oneapi/dal/table/row_accessor.hpp"
+#include "oneapi/dal/backend/dispatcher.hpp"
 #include "oneapi/dal/backend/interop/common.hpp"
 #include "oneapi/dal/backend/interop/error_converter.hpp"
 #include "oneapi/dal/backend/interop/table_conversion.hpp"

--- a/cpp/oneapi/dal/algo/decision_forest/backend/cpu/infer_kernel_cls.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/cpu/infer_kernel_cls.cpp
@@ -129,16 +129,14 @@ static daal_hyperparameters_t convert_parameters(const param_t& params) {
     using daal_df::internal::HyperparameterId;
     using daal_df::internal::DoubleHyperparameterId;
 
-    const std::int64_t block = params.get_default_block_size();
-    const std::int64_t blockCommon = params.get_default_block_size_common();
+    const std::int64_t block = params.get_block_size();
     const std::int64_t minTrees = params.get_min_trees_for_threading();
-    const std::int64_t minRows = params.get_min_number_of_rows_for_sequential_compute();
+    const std::int64_t minRows = params.get_min_number_of_rows_for_vect_seq_compute();
     const double scale = params.get_scale_factor_for_vect_parallel_compute();
 
     daal_hyperparameters_t daal_hyperparameter;
 
-    auto status = daal_hyperparameter.set(HyperparameterId::defaultBlockSize, block);
-    status |= daal_hyperparameter.set(HyperparameterId::defaultBlockSizeCommon, blockCommon);
+    auto status = daal_hyperparameter.set(HyperparameterId::blockSize, block);
     status |= daal_hyperparameter.set(HyperparameterId::minTreesForThreading, minTrees);
     status |= daal_hyperparameter.set(HyperparameterId::minNumberOfRowsForVectSeqCompute, minRows);
     status |=

--- a/cpp/oneapi/dal/algo/decision_forest/backend/cpu/infer_kernel_cls.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/cpu/infer_kernel_cls.cpp
@@ -62,6 +62,7 @@ static daal_hyperparameters_t convert_parameters(const param_t& params) {
     using daal_df::internal::HyperparameterId;
     using daal_df::internal::DoubleHyperparameterId;
 
+    const std::int64_t blockMultiplier = params.get_block_size_multiplier();
     const std::int64_t block = params.get_block_size();
     const std::int64_t minTrees = params.get_min_trees_for_threading();
     const std::int64_t minRows = params.get_min_number_of_rows_for_vect_seq_compute();
@@ -69,7 +70,8 @@ static daal_hyperparameters_t convert_parameters(const param_t& params) {
 
     daal_hyperparameters_t daal_hyperparameter;
 
-    auto status = daal_hyperparameter.set(HyperparameterId::blockSize, block);
+    auto status = daal_hyperparameter.set(HyperparameterId::blockSizeMultiplier, blockMultiplier);
+    status |= daal_hyperparameter.set(HyperparameterId::blockSize, block);
     status |= daal_hyperparameter.set(HyperparameterId::minTreesForThreading, minTrees);
     status |= daal_hyperparameter.set(HyperparameterId::minNumberOfRowsForVectSeqCompute, minRows);
     status |=

--- a/cpp/oneapi/dal/algo/decision_forest/backend/cpu/infer_kernel_reg.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/cpu/infer_kernel_reg.cpp
@@ -31,6 +31,7 @@ using dal::backend::context_cpu;
 using model_t = model<task::regression>;
 using input_t = infer_input<task::regression>;
 using result_t = infer_result<task::regression>;
+using param_t = detail::infer_parameters<task::regression>;
 using descriptor_t = detail::descriptor_base<task::regression>;
 
 namespace daal_df = daal::algorithms::decision_forest;
@@ -90,6 +91,7 @@ template <typename Float>
 struct infer_kernel_cpu<Float, method::by_default, task::regression> {
     result_t operator()(const context_cpu& ctx,
                         const descriptor_t& desc,
+                        const param_t& params,
                         const input_t& input) const {
         return infer<Float>(ctx, desc, input);
     }

--- a/cpp/oneapi/dal/algo/decision_forest/backend/cpu/infer_kernel_reg.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/cpu/infer_kernel_reg.cpp
@@ -20,6 +20,7 @@
 #include "oneapi/dal/algo/decision_forest/backend/cpu/infer_kernel.hpp"
 
 #include "oneapi/dal/table/row_accessor.hpp"
+#include "oneapi/dal/backend/dispatcher.hpp"
 #include "oneapi/dal/backend/interop/common.hpp"
 #include "oneapi/dal/backend/interop/error_converter.hpp"
 #include "oneapi/dal/backend/interop/table_conversion.hpp"

--- a/cpp/oneapi/dal/algo/decision_forest/backend/gpu/BUILD
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/gpu/BUILD
@@ -11,6 +11,6 @@ dal_module(
         "@onedal//cpp/oneapi/dal/algo/decision_forest:core",
     ],
     extra_deps = [
-        "@onedal//cpp/daal/src/algorithms/decision_forest:kernel",
+        "@onedal//cpp/daal/src/algorithms/decision_tree:kernel",
     ]
 )

--- a/cpp/oneapi/dal/algo/decision_forest/backend/gpu/BUILD
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/gpu/BUILD
@@ -9,8 +9,10 @@ dal_module(
     auto = True,
     dal_deps = [
         "@onedal//cpp/oneapi/dal/algo/decision_forest:core",
+        "@onedal//cpp/oneapi/dal/backend/primitives:common",
     ],
     extra_deps = [
+        "@onedal//cpp/daal:core",
         "@onedal//cpp/daal/src/algorithms/dtrees:kernel",
     ]
 )

--- a/cpp/oneapi/dal/algo/decision_forest/backend/gpu/BUILD
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/gpu/BUILD
@@ -8,10 +8,6 @@ dal_module(
     name = "gpu",
     auto = True,
     dal_deps = [
-        "@onedal//cpp/oneapi/dal/backend/primitives:common",
-        "@onedal//cpp/oneapi/dal/backend/primitives:lapack",
-        "@onedal//cpp/oneapi/dal/backend/primitives:stat",
-        "@onedal//cpp/oneapi/dal/backend/primitives:reduction",
         "@onedal//cpp/oneapi/dal/algo/decision_forest:core",
     ],
     extra_deps = [

--- a/cpp/oneapi/dal/algo/decision_forest/backend/gpu/BUILD
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/gpu/BUILD
@@ -11,6 +11,6 @@ dal_module(
         "@onedal//cpp/oneapi/dal/algo/decision_forest:core",
     ],
     extra_deps = [
-        "@onedal//cpp/daal/src/algorithms/decision_tree:kernel",
+        "@onedal//cpp/daal/src/algorithms/dtrees:kernel",
     ]
 )

--- a/cpp/oneapi/dal/algo/decision_forest/backend/gpu/BUILD
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/gpu/BUILD
@@ -10,9 +10,15 @@ dal_module(
     dal_deps = [
         "@onedal//cpp/oneapi/dal/algo/decision_forest:core",
         "@onedal//cpp/oneapi/dal/backend/primitives:common",
+        "@onedal//cpp/oneapi/dal/backend/primitives:sort",
+        "@onedal//cpp/oneapi/dal/backend/primitives:rng",
     ],
     extra_deps = [
         "@onedal//cpp/daal:core",
         "@onedal//cpp/daal/src/algorithms/dtrees:kernel",
+        "@onedal//cpp/daal/src/algorithms/dtrees/forest/classification:kernel",
+        "@onedal//cpp/daal/src/algorithms/dtrees/forest/classification:model_impl",
+        "@onedal//cpp/daal/src/algorithms/dtrees/forest/regression:kernel",
+        "@onedal//cpp/daal/src/algorithms/dtrees/forest/regression:model_impl",
     ]
 )

--- a/cpp/oneapi/dal/algo/decision_forest/backend/gpu/BUILD
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/gpu/BUILD
@@ -12,7 +12,7 @@ dal_module(
         "@onedal//cpp/oneapi/dal/backend/primitives:lapack",
         "@onedal//cpp/oneapi/dal/backend/primitives:stat",
         "@onedal//cpp/oneapi/dal/backend/primitives:reduction",
-        "@onedal//cpp/oneapi/dal/algo/covariance:core",
+        "@onedal//cpp/oneapi/dal/algo/decision_forest:core",
     ],
     extra_deps = [
         "@onedal//cpp/daal/src/algorithms/decision_forest:kernel",

--- a/cpp/oneapi/dal/algo/decision_forest/backend/gpu/BUILD
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/gpu/BUILD
@@ -1,0 +1,20 @@
+package(default_visibility = ["//visibility:public"])
+load("@onedal//dev/bazel:dal.bzl",
+    "dal_module",
+    "dal_test_suite",
+)
+
+dal_module(
+    name = "gpu",
+    auto = True,
+    dal_deps = [
+        "@onedal//cpp/oneapi/dal/backend/primitives:common",
+        "@onedal//cpp/oneapi/dal/backend/primitives:lapack",
+        "@onedal//cpp/oneapi/dal/backend/primitives:stat",
+        "@onedal//cpp/oneapi/dal/backend/primitives:reduction",
+        "@onedal//cpp/oneapi/dal/algo/covariance:core",
+    ],
+    extra_deps = [
+        "@onedal//cpp/daal/src/algorithms/decision_forest:kernel",
+    ]
+)

--- a/cpp/oneapi/dal/algo/decision_forest/backend/gpu/infer_kernel.hpp
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/gpu/infer_kernel.hpp
@@ -25,6 +25,10 @@ template <typename Float, typename Method, typename Task>
 struct infer_kernel_gpu {
     infer_result<Task> operator()(const dal::backend::context_gpu& ctx,
                                   const detail::descriptor_base<Task>& desc,
+                                  const infer_input<Task>& input) const;
+
+    infer_result<Task> operator()(const dal::backend::context_gpu& ctx,
+                                  const detail::descriptor_base<Task>& desc,
                                   const detail::infer_parameters<Task>& params,
                                   const infer_input<Task>& input) const;
 };

--- a/cpp/oneapi/dal/algo/decision_forest/backend/gpu/infer_kernel.hpp
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/gpu/infer_kernel.hpp
@@ -25,10 +25,6 @@ template <typename Float, typename Method, typename Task>
 struct infer_kernel_gpu {
     infer_result<Task> operator()(const dal::backend::context_gpu& ctx,
                                   const detail::descriptor_base<Task>& desc,
-                                  const infer_input<Task>& input) const;
-
-    infer_result<Task> operator()(const dal::backend::context_gpu& ctx,
-                                  const detail::descriptor_base<Task>& desc,
                                   const detail::infer_parameters<Task>& params,
                                   const infer_input<Task>& input) const;
 };

--- a/cpp/oneapi/dal/algo/decision_forest/backend/gpu/infer_kernel_cls_dpc.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/gpu/infer_kernel_cls_dpc.cpp
@@ -14,6 +14,7 @@
 * limitations under the License.
 *******************************************************************************/
 
+#include "oneapi/dal/backend/dispatcher.hpp"
 #include "oneapi/dal/algo/decision_forest/backend/gpu/infer_kernel.hpp"
 #include "oneapi/dal/algo/decision_forest/backend/gpu/infer_kernel_impl.hpp"
 

--- a/cpp/oneapi/dal/algo/decision_forest/backend/gpu/infer_kernel_cls_dpc.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/gpu/infer_kernel_cls_dpc.cpp
@@ -23,6 +23,7 @@ using dal::backend::context_gpu;
 using model_t = model<task::classification>;
 using input_t = infer_input<task::classification>;
 using result_t = infer_result<task::classification>;
+using param_t = detail::infer_parameters<task::classification>;
 using descriptor_t = detail::descriptor_base<task::classification>;
 
 template <typename Float>
@@ -41,10 +42,15 @@ static result_t infer(const context_gpu& ctx, const descriptor_t& desc, const in
 
 template <typename Float>
 struct infer_kernel_gpu<Float, method::by_default, task::classification> {
+    result_t operator()(context_gpu& ctx, const descriptor_t& desc, const input_t& input) const {
+        return infer<Float>(ctx, desc, input);
+    }
+
     result_t operator()(const context_gpu& ctx,
                         const descriptor_t& desc,
+                        const param_t& params,
                         const input_t& input) const {
-        return infer<Float>(ctx, desc, input);
+        return operator()<Float>(ctx, desc, input);
     }
 };
 

--- a/cpp/oneapi/dal/algo/decision_forest/backend/gpu/infer_kernel_cls_dpc.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/gpu/infer_kernel_cls_dpc.cpp
@@ -50,7 +50,7 @@ struct infer_kernel_gpu<Float, method::by_default, task::classification> {
                         const descriptor_t& desc,
                         const param_t& params,
                         const input_t& input) const {
-        return operator()<Float>(ctx, desc, input);
+        return infer<Float>(ctx, desc, input);
     }
 };
 

--- a/cpp/oneapi/dal/algo/decision_forest/backend/gpu/infer_kernel_cls_dpc.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/gpu/infer_kernel_cls_dpc.cpp
@@ -43,10 +43,6 @@ static result_t infer(const context_gpu& ctx, const descriptor_t& desc, const in
 
 template <typename Float>
 struct infer_kernel_gpu<Float, method::by_default, task::classification> {
-    result_t operator()(context_gpu& ctx, const descriptor_t& desc, const input_t& input) const {
-        return infer<Float>(ctx, desc, input);
-    }
-
     result_t operator()(const context_gpu& ctx,
                         const descriptor_t& desc,
                         const param_t& params,

--- a/cpp/oneapi/dal/algo/decision_forest/backend/gpu/infer_kernel_reg_dpc.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/gpu/infer_kernel_reg_dpc.cpp
@@ -43,10 +43,6 @@ static result_t infer(const context_gpu& ctx, const descriptor_t& desc, const in
 
 template <typename Float>
 struct infer_kernel_gpu<Float, method::by_default, task::regression> {
-    result_t operator()(context_gpu& ctx, const descriptor_t& desc, const input_t& input) const {
-        return infer<Float>(ctx, desc, input);
-    }
-
     result_t operator()(const context_gpu& ctx,
                         const descriptor_t& desc,
                         const param_t& infer_params,

--- a/cpp/oneapi/dal/algo/decision_forest/backend/gpu/infer_kernel_reg_dpc.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/gpu/infer_kernel_reg_dpc.cpp
@@ -41,10 +41,15 @@ static result_t infer(const context_gpu& ctx, const descriptor_t& desc, const in
 
 template <typename Float>
 struct infer_kernel_gpu<Float, method::by_default, task::regression> {
+    result_t operator()(context_gpu& ctx, const descriptor_t& desc, const input_t& input) const {
+        return infer<Float>(ctx, desc, input);
+    }
+
     result_t operator()(const context_gpu& ctx,
                         const descriptor_t& desc,
+                        const param_t& infer_params,
                         const input_t& input) const {
-        return infer<Float>(ctx, desc, input);
+        return operator()<Float>(ctx, desc, input);
     }
 };
 

--- a/cpp/oneapi/dal/algo/decision_forest/backend/gpu/infer_kernel_reg_dpc.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/gpu/infer_kernel_reg_dpc.cpp
@@ -24,7 +24,7 @@ using dal::backend::context_gpu;
 using model_t = model<task::regression>;
 using input_t = infer_input<task::regression>;
 using result_t = infer_result<task::regression>;
-using param_t = detail::infer_parameters<task::classification>;
+using param_t = detail::infer_parameters<task::regression>;
 using descriptor_t = detail::descriptor_base<task::regression>;
 
 template <typename Float>

--- a/cpp/oneapi/dal/algo/decision_forest/backend/gpu/infer_kernel_reg_dpc.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/gpu/infer_kernel_reg_dpc.cpp
@@ -14,6 +14,7 @@
 * limitations under the License.
 *******************************************************************************/
 
+#include "oneapi/dal/backend/dispatcher.hpp"
 #include "oneapi/dal/algo/decision_forest/backend/gpu/infer_kernel.hpp"
 #include "oneapi/dal/algo/decision_forest/backend/gpu/infer_kernel_impl.hpp"
 

--- a/cpp/oneapi/dal/algo/decision_forest/backend/gpu/infer_kernel_reg_dpc.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/gpu/infer_kernel_reg_dpc.cpp
@@ -23,6 +23,7 @@ using dal::backend::context_gpu;
 using model_t = model<task::regression>;
 using input_t = infer_input<task::regression>;
 using result_t = infer_result<task::regression>;
+using param_t = detail::infer_parameters<task::classification>;
 using descriptor_t = detail::descriptor_base<task::regression>;
 
 template <typename Float>
@@ -49,7 +50,7 @@ struct infer_kernel_gpu<Float, method::by_default, task::regression> {
                         const descriptor_t& desc,
                         const param_t& infer_params,
                         const input_t& input) const {
-        return operator()<Float>(ctx, desc, input);
+        return infer<Float>(ctx, desc, input);
     }
 };
 

--- a/cpp/oneapi/dal/algo/decision_forest/detail/BUILD
+++ b/cpp/oneapi/dal/algo/decision_forest/detail/BUILD
@@ -9,7 +9,8 @@ dal_module(
     auto=True,
     dal_deps = [
         "@onedal//cpp/oneapi/dal/algo/decision_forest:core",
-        "@onedal//cpp/oneapi/dal/algo/decision_forest/backend",
+        "@onedal//cpp/oneapi/dal/algo/decision_forest/backend/cpu",
+        "@onedal//cpp/oneapi/dal/algo/decision_forest/backend/gpu",
         "@onedal//cpp/oneapi/dal/algo/decision_forest/parameters",
     ]
 )

--- a/cpp/oneapi/dal/algo/decision_forest/detail/BUILD
+++ b/cpp/oneapi/dal/algo/decision_forest/detail/BUILD
@@ -9,8 +9,7 @@ dal_module(
     auto=True,
     dal_deps = [
         "@onedal//cpp/oneapi/dal/algo/decision_forest:core",
-        "@onedal//cpp/oneapi/dal/algo/decision_forest/backend/cpu",
-        "@onedal//cpp/oneapi/dal/algo/decision_forest/backend/gpu",
+        "@onedal//cpp/oneapi/dal/algo/decision_forest/backend",
         "@onedal//cpp/oneapi/dal/algo/decision_forest/parameters",
     ]
 )

--- a/cpp/oneapi/dal/algo/decision_forest/detail/BUILD
+++ b/cpp/oneapi/dal/algo/decision_forest/detail/BUILD
@@ -1,0 +1,16 @@
+package(default_visibility = ["//visibility:public"])
+load("@onedal//dev/bazel:dal.bzl",
+    "dal_module",
+    "dal_test_suite",
+)
+
+dal_module(
+    name = "detail",
+    auto=True,
+    dal_deps = [
+        "@onedal//cpp/oneapi/dal/algo/decision_forest:core",
+        "@onedal//cpp/oneapi/dal/algo/decision_forest/backend/cpu",
+        "@onedal//cpp/oneapi/dal/algo/decision_forest/backend/gpu",
+        "@onedal//cpp/oneapi/dal/algo/decision_forest/parameters",
+    ]
+)

--- a/cpp/oneapi/dal/algo/decision_forest/detail/infer_ops.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/detail/infer_ops.cpp
@@ -60,10 +60,15 @@ private:
 #define INSTANTIATE(F, T, M) \
     template struct ONEDAL_EXPORT infer_ops_dispatcher<dal::detail::host_policy, F, T, M>;
 
-INSTANTIATE(float, task::classification, method::by_default)
-INSTANTIATE(float, task::regression, method::by_default)
-INSTANTIATE(double, task::classification, method::by_default)
-INSTANTIATE(double, task::regression, method::by_default)
+INSTANTIATE(float, task::classification, method::dense)
+INSTANTIATE(float, task::regression, method::dense)
+INSTANTIATE(double, task::classification, method::dense)
+INSTANTIATE(double, task::regression, method::dense)
+
+INSTANTIATE(float, task::classification, method::hist)
+INSTANTIATE(float, task::regression, method::hist)
+INSTANTIATE(double, task::classification, method::hist)
+INSTANTIATE(double, task::regression, method::hist)
 
 } // namespace v1
 } // namespace oneapi::dal::decision_forest::detail

--- a/cpp/oneapi/dal/algo/decision_forest/detail/infer_ops.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/detail/infer_ops.cpp
@@ -57,18 +57,14 @@ private:
     }
 };
 
-#define INSTANTIATE(F, T, M) \
-    template struct ONEDAL_EXPORT infer_ops_dispatcher<dal::detail::host_policy, F, T, M>;
+#define INSTANTIATE(F, T, M)                                                               \
+    template struct ONEDAL_EXPORT infer_ops_dispatcher<dal::detail::host_policy, F, T, M>; \
+    template struct ONEDAL_EXPORT infer_ops_dispatcher<dal::detail::spmd_host_policy, F, T, M>;
 
-INSTANTIATE(float, task::classification, method::dense)
-INSTANTIATE(float, task::regression, method::dense)
-INSTANTIATE(double, task::classification, method::dense)
-INSTANTIATE(double, task::regression, method::dense)
-
-INSTANTIATE(float, task::classification, method::hist)
-INSTANTIATE(float, task::regression, method::hist)
-INSTANTIATE(double, task::classification, method::hist)
-INSTANTIATE(double, task::regression, method::hist)
+INSTANTIATE(float, task::classification, method::by_default)
+INSTANTIATE(float, task::regression, method::by_default)
+INSTANTIATE(double, task::classification, method::by_default)
+INSTANTIATE(double, task::regression, method::by_default)
 
 } // namespace v1
 } // namespace oneapi::dal::decision_forest::detail

--- a/cpp/oneapi/dal/algo/decision_forest/detail/infer_ops.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/detail/infer_ops.cpp
@@ -25,14 +25,14 @@ namespace v1 {
 template <typename Context, typename Float, typename Task, typename Method>
 struct infer_ops_dispatcher<Context, Float, Task, Method> {
     infer_result<Task> operator()(const Context& context,
-                                  const descriptor<Float, Method, Task>& desc,
+                                  const descriptor_base<Task>& desc,
                                   const infer_parameters<Task>& params,
                                   const infer_input<Task>& input) const {
         return implementation(context, desc, params, input);
     }
 
     infer_parameters<Task> select_parameters(const Context& ctx,
-                                             const descriptor<Float, Method, Task>& desc,
+                                             const descriptor_base<Task>& desc,
                                              const infer_input<Task>& input) const {
         using kernel_dispatcher_t = dal::backend::kernel_dispatcher< //
             KERNEL_SINGLE_NODE_CPU(parameters::infer_parameters_cpu<Float, Method, Task>)>;
@@ -40,7 +40,7 @@ struct infer_ops_dispatcher<Context, Float, Task, Method> {
     }
 
     infer_result<Task> operator()(const Context& context,
-                                  const descriptor<Float, Method, Task>& desc,
+                                  const descriptor_base<Task>& desc,
                                   const infer_input<Task>& input) const {
         const auto params = select_parameters(context, desc, input);
         return implementation(context, desc, params, input);
@@ -48,7 +48,7 @@ struct infer_ops_dispatcher<Context, Float, Task, Method> {
 
 private:
     inline auto implementation(const Context& context,
-                               const descriptor<Float, Method, Task>& desc,
+                               const descriptor_base<Task>& desc,
                                const infer_parameters<Task>& params,
                                const infer_input<Task>& input) const {
         using kernel_dispatcher_t = dal::backend::kernel_dispatcher< //

--- a/cpp/oneapi/dal/algo/decision_forest/detail/infer_ops.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/detail/infer_ops.cpp
@@ -57,19 +57,13 @@ private:
     }
 };
 
-#define INSTANTIATE(F, T, M)                                                               \
-    template struct ONEDAL_EXPORT infer_ops_dispatcher<dal::detail::host_policy, F, T, M>; \
-    template struct ONEDAL_EXPORT infer_ops_dispatcher<dal::detail::spmd_host_policy, F, T, M>;
+#define INSTANTIATE(F, T, M) \
+    template struct ONEDAL_EXPORT infer_ops_dispatcher<dal::detail::host_policy, F, T, M>;
 
-INSTANTIATE(float, task::classification, method::dense)
-INSTANTIATE(float, task::classification, method::hist)
-INSTANTIATE(float, task::regression, method::dense)
-INSTANTIATE(float, task::regression, method::hist)
-
-INSTANTIATE(double, task::classification, method::dense)
-INSTANTIATE(double, task::classification, method::hist)
-INSTANTIATE(double, task::regression, method::dense)
-INSTANTIATE(double, task::regression, method::hist)
+INSTANTIATE(float, task::classification, method::by_default)
+INSTANTIATE(float, task::regression, method::by_default)
+INSTANTIATE(double, task::classification, method::by_default)
+INSTANTIATE(double, task::regression, method::by_default)
 
 } // namespace v1
 } // namespace oneapi::dal::decision_forest::detail

--- a/cpp/oneapi/dal/algo/decision_forest/detail/infer_ops.hpp
+++ b/cpp/oneapi/dal/algo/decision_forest/detail/infer_ops.hpp
@@ -60,6 +60,8 @@ struct infer_ops {
 
     /// Check that the hyperparameters of the algorithm belong to the expected ranges
     void check_parameters_ranges(const param_t& params, const input_t& input) const {
+        ONEDAL_ASSERT(params.get_block_size_multiplier() > 0x0l);
+        ONEDAL_ASSERT((params.get_block_size_multiplier() % 0x8l) == 0x0l);
         ONEDAL_ASSERT(params.get_block_size() > 0x0l);
         ONEDAL_ASSERT(params.get_block_size() <= 0x10000l);
         ONEDAL_ASSERT(params.get_min_trees_for_threading() > 0x0l);

--- a/cpp/oneapi/dal/algo/decision_forest/detail/infer_ops.hpp
+++ b/cpp/oneapi/dal/algo/decision_forest/detail/infer_ops.hpp
@@ -25,14 +25,14 @@ namespace v1 {
 template <typename Context, typename Float, typename Task, typename Method, typename... Options>
 struct infer_ops_dispatcher {
     infer_result<Task> operator()(const Context&,
-                                  const descriptor<Float, Method, Task>&,
+                                  const descriptor_base<Task>&,
                                   const infer_parameters<Task>&,
                                   const infer_input<Task>&) const;
     infer_result<Task> operator()(const Context&,
-                                  const descriptor<Float, Method, Task>&,
+                                  const descriptor_base<Task>&,
                                   const infer_input<Task>&) const;
     infer_parameters<Task> select_parameters(const Context&,
-                                             const descriptor<Float, Method, Task>&,
+                                             const descriptor_base<Task>&,
                                              const infer_input<Task>&) const;
 };
 
@@ -40,7 +40,7 @@ template <typename Descriptor>
 struct infer_ops {
     using float_t = typename Descriptor::float_t;
     using task_t = typename Descriptor::task_t;
-    using method_t = typename Descriptor::method_t;
+    using method_t = method::by_default;
     using input_t = infer_input<task_t>;
     using result_t = infer_result<task_t>;
     using param_t = infer_parameters<task_t>;

--- a/cpp/oneapi/dal/algo/decision_forest/detail/infer_ops.hpp
+++ b/cpp/oneapi/dal/algo/decision_forest/detail/infer_ops.hpp
@@ -61,7 +61,7 @@ struct infer_ops {
     /// Check that the hyperparameters of the algorithm belong to the expected ranges
     void check_parameters_ranges(const param_t& params, const input_t& input) const {
         ONEDAL_ASSERT(params.get_block_size_multiplier() > 0x0l);
-        ONEDAL_ASSERT((params.get_block_size_multiplier() % 0x8l) == 0x0l);
+        ONEDAL_ASSERT(params.get_block_size_multiplier() < 0x100l);
         ONEDAL_ASSERT(params.get_block_size() > 0x0l);
         ONEDAL_ASSERT(params.get_block_size() <= 0x10000l);
         ONEDAL_ASSERT(params.get_min_trees_for_threading() > 0x0l);

--- a/cpp/oneapi/dal/algo/decision_forest/detail/infer_ops.hpp
+++ b/cpp/oneapi/dal/algo/decision_forest/detail/infer_ops.hpp
@@ -25,14 +25,14 @@ namespace v1 {
 template <typename Context, typename Float, typename Task, typename Method, typename... Options>
 struct infer_ops_dispatcher {
     infer_result<Task> operator()(const Context&,
-                                  const descriptor_base<Task>&,
+                                  const descriptor<Float, Method, Task>&,
                                   const infer_parameters<Task>&,
                                   const infer_input<Task>&) const;
     infer_result<Task> operator()(const Context&,
-                                  const descriptor_base<Task>&,
+                                  const descriptor<Float, Method, Task>&,
                                   const infer_input<Task>&) const;
     infer_parameters<Task> select_parameters(const Context&,
-                                             const descriptor_base<Task>&,
+                                             const descriptor<Float, Method, Task>&,
                                              const infer_input<Task>&) const;
 };
 
@@ -71,7 +71,7 @@ struct infer_ops {
     template <typename Context>
     auto select_parameters(const Context& ctx, const Descriptor& desc, const input_t& input) const {
         check_preconditions(desc, input);
-        return infer_ops_dispatcher<Context, float_t, method_t, task_t>{}.select_parameters(ctx,
+        return infer_ops_dispatcher<Context, float_t, task_t, method_t>{}.select_parameters(ctx,
                                                                                             desc,
                                                                                             input);
     }

--- a/cpp/oneapi/dal/algo/decision_forest/detail/infer_ops.hpp
+++ b/cpp/oneapi/dal/algo/decision_forest/detail/infer_ops.hpp
@@ -40,7 +40,7 @@ template <typename Descriptor>
 struct infer_ops {
     using float_t = typename Descriptor::float_t;
     using task_t = typename Descriptor::task_t;
-    using method_t = method::by_default;
+    using method_t = typename Descriptor::method_t;
     using input_t = infer_input<task_t>;
     using result_t = infer_result<task_t>;
     using param_t = infer_parameters<task_t>;

--- a/cpp/oneapi/dal/algo/decision_forest/detail/infer_ops.hpp
+++ b/cpp/oneapi/dal/algo/decision_forest/detail/infer_ops.hpp
@@ -26,7 +26,14 @@ template <typename Context, typename Float, typename Task, typename Method, type
 struct infer_ops_dispatcher {
     infer_result<Task> operator()(const Context&,
                                   const descriptor_base<Task>&,
+                                  const infer_parameters<Task>&,
                                   const infer_input<Task>&) const;
+    infer_result<Task> operator()(const Context&,
+                                  const descriptor_base<Task>&,
+                                  const infer_input<Task>&) const;
+    infer_parameters<Task> select_parameters(const Context&,
+                                             const descriptor_base<Task>&,
+                                             const infer_input<Task>&) const;
 };
 
 template <typename Descriptor>
@@ -36,6 +43,7 @@ struct infer_ops {
     using method_t = method::by_default;
     using input_t = infer_input<task_t>;
     using result_t = infer_result<task_t>;
+    using param_t = infer_parameters<task_t>;
     using descriptor_base_t = descriptor_base<task_t>;
 
     void check_preconditions(const Descriptor& params, const input_t& input) const {
@@ -50,13 +58,40 @@ struct infer_ops {
                               const input_t& input,
                               const result_t& result) const {}
 
+    /// Check that the hyperparameters of the algorithm belong to the expected ranges
+    void check_parameters_ranges(const param_t& params, const input_t& input) const {
+        ONEDAL_ASSERT(params.get_block_size() > 0x0l);
+        ONEDAL_ASSERT(params.get_block_size() <= 0x10000l);
+        ONEDAL_ASSERT(params.get_min_trees_for_threading() > 0x0l);
+        ONEDAL_ASSERT(params.get_min_number_of_rows_for_vect_seq_compute() >= 0x0l);
+        ONEDAL_ASSERT(params.get_scale_factor_for_vect_parallel_compute() > 0.0f);
+        ONEDAL_ASSERT(params.get_scale_factor_for_vect_parallel_compute() < 1.0f);
+    }
+
     template <typename Context>
-    auto operator()(const Context& ctx, const Descriptor& desc, const input_t& input) const {
+    auto select_parameters(const Context& ctx, const Descriptor& desc, const input_t& input) const {
+        check_preconditions(desc, input);
+        return infer_ops_dispatcher<Context, float_t, method_t, task_t>{}.select_parameters(ctx,
+                                                                                            desc,
+                                                                                            input);
+    }
+
+    template <typename Context>
+    auto operator()(const Context& ctx,
+                    const Descriptor& desc,
+                    const param_t& params,
+                    const input_t& input) const {
         check_preconditions(desc, input);
         const auto result =
-            infer_ops_dispatcher<Context, float_t, task_t, method_t>()(ctx, desc, input);
+            infer_ops_dispatcher<Context, float_t, task_t, method_t>{}(ctx, desc, params, input);
         check_postconditions(desc, input, result);
         return result;
+    }
+
+    template <typename Context>
+    auto operator()(const Context& ctx, const Descriptor& desc, const input_t& input) const {
+        const auto params = select_parameters(ctx, desc, input);
+        return this->operator()(ctx, desc, params, input);
     }
 };
 

--- a/cpp/oneapi/dal/algo/decision_forest/detail/infer_ops_dpc.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/detail/infer_ops_dpc.cpp
@@ -69,7 +69,6 @@ private:
 
 INSTANTIATE(float, task::classification, method::by_default)
 INSTANTIATE(double, task::classification, method::by_default)
-
 INSTANTIATE(float, task::regression, method::by_default)
 INSTANTIATE(double, task::regression, method::by_default)
 

--- a/cpp/oneapi/dal/algo/decision_forest/detail/infer_ops_dpc.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/detail/infer_ops_dpc.cpp
@@ -14,10 +14,10 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include "oneapi/dal/algo/decision_forest/backend/cpu/infer_kernel.hpp"
-#include "oneapi/dal/algo/decision_forest/backend/gpu/infer_kernel.hpp"
 #include "oneapi/dal/algo/decision_forest/parameters/cpu/infer_parameters.hpp"
 #include "oneapi/dal/algo/decision_forest/parameters/gpu/infer_parameters.hpp"
+#include "oneapi/dal/algo/decision_forest/backend/cpu/infer_kernel.hpp"
+#include "oneapi/dal/algo/decision_forest/backend/gpu/infer_kernel.hpp"
 #include "oneapi/dal/algo/decision_forest/detail/infer_ops.hpp"
 #include "oneapi/dal/backend/dispatcher.hpp"
 

--- a/cpp/oneapi/dal/algo/decision_forest/detail/infer_ops_dpc.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/detail/infer_ops_dpc.cpp
@@ -16,6 +16,8 @@
 
 #include "oneapi/dal/algo/decision_forest/backend/cpu/infer_kernel.hpp"
 #include "oneapi/dal/algo/decision_forest/backend/gpu/infer_kernel.hpp"
+#include "oneapi/dal/algo/decision_forest/parameters/cpu/infer_parameters.hpp"
+#include "oneapi/dal/algo/decision_forest/parameters/gpu/infer_parameters.hpp"
 #include "oneapi/dal/algo/decision_forest/detail/infer_ops.hpp"
 #include "oneapi/dal/backend/dispatcher.hpp"
 
@@ -26,11 +28,36 @@ template <typename Policy, typename Float, typename Task, typename Method>
 struct infer_ops_dispatcher<Policy, Float, Task, Method> {
     infer_result<Task> operator()(const Policy& policy,
                                   const descriptor_base<Task>& desc,
+                                  const infer_parameters<Task>& params,
                                   const infer_input<Task>& input) const {
+        return implementation(policy, desc, params, input);
+    }
+
+    infer_parameters<Task> select_parameters(const Policy& policy,
+                                             const descriptor_base<Task>& desc,
+                                             const infer_input<Task>& input) const {
+        using kernel_dispatcher_t = dal::backend::kernel_dispatcher<
+            KERNEL_SINGLE_NODE_CPU(parameters::infer_parameters_cpu<Float, Method, Task>),
+            KERNEL_UNIVERSAL_SPMD_GPU(parameters::infer_parameters_gpu<Float, Method, Task>)>;
+        return kernel_dispatcher_t{}(policy, desc, input);
+    }
+
+    infer_result<Task> operator()(const Policy& policy,
+                                  const descriptor_base<Task>& desc,
+                                  const infer_input<Task>& input) const {
+        const auto params = select_parameters(policy, desc, input);
+        return implementation(policy, desc, params, input);
+    }
+
+private:
+    inline auto implementation(const Policy& policy,
+                               const descriptor_base<Task>& desc,
+                               const infer_parameters<Task>& params,
+                               const infer_input<Task>& input) const {
         using kernel_dispatcher_t = dal::backend::kernel_dispatcher<
             KERNEL_SINGLE_NODE_CPU(backend::infer_kernel_cpu<Float, Method, Task>),
             KERNEL_UNIVERSAL_SPMD_GPU(backend::infer_kernel_gpu<Float, Method, Task>)>;
-        return kernel_dispatcher_t{}(policy, desc, input);
+        return kernel_dispatcher_t{}(policy, desc, params, input);
     }
 };
 

--- a/cpp/oneapi/dal/algo/decision_forest/infer_types.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/infer_types.cpp
@@ -19,6 +19,64 @@
 
 namespace oneapi::dal::decision_forest {
 
+namespace detail::v1 {
+
+template <typename Task>
+infer_parameters<Task>::infer_parameters() : impl_(new infer_parameters_impl<Task>{}) {}
+
+template <typename Task>
+std::int64_t infer_parameters<Task>::get_default_block_size() const {
+    return impl_->default_block_size;
+}
+
+template <typename Task>
+void infer_parameters<Task>::set_default_block_size_impl(std::int64_t val) {
+    impl_->default_block_size = val;
+}
+
+template <typename Task>
+std::int64_t infer_parameters<Task>::get_default_block_size_common() const {
+    return impl_->default_block_size_common;
+}
+
+template <typename Task>
+void infer_parameters<Task>::set_default_block_size_common_impl(std::int64_t val) {
+    impl_->default_block_size_common = val;
+}
+
+template <typename Task>
+std::int64_t infer_parameters<Task>::get_min_trees_for_threading() const {
+    return impl_->min_trees_for_threading;
+}
+
+template <typename Task>
+void infer_parameters<Task>::set_min_trees_for_threading_impl(std::int64_t val) {
+    impl_->min_trees_for_threading = val;
+}
+
+template <typename Task>
+std::int64_t infer_parameters<Task>::get_min_number_of_rows_for_vect_sequential_compute() const {
+    return impl_->min_number_of_rows_for_vect_seq_compute;
+}
+
+template <typename Task>
+void infer_parameters<Task>::set_min_number_of_rows_for_vect_sequential_compute_impl(
+    std::int64_t val) {
+    impl_->min_number_of_rows_for_vect_seq_compute = val;
+}
+
+template <typename Task>
+double infer_parameters<Task>::get_scale_factor_for_vect_parallel_compute() const {
+    return impl_->scale_factor_for_vect_parallel_compute;
+}
+
+template <typename Task>
+void infer_parameters<Task>::set_scale_factor_for_vect_parallel_compute_impl(double val) {
+    impl_->scale_factor_for_vect_parallel_compute = val;
+}
+
+} // namespace detail::v1
+
 template <typename Task>
 class detail::v1::infer_input_impl : public base {
 public:
@@ -34,6 +92,15 @@ class detail::v1::infer_result_impl : public base {
 public:
     table responses;
     table probabilities;
+};
+
+template <typename Task>
+struct infer_parameters_impl : public base {
+    std::int64_t default_block_size = 32l;
+    std::int64_t default_block_size_common = 22l;
+    std::int64_t min_trees_for_threading = 100l;
+    std::int64_t min_number_of_rows_for_vect_seq_compute = 32l;
+    double scale_factor_for_vect_parallel_compute = 0.3f;
 };
 
 using detail::v1::infer_input_impl;

--- a/cpp/oneapi/dal/algo/decision_forest/infer_types.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/infer_types.cpp
@@ -26,7 +26,7 @@ infer_parameters<Task>::infer_parameters() : impl_(new infer_parameters_impl<Tas
 
 template <typename Task>
 std::int64_t infer_parameters<Task>::get_block_size() const {
-    return impl_->default_block_size;
+    return impl_->block_size;
 }
 
 template <typename Task>
@@ -50,8 +50,7 @@ std::int64_t infer_parameters<Task>::get_min_number_of_rows_for_vect_seq_compute
 }
 
 template <typename Task>
-void infer_parameters<Task>::set_min_number_of_rows_for_vect_seq_compute_impl(
-    std::int64_t val) {
+void infer_parameters<Task>::set_min_number_of_rows_for_vect_seq_compute_impl(std::int64_t val) {
     impl_->min_number_of_rows_for_vect_seq_compute = val;
 }
 
@@ -65,10 +64,16 @@ void infer_parameters<Task>::set_scale_factor_for_vect_parallel_compute_impl(dou
     impl_->scale_factor_for_vect_parallel_compute = val;
 }
 
-} // namespace detail::v1
+template <typename Task>
+struct infer_parameters_impl : public base {
+    std::int64_t block_size = 22l;
+    std::int64_t min_trees_for_threading = 100l;
+    std::int64_t min_number_of_rows_for_vect_seq_compute = 32l;
+    double scale_factor_for_vect_parallel_compute = 0.3f;
+};
 
 template <typename Task>
-class detail::v1::infer_input_impl : public base {
+class infer_input_impl : public base {
 public:
     infer_input_impl(const model<Task>& trained_model, const table& data)
             : trained_model(trained_model),
@@ -78,20 +83,18 @@ public:
 };
 
 template <typename Task>
-class detail::v1::infer_result_impl : public base {
+class infer_result_impl : public base {
 public:
     table responses;
     table probabilities;
 };
 
-template <typename Task>
-struct infer_parameters_impl : public base {
-    std::int64_t block_size = 22l;
-    std::int64_t min_trees_for_threading = 100l;
-    std::int64_t min_number_of_rows_for_vect_seq_compute = 32l;
-    double scale_factor_for_vect_parallel_compute = 0.3f;
-};
+template class ONEDAL_EXPORT infer_parameters<task::classification>;
+template class ONEDAL_EXPORT infer_parameters<task::regression>;
 
+} // namespace detail::v1
+
+using detail::v1::infer_parameters;
 using detail::v1::infer_input_impl;
 using detail::v1::infer_result_impl;
 

--- a/cpp/oneapi/dal/algo/decision_forest/infer_types.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/infer_types.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020 Intel Corporation
+* Copyright contributors to the oneDAL project
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -23,6 +23,16 @@ namespace detail::v1 {
 
 template <typename Task>
 infer_parameters<Task>::infer_parameters() : impl_(new infer_parameters_impl<Task>{}) {}
+
+template <typename Task>
+std::int64_t infer_parameters<Task>::get_block_size_multiplier() const {
+    return impl_->block_size_multiplier;
+}
+
+template <typename Task>
+void infer_parameters<Task>::set_block_size_multiplier_impl(std::int64_t val) {
+    impl_->block_size_multiplier = val;
+}
 
 template <typename Task>
 std::int64_t infer_parameters<Task>::get_block_size() const {
@@ -66,7 +76,8 @@ void infer_parameters<Task>::set_scale_factor_for_vect_parallel_compute_impl(dou
 
 template <typename Task>
 struct infer_parameters_impl : public base {
-    std::int64_t block_size = 22l;
+    std::int64_t block_size_multiplier = 8l;
+    std::int64_t block_size = 32l;
     std::int64_t min_trees_for_threading = 100l;
     std::int64_t min_number_of_rows_for_vect_seq_compute = 32l;
     double scale_factor_for_vect_parallel_compute = 0.3f;

--- a/cpp/oneapi/dal/algo/decision_forest/infer_types.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/infer_types.cpp
@@ -25,23 +25,13 @@ template <typename Task>
 infer_parameters<Task>::infer_parameters() : impl_(new infer_parameters_impl<Task>{}) {}
 
 template <typename Task>
-std::int64_t infer_parameters<Task>::get_default_block_size() const {
+std::int64_t infer_parameters<Task>::get_block_size() const {
     return impl_->default_block_size;
 }
 
 template <typename Task>
-void infer_parameters<Task>::set_default_block_size_impl(std::int64_t val) {
-    impl_->default_block_size = val;
-}
-
-template <typename Task>
-std::int64_t infer_parameters<Task>::get_default_block_size_common() const {
-    return impl_->default_block_size_common;
-}
-
-template <typename Task>
-void infer_parameters<Task>::set_default_block_size_common_impl(std::int64_t val) {
-    impl_->default_block_size_common = val;
+void infer_parameters<Task>::set_block_size_impl(std::int64_t val) {
+    impl_->block_size = val;
 }
 
 template <typename Task>
@@ -55,12 +45,12 @@ void infer_parameters<Task>::set_min_trees_for_threading_impl(std::int64_t val) 
 }
 
 template <typename Task>
-std::int64_t infer_parameters<Task>::get_min_number_of_rows_for_vect_sequential_compute() const {
+std::int64_t infer_parameters<Task>::get_min_number_of_rows_for_vect_seq_compute() const {
     return impl_->min_number_of_rows_for_vect_seq_compute;
 }
 
 template <typename Task>
-void infer_parameters<Task>::set_min_number_of_rows_for_vect_sequential_compute_impl(
+void infer_parameters<Task>::set_min_number_of_rows_for_vect_seq_compute_impl(
     std::int64_t val) {
     impl_->min_number_of_rows_for_vect_seq_compute = val;
 }
@@ -96,8 +86,7 @@ public:
 
 template <typename Task>
 struct infer_parameters_impl : public base {
-    std::int64_t default_block_size = 32l;
-    std::int64_t default_block_size_common = 22l;
+    std::int64_t block_size = 22l;
     std::int64_t min_trees_for_threading = 100l;
     std::int64_t min_number_of_rows_for_vect_seq_compute = 32l;
     double scale_factor_for_vect_parallel_compute = 0.3f;

--- a/cpp/oneapi/dal/algo/decision_forest/infer_types.hpp
+++ b/cpp/oneapi/dal/algo/decision_forest/infer_types.hpp
@@ -29,7 +29,7 @@ template <typename Task>
 class infer_result_impl;
 
 template <typename Task>
-class infer_parameters_impl;
+struct infer_parameters_impl;
 
 template <typename Task = task::by_default>
 class infer_parameters : public base {

--- a/cpp/oneapi/dal/algo/decision_forest/infer_types.hpp
+++ b/cpp/oneapi/dal/algo/decision_forest/infer_types.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright contributors to the oneDAL project
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -38,6 +38,12 @@ public:
     infer_parameters(infer_parameters&&) = default;
     infer_parameters(const infer_parameters&) = default;
 
+    std::int64_t get_block_size_multiplier() const;
+    auto& set_block_size_multiplier(std::int64_t val) {
+        set_block_size_multiplier_impl(val);
+        return *this;
+    }
+
     std::int64_t get_block_size() const;
     auto& set_block_size(std::int64_t val) {
         set_block_size_impl(val);
@@ -63,6 +69,7 @@ public:
     }
 
 private:
+    void set_block_size_multiplier_impl(std::int64_t val);
     void set_block_size_impl(std::int64_t val);
     void set_min_trees_for_threading_impl(std::int64_t val);
     void set_min_number_of_rows_for_vect_seq_compute_impl(std::int64_t val);

--- a/cpp/oneapi/dal/algo/decision_forest/infer_types.hpp
+++ b/cpp/oneapi/dal/algo/decision_forest/infer_types.hpp
@@ -38,15 +38,9 @@ public:
     infer_parameters(infer_parameters&&) = default;
     infer_parameters(const infer_parameters&) = default;
 
-    std::int64_t get_default_block_size() const;
-    auto& set_default_block_size(std::int64_t val) {
-        set_default_block_size_impl(val);
-        return *this;
-    }
-
-    std::int64_t get_default_block_size_common() const;
-    auto& set_default_block_size_common(std::int64_t val) {
-        set_default_block_size_common_impl(val);
+    std::int64_t get_block_size() const;
+    auto& set_block_size(std::int64_t val) {
+        set_block_size_impl(val);
         return *this;
     }
 
@@ -56,9 +50,9 @@ public:
         return *this;
     }
 
-    std::int64_t get_min_number_of_rows_for_vect_sequential_compute() const;
-    auto& set_min_number_of_rows_for_vect_sequential_compute(std::int64_t val) {
-        set_min_number_of_rows_for_vect_sequential_compute_impl(val);
+    std::int64_t get_min_number_of_rows_for_vect_seq_compute() const;
+    auto& set_min_number_of_rows_for_vect_seq_compute(std::int64_t val) {
+        set_min_number_of_rows_for_vect_seq_compute_impl(val);
         return *this;
     }
 
@@ -69,10 +63,9 @@ public:
     }
 
 private:
-    void set_default_block_size_impl(std::int64_t val);
-    void set_default_block_size_common_impl(std::int64_t val);
+    void set_block_size_impl(std::int64_t val);
     void set_min_trees_for_threading_impl(std::int64_t val);
-    void set_min_number_of_rows_for_vect_sequential_compute_impl(std::int64_t val);
+    void set_min_number_of_rows_for_vect_seq_compute_impl(std::int64_t val);
     void set_scale_factor_for_vect_parallel_compute_impl(double val);
     dal::detail::pimpl<infer_parameters_impl<Task>> impl_;
 };

--- a/cpp/oneapi/dal/algo/decision_forest/infer_types.hpp
+++ b/cpp/oneapi/dal/algo/decision_forest/infer_types.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020 Intel Corporation
+* Copyright 2024 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -27,10 +27,61 @@ class infer_input_impl;
 
 template <typename Task>
 class infer_result_impl;
+
+template <typename Task>
+class infer_parameters_impl;
+
+template <typename Task = task::by_default>
+class infer_parameters : public base {
+public:
+    explicit infer_parameters();
+    infer_parameters(infer_parameters&&) = default;
+    infer_parameters(const infer_parameters&) = default;
+
+    std::int64_t get_default_block_size() const;
+    auto& set_default_block_size(std::int64_t val) {
+        set_default_block_size_impl(val);
+        return *this;
+    }
+
+    std::int64_t get_default_block_size_common() const;
+    auto& set_default_block_size_common(std::int64_t val) {
+        set_default_block_size_common_impl(val);
+        return *this;
+    }
+
+    std::int64_t get_min_trees_for_threading() const;
+    auto& set_min_trees_for_threading(std::int64_t val) {
+        set_min_trees_for_threading_impl(val);
+        return *this;
+    }
+
+    std::int64_t get_min_number_of_rows_for_vect_sequential_compute() const;
+    auto& set_min_number_of_rows_for_vect_sequential_compute(std::int64_t val) {
+        set_min_number_of_rows_for_vect_sequential_compute_impl(val);
+        return *this;
+    }
+
+    double get_scale_factor_for_vect_parallel_compute() const;
+    auto& set_scale_factor_for_vect_parallel_compute(double val) {
+        set_scale_factor_for_vect_parallel_compute_impl(val);
+        return *this;
+    }
+
+private:
+    void set_default_block_size_impl(std::int64_t val);
+    void set_default_block_size_common_impl(std::int64_t val);
+    void set_min_trees_for_threading_impl(std::int64_t val);
+    void set_min_number_of_rows_for_vect_sequential_compute_impl(std::int64_t val);
+    void set_scale_factor_for_vect_parallel_compute_impl(double val);
+    dal::detail::pimpl<infer_parameters_impl<Task>> impl_;
+};
+
 } // namespace v1
 
 using v1::infer_input_impl;
 using v1::infer_result_impl;
+using v1::infer_parameters;
 
 } // namespace detail
 

--- a/cpp/oneapi/dal/algo/decision_forest/parameters/BUILD
+++ b/cpp/oneapi/dal/algo/decision_forest/parameters/BUILD
@@ -1,0 +1,13 @@
+package(default_visibility = ["//visibility:public"])
+load("@onedal//dev/bazel:dal.bzl",
+    "dal_module",
+    "dal_test_suite",
+)
+
+dal_module(
+    name = "parameters",
+    dal_deps = [
+        "@onedal//cpp/oneapi/dal/algo/decision_forest/parameters/cpu",
+        "@onedal//cpp/oneapi/dal/algo/decision_forest/parameters/gpu",
+    ],
+)

--- a/cpp/oneapi/dal/algo/decision_forest/parameters/BUILD
+++ b/cpp/oneapi/dal/algo/decision_forest/parameters/BUILD
@@ -1,13 +1,12 @@
 package(default_visibility = ["//visibility:public"])
 load("@onedal//dev/bazel:dal.bzl",
     "dal_module",
-    "dal_test_suite",
 )
 
 dal_module(
     name = "parameters",
     dal_deps = [
-        "@onedal//cpp/oneapi/dal/algo/decision_forest/parameters/cpu",
-        "@onedal//cpp/oneapi/dal/algo/decision_forest/parameters/gpu",
+        "@onedal//cpp/oneapi/dal/algo/decision_forest/parameters/cpu:cpu",
+        "@onedal//cpp/oneapi/dal/algo/decision_forest/parameters/gpu:gpu",
     ],
 )

--- a/cpp/oneapi/dal/algo/decision_forest/parameters/cpu/BUILD
+++ b/cpp/oneapi/dal/algo/decision_forest/parameters/cpu/BUILD
@@ -1,0 +1,13 @@
+package(default_visibility = ["//visibility:public"])
+load("@onedal//dev/bazel:dal.bzl",
+    "dal_module",
+    "dal_test_suite",
+)
+
+dal_module(
+    name = "cpu",
+    auto = True,
+    dal_deps = [
+        "@onedal//cpp/oneapi/dal/algo/decision_forest:core",
+    ],
+)

--- a/cpp/oneapi/dal/algo/decision_forest/parameters/cpu/BUILD
+++ b/cpp/oneapi/dal/algo/decision_forest/parameters/cpu/BUILD
@@ -1,7 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 load("@onedal//dev/bazel:dal.bzl",
     "dal_module",
-    "dal_test_suite",
 )
 
 dal_module(

--- a/cpp/oneapi/dal/algo/decision_forest/parameters/cpu/infer_parameters.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/parameters/cpu/infer_parameters.cpp
@@ -32,11 +32,8 @@ std::int64_t propose_block_size(const context_cpu& ctx) {
 
 using method::by_default;
 using task::classification;
-using task::regression;
 
 template struct ONEDAL_EXPORT infer_parameters_cpu<float, by_default, classification>;
-template struct ONEDAL_EXPORT infer_parameters_cpu<float, by_default, regression>;
 template struct ONEDAL_EXPORT infer_parameters_cpu<double, by_default, task::classification>;
-template struct ONEDAL_EXPORT infer_parameters_cpu<double, by_default, regression>;
 
 } // namespace oneapi::dal::decision_forest::parameters

--- a/cpp/oneapi/dal/algo/decision_forest/parameters/cpu/infer_parameters.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/parameters/cpu/infer_parameters.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright contributors to the oneDAL project
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/cpp/oneapi/dal/algo/decision_forest/parameters/cpu/infer_parameters.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/parameters/cpu/infer_parameters.cpp
@@ -21,7 +21,6 @@ namespace oneapi::dal::decision_forest::parameters {
 
 using dal::backend::context_cpu;
 
-template <typename Float>
 std::int64_t propose_block_size(const context_cpu& ctx) {
     std::int64_t block_size = 22l;
     if (ctx.get_enabled_cpu_extensions() == dal::detail::cpu_extension::avx512) {
@@ -50,17 +49,20 @@ struct infer_parameters_cpu<Float, method::by_default, Task> {
     params_t operator()(const context_cpu& ctx,
                         const detail::descriptor_base<Task>& desc,
                         const infer_input<Task>& input) const {
-        const auto block = propose_block_size<Float>(ctx);
-        const auto trees = propose_min_trees_for_threading<Float>();
-        const auto seq_nrows = propose_min_number_of_rows_for_vect_seq_compute<Float>();
-        const auto seq_trees = propose_scale_factor_for_vect_seq_compute<Float>();
+        const auto block = propose_block_size(ctx);
+        const auto trees = propose_min_trees_for_threading();
+        const auto seq_nrows = propose_min_number_of_rows_for_vect_seq_compute();
+        const auto seq_trees = propose_scale_factor_for_vect_seq_compute();
 
         return params_t{}
             .set_block_size(block)
-            .set_min_trees_for_threading(thread)
-            .set_enable_vect_sequential_compute(seq)
-            .set_scale_factor_for_vect_parallel_compute(seq_sf);
+            .set_min_trees_for_threading(trees)
+            .set_min_number_of_rows_for_vect_seq_compute(seq_nrows)
+            .set_scale_factor_for_vect_parallel_compute(seq_trees);
     }
 };
+
+template struct ONEDAL_EXPORT infer_parameters_cpu<float, method::dense, task::by_default>;
+template struct ONEDAL_EXPORT infer_parameters_cpu<double, method::dense, task::by_default>;
 
 } // namespace oneapi::dal::decision_forest::parameters

--- a/cpp/oneapi/dal/algo/decision_forest/parameters/cpu/infer_parameters.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/parameters/cpu/infer_parameters.cpp
@@ -62,7 +62,9 @@ struct infer_parameters_cpu<Float, method::by_default, Task> {
     }
 };
 
-template struct ONEDAL_EXPORT infer_parameters_cpu<float, method::dense, task::by_default>;
-template struct ONEDAL_EXPORT infer_parameters_cpu<double, method::dense, task::by_default>;
+template struct ONEDAL_EXPORT infer_parameters_cpu<float, method::dense, task::classification>;
+template struct ONEDAL_EXPORT infer_parameters_cpu<float, method::dense, task::regression>;
+template struct ONEDAL_EXPORT infer_parameters_cpu<double, method::dense, task::classification>;
+template struct ONEDAL_EXPORT infer_parameters_cpu<double, method::dense, task::regression>;
 
 } // namespace oneapi::dal::decision_forest::parameters

--- a/cpp/oneapi/dal/algo/decision_forest/parameters/cpu/infer_parameters.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/parameters/cpu/infer_parameters.cpp
@@ -30,4 +30,13 @@ std::int64_t propose_block_size(const context_cpu& ctx) {
     return block_size;
 }
 
+using method::by_default;
+using task::classification;
+using task::regression;
+
+template struct ONEDAL_EXPORT infer_parameters_cpu<float, by_default, classification>;
+template struct ONEDAL_EXPORT infer_parameters_cpu<float, by_default, regression>;
+template struct ONEDAL_EXPORT infer_parameters_cpu<double, by_default, task::classification>;
+template struct ONEDAL_EXPORT infer_parameters_cpu<double, by_default, regression>;
+
 } // namespace oneapi::dal::decision_forest::parameters

--- a/cpp/oneapi/dal/algo/decision_forest/parameters/cpu/infer_parameters.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/parameters/cpu/infer_parameters.cpp
@@ -1,0 +1,66 @@
+/*******************************************************************************
+* Copyright 2024 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "oneapi/dal/algo/decision_forest/parameters/cpu/infer_parameters.hpp"
+#include "oneapi/dal/backend/dispatcher.hpp"
+
+namespace oneapi::dal::decision_forest::parameters {
+
+using dal::backend::context_cpu;
+
+template <typename Float>
+std::int64_t propose_block_size(const context_cpu& ctx) {
+    std::int64_t block_size = 22l;
+    if (ctx.get_enabled_cpu_extensions() == dal::detail::cpu_extension::avx512) {
+        /// Here if AVX512 extensions are available on CPU
+        block_size = 32l;
+    }
+    return block_size;
+}
+
+constexpr std::int64_t propose_min_trees_for_threading() {
+    return 100l;
+}
+
+constexpr std::int64_t propose_min_number_of_rows_for_vect_seq_compute() {
+    return 32l;
+}
+
+constexpr double propose_scale_factor_for_vect_seq_compute() {
+    return 0.3f;
+}
+
+// TODO: Is it correct to use method::by_default here?
+template <typename Float, typename Task>
+struct infer_parameters_cpu<Float, method::by_default, Task> {
+    using params_t = detail::infer_parameters<Task>;
+    params_t operator()(const context_cpu& ctx,
+                        const detail::descriptor_base<Task>& desc,
+                        const infer_input<Task>& input) const {
+        const auto block = propose_block_size<Float>(ctx);
+        const auto trees = propose_min_trees_for_threading<Float>();
+        const auto seq_nrows = propose_min_number_of_rows_for_vect_seq_compute<Float>();
+        const auto seq_trees = propose_scale_factor_for_vect_seq_compute<Float>();
+
+        return params_t{}
+            .set_block_size(block)
+            .set_min_trees_for_threading(thread)
+            .set_enable_vect_sequential_compute(seq)
+            .set_scale_factor_for_vect_parallel_compute(seq_sf);
+    }
+};
+
+} // namespace oneapi::dal::decision_forest::parameters

--- a/cpp/oneapi/dal/algo/decision_forest/parameters/cpu/infer_parameters.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/parameters/cpu/infer_parameters.cpp
@@ -30,41 +30,4 @@ std::int64_t propose_block_size(const context_cpu& ctx) {
     return block_size;
 }
 
-constexpr std::int64_t propose_min_trees_for_threading() {
-    return 100l;
-}
-
-constexpr std::int64_t propose_min_number_of_rows_for_vect_seq_compute() {
-    return 32l;
-}
-
-constexpr double propose_scale_factor_for_vect_seq_compute() {
-    return 0.3f;
-}
-
-// TODO: Is it correct to use method::by_default here?
-template <typename Float, typename Task>
-struct infer_parameters_cpu<Float, method::by_default, Task> {
-    using params_t = detail::infer_parameters<Task>;
-    params_t operator()(const context_cpu& ctx,
-                        const detail::descriptor_base<Task>& desc,
-                        const infer_input<Task>& input) const {
-        const auto block = propose_block_size(ctx);
-        const auto trees = propose_min_trees_for_threading();
-        const auto seq_nrows = propose_min_number_of_rows_for_vect_seq_compute();
-        const auto seq_trees = propose_scale_factor_for_vect_seq_compute();
-
-        return params_t{}
-            .set_block_size(block)
-            .set_min_trees_for_threading(trees)
-            .set_min_number_of_rows_for_vect_seq_compute(seq_nrows)
-            .set_scale_factor_for_vect_parallel_compute(seq_trees);
-    }
-};
-
-template struct ONEDAL_EXPORT infer_parameters_cpu<float, method::dense, task::classification>;
-template struct ONEDAL_EXPORT infer_parameters_cpu<float, method::dense, task::regression>;
-template struct ONEDAL_EXPORT infer_parameters_cpu<double, method::dense, task::classification>;
-template struct ONEDAL_EXPORT infer_parameters_cpu<double, method::dense, task::regression>;
-
 } // namespace oneapi::dal::decision_forest::parameters

--- a/cpp/oneapi/dal/algo/decision_forest/parameters/cpu/infer_parameters.hpp
+++ b/cpp/oneapi/dal/algo/decision_forest/parameters/cpu/infer_parameters.hpp
@@ -56,14 +56,4 @@ struct infer_parameters_cpu {
             .set_scale_factor_for_vect_parallel_compute(seq_trees);
     }
 };
-
-using method::by_default;
-using task::classification;
-using task::regression;
-
-template struct ONEDAL_EXPORT infer_parameters_cpu<float, by_default, classification>;
-template struct ONEDAL_EXPORT infer_parameters_cpu<float, by_default, regression>;
-template struct ONEDAL_EXPORT infer_parameters_cpu<double, by_default, task::classification>;
-template struct ONEDAL_EXPORT infer_parameters_cpu<double, by_default, regression>;
-
 } // namespace oneapi::dal::decision_forest::parameters

--- a/cpp/oneapi/dal/algo/decision_forest/parameters/cpu/infer_parameters.hpp
+++ b/cpp/oneapi/dal/algo/decision_forest/parameters/cpu/infer_parameters.hpp
@@ -1,0 +1,37 @@
+/*******************************************************************************
+* Copyright 2024 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#pragma once
+
+#include "oneapi/dal/algo/decision_forest/infer_types.hpp"
+
+namespace oneapi::dal::decision_forest::parameters {
+
+template <typename Float, typename Method, typename Task>
+struct ONEDAL_EXPORT infer_parameters_cpu {
+    using params_t = detail::infer_parameters<Task>;
+    params_t operator()(const dal::backend::context_cpu& ctx,
+                        const detail::descriptor_base<Task>& desc,
+                        const infer_input<Task>& input) const;
+    params_t operator()(const dal::backend::context_cpu& ctx,
+                        const detail::descriptor_base<Task>& desc,
+                        const partial_infer_input<Task>& input) const;
+    params_t operator()(const dal::backend::context_cpu& ctx,
+                        const detail::descriptor_base<Task>& desc,
+                        const partial_infer_result<Task>& input) const;
+};
+
+} // namespace oneapi::dal::decision_forest::parameters

--- a/cpp/oneapi/dal/algo/decision_forest/parameters/cpu/infer_parameters.hpp
+++ b/cpp/oneapi/dal/algo/decision_forest/parameters/cpu/infer_parameters.hpp
@@ -57,13 +57,13 @@ struct infer_parameters_cpu {
     }
 };
 
-template struct ONEDAL_EXPORT infer_parameters_cpu<float, method::dense, task::classification>;
-template struct ONEDAL_EXPORT infer_parameters_cpu<float, method::dense, task::regression>;
-template struct ONEDAL_EXPORT infer_parameters_cpu<double, method::dense, task::classification>;
-template struct ONEDAL_EXPORT infer_parameters_cpu<double, method::dense, task::regression>;
+using method::by_default;
+using task::classification;
+using task::regression;
 
-template struct ONEDAL_EXPORT infer_parameters_cpu<float, method::hist, task::classification>;
-template struct ONEDAL_EXPORT infer_parameters_cpu<float, method::hist, task::regression>;
-template struct ONEDAL_EXPORT infer_parameters_cpu<double, method::hist, task::classification>;
-template struct ONEDAL_EXPORT infer_parameters_cpu<double, method::hist, task::regression>;
+template struct ONEDAL_EXPORT infer_parameters_cpu<float, by_default, classification>;
+template struct ONEDAL_EXPORT infer_parameters_cpu<float, by_default, regression>;
+template struct ONEDAL_EXPORT infer_parameters_cpu<double, by_default, task::classification>;
+template struct ONEDAL_EXPORT infer_parameters_cpu<double, by_default, regression>;
+
 } // namespace oneapi::dal::decision_forest::parameters

--- a/cpp/oneapi/dal/algo/decision_forest/parameters/cpu/infer_parameters.hpp
+++ b/cpp/oneapi/dal/algo/decision_forest/parameters/cpu/infer_parameters.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright contributors to the oneDAL project
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/cpp/oneapi/dal/algo/decision_forest/parameters/cpu/infer_parameters.hpp
+++ b/cpp/oneapi/dal/algo/decision_forest/parameters/cpu/infer_parameters.hpp
@@ -26,6 +26,16 @@ using dal::backend::context_cpu;
 
 std::int64_t propose_block_size(const context_cpu& ctx);
 
+template <typename Float>
+std::int64_t propose_block_size_multiplier(const context_cpu& ctx) {
+    std::int64_t multiplier = 1l;
+    if (ctx.get_enabled_cpu_extensions() == dal::detail::cpu_extension::avx512) {
+        /// Here if AVX512 extensions are available on CPU
+        multiplier = 64 / sizeof(Float);
+    }
+    return multiplier;
+}
+
 constexpr std::int64_t propose_min_trees_for_threading() {
     return 100l;
 }
@@ -44,12 +54,14 @@ struct infer_parameters_cpu {
     params_t operator()(const context_cpu& ctx,
                         const detail::descriptor_base<Task>& desc,
                         const infer_input<Task>& input) const {
+        const auto mult = propose_block_size_multiplier<Float>(ctx);
         const auto block = propose_block_size(ctx);
         const auto trees = propose_min_trees_for_threading();
         const auto seq_nrows = propose_min_number_of_rows_for_vect_seq_compute();
         const auto seq_trees = propose_scale_factor_for_vect_seq_compute();
 
         return params_t{}
+            .set_block_size_multiplier(mult)
             .set_block_size(block)
             .set_min_trees_for_threading(trees)
             .set_min_number_of_rows_for_vect_seq_compute(seq_nrows)

--- a/cpp/oneapi/dal/algo/decision_forest/parameters/gpu/BUILD
+++ b/cpp/oneapi/dal/algo/decision_forest/parameters/gpu/BUILD
@@ -1,7 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 load("@onedal//dev/bazel:dal.bzl",
     "dal_module",
-    "dal_test_suite",
 )
 
 dal_module(

--- a/cpp/oneapi/dal/algo/decision_forest/parameters/gpu/BUILD
+++ b/cpp/oneapi/dal/algo/decision_forest/parameters/gpu/BUILD
@@ -1,0 +1,13 @@
+package(default_visibility = ["//visibility:public"])
+load("@onedal//dev/bazel:dal.bzl",
+    "dal_module",
+    "dal_test_suite",
+)
+
+dal_module(
+    name = "gpu",
+    auto = True,
+    dal_deps = [
+        "@onedal//cpp/oneapi/dal/algo/decision_forest:core",
+    ],
+)

--- a/cpp/oneapi/dal/algo/decision_forest/parameters/gpu/infer_parameters.hpp
+++ b/cpp/oneapi/dal/algo/decision_forest/parameters/gpu/infer_parameters.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020 Intel Corporation
+* Copyright 2024 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -16,17 +16,18 @@
 
 #pragma once
 
-#include "oneapi/dal/algo/decision_forest/infer_types.hpp"
 #include "oneapi/dal/backend/dispatcher.hpp"
 
-namespace oneapi::dal::decision_forest::backend {
+#include "oneapi/dal/algo/decision_forest/infer_types.hpp"
+
+namespace oneapi::dal::decision_forest::parameters {
 
 template <typename Float, typename Method, typename Task>
-struct infer_kernel_gpu {
-    infer_result<Task> operator()(const dal::backend::context_gpu& ctx,
-                                  const detail::descriptor_base<Task>& desc,
-                                  const detail::infer_parameters<Task>& params,
-                                  const infer_input<Task>& input) const;
+struct ONEDAL_EXPORT infer_parameters_gpu {
+    using params_t = detail::infer_parameters<Task>;
+    params_t operator()(const dal::backend::context_cpu& ctx,
+                        const detail::descriptor_base<Task>& desc,
+                        const infer_input<Task>& input) const;
 };
 
-} // namespace oneapi::dal::decision_forest::backend
+} // namespace oneapi::dal::decision_forest::parameters

--- a/cpp/oneapi/dal/algo/decision_forest/parameters/gpu/infer_parameters.hpp
+++ b/cpp/oneapi/dal/algo/decision_forest/parameters/gpu/infer_parameters.hpp
@@ -25,7 +25,7 @@ namespace oneapi::dal::decision_forest::parameters {
 template <typename Float, typename Method, typename Task>
 struct ONEDAL_EXPORT infer_parameters_gpu {
     using params_t = detail::infer_parameters<Task>;
-    params_t operator()(const dal::backend::context_cpu& ctx,
+    params_t operator()(const dal::backend::context_gpu& ctx,
                         const detail::descriptor_base<Task>& desc,
                         const infer_input<Task>& input) const;
 };

--- a/cpp/oneapi/dal/algo/decision_forest/parameters/gpu/infer_parameters_dpc.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/parameters/gpu/infer_parameters_dpc.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2024 Intel Corporation
+* Copyright contributors to the oneDAL project
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/cpp/oneapi/dal/algo/decision_forest/parameters/gpu/infer_parameters_dpc.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/parameters/gpu/infer_parameters_dpc.cpp
@@ -20,9 +20,12 @@
 namespace oneapi::dal::decision_forest::parameters {
 
 using dal::backend::context_gpu;
+using method::by_default;
+using task::classification;
+using task::regression;
 
 template <typename Float, typename Task>
-struct infer_parameters_gpu<Float, method::by_default, Task> {
+struct infer_parameters_gpu<Float, by_default, Task> {
     using params_t = detail::infer_parameters<Task>;
     params_t operator()(const context_gpu& ctx,
                         const detail::descriptor_base<Task>& desc,
@@ -31,7 +34,9 @@ struct infer_parameters_gpu<Float, method::by_default, Task> {
     }
 };
 
-template struct ONEDAL_EXPORT infer_parameters_gpu<float, method::dense, task::by_default>;
-template struct ONEDAL_EXPORT infer_parameters_gpu<double, method::dense, task::by_default>;
+template struct ONEDAL_EXPORT infer_parameters_gpu<float, by_default, classification>;
+template struct ONEDAL_EXPORT infer_parameters_gpu<double, by_default, classification>;
+template struct ONEDAL_EXPORT infer_parameters_gpu<float, by_default, regression>;
+template struct ONEDAL_EXPORT infer_parameters_gpu<double, by_default, regression>;
 
 } // namespace oneapi::dal::decision_forest::parameters

--- a/cpp/oneapi/dal/algo/decision_forest/parameters/gpu/infer_parameters_dpc.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/parameters/gpu/infer_parameters_dpc.cpp
@@ -14,20 +14,25 @@
 * limitations under the License.
 *******************************************************************************/
 
-#pragma once
-
+#include "oneapi/dal/algo/decision_forest/parameters/cpu/infer_parameters.hpp"
 #include "oneapi/dal/backend/dispatcher.hpp"
-
-#include "oneapi/dal/algo/decision_forest/infer_types.hpp"
 
 namespace oneapi::dal::decision_forest::parameters {
 
-template <typename Float, typename Method, typename Task>
-struct ONEDAL_EXPORT infer_parameters_cpu {
+using dal::backend::context_gpu;
+
+// TODO: Is it correct to use method::by_default here?
+template <typename Float, typename Task>
+struct infer_parameters_gpu<Float, method::by_default, Task> {
     using params_t = detail::infer_parameters<Task>;
-    params_t operator()(const dal::backend::context_cpu& ctx,
+    params_t operator()(const context_gpu& ctx,
                         const detail::descriptor_base<Task>& desc,
-                        const infer_input<Task>& input) const;
+                        const infer_input<Task>& input) const {
+        return params_t{};
+    }
 };
+
+template struct ONEDAL_EXPORT infer_parameters_gpu<float, method::dense, task::by_default>;
+template struct ONEDAL_EXPORT infer_parameters_gpu<double, method::dense, task::by_default>;
 
 } // namespace oneapi::dal::decision_forest::parameters

--- a/cpp/oneapi/dal/algo/decision_forest/parameters/gpu/infer_parameters_dpc.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/parameters/gpu/infer_parameters_dpc.cpp
@@ -21,7 +21,6 @@ namespace oneapi::dal::decision_forest::parameters {
 
 using dal::backend::context_gpu;
 
-// TODO: Is it correct to use method::by_default here?
 template <typename Float, typename Task>
 struct infer_parameters_gpu<Float, method::by_default, Task> {
     using params_t = detail::infer_parameters<Task>;

--- a/cpp/oneapi/dal/algo/decision_forest/parameters/gpu/infer_parameters_dpc.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/parameters/gpu/infer_parameters_dpc.cpp
@@ -14,7 +14,7 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include "oneapi/dal/algo/decision_forest/parameters/cpu/infer_parameters.hpp"
+#include "oneapi/dal/algo/decision_forest/parameters/gpu/infer_parameters.hpp"
 #include "oneapi/dal/backend/dispatcher.hpp"
 
 namespace oneapi::dal::decision_forest::parameters {

--- a/cpp/oneapi/dal/backend/interop/error_converter.cpp
+++ b/cpp/oneapi/dal/backend/interop/error_converter.cpp
@@ -244,6 +244,9 @@ void status_to_exception(const daal::services::Status& s) {
         case ErrorID::ErrorPrecomputedMinNotAvailable:
         case ErrorID::ErrorPrecomputedMaxNotAvailable:
         case ErrorID::ErrorSourceDataNotAvailable:
+        case ErrorID::ErrorHyperparameterNotFound:
+        case ErrorID::ErrorHyperparameterCanNotBeSet:
+        case ErrorID::ErrorHyperparameterBadValue:
         case ErrorID::ErrorFeatureNamesNotAvailable: throw internal_error(description);
         case ErrorID::ErrorMemoryAllocationFailed:
         case ErrorID::ErrorZlibMemoryAllocationFailed:


### PR DESCRIPTION
# Description
Adds hyperparameters to random forest classification. Adds all the necessary glue logic in oneDAL to set the parameters in the DAAL kernel, to which the oneDAL implementation falls back.

Changes proposed in this pull request:
- Replace hard-coded `#define` statements in `df_classification_predict_dense_default_batch_impl.i` with oneDALs hyperparameter framework
- Per default, the non-AVX512 values are configured, AVX512 will be configured through the Python interface (to be added)