### PR TITLE
Cache BLAS and TBB builds in CI

### DIFF
--- a/.ci/env/tbb.sh
+++ b/.ci/env/tbb.sh
@@ -20,6 +20,7 @@ set -eo pipefail
 SCRIPT_PATH=$(readlink -f "${BASH_SOURCE[0]}")
 SCRIPT_DIR=$(dirname "${SCRIPT_PATH}")
 ONEDAL_DIR=$(readlink -f "${SCRIPT_DIR}/../..")
+TBB_DEFAULT_VERSION="v2021.10.0"
 
 # Function to display help
 show_help() {
@@ -33,6 +34,7 @@ show_help() {
 --tbb-src <path>:The path to an existing TBB source directory. This is downloaded if not passed
 --prefix <path>:The path to install oneTBB into. Defaults to ${ONEDAL_DIR}/__deps/tbb-$${target_arch}
 --build-dir <path>:The path to build in. Defaults to ${ONEDAL_DIR}/__work/tbb-$${target_arch}
+--version <version string>:The version of oneTBB to fetch and build. Must be a valid git reference in the upstream oneTBB repo
 '
 }
 
@@ -67,6 +69,9 @@ while [[ $# -gt 0 ]]; do
         shift;;
         --build-dir)
         build_dir="$2"
+        shift;;
+        --version)
+        TBB_VERSION="$2"
         shift;;
         *)
         echo "Unknown option: $1"
@@ -112,7 +117,7 @@ sudo apt-get update
 sudo apt-get install build-essential gcc gfortran cmake -y
 tbb_src=${tbb_src:-${ONEDAL_DIR}/__work/onetbb-src}
 if [[ ! -d "${tbb_src}" ]] ; then
-  TBB_VERSION="v2021.10.0"
+  TBB_VERSION="${TBB_VERSION:-${TBB_DEFAULT_VERSION}}"
   git clone --depth 1 --branch "${TBB_VERSION}" https://github.com/oneapi-src/oneTBB.git "${tbb_src}"
 fi
 

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -23,10 +23,15 @@ pr:
     - docs
     - .ci/pipeline/docs.yml
 
+variables:
+  OPENBLAS_VERSION : 'v0.3.27'
+  TBB_VERSION : 'v2021.10.0'
+  VM_IMAGE : 'ubuntu-22.04'
+
 jobs:
 - job: 'ClangFormat'
   pool:
-    vmImage: 'ubuntu-22.04'
+    vmImage: '$(VM_IMAGE)'
   steps:
     - script: |
         .ci/env/apt.sh clang-format
@@ -42,7 +47,7 @@ jobs:
     release.dir: '__release_lnx_gnu'
     platform.type : 'lnx32e'
   pool:
-    vmImage: 'ubuntu-22.04'
+    vmImage: '$(VM_IMAGE)'
   steps:
   - script: |
       .ci/env/apt.sh dev-base
@@ -89,12 +94,10 @@ jobs:
   variables:
     release.dir: '__release_lnx_gnu'
     platform.type : 'lnxarm'
-    OPENBLAS_VERSION : 'v0.3.27'
     OPENBLAS_CACHE_DIR: $(Pipeline.Workspace)/openblas-aarch64-gnu
-    TBB_VERSION : 'v2021.10.0'
     TBB_CACHE_DIR: $(Pipeline.Workspace)/tbb-aarch64-gnu
   pool:
-    vmImage: 'ubuntu-22.04'
+    vmImage: '$(VM_IMAGE)'
   steps:
   - script: |
       .ci/env/apt.sh dev-base
@@ -110,7 +113,7 @@ jobs:
     displayName: 'System info'
   - task: Cache@2
     inputs:
-      key: '"gcc" | "aarch64" | "openblas" | "$(OPENBLAS_VERSION)"'
+      key: '"gcc" | "aarch64" | "openblas" | "$(OPENBLAS_VERSION)" | "$(VM_IMAGE)"'
       path: $(OPENBLAS_CACHE_DIR)
       cacheHitVar: OPENBLAS_RESTORED
   - script: |
@@ -119,7 +122,7 @@ jobs:
     condition: ne(variables.OPENBLAS_RESTORED, 'true')
   - task: Cache@2
     inputs:
-      key: '"gcc" | "aarch64" | "tbb" | "$(TBB_VERSION)"'
+      key: '"gcc" | "aarch64" | "tbb" | "$(TBB_VERSION)" | "$(VM_IMAGE)"'
       path: $(TBB_CACHE_DIR)
       cacheHitVar: TBB_RESTORED
   - script: |
@@ -165,10 +168,9 @@ jobs:
   variables:
     release.dir: '__release_lnx_gnu'
     platform.type : 'lnx32e'
