### PR TITLE
[bug] Add signflip to CPU online PCA

### DIFF
--- a/cpp/daal/src/algorithms/pca/pca_dense_correlation_online_kernel.h
+++ b/cpp/daal/src/algorithms/pca/pca_dense_correlation_online_kernel.h
@@ -51,6 +51,8 @@ public:
 
     using PCADenseBase<algorithmFPType, cpu>::computeExplainedVariancesRatio;
 
+    using PCADenseBase<algorithmFPType, cpu>::signFlipEigenvectors;
+
     services::Status compute(const data_management::NumericTablePtr & pData, PartialResult<correlationDense> * partialResult,
                              const OnlineParameter<algorithmFPType, correlationDense> * parameter);
 

--- a/cpp/oneapi/dal/algo/pca/backend/cpu/finalize_train_kernel_cov.cpp
+++ b/cpp/oneapi/dal/algo/pca/backend/cpu/finalize_train_kernel_cov.cpp
@@ -136,6 +136,18 @@ static train_result<Task> call_daal_kernel_finalize_train(const context_cpu& ctx
     }
 
     {
+        if (desc.get_deterministic()) {
+            const auto status = dal::backend::dispatch_by_cpu(ctx, [&](auto cpu) {
+                constexpr auto cpu_type = interop::to_daal_cpu_type<decltype(cpu)>::value;
+                return daal_pca_cor_kernel_t<Float, cpu_type>().signFlipEigenvectors(
+                    *daal_eigenvectors);
+            });
+
+            interop::status_to_exception(status);
+        }
+    }
+
+    {
         const auto status = dal::backend::dispatch_by_cpu(ctx, [&](auto cpu) {
             constexpr auto cpu_type = interop::to_daal_cpu_type<decltype(cpu)>::value;
             return daal_pca_cor_kernel_t<Float, cpu_type>().computeSingularValues(

--- a/cpp/oneapi/dal/algo/pca/test/fixture.hpp
+++ b/cpp/oneapi/dal/algo/pca/test/fixture.hpp
@@ -145,7 +145,7 @@ public:
         check_train_result(pca_desc, data, train_result);
         INFO("run inference");
         const auto infer_result = this->infer(pca_desc, model, x);
-        check_infer_result(pca_desc, data, infer_result);
+        check_infer_result(pca_desc, model, x, infer_result);
     }
 
     void online_general_checks(const te::dataframe& data,
@@ -170,7 +170,7 @@ public:
         check_train_result_online(pca_desc, data, train_result);
         INFO("run inference");
         const auto infer_result = this->infer(pca_desc, model, x);
-        check_infer_result(pca_desc, data, infer_result);
+        check_infer_result(pca_desc, model, x, infer_result);
     }
 
     void check_train_result(const pca::descriptor<Float, Method>& desc,
@@ -212,8 +212,19 @@ public:
     }
 
     void check_infer_result(const pca::descriptor<Float, Method>& desc,
-                            const te::dataframe& data,
-                            const pca::infer_result<>& result) {}
+                            const pca::model<>& model,
+                            const table& data,
+                            const pca::infer_result<>& result) {
+
+        const auto eigenvectors = model.get_eigenvectors();
+        const auto transformed_data = result.get_transformed_data();
+
+        CAPTURE(desc.whiten());
+        CAPTURE(desc.get_normalization_mode());
+        
+        check_infer_nans(transformed_data);
+        check_infer_shapes(transformed_data, eigenvectors, data);
+    }
 
     void check_online_shapes(const pca::descriptor<Float, Method>& desc,
                              const te::dataframe& data,
@@ -257,6 +268,15 @@ public:
         REQUIRE(variances.get_column_count() == data.get_column_count());
     }
 
+    void check_infer_shapes(const table& transformed_data,
+                            const table& eigenvectors,
+                            const table& data) {
+        INFO("check if transformed data shape is expected");
+
+        REQUIRE(transformed_data.get_column_count() == eigenvectors.get_row_count());
+        REQUIRE(transformed_data.get_row_count() == data.get_row_count());
+    }
+
     void check_nans(const pca::train_result<>& result) {
         const auto [means, variances, eigenvalues, eigenvectors] = unpack_result(result);
 
@@ -271,6 +291,11 @@ public:
 
         INFO("check if there is no NaN in variances");
         REQUIRE(te::has_no_nans(variances));
+    }
+
+    void check_infer_nans(const table& transformed_data) {
+        INFO("check if there is no NaN in transformed_data");
+        REQUIRE(te::has_no_nans(transformed_data));
     }
 
     void check_eigenvalues_order(const table& eigenvalues) const {

--- a/cpp/oneapi/dal/algo/pca/test/fixture.hpp
+++ b/cpp/oneapi/dal/algo/pca/test/fixture.hpp
@@ -131,6 +131,7 @@ public:
         return result;
     }
 
+    // TODO: add more checks, for example, check if eigenvectors are correct, checks for all possible values of normalization/whitening, check for infer gold data.
     void general_checks(const te::dataframe& data,
                         std::int64_t component_count,
                         const te::table_id& data_table_id) {
@@ -145,7 +146,7 @@ public:
         check_train_result(pca_desc, data, train_result);
         INFO("run inference");
         const auto infer_result = this->infer(pca_desc, model, x);
-        check_infer_result(pca_desc, model, x, infer_result);
+        check_infer_result(pca_desc, model, data, infer_result);
     }
 
     void online_general_checks(const te::dataframe& data,
@@ -170,7 +171,7 @@ public:
         check_train_result_online(pca_desc, data, train_result);
         INFO("run inference");
         const auto infer_result = this->infer(pca_desc, model, x);
-        check_infer_result(pca_desc, model, x, infer_result);
+        check_infer_result(pca_desc, model, data, infer_result);
     }
 
     void check_train_result(const pca::descriptor<Float, Method>& desc,
@@ -213,7 +214,7 @@ public:
 
     void check_infer_result(const pca::descriptor<Float, Method>& desc,
                             const pca::model<>& model,
-                            const table& data,
+                            const te::dataframe& data,
                             const pca::infer_result<>& result) {
         const auto eigenvectors = model.get_eigenvectors();
         const auto transformed_data = result.get_transformed_data();
@@ -266,7 +267,7 @@ public:
 
     void check_infer_shapes(const table& transformed_data,
                             const table& eigenvectors,
-                            const table& data) {
+                            const te::dataframe& data) {
         INFO("check if transformed data shape is expected");
 
         REQUIRE(transformed_data.get_column_count() == eigenvectors.get_row_count());

--- a/cpp/oneapi/dal/algo/pca/test/fixture.hpp
+++ b/cpp/oneapi/dal/algo/pca/test/fixture.hpp
@@ -215,13 +215,12 @@ public:
                             const pca::model<>& model,
                             const table& data,
                             const pca::infer_result<>& result) {
-
         const auto eigenvectors = model.get_eigenvectors();
         const auto transformed_data = result.get_transformed_data();
 
         CAPTURE(desc.whiten());
         CAPTURE(desc.get_normalization_mode());
-        
+
         check_infer_nans(transformed_data);
         check_infer_shapes(transformed_data, eigenvectors, data);
     }

--- a/cpp/oneapi/dal/algo/pca/test/fixture.hpp
+++ b/cpp/oneapi/dal/algo/pca/test/fixture.hpp
@@ -218,9 +218,6 @@ public:
         const auto eigenvectors = model.get_eigenvectors();
         const auto transformed_data = result.get_transformed_data();
 
-        CAPTURE(desc.whiten());
-        CAPTURE(desc.get_normalization_mode());
-
         check_infer_nans(transformed_data);
         check_infer_shapes(transformed_data, eigenvectors, data);
     }

--- a/cpp/oneapi/dal/algo/pca/test/online.cpp
+++ b/cpp/oneapi/dal/algo/pca/test/online.cpp
@@ -58,7 +58,7 @@ TEMPLATE_LIST_TEST_M(pca_online_test,
     SECTION("check eigenvectors") {
         const auto gold_eigenvectors = this->get_gold_eigenvectors();
         this->check_eigenvectors(gold_eigenvectors, eigenvectors);
-    }    
+    }
 }
 
 TEMPLATE_LIST_TEST_M(pca_online_test,

--- a/cpp/oneapi/dal/algo/pca/test/online.cpp
+++ b/cpp/oneapi/dal/algo/pca/test/online.cpp
@@ -28,7 +28,41 @@ template <typename TestType>
 class pca_online_test : public pca_test<TestType, pca_online_test<TestType>> {};
 
 TEMPLATE_LIST_TEST_M(pca_online_test,
-                     "pca common flow",
+                     "pca online on gold data",
+                     "[pca][integration][online][gold]",
+                     pca_types_cov) {
+    SKIP_IF(this->not_float64_friendly());
+    const int64_t nBlocks = GENERATE(1, 3, 10);
+
+    const std::int64_t component_count = 0;
+    const bool deterministic = true;
+    const auto pca_desc = this->get_descriptor(component_count, deterministic);
+    const auto gold_data = this->get_gold_data();
+
+    auto partial_result = dal::pca::partial_train_result();
+    auto input_table = this->template split_table_by_rows<float>(gold_data, nBlocks);
+    for (std::int64_t i = 0; i < nBlocks; ++i) {
+        partial_result = this->partial_train(pca_desc, partial_result, input_table[i]);
+    }
+
+    const auto pca_result = this->finalize_train(pca_desc, partial_result);
+
+    const auto eigenvalues = pca_result.get_eigenvalues();
+    const auto eigenvectors = pca_result.get_eigenvectors();
+
+    SECTION("check eigenvalues") {
+        const auto gold_eigenvalues = this->get_gold_eigenvalues();
+        this->check_eigenvalues(gold_eigenvalues, eigenvalues);
+    }
+
+    SECTION("check eigenvectors") {
+        const auto gold_eigenvectors = this->get_gold_eigenvectors();
+        this->check_eigenvectors(gold_eigenvectors, eigenvectors);
+    }    
+}
+
+TEMPLATE_LIST_TEST_M(pca_online_test,
+                     "pca fill_normal flow svd",
                      "[pca][integration][online]",
                      pca_types_cov) {
     SKIP_IF(this->not_float64_friendly());

--- a/cpp/oneapi/dal/algo/pca/test/online.cpp
+++ b/cpp/oneapi/dal/algo/pca/test/online.cpp
@@ -62,7 +62,7 @@ TEMPLATE_LIST_TEST_M(pca_online_test,
 }
 
 TEMPLATE_LIST_TEST_M(pca_online_test,
-                     "pca fill_normal flow svd",
+                     "pca fill_uniform flow cov",
                      "[pca][integration][online]",
                      pca_types_cov) {
     SKIP_IF(this->not_float64_friendly());


### PR DESCRIPTION
Changes proposed in this pull request:
- Added handling of isDeterministic option to CPP online part of PCA algorithm
- signFlip is now called if isDeterministic is true for CPP online part as well