### PR TITLE
Only load conda environment if required

### DIFF
--- a/.ci/scripts/build.sh
+++ b/.ci/scripts/build.sh
@@ -90,8 +90,8 @@ backend_config=${backend_config:-mkl}
 GLOBAL_RETURN=0
 
 if [ "${OS}" == "lnx" ]; then
-    source /usr/share/miniconda/etc/profile.d/conda.sh
     if [ "${conda_env}" != "" ]; then
+        command -v conda >/dev/null 2>&1 || source /usr/share/miniconda/etc/profile.d/conda.sh
         conda activate ${conda_env}
         echo "conda '${conda_env}' env activated at ${CONDA_PREFIX}"
     fi
@@ -104,8 +104,8 @@ if [ "${OS}" == "lnx" ]; then
             with_gpu="false"
     fi
 elif [ "${OS}" == "mac" ]; then
-    source /usr/local/miniconda/etc/profile.d/conda.sh
     if [ "${conda_env}" != "" ]; then
+        command -v conda >/dev/null 2>&1 || source /usr/local/miniconda/etc/profile.d/conda.sh
         conda activate ${conda_env}
         echo "conda '${conda_env}' env activated at ${CONDA_PREFIX}"
     fi


### PR DESCRIPTION
The build script for CI is useful to use locally. However, the conda path does not need to be the same on the local system. As such, we only source the conda environment in the case that we request it.

Locally, having conda available in PATH will prevent conda from being sourced again, meaning we can have a different conda environment installed on the system

# Description
- Moves the sourcing of an absolute path, available in the CI images, behind and if statement
- Protects the loading of a conda installation, if one has already been found