### PR TITLE
Add inner_iterations_count result option to LogisticRegression

### DIFF
--- a/cpp/oneapi/dal/algo/logistic_regression/backend/gpu/train_kernel_dense_batch_dpc.cpp
+++ b/cpp/oneapi/dal/algo/logistic_regression/backend/gpu/train_kernel_dense_batch_dpc.cpp
@@ -88,6 +88,8 @@ static train_result<Task> call_dal_kernel(const context_gpu& ctx,
 
     auto [train_event, iter_num] = opt_impl->minimize(queue, loss_func, x_suf, { fill_event });
 
+    train_event.wait_and_throw();
+
     auto all_coefs = homogen_table::wrap(x.flatten(queue, { train_event }), 1, feature_count + 1);
 
     const auto model_impl = std::make_shared<model_impl_t>(all_coefs);
@@ -111,6 +113,10 @@ static train_result<Task> call_dal_kernel(const context_gpu& ctx,
 
     if (options.test(result_options::iterations_count)) {
         result.set_iterations_count(iter_num);
+    }
+
+    if (options.test(result_options::inner_iterations_count)) {
+        result.set_inner_iterations_count(opt_impl->get_inner_iter());
     }
 
     return result;

--- a/cpp/oneapi/dal/algo/logistic_regression/backend/gpu/train_kernel_dense_batch_dpc.cpp
+++ b/cpp/oneapi/dal/algo/logistic_regression/backend/gpu/train_kernel_dense_batch_dpc.cpp
@@ -88,8 +88,6 @@ static train_result<Task> call_dal_kernel(const context_gpu& ctx,
 
     auto [train_event, iter_num] = opt_impl->minimize(queue, loss_func, x_suf, { fill_event });
 
-    train_event.wait_and_throw();
-
     auto all_coefs = homogen_table::wrap(x.flatten(queue, { train_event }), 1, feature_count + 1);
 
     const auto model_impl = std::make_shared<model_impl_t>(all_coefs);

--- a/cpp/oneapi/dal/algo/logistic_regression/backend/optimizer_impl.hpp
+++ b/cpp/oneapi/dal/algo/logistic_regression/backend/optimizer_impl.hpp
@@ -37,6 +37,13 @@ public:
     virtual std::int64_t get_max_iter() = 0;
 
 #ifdef ONEDAL_DATA_PARALLEL
+
+    // this function returns meaningful value only for newton_cg optimizer
+    // inner iterations value can be accessed after minimize method was called
+    virtual std::int64_t get_inner_iter() {
+        return -1;
+    }
+
     virtual std::pair<sycl::event, std::int64_t> minimize(sycl::queue& q,
                                                           pr::base_function<float>& f,
                                                           pr::ndview<float, 1>& x,

--- a/cpp/oneapi/dal/algo/logistic_regression/backend/optimizer_impl.hpp
+++ b/cpp/oneapi/dal/algo/logistic_regression/backend/optimizer_impl.hpp
@@ -36,13 +36,13 @@ public:
     virtual double get_tol() = 0;
     virtual std::int64_t get_max_iter() = 0;
 
-#ifdef ONEDAL_DATA_PARALLEL
-
     // this function returns meaningful value only for newton_cg optimizer
     // inner iterations value can be accessed after minimize method was called
     virtual std::int64_t get_inner_iter() {
         return -1;
     }
+
+#ifdef ONEDAL_DATA_PARALLEL
 
     virtual std::pair<sycl::event, std::int64_t> minimize(sycl::queue& q,
                                                           pr::base_function<float>& f,

--- a/cpp/oneapi/dal/algo/logistic_regression/common.cpp
+++ b/cpp/oneapi/dal/algo/logistic_regression/common.cpp
@@ -34,6 +34,10 @@ result_option_id get_iterations_count_id() {
     return result_option_id{ result_option_id::make_by_index(2) };
 }
 
+result_option_id get_inner_iterations_count_id() {
+    return result_option_id{ result_option_id::make_by_index(3) };
+}
+
 template <typename Task>
 result_option_id get_default_result_options() {
     return result_option_id{};

--- a/cpp/oneapi/dal/algo/logistic_regression/common.hpp
+++ b/cpp/oneapi/dal/algo/logistic_regression/common.hpp
@@ -68,6 +68,7 @@ namespace detail {
 ONEDAL_EXPORT result_option_id get_intercept_id();
 ONEDAL_EXPORT result_option_id get_coefficients_id();
 ONEDAL_EXPORT result_option_id get_iterations_count_id();
+ONEDAL_EXPORT result_option_id get_inner_iterations_count_id();
 
 } // namespace detail
 
@@ -83,6 +84,9 @@ const inline result_option_id coefficients = detail::get_coefficients_id();
 
 /// Return the number of iterations made by optimizer
 const inline result_option_id iterations_count = detail::get_iterations_count_id();
+
+/// Return the number of subiterations made by optimizer. Only available for newton-cg optimizer
+const inline result_option_id inner_iterations_count = detail::get_inner_iterations_count_id();
 
 } // namespace result_options
 

--- a/cpp/oneapi/dal/algo/logistic_regression/detail/optimizer.cpp
+++ b/cpp/oneapi/dal/algo/logistic_regression/detail/optimizer.cpp
@@ -49,12 +49,12 @@ public:
         return max_iter_;
     }
 
-#ifdef ONEDAL_DATA_PARALLEL
-
     // this parameter is set after minimize function was called
     std::int64_t get_inner_iter() override {
         return inner_iter_;
     }
+
+#ifdef ONEDAL_DATA_PARALLEL
 
     template <typename Float>
     std::pair<sycl::event, std::int64_t> minimize_impl(sycl::queue& q,

--- a/cpp/oneapi/dal/algo/logistic_regression/train_types.cpp
+++ b/cpp/oneapi/dal/algo/logistic_regression/train_types.cpp
@@ -39,6 +39,7 @@ public:
     table intercept;
     table coefficients;
     std::int64_t iter_cnt;
+    std::int64_t inner_iter_cnt;
 
     result_option_id options;
 
@@ -155,6 +156,24 @@ void train_result<Task>::set_iterations_count_impl(std::int64_t value) {
         throw domain_error(msg::this_result_is_not_enabled_via_result_options());
     }
     impl_->iter_cnt = value;
+}
+
+template <typename Task>
+std::int64_t train_result<Task>::get_inner_iterations_count() const {
+    using msg = dal::detail::error_messages;
+    if (!get_result_options().test(result_options::inner_iterations_count)) {
+        throw domain_error(msg::this_result_is_not_enabled_via_result_options());
+    }
+    return impl_->inner_iter_cnt;
+}
+
+template <typename Task>
+void train_result<Task>::set_inner_iterations_count_impl(std::int64_t value) {
+    using msg = dal::detail::error_messages;
+    if (!get_result_options().test(result_options::inner_iterations_count)) {
+        throw domain_error(msg::this_result_is_not_enabled_via_result_options());
+    }
+    impl_->inner_iter_cnt = value;
 }
 
 template <typename Task>

--- a/cpp/oneapi/dal/algo/logistic_regression/train_types.hpp
+++ b/cpp/oneapi/dal/algo/logistic_regression/train_types.hpp
@@ -150,6 +150,14 @@ public:
         return *this;
     }
 
+    /// Number of optimizer subiterations
+    std::int64_t get_inner_iterations_count() const;
+
+    auto& set_inner_iterations_count(std::int64_t value) {
+        set_inner_iterations_count_impl(value);
+        return *this;
+    }
+
     /// Table of Logistic Regression coefficients and intercept
     const table& get_packed_coefficients() const;
 
@@ -173,6 +181,7 @@ protected:
     void set_coefficients_impl(const table&);
     void set_packed_coefficients_impl(const table&);
     void set_iterations_count_impl(std::int64_t);
+    void set_inner_iterations_count_impl(std::int64_t);
 
     void set_result_options_impl(const result_option_id&);
 

--- a/cpp/oneapi/dal/backend/primitives/optimizers/newton_cg.hpp
+++ b/cpp/oneapi/dal/backend/primitives/optimizers/newton_cg.hpp
@@ -25,12 +25,12 @@ namespace oneapi::dal::backend::primitives {
 // pp. 168 (also known as the truncated Newton method)
 // https://link.springer.com/book/10.1007/978-0-387-40065-5
 template <typename Float>
-std::pair<sycl::event, std::int64_t> newton_cg(sycl::queue& queue,
-                                               base_function<Float>& f,
-                                               ndview<Float, 1>& x,
-                                               Float tol = 1.0e-5,
-                                               std::int64_t maxiter = 100l,
-                                               std::int64_t maxinner = 200l,
-                                               const event_vector& deps = {});
+std::tuple<sycl::event, std::int64_t, std::int64_t> newton_cg(sycl::queue& queue,
+                                                              base_function<Float>& f,
+                                                              ndview<Float, 1>& x,
+                                                              Float tol = 1.0e-5,
+                                                              std::int64_t maxiter = 100l,
+                                                              std::int64_t maxinner = 200l,
+                                                              const event_vector& deps = {});
 
 } // namespace oneapi::dal::backend::primitives

--- a/cpp/oneapi/dal/backend/primitives/optimizers/test/newton_cg_dpc.cpp
+++ b/cpp/oneapi/dal/backend/primitives/optimizers/test/newton_cg_dpc.cpp
@@ -90,13 +90,13 @@ public:
             logloss_function<float_t>(this->get_queue(), data, y_gpu, 3.0, true, bsz);
         auto [solution_, fill_e] =
             ndarray<float_t, 1>::zeros(this->get_queue(), { p_ + 1 }, sycl::usm::alloc::device);
-        auto [opt_event, num_iter] = newton_cg(this->get_queue(),
-                                               logloss_func,
-                                               solution_,
-                                               float_t(1e-8),
-                                               100l,
-                                               200l,
-                                               { fill_e });
+        auto [opt_event, num_iter, inner_iter] = newton_cg(this->get_queue(),
+                                                           logloss_func,
+                                                           solution_,
+                                                           float_t(1e-8),
+                                                           100l,
+                                                           200l,
+                                                           { fill_e });
         opt_event.wait_and_throw();
         auto solution_host = solution_.to_host(this->get_queue());
 
@@ -200,7 +200,7 @@ public:
             ndarray<float_t, 1>::zeros(this->get_queue(), { n_ }, sycl::usm::alloc::device);
 
         float_t conv_tol = sizeof(float_t) == 4 ? 1e-7 : 1e-14;
-        auto [opt_event, num_iter] =
+        auto [opt_event, num_iter, inner_iter] =
             newton_cg(this->get_queue(), *func_, x, conv_tol, 100, 200l, { x_event });
         opt_event.wait_and_throw();
         auto x_host = x.to_host(this->get_queue());


### PR DESCRIPTION
# Description
To access the number of iterations done by cg-solver on the python side we need to add a new result_option to oneDAL algorithm
