### PR TITLE
Allow overriding of ARCH_ONEDAL in Linux vars.sh

### DIFF
--- a/deploy/local/vars_lnx.sh
+++ b/deploy/local/vars_lnx.sh
@@ -224,7 +224,7 @@ if [ ! -d $__daal_tmp_dir ]; then
     __daal_tmp_dir=${component_root}
 fi
 
-ARCH_ONEDAL=$(uname -m)
+ARCH_ONEDAL=${ARCH_ONEDAL:-$(uname -m)}
 
 if [ "${ARCH_ONEDAL}" = "x86_64" ]; then
     ARCH_DIR_ONEDAL="intel64"


### PR DESCRIPTION
# Description
To support cross-compilation we want to allow the architecture to be specified, rather than being auto-detected in lnx_vars.sh. As such we only check the uname in the case that ARCH_ONEDAL is unset.

Changes proposed in this pull request:
- Update auto-generated lnx_vars.sh to use value set for environment variable ARCH_ONEDAL, if se