### PR TITLE
Refactor OpenBLAS build script

### DIFF
--- a/.ci/env/openblas.sh
+++ b/.ci/env/openblas.sh
@@ -96,7 +96,6 @@ pushd "${blas_src_dir}"
   # USE_THREAD=0.
   # The library may still be used in a multithreaded environment, so we set
   # USE_LOCKING=1 to ensure thread safety
-  make clean
   if [ "${cross_compile}" == "yes" ]; then
     make_options=(-j"${CoreCount}"
         TARGET="${target}"
@@ -114,6 +113,10 @@ pushd "${blas_src_dir}"
         USE_THREAD=0
         USE_LOCKING=1)
   fi
+  # Clean
+  echo make "${make_options[@]}" clean
+  make "${make_options[@]}" clean
+  # Build
   echo make "${make_options[@]}"
   make "${make_options[@]}"
   # The install needs to be done with the same options as the build

--- a/.ci/env/openblas.sh
+++ b/.ci/env/openblas.sh
@@ -84,7 +84,7 @@ sudo apt-get update
 sudo apt-get -y install build-essential gcc gfortran
 blas_src_dir=${blas_src_dir:-$OPENBLAS_DEFAULT_SOURCE_DIR}
 if [[ ! -d "${blas_src_dir}" ]] ; then
-  git clone https://github.com/xianyi/OpenBLAS.git "${blas_src_dir}"
+  git clone https://github.com/OpenMathLib/OpenBLAS "${blas_src_dir}"
 fi
 
 CoreCount=$(nproc --all)

--- a/.ci/env/openblas.sh
+++ b/.ci/env/openblas.sh
@@ -77,11 +77,7 @@ target=${target:-ARMV8}
 host_compiler=${host_compiler:-gcc}
 compiler=${compiler:-aarch64-linux-gnu-gcc}
 
-if [[ -z "${target_arch}" ]] ; then
-  echo "The target architecture must be specified with the --target-arch option"
-  exit 1
-fi
-
+target_arch=${target_arch:-$(uname -m)}
 blas_prefix="${ONEDAL_DIR}/__deps/openblas_${target_arch}"
 
 sudo apt-get update

--- a/.ci/scripts/build.sh
+++ b/.ci/scripts/build.sh
@@ -18,7 +18,8 @@
 
 set -eo pipefail
 
