### PR TITLE
OpenBLAS use make options in install

### DIFF
--- a/.ci/env/openblas.sh
+++ b/.ci/env/openblas.sh
@@ -55,13 +55,14 @@ CoreCount=$(lscpu -p | grep -Ev '^#' | wc -l)
 pushd OpenBLAS
   make clean
   if [ "${cross_compile}" == "yes" ]; then
-    make_options="-j${CoreCount} TARGET=${target} HOSTCC=${host_compiler} CC=${compiler} NO_FORTRAN=1 USE_OPENMP=0 USE_THREAD=0 USE_LOCKING=1 CFLAGS=\"${cflags}\""
-    echo "make ${make_options}"
-    make ${make_options}
+    make_options=(-j"${CoreCount}" TARGET="${target}" HOSTCC="${host_compiler}" CC="${compiler}" NO_FORTRAN=1 USE_OPENMP=0 USE_THREAD=0 USE_LOCKING=1 CFLAGS="${cflags}")
+    echo make "${make_options[@]}"
+    make "${make_options[@]}"
   else
-    make_options="-j${CoreCount} NO_FORTRAN=1 USE_OPENMP=0 USE_THREAD=0 USE_LOCKING=1"
-    make ${make_options}
+    make_options=(-j"${CoreCount}" NO_FORTRAN=1 USE_OPENMP=0 USE_THREAD=0 USE_LOCKING=1)
+    echo make "${make_options[@]}"
+    make "${make_options[@]}"
   fi
   # The install needs to be done with the same options as the build
-  make install ${make_options} PREFIX=../__deps/open_blas
+  make install "${make_options[@]}" PREFIX=../__deps/open_blas
 popd

--- a/.ci/env/openblas.sh
+++ b/.ci/env/openblas.sh
@@ -55,10 +55,13 @@ CoreCount=$(lscpu -p | grep -Ev '^#' | wc -l)
 pushd OpenBLAS
   make clean
   if [ "${cross_compile}" == "yes" ]; then
-    echo make -j${CoreCount} TARGET=${target} HOSTCC=${host_compiler} CC=${compiler} NO_FORTRAN=1 USE_OPENMP=0 USE_THREAD=0 USE_LOCKING=1 CFLAGS=\"${cflags}\"
-    make -j${CoreCount} TARGET=${target} HOSTCC=${host_compiler} CC=${compiler} NO_FORTRAN=1 USE_OPENMP=0 USE_THREAD=0 USE_LOCKING=1 CFLAGS=\"${cflags}\"
+    make_options="-j${CoreCount} TARGET=${target} HOSTCC=${host_compiler} CC=${compiler} NO_FORTRAN=1 USE_OPENMP=0 USE_THREAD=0 USE_LOCKING=1 CFLAGS=\"${cflags}\""
+    echo "make ${make_options}"
+    make ${make_options}
   else
-    make -j${CoreCount} NO_FORTRAN=1 USE_OPENMP=0 USE_THREAD=0 USE_LOCKING=1
+    make_options="-j${CoreCount} CC=${compiler} NO_FORTRAN=1 USE_OPENMP=0 USE_THREAD=0 USE_LOCKING=1"
+    make ${make_options}
   fi
-  make install PREFIX=../__deps/open_blas
+  # The install needs to be done with the same options as the build
+  make install ${make_options} PREFIX=../__deps/open_blas
 popd

--- a/.ci/env/openblas.sh
+++ b/.ci/env/openblas.sh
@@ -59,7 +59,7 @@ pushd OpenBLAS
     echo "make ${make_options}"
     make ${make_options}
   else
-    make_options="-j${CoreCount} CC=${compiler} NO_FORTRAN=1 USE_OPENMP=0 USE_THREAD=0 USE_LOCKING=1"
+    make_options="-j${CoreCount} NO_FORTRAN=1 USE_OPENMP=0 USE_THREAD=0 USE_LOCKING=1"
     make ${make_options}
   fi
   # The install needs to be done with the same options as the build


### PR DESCRIPTION
OpenBLAS recommends using the same options in the make command line for installation, as was used for building. Without the correct options, the installation target may look for non-existent files, and at worst will install the incorrect target.

Changes proposed in this pull request:
- Store the options used in the OpenBLAS build command, and re-use these in the install target