### PR TITLE
Allow test.sh CI script to run locally

### DIFF
--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -63,13 +63,13 @@ jobs:
     displayName: 'Upload build artifacts'
     continueOnError: true
   - script: |
-      .ci/scripts/test.sh --test-kind examples --build-dir $(release.dir) --compiler gnu --interface daal/cpp --build_system cmake
+      .ci/scripts/test.sh --test-kind examples --build-dir $(release.dir) --compiler gnu --interface daal/cpp --build-system cmake
     displayName: 'daal/cpp examples'
   - script: |
-      .ci/scripts/test.sh --test-kind examples --build-dir $(release.dir) --compiler gnu --interface oneapi/cpp --build_system cmake
+      .ci/scripts/test.sh --test-kind examples --build-dir $(release.dir) --compiler gnu --interface oneapi/cpp --build-system cmake
     displayName: 'oneapi/cpp examples'
   - script: |
-      .ci/scripts/test.sh --test-kind samples --build-dir $(release.dir) --compiler gnu --interface daal/cpp/mpi --conda-env ci-env --build_system make
+      .ci/scripts/test.sh --test-kind samples --build-dir $(release.dir) --compiler gnu --interface daal/cpp/mpi --conda-env ci-env --build-system make
     displayName: 'daal/cpp/mpi samples'
   - script: |
       deploy/nuget/prepare_dal_nuget.sh --release-dir $(release.dir) --build-nupkg yes
@@ -148,10 +148,10 @@ jobs:
     displayName: 'Upload build artifacts'
     continueOnError: true
   - script: |
-      .ci/scripts/test.sh --test-kind examples --build-dir $(release.dir) --compiler gnu --interface daal/cpp --build_system cmake --backend ref
+      .ci/scripts/test.sh --test-kind examples --build-dir $(release.dir) --compiler gnu --interface daal/cpp --build-system cmake --backend ref
     displayName: 'daal/cpp examples'
   - script: |
-      .ci/scripts/test.sh --test-kind examples --build-dir $(release.dir) --compiler gnu --interface oneapi/cpp --build_system cmake --backend ref
+      .ci/scripts/test.sh --test-kind examples --build-dir $(release.dir) --compiler gnu --interface oneapi/cpp --build-system cmake --backend ref
     displayName: 'oneapi/cpp examples'
   - task: PublishPipelineArtifact@1
     inputs:
@@ -195,15 +195,15 @@ jobs:
     continueOnError: true
   - script: |
       source /opt/intel/oneapi/compiler/latest/env/vars.sh
-      .ci/scripts/test.sh --test-kind examples --build-dir $(release.dir) --compiler clang --interface daal/cpp --build_system cmake
+      .ci/scripts/test.sh --test-kind examples --build-dir $(release.dir) --compiler clang --interface daal/cpp --build-system cmake
     displayName: 'daal/cpp examples'
   - script: |
       source /opt/intel/oneapi/compiler/latest/env/vars.sh
-      .ci/scripts/test.sh --test-kind examples --build-dir $(release.dir) --compiler clang --interface oneapi/cpp --build_system cmake
+      .ci/scripts/test.sh --test-kind examples --build-dir $(release.dir) --compiler clang --interface oneapi/cpp --build-system cmake
     displayName: 'oneapi/cpp examples'
   - script: |
       source /opt/intel/oneapi/compiler/latest/env/vars.sh
-      .ci/scripts/test.sh --test-kind samples --build-dir $(release.dir) --compiler gnu --interface daal/cpp/mpi --conda-env ci-env --build_system make
+      .ci/scripts/test.sh --test-kind samples --build-dir $(release.dir) --compiler gnu --interface daal/cpp/mpi --conda-env ci-env --build-system make
     displayName: 'daal/cpp/mpi samples'
   - task: PublishPipelineArtifact@1
     inputs:
@@ -446,10 +446,10 @@ jobs:
     displayName: 'Upload build artifacts'
     continueOnError: true
   - script: |
-      .ci/scripts/test.sh --test-kind examples --build-dir $(release.dir) --compiler clang --interface daal/cpp --build_system cmake
+      .ci/scripts/test.sh --test-kind examples --build-dir $(release.dir) --compiler clang --interface daal/cpp --build-system cmake
     displayName: 'daal/cpp examples'
   - script: |
-      .ci/scripts/test.sh --test-kind examples --build-dir $(release.dir) --compiler clang --interface oneapi/cpp --build_system cmake
+      .ci/scripts/test.sh --test-kind examples --build-dir $(release.dir) --compiler clang --interface oneapi/cpp --build-system cmake
     displayName: 'oneapi/cpp examples'
   - script: |
       deploy/nuget/prepare_dal_nuget.sh --release-dir $(release.dir) --build-nupkg yes


### PR DESCRIPTION
So that it is easier to run the CI test scripts on a developer machine, a few changes are made to the script. As well as making some functional changes, shellcheck is run and some escaping in the script is cleaned up.

Running the script locally makes it easier to check that the tests are running as expected when porting to other architectures, before pushing changes to a pull request.

The main changes are:

* Made paths relative to the oneDAL root directory, to allow an out-of-source run
* Only source miniconda in the case that the file exists. This means that the CI runs are the same, but that a developer doesn't need to install miniconda on their own system
* Write stderr from tests to file. The redirects were in the wrong order for this to happen

Minor changes are:

* Added help text
* Changed the naming of command-line arguments to use '-' instead of '_' to make naming consistent
* Iterate over a list of elements, rather than a string
* Update escaping, as suggested by shellcheck
* Add some exit paths (e.g. if directories do not exist)