### PR TITLE
Align Newton-CG and CG-solver stopping conditions with sklearn.utils

### DIFF
--- a/cpp/oneapi/dal/algo/logistic_regression/detail/optimizer.cpp
+++ b/cpp/oneapi/dal/algo/logistic_regression/detail/optimizer.cpp
@@ -52,7 +52,7 @@ public:
                                                        pr::base_function<Float>& f,
                                                        pr::ndview<Float, 1>& x,
                                                        const be::event_vector& deps = {}) {
-        return pr::newton_cg(q, f, x, Float(tol_), max_iter_, deps);
+        return pr::newton_cg(q, f, x, Float(tol_), max_iter_, 200l, deps);
     }
 
     std::pair<sycl::event, std::int64_t> minimize(sycl::queue& q,

--- a/cpp/oneapi/dal/backend/primitives/objective_function/logloss_dpc.cpp
+++ b/cpp/oneapi/dal/backend/primitives/objective_function/logloss_dpc.cpp
@@ -30,6 +30,7 @@ sycl::event compute_probabilities(sycl::queue& q,
                                   ndview<Float, 1>& probabilities,
                                   bool fit_intercept,
                                   const event_vector& deps) {
+    ONEDAL_PROFILER_TASK(compute_probabilities, q);
     const std::int64_t n = data.get_dimension(0);
     const std::int64_t p = data.get_dimension(1);
 
@@ -78,6 +79,7 @@ sycl::event compute_logloss(sycl::queue& q,
                             ndview<Float, 1>& out,
                             bool fit_intercept,
                             const event_vector& deps) {
+    ONEDAL_PROFILER_TASK(compute_logloss, q);
     const std::int64_t n = labels.get_dimension(0);
     ONEDAL_ASSERT(probabilities.get_dimension(0) == n);
     ONEDAL_ASSERT(labels.has_data());
@@ -116,7 +118,7 @@ sycl::event compute_logloss_with_der(sycl::queue& q,
                                      bool fit_intercept,
                                      const event_vector& deps) {
     // out, out_derivative should be filled with zeros
-
+    ONEDAL_PROFILER_TASK(compute_logloss_with_grad, q);
     const std::int64_t n = data.get_dimension(0);
     const std::int64_t p = data.get_dimension(1);
 
@@ -201,7 +203,7 @@ sycl::event compute_derivative(sycl::queue& q,
                                bool fit_intercept,
                                const event_vector& deps) {
     // out_derivative should be filled with zeros
-
+    ONEDAL_PROFILER_TASK(compute_logloss_grad, q);
     const std::int64_t n = data.get_dimension(0);
     const std::int64_t p = data.get_dimension(1);
 
@@ -273,6 +275,7 @@ sycl::event add_regularization_loss(sycl::queue& q,
                                     Float L2,
                                     bool fit_intercept,
                                     const event_vector& deps) {
+    ONEDAL_PROFILER_TASK(add_regularization_loss, q);
     using dal::backend::operator+;
     auto [out_reg, out_reg_e] = ndarray<Float, 1>::zeros(q, { 1 }, sycl::usm::alloc::device);
     auto* const reg_ptr = out_reg.get_mutable_data();
@@ -308,6 +311,7 @@ sycl::event add_regularization_gradient_loss(sycl::queue& q,
                                              Float L2,
                                              bool fit_intercept,
                                              const event_vector& deps) {
+    ONEDAL_PROFILER_TASK(add_regularization_grad_loss, q);
     using dal::backend::operator+;
     auto [reg_val, reg_val_e] = ndarray<Float, 1>::zeros(q, { 1 }, sycl::usm::alloc::device);
 
@@ -347,6 +351,7 @@ sycl::event add_regularization_gradient(sycl::queue& q,
                                         Float L2,
                                         bool fit_intercept,
                                         const event_vector& deps) {
+    ONEDAL_PROFILER_TASK(add_regularization_grad, q);
     auto* const grad_ptr = out_derivative.get_mutable_data();
     const auto* const param_ptr = parameters.get_data();
     const std::int64_t p =
@@ -372,6 +377,7 @@ sycl::event compute_hessian(sycl::queue& q,
                             const Float L2,
                             bool fit_intercept,
                             const event_vector& deps) {
+    ONEDAL_PROFILER_TASK(compute_logloss_hessian, q);
     const int64_t n = data.get_dimension(0);
     const int64_t p = data.get_dimension(1);
 
@@ -450,6 +456,7 @@ sycl::event compute_raw_hessian(sycl::queue& q,
                                 const ndview<Float, 1>& probabilities,
                                 ndview<Float, 1>& out_hessian,
                                 const event_vector& deps) {
+    ONEDAL_PROFILER_TASK(compute_raw_hessian, q);
     const std::int64_t n = probabilities.get_dimension(0);
 
     ONEDAL_ASSERT(out_hessian.get_dimension(0) == n);
@@ -514,6 +521,7 @@ template <typename Float>
 sycl::event logloss_hessian_product<Float>::compute_with_fit_intercept(const ndview<Float, 1>& vec,
                                                                        ndview<Float, 1>& out,
                                                                        const event_vector& deps) {
+    ONEDAL_PROFILER_TASK(compute_hessp_with_fit_intercept, q_);
     auto* const tmp_ptr = tmp_gpu_.get_mutable_data();
     ONEDAL_ASSERT(vec.get_dimension(0) == p_ + 1);
     ONEDAL_ASSERT(out.get_dimension(0) == p_ + 1);
@@ -593,6 +601,7 @@ sycl::event logloss_hessian_product<Float>::compute_without_fit_intercept(
     const ndview<Float, 1>& vec,
     ndview<Float, 1>& out,
     const event_vector& deps) {
+    ONEDAL_PROFILER_TASK(compute_hessp_without_fit_intercept, q_);
     ONEDAL_ASSERT(vec.get_dimension(0) == p_);
     ONEDAL_ASSERT(out.get_dimension(0) == p_);
 
@@ -726,6 +735,7 @@ template <typename Float>
 event_vector logloss_function<Float>::update_x(const ndview<Float, 1>& x,
                                                bool need_hessp,
                                                const event_vector& deps) {
+    ONEDAL_PROFILER_TASK(logloss_function_update_weights, q_);
     using dal::backend::operator+;
     value_ = 0;
     auto fill_event = fill(q_, gradient_, Float(0), deps);

--- a/cpp/oneapi/dal/backend/primitives/optimizers/cg_solver.hpp
+++ b/cpp/oneapi/dal/backend/primitives/optimizers/cg_solver.hpp
@@ -24,16 +24,16 @@ namespace oneapi::dal::backend::primitives {
 // Method of Conjugate Gradients for Solving Linear Systems
 // https://nvlpubs.nist.gov/nistpubs/jres/049/jresv49n6p409_a1b.pdf
 template <typename Float>
-sycl::event cg_solve(sycl::queue& queue,
-                     base_matrix_operator<Float>& mul_operator,
-                     const ndview<Float, 1>& b,
-                     ndview<Float, 1>& x,
-                     ndview<Float, 1>& residual,
-                     ndview<Float, 1>& conj_vector,
-                     ndview<Float, 1>& buffer,
-                     Float tol = 1.0e-5,
-                     Float atol = -1.0,
-                     std::int64_t maxiter = 100l,
-                     const event_vector& deps = {});
+std::pair<sycl::event, std::int64_t> cg_solve(sycl::queue& queue,
+                                              base_matrix_operator<Float>& mul_operator,
+                                              const ndview<Float, 1>& b,
+                                              ndview<Float, 1>& x,
+                                              ndview<Float, 1>& residual,
+                                              ndview<Float, 1>& conj_vector,
+                                              ndview<Float, 1>& buffer,
+                                              Float tol = 1.0e-5,
+                                              Float atol = -1.0,
+                                              std::int64_t maxiter = 100l,
+                                              const event_vector& deps = {});
 
 } // namespace oneapi::dal::backend::primitives

--- a/cpp/oneapi/dal/backend/primitives/optimizers/common.hpp
+++ b/cpp/oneapi/dal/backend/primitives/optimizers/common.hpp
@@ -36,6 +36,13 @@ sycl::event dot_product(sycl::queue& queue,
                         const event_vector& deps = {});
 
 template <typename Float>
+sycl::event max_abs(sycl::queue& queue,
+                    const ndview<Float, 1>& x,
+                    Float* res_gpu,
+                    Float* res_host,
+                    const event_vector& deps = {});
+
+template <typename Float>
 class base_matrix_operator {
 public:
     virtual ~base_matrix_operator() {}

--- a/cpp/oneapi/dal/backend/primitives/optimizers/line_search.hpp
+++ b/cpp/oneapi/dal/backend/primitives/optimizers/line_search.hpp
@@ -21,8 +21,8 @@
 
 namespace oneapi::dal::backend::primitives {
 
-// Decrease alpha while Armicho condition is not satisfied
-// Armicho condition phi(alpha) <= phi(0) + c1 * alpha * phi'(0)
+// Decrease alpha while Armijo condition is not satisfied
+// Armijo condition phi(alpha) <= phi(0) + c1 * alpha * phi'(0)
 // phi(alpha) = f(x + alpha * d)
 // phi'(alpha) = <f'(x + alpha * d), d>
 /// @brief
@@ -33,7 +33,7 @@ namespace oneapi::dal::backend::primitives {
 /// @param direction - descent direction
 /// @param result - x + alpha * direction will be written here
 /// @param alpha - initial constant, should be equal to 1.0 for newton methods
-/// @param c1 - constant for Armicho condition
+/// @param c1 - constant for Armijo condition
 /// @param x0_initialized - if function f is computed at point x
 /// @param deps
 /// @return

--- a/cpp/oneapi/dal/backend/primitives/optimizers/line_search_dpc.cpp
+++ b/cpp/oneapi/dal/backend/primitives/optimizers/line_search_dpc.cpp
@@ -42,7 +42,8 @@ Float backtracking(sycl::queue queue,
         .wait_and_throw();
     std::int64_t iter_num = 0;
     Float cur_val = 0;
-    while ((iter_num == 0 || cur_val > f0 + c1 * alpha * df0) && iter_num < 100) {
+    constexpr Float eps = std::numeric_limits<Float>::epsilon();
+    while ((iter_num == 0 || cur_val > f0 + c1 * alpha * df0) && alpha > eps) {
         // TODO check that conditions are the same across diferent devices
         if (iter_num > 0) {
             alpha /= 2;

--- a/cpp/oneapi/dal/backend/primitives/optimizers/line_search_dpc.cpp
+++ b/cpp/oneapi/dal/backend/primitives/optimizers/line_search_dpc.cpp
@@ -17,6 +17,7 @@
 #include "oneapi/dal/backend/primitives/optimizers/line_search.hpp"
 #include "oneapi/dal/backend/primitives/optimizers/common.hpp"
 #include "oneapi/dal/backend/primitives/element_wise.hpp"
+#include "oneapi/dal/detail/profiler.hpp"
 
 namespace oneapi::dal::backend::primitives {
 
@@ -30,6 +31,7 @@ Float backtracking(sycl::queue queue,
                    Float c1,
                    bool x0_initialized,
                    const event_vector& deps) {
+    ONEDAL_PROFILER_TASK(armijo_backtracking, queue);
     using dal::backend::operator+;
     event_vector precompute = {};
     if (!x0_initialized) {
@@ -40,15 +42,17 @@ Float backtracking(sycl::queue queue,
     Float df0 = 0;
     dot_product(queue, grad_f0, direction, result.get_mutable_data(), &df0, deps + precompute)
         .wait_and_throw();
-    std::int64_t iter_num = 0;
     Float cur_val = 0;
     constexpr Float eps = std::numeric_limits<Float>::epsilon();
-    while ((iter_num == 0 || cur_val > f0 + c1 * alpha * df0) && alpha > eps) {
+    bool is_first_iter = true;
+    while ((is_first_iter || cur_val > f0 + c1 * alpha * df0) && alpha > eps) {
         // TODO check that conditions are the same across diferent devices
-        if (iter_num > 0) {
+        if (!is_first_iter) {
             alpha /= 2;
         }
-        iter_num++;
+        else {
+            is_first_iter = false;
+        }
         const auto update_x_kernel = [=](const Float x_val, const Float dir_val) -> Float {
             return x_val + alpha * dir_val;
         };

--- a/cpp/oneapi/dal/backend/primitives/optimizers/newton_cg.hpp
+++ b/cpp/oneapi/dal/backend/primitives/optimizers/newton_cg.hpp
@@ -30,6 +30,7 @@ std::pair<sycl::event, std::int64_t> newton_cg(sycl::queue& queue,
                                                ndview<Float, 1>& x,
                                                Float tol = 1.0e-5,
                                                std::int64_t maxiter = 100l,
+                                               std::int64_t maxinner = 200l,
                                                const event_vector& deps = {});
 
 } // namespace oneapi::dal::backend::primitives

--- a/cpp/oneapi/dal/backend/primitives/optimizers/test/cg_solver_dpc.cpp
+++ b/cpp/oneapi/dal/backend/primitives/optimizers/test/cg_solver_dpc.cpp
@@ -71,18 +71,18 @@ public:
         auto buffer2 = buffer.get_slice(n_, 2 * n_);
         auto buffer3 = buffer.get_slice(2 * n_, 3 * n_);
 
-        cg_solve(this->get_queue(),
-                 mul_operator,
-                 b,
-                 x0,
-                 buffer1,
-                 buffer2,
-                 buffer3,
-                 float_t(1e-6),
-                 float_t(1e-5),
-                 n_,
-                 {})
-            .wait_and_throw();
+        auto [cg_event, inner_iter] = cg_solve(this->get_queue(),
+                                               mul_operator,
+                                               b,
+                                               x0,
+                                               buffer1,
+                                               buffer2,
+                                               buffer3,
+                                               float_t(1e-6),
+                                               float_t(1e-5),
+                                               n_,
+                                               {});
+        cg_event.wait_and_throw();
         auto answer_host = x0.to_host(this->get_queue());
 
         float_t r_norm = 0;

--- a/cpp/oneapi/dal/backend/primitives/optimizers/test/newton_cg_dpc.cpp
+++ b/cpp/oneapi/dal/backend/primitives/optimizers/test/newton_cg_dpc.cpp
@@ -90,8 +90,13 @@ public:
             logloss_function<float_t>(this->get_queue(), data, y_gpu, 3.0, true, bsz);
         auto [solution_, fill_e] =
             ndarray<float_t, 1>::zeros(this->get_queue(), { p_ + 1 }, sycl::usm::alloc::device);
-        auto [opt_event, num_iter] =
-            newton_cg(this->get_queue(), logloss_func, solution_, float_t(1e-8), 100, { fill_e });
+        auto [opt_event, num_iter] = newton_cg(this->get_queue(),
+                                               logloss_func,
+                                               solution_,
+                                               float_t(1e-8),
+                                               100l,
+                                               200l,
+                                               { fill_e });
         opt_event.wait_and_throw();
         auto solution_host = solution_.to_host(this->get_queue());
 
@@ -196,7 +201,7 @@ public:
 
         float_t conv_tol = sizeof(float_t) == 4 ? 1e-7 : 1e-14;
         auto [opt_event, num_iter] =
-            newton_cg(this->get_queue(), *func_, x, conv_tol, 100, { x_event });
+            newton_cg(this->get_queue(), *func_, x, conv_tol, 100, 200l, { x_event });
         opt_event.wait_and_throw();
         auto x_host = x.to_host(this->get_queue());
         float_t tol = sizeof(float_t) == 4 ? 1e-4 : 1e-7;


### PR DESCRIPTION
# Description
Aligning implementation of cg-solver and newton-cg with https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/utils/optimize.py#L148 and https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/utils/optimize.py#L84

Changes proposed in this pull request:
- Change newton-cg and cg-solver primitives stopping conditions
- Change the default number of maxinner iterations for newton-cg
- Add profiler kernels