### PR TITLE
[fix] update float sycl::abs calls to sycl::fabs due to depreciation

### DIFF
--- a/cpp/oneapi/dal/algo/objective_function/backend/gpu/compute_kernel_dense_batch_impl_dpc.cpp
+++ b/cpp/oneapi/dal/algo/objective_function/backend/gpu/compute_kernel_dense_batch_impl_dpc.cpp
@@ -70,7 +70,7 @@ void add_regularization(sycl::queue& q_,
                 ans_loss_ptr[0] *= inv_n;
                 for (std::int64_t i = 1; i < p + 1; ++i) {
                     ans_loss_ptr[0] +=
-                        L2 * params_ptr[i] * params_ptr[i] + L1 * sycl::abs(params_ptr[i]);
+                        L2 * params_ptr[i] * params_ptr[i] + L1 * sycl::fabs(params_ptr[i]);
                 }
             });
         });

--- a/cpp/oneapi/dal/backend/primitives/objective_function/logloss_dpc.cpp
+++ b/cpp/oneapi/dal/backend/primitives/objective_function/logloss_dpc.cpp
@@ -288,7 +288,7 @@ sycl::event add_regularization_loss(sycl::queue& q,
         const std::int64_t st_id = fit_intercept;
         cgh.parallel_for(range, sum_reduction, [=](sycl::id<1> idx, auto& sum) {
             const Float param = param_ptr[idx + st_id];
-            sum += L1 * sycl::abs(param) + L2 * param * param;
+            sum += L1 * sycl::fabs(param) + L2 * param * param;
         });
     });
     return q.submit([&](sycl::handler& cgh) {
@@ -326,7 +326,7 @@ sycl::event add_regularization_gradient_loss(sycl::queue& q,
         std::int64_t st_id = fit_intercept;
         cgh.parallel_for(range, sum_reduction, [=](sycl::id<1> idx, auto& sum) {
             const Float param = param_ptr[idx + st_id];
-            sum += L1 * sycl::abs(param) + L2 * param * param;
+            sum += L1 * sycl::fabs(param) + L2 * param * param;
             grad_ptr[idx + st_id] += L2 * 2 * param;
         });
     });


### PR DESCRIPTION
# Description
Future oneapi sycl compilers (icpx) will raise 
```C++
error: 'abs<float>' is deprecated: abs for floating point types is non-standard and has been deprecated. Please use fabs instead. [-Werror,-Wdeprecated-declarations]
```
In the standard build setup. Cases which use sycl::abs with floats need to switch to using sycl::fabs.
Changes proposed in this pull request:
- sycl::abs -> sycl::fabs