### PR TITLE
Fix exports in FPK on Windows

### DIFF
--- a/cpp/daal/src/algorithms/export_win32e.def
+++ b/cpp/daal/src/algorithms/export_win32e.def
@@ -21,9 +21,6 @@ fpk_serv_memcpy_s
 fpk_serv_lock
 fpk_serv_unlock
 fpk_serv_strnlen_s
-fpk_serv_strncpy_s
-fpk_serv_strncat_s
-fpk_serv_thread_yield
 fpk_serv_core_register_cleanup
 fpk_serv_calloc
 fpk_serv_printf_s

--- a/cpp/daal/src/algorithms/export_win32e.def
+++ b/cpp/daal/src/algorithms/export_win32e.def
@@ -21,6 +21,9 @@ fpk_serv_memcpy_s
 fpk_serv_lock
 fpk_serv_unlock
 fpk_serv_strnlen_s
+fpk_serv_strncpy_s
+fpk_serv_strncat_s
+fpk_serv_thread_yield
 fpk_serv_core_register_cleanup
 fpk_serv_calloc
 fpk_serv_printf_s


### PR DESCRIPTION
Add missing symbols to mklfpk on Windows.