-SCRIPT_DIR=$(dirname $(readlink -f "${BASH_SOURCE[0]}"))
+SCRIPT_PATH=$(readlink -f "${BASH_SOURCE[0]}")
+SCRIPT_DIR=$(dirname "${SCRIPT_PATH}")
 ONEDAL_DIR=$(readlink -f "${SCRIPT_DIR}/../../")
 
 show_help() {
@@ -70,7 +71,7 @@ while [[ $# -gt 0 ]]; do
     shift
 done
 
-PLAT=${PLAT:-$(bash ${ONEDAL_DIR}/dev/make/identify_os.sh)}
+PLAT=${PLAT:-$(bash "${ONEDAL_DIR}"/dev/make/identify_os.sh)}
 OS=${PLAT::3}
 ARCH=${PLAT:3:3}
 
@@ -109,9 +110,9 @@ else
     exit 1
 fi
 
-#setting build parrlelization based on number of thereads
+#setting build parallelization based on number of threads
 if [ "$(uname)" == "Linux" ]; then
-    make_op="-j$(grep -c processor /proc/cpuinfo)"
+    make_op="-j$(nproc --all)"
 else
     make_op="-j$(sysctl -n hw.physicalcpu)"
 fi
@@ -120,28 +121,29 @@ fi
 echo "Call env scripts"
 if [ "${backend_config}" == "mkl" ]; then
     echo "Sourcing MKL env"
-    ${ONEDAL_DIR}/dev/download_micromkl.sh with_gpu=${with_gpu}
+    "${ONEDAL_DIR}"/dev/download_micromkl.sh with_gpu="${with_gpu}"
 elif [ "${backend_config}" == "ref" ]; then
     echo "Sourcing ref(openblas) env"
-    if [ ! -d "__deps/open_blas" ]; then
+    if [ ! -d "${ONEDAL_DIR}/__deps/openblas_${ARCH}" ]; then
         if [ "${optimizations}" == "sve" ] && [ "${cross_compile}" == "yes" ]; then
-            ${ONEDAL_DIR}/.ci/env/openblas.sh --target ARMV8 --host_compiler gcc --compiler aarch64-linux-gnu-gcc --cflags -march=armv8-a+sve --cross_compile
+            "${ONEDAL_DIR}"/.ci/env/openblas.sh --target ARMV8 --host-compiler gcc --compiler aarch64-linux-gnu-gcc --cflags -march=armv8-a+sve --cross-compile --target-arch "${ARCH}"
         else
-            ${ONEDAL_DIR}/.ci/env/openblas.sh
+            "${ONEDAL_DIR}"/.ci/env/openblas.sh --target-arch "${ARCH}"
         fi
     fi
+    export OPENBLASROOT="${ONEDAL_DIR}/__deps/openblas_${ARCH}"
 else
     echo "Not supported backend env"
 fi
 
 # TBB setup
 if [[ "${ARCH}" == "32e" ]]; then
-    ${ONEDAL_DIR}/dev/download_tbb.sh
+    "${ONEDAL_DIR}"/dev/download_tbb.sh
 elif [[ "${ARCH}" == "arm" ]]; then
     if [[ "${cross_compile}" == "yes" ]]; then
-        ${ONEDAL_DIR}/.ci/env/tbb.sh --cross_compile --toolchain_file $(pwd)/.ci/env/arm-gcc-crosscompile-toolchain.cmake --target_arch aarch64
+        "${ONEDAL_DIR}"/.ci/env/tbb.sh --cross_compile --toolchain_file "$(pwd)"/.ci/env/arm-gcc-crosscompile-toolchain.cmake --target_arch aarch64
     else
-        ${ONEDAL_DIR}/.ci/env/tbb.sh
+        "${ONEDAL_DIR}"/.ci/env/tbb.sh
     fi
 fi
 
@@ -151,15 +153,14 @@ if [ "${optimizations}" == "sve" ] && [ "${cross_compile}" == "yes" ]; then
 fi
 
 echo "Calling make"
-echo $CXX
-echo $CC
-echo make ${target:-onedal_c} ${make_op} \
-    COMPILER=${compiler} \
-    REQCPU="${optimizations}" \
-    BACKEND_CONFIG="${backend_config}" \
-    PLAT=${PLAT}
-make ${target:-onedal_c} ${make_op} \
-    COMPILER=${compiler} \
-    REQCPU="${optimizations}" \
-    BACKEND_CONFIG="${backend_config}" \
-    PLAT=${PLAT}
+echo "CXX=$CXX"
+echo "CC=$CC"
+make_options=("${target:-onedal_c}"
+    "${make_op}"
+    COMPILER="${compiler}"
+    REQCPU="${optimizations}"
+    BACKEND_CONFIG="${backend_config}"
+    PLAT="${PLAT}"
+)
+echo make "${make_options[@]}"
+make "${make_options[@]}"

--- a/dev/make/deps.ref.mk
+++ b/dev/make/deps.ref.mk
@@ -20,7 +20,7 @@
 
 OPENBLASDIR:= $(if $(wildcard $(DIR)/__deps/open_blas/*),$(DIR)/__deps/open_blas,                            \
                 $(if $(wildcard $(OPENBLASROOT)/include/*),$(subst \,/,$(OPENBLASROOT)),                              \
-                    $(error Can`t find OPENBLAS libs nether in $(DIR)/__deps/open_blas not in OPENBLASROOT.)))
+                    $(error Can`t find OPENBLAS libs in $(DIR)/__deps/open_blas or OPENBLASROOT.)))
 OPENBLASDIR.include := $(OPENBLASDIR)/include
 OPENBLASDIR.libia := $(OPENBLASDIR)/lib
 


### PR DESCRIPTION
Getting ready to add a clang cross-compile path, we tidy up the OpenBLAS build script a little. LLVM is the preferred compiler toolchain for RISC-V at the moment, but the changes to come start with adding an aarch64 cross-compilation build.

As a bonus, because I recently learned about shellcheck, run this on the openblas.sh and build.sh scripts and tidy up warnings. The shellcheck changes are mostly to do with escaping.

Changes proposed in this pull request for openblas.sh CI build script:
- Add help text. Use the 'column' command to indent this properly
- Make the command-line arguments use a '-' instead of '_' to match build.sh
- Add an option to set the source directory of OpenBLAS. This makes it easier to run this script locally, and build out-of-source
- Make paths relative to the oneDAL root directory, rather than the current working directory. This enables out-of-source builds
- Change the install directory to at least contain the architecture being built for. Also update the build script to point to the correct custom install location. This just makes things a little neater when building for different platforms.