-    OPENBLAS_VERSION: 'v0.3.27'
     OPENBLAS_CACHE_DIR: $(Pipeline.Workspace)/openblas-x86_64-gnu
   pool:
-    vmImage: 'ubuntu-22.04'
+    vmImage: '$(VM_IMAGE)'
   steps:
   - script: |
       .ci/env/apt.sh dev-base
@@ -178,7 +180,7 @@ jobs:
     displayName: 'System info'
   - task: Cache@2
     inputs:
-      key: '"gnu" | "x86_64" | "tbb" | "$(OPENBLAS_VERSION)"'
+      key: '"gnu" | "x86_64" | "openblas" | "$(OPENBLAS_VERSION)" | "$(VM_IMAGE)"'
       path: $(OPENBLAS_CACHE_DIR)
       cacheHitVar: OPENBLAS_RESTORED
   - script: |
@@ -217,7 +219,7 @@ jobs:
     release.dir: '__release_lnx_icx'
     platform.type : 'lnx32e'
   pool:
-    vmImage: 'ubuntu-22.04'
+    vmImage: '$(VM_IMAGE)'
   steps:
   - script: |
       .ci/env/apt.sh dev-base
@@ -265,7 +267,7 @@ jobs:
 - job: 'LinuxBazel'
   timeoutInMinutes: 0
   pool:
-    vmImage: 'ubuntu-22.04'
+    vmImage: '$(VM_IMAGE)'
   variables:
     platform.type : 'lnx32e'
     BAZEL_CACHE_DIR: $(Pipeline.Workspace)/.bazel-cache
@@ -380,7 +382,7 @@ jobs:
     release.dir: '__release_lnx_gnu'
     platform.type : 'lnx32e'
   pool:
-    vmImage: 'ubuntu-22.04'
+    vmImage: '$(VM_IMAGE)'
     maxParallel: 2
   strategy:
     matrix:

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -89,6 +89,10 @@ jobs:
   variables:
     release.dir: '__release_lnx_gnu'
     platform.type : 'lnxarm'
+    OPENBLAS_VERSION : 'v0.3.27'
+    OPENBLAS_CACHE_DIR: $(Pipeline.Workspace)/openblas-aarch64-gnu
+    TBB_VERSION : 'v2021.10.0'
+    TBB_CACHE_DIR: $(Pipeline.Workspace)/tbb-aarch64-gnu
   pool:
     vmImage: 'ubuntu-22.04'
   steps:
@@ -104,11 +108,29 @@ jobs:
   - script: |
       .ci/scripts/describe_system.sh
     displayName: 'System info'
+  - task: Cache@2
+    inputs:
+      key: '"gcc" | "aarch64" | "openblas" | "$(OPENBLAS_VERSION)"'
+      path: $(OPENBLAS_CACHE_DIR)
+      cacheHitVar: OPENBLAS_RESTORED
   - script: |
-      .ci/scripts/build.sh --compiler gnu --optimizations sve --target daal --backend-config ref --conda-env ci-env --cross-compile --plat lnxarm
+      .ci/env/openblas.sh --target ARMV8 --host-compiler gcc --compiler aarch64-linux-gnu-gcc --cflags -march=armv8-a+sve --cross-compile --target-arch aarch64 --prefix $(OPENBLAS_CACHE_DIR) --version $(OPENBLAS_VERSION)
+    displayName: 'Build OpenBLAS'
+    condition: ne(variables.OPENBLAS_RESTORED, 'true')
+  - task: Cache@2
+    inputs:
+      key: '"gcc" | "aarch64" | "tbb" | "$(TBB_VERSION)"'
+      path: $(TBB_CACHE_DIR)
+      cacheHitVar: TBB_RESTORED
+  - script: |
+      .ci/env/tbb.sh --cross-compile --toolchain-file $(Build.Repository.LocalPath)/.ci/env/arm-gcc-crosscompile-toolchain.cmake --target-arch aarch64 --prefix $(TBB_CACHE_DIR) --version $(TBB_VERSION)
+    displayName: 'Build oneTBB'
+    condition: ne(variables.TBB_RESTORED, 'true')
+  - script: |
+      .ci/scripts/build.sh --compiler gnu --optimizations sve --target daal --backend-config ref --conda-env ci-env --cross-compile --plat lnxarm --blas-dir $(OPENBLAS_CACHE_DIR) --tbb-dir $(TBB_CACHE_DIR)
     displayName: 'make daal'
   - script: |
-      .ci/scripts/build.sh --compiler gnu --optimizations sve --target onedal_c --backend-config ref --cross-compile --plat lnxarm
+      .ci/scripts/build.sh --compiler gnu --optimizations sve --target onedal_c --backend-config ref --cross-compile --plat lnxarm --blas-dir $(OPENBLAS_CACHE_DIR) --tbb-dir $(TBB_CACHE_DIR)
     displayName: 'make onedal_c'
   - task: PublishPipelineArtifact@1
     inputs:
