### PR TITLE
Update doc/readme.md to define how to create cross references

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,38 @@
 * limitations under the License.
 *******************************************************************************/-->
 
+# Authoring and Editing
+
+## Cross references (internal links)
+
+To create a cross reference from one page of this document to another page,
+ensure that an explicit target is used so that the cross reference is pointing
+to a unique identifier, rather than a heading that could be repeated somewhere
+else in the document.
+
+The syntax for explicit targets is as follows:
+
+For the target:
+
+```none
+.. _my-page:
+
+My Page of Information
+~~~~~~~~~~~~~~~~~~~~~~
+
+```
+
+
+For the cross reference:
+
+```none
+To learn more about my information, see :ref:`My Page of Information <my-page>`
+```
+
+To learn more about explicit targets, see:
+<https://docs.readthedocs.io/en/stable/guides/cross-referencing-with-sphinx.html#explicit-targets>
+
+
 # Build oneDAL documentation
 
 Our documentation is written in restructured text markup and built with [Sphinx](http://www.sphinx-doc.org/en/master/).


### PR DESCRIPTION
# Description
Instructions on how to define an explicit target for cross references so that duplicate targets are not created.

Using implicit targets (using the heading as the link you put in your cross reference) introduces the possibility of having two targets with the same name. For example, if you have a section titled "Configuration" in the introduction section, but you have another "Configuration" section in the API section, then the reference will break because the generator (Sphinx) will not know which target to point to. Explicit targets solves this problem.

Some lines you may not see a change because the only change is that a trailing space at the end of the line has been removed. This is the default in my text editor because I work with some repositories that require that no file has a trailing space.

Changes proposed in this pull request:
- add new section describing how to create an explicit target cross reference
-
-