### PR TITLE
FIX: kmeans_init bazel test enabling

### DIFF
--- a/cpp/daal/src/algorithms/kmeans/kmeans_plusplus_init_impl.i
+++ b/cpp/daal/src/algorithms/kmeans/kmeans_plusplus_init_impl.i
@@ -915,9 +915,9 @@ Status TaskParallelPlusBatch<algorithmFPType, cpu, DataHelper>::getCandidates(Ho
                 s |= this->copyPoints(candidatesBD.get() + _nCandidates * this->_data.dim, this->_lastAddedCenter.get(), nNewCandidates);
                 const size_t iFirstNewCandidate = _nCandidates;
                 _nCandidates += nNewCandidates;
-                bDone = ((iRound + 1 >= _R) && (_nCandidates > this->_nClusters));
                 DAAL_CHECK_STATUS(s, this->updateMinDist(iFirstNewCandidate, nNewCandidates));
             }
+            bDone = ((iRound + 1 >= _R) && (_nCandidates > this->_nClusters));
         }
     }
     if (_nCandidates < maxNumberOfCandidates) pCandidates->resize(_nCandidates);

--- a/cpp/oneapi/dal/algo/kmeans_init/BUILD
+++ b/cpp/oneapi/dal/algo/kmeans_init/BUILD
@@ -37,7 +37,7 @@ dal_test_suite(
 
 dal_test_suite(
     name = "tests",
-    host_tests = [
+    tests = [
         ":interface_tests",
     ],
 )


### PR DESCRIPTION
- Update kmeans_init BUILD file so tests are ran from CI bazel test scope (in current main branch tests are NOT ran)
- Fix infinite loop kmeans_init++ that led to timeout in testing