@@ -143,6 +165,8 @@ jobs:
   variables:
     release.dir: '__release_lnx_gnu'
     platform.type : 'lnx32e'
+    OPENBLAS_VERSION: 'v0.3.27'
+    OPENBLAS_CACHE_DIR: $(Pipeline.Workspace)/openblas-x86_64-gnu
   pool:
     vmImage: 'ubuntu-22.04'
   steps:
@@ -152,11 +176,20 @@ jobs:
   - script: |
       .ci/scripts/describe_system.sh
     displayName: 'System info'
+  - task: Cache@2
+    inputs:
+      key: '"gnu" | "x86_64" | "tbb" | "$(OPENBLAS_VERSION)"'
+      path: $(OPENBLAS_CACHE_DIR)
+      cacheHitVar: OPENBLAS_RESTORED
   - script: |
-      .ci/scripts/build.sh --compiler gnu --optimizations avx2 --target daal --backend-config ref --conda-env ci-env
+      .ci/env/openblas.sh --target-arch x86_64 --prefix $(OPENBLAS_CACHE_DIR) --version $(OPENBLAS_VERSION)
+    displayName: 'Build OpenBLAS'
+    condition: ne(variables.OPENBLAS_RESTORED, 'true')
+  - script: |
+      .ci/scripts/build.sh --compiler gnu --optimizations avx2 --target daal --backend-config ref --conda-env ci-env --blas-dir $(OPENBLAS_CACHE_DIR)
     displayName: 'make daal'
   - script: |
-      .ci/scripts/build.sh --compiler gnu --optimizations avx2 --target onedal_c --backend-config ref
+      .ci/scripts/build.sh --compiler gnu --optimizations avx2 --target onedal_c --backend-config ref --blas-dir $(OPENBLAS_CACHE_DIR)
     displayName: 'make onedal_c'
   - task: PublishPipelineArtifact@1
     inputs:

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -141,14 +141,14 @@ jobs:
   - script: |
       export QEMU_LD_PREFIX=/usr/aarch64-linux-gnu
       export QEMU_CPU="max,sve-default-vector-length=256"
-      export TBBROOT=$(Build.Repository.LocalPath)/__deps/tbb-aarch64
+      export TBBROOT=$(TBB_CACHE_DIR)
       export ARCH_ONEDAL=aarch64
       .ci/scripts/test.sh --test-kind examples --build-dir $(release.dir) --compiler gnu --interface daal/cpp --build-system cmake --platform lnxarm --cross-compile --backend ref
     displayName: 'daal/cpp examples'
   - script: |
       export QEMU_LD_PREFIX=/usr/aarch64-linux-gnu
       export QEMU_CPU="max,sve-default-vector-length=256"
-      export TBBROOT=$(Build.Repository.LocalPath)/__deps/tbb-aarch64
+      export TBBROOT=$(TBB_CACHE_DIR)
       export ARCH_ONEDAL=aarch64
       .ci/scripts/test.sh --test-kind examples --build-dir $(release.dir) --compiler gnu --interface oneapi/cpp --build-system cmake --platform lnxarm --cross-compile --backend ref
     displayName: 'oneapi/cpp examples'

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -123,7 +123,7 @@ jobs:
       path: $(TBB_CACHE_DIR)
       cacheHitVar: TBB_RESTORED
   - script: |
-      .ci/env/tbb.sh --cross-compile --toolchain-file $(Build.Repository.LocalPath)/.ci/env/arm-gcc-crosscompile-toolchain.cmake --target-arch aarch64 --prefix $(TBB_CACHE_DIR) --version $(TBB_VERSION)
+      .ci/env/tbb.sh --cross-compile --toolchain-file $(Build.Repository.LocalPath)/.ci/env/arm-gnu-crosscompile-toolchain.cmake --target-arch aarch64 --prefix $(TBB_CACHE_DIR) --version $(TBB_VERSION)
     displayName: 'Build oneTBB'
     condition: ne(variables.TBB_RESTORED, 'true')
   - script: |


### PR DESCRIPTION
# Description
In the case that a CI pipeline builds OpenBLAS or oneTBB from source, those should be cached and reused. The version of the libraries will be the same from run to run, so that we can leverage the Azure caching capability.

Changes made:
- build.sh will not try to build OpenBLAS or oneTBB in the case that explicit install paths are passed in
- OpenBLAS and oneTBB install scripts explicitly take a version string, so that we can use this as part of CI, and pass it through to the build scripts
- Use a cache task in the Arm and x86 CI builds when OpenBLAS or oneTBB is used as the backend