### PR TITLE
FIX: distributed knn double sqrt bug

### DIFF
--- a/cpp/oneapi/dal/algo/knn/backend/gpu/infer_kernel_impl_dpc.hpp
+++ b/cpp/oneapi/dal/algo/knn/backend/gpu/infer_kernel_impl_dpc.hpp
@@ -289,8 +289,8 @@ protected:
 
         bk::event_vector ndeps{ deps.cbegin(), deps.cend() };
         if (this->compute_sqrt_) {
-            auto sq_event = copy_with_sqrt(this->queue_, inp_dts, inp_dts, deps);
-            ndeps.push_back(sq_event);
+            auto sqrt_event = copy_with_sqrt(this->queue_, inp_dts, inp_dts, deps);
+            ndeps.push_back(sqrt_event);
         }
 
         auto out_rps = this->responses_.get_slice(first, last);

--- a/cpp/oneapi/dal/algo/knn/backend/gpu/infer_kernel_impl_dpc.hpp
+++ b/cpp/oneapi/dal/algo/knn/backend/gpu/infer_kernel_impl_dpc.hpp
@@ -313,8 +313,8 @@ protected:
 
         bk::event_vector ndeps{ deps.cbegin(), deps.cend() };
         if (this->compute_sqrt_) {
-            auto sq_event = copy_with_sqrt(this->queue_, inp_dts, inp_dts, deps);
-            ndeps.push_back(sq_event);
+            auto sqrt_event = copy_with_sqrt(this->queue_, inp_dts, inp_dts, deps);
+            ndeps.push_back(sqrt_event);
         }
 
         auto out_rps = this->responses_.get_slice(first, last);

--- a/cpp/oneapi/dal/algo/knn/backend/gpu/infer_kernel_impl_dpc.hpp
+++ b/cpp/oneapi/dal/algo/knn/backend/gpu/infer_kernel_impl_dpc.hpp
@@ -286,12 +286,12 @@ protected:
 
         const auto& [first, last] = bnds;
         ONEDAL_ASSERT(last > first);
-        auto& queue = this->queue_;
 
         bk::event_vector ndeps{ deps.cbegin(), deps.cend() };
-        auto sq_event = copy_with_sqrt(queue, inp_dts, inp_dts, deps);
-        if (this->compute_sqrt_)
+        if (this->compute_sqrt_) {
+            auto sq_event = copy_with_sqrt(this->queue_, inp_dts, inp_dts, deps);
             ndeps.push_back(sq_event);
+        }
 
         auto out_rps = this->responses_.get_slice(first, last);
         ONEDAL_ASSERT((last - first) == out_rps.get_count());
@@ -310,12 +310,12 @@ protected:
 
         const auto& [first, last] = bnds;
         ONEDAL_ASSERT(last > first);
-        auto& queue = this->queue_;
 
         bk::event_vector ndeps{ deps.cbegin(), deps.cend() };
-        auto sq_event = copy_with_sqrt(queue, inp_dts, inp_dts, deps);
-        if (this->compute_sqrt_)
+        if (this->compute_sqrt_) {
+            auto sq_event = copy_with_sqrt(this->queue_, inp_dts, inp_dts, deps);
             ndeps.push_back(sq_event);
+        }
 
         auto out_rps = this->responses_.get_slice(first, last);
         ONEDAL_ASSERT((last - first) == out_rps.get_count());

--- a/cpp/oneapi/dal/algo/knn/backend/gpu/infer_kernel_impl_dpc_distr.hpp
+++ b/cpp/oneapi/dal/algo/knn/backend/gpu/infer_kernel_impl_dpc_distr.hpp
@@ -277,15 +277,10 @@ public:
                                                 min_indc_dest,
                                                 { select_resp_event });
         if (last_iteration_) {
-            sycl::event copy_sqrt_event;
-            if (this->compute_sqrt_) {
-                copy_sqrt_event =
-                    copy_with_sqrt(queue_, min_dist_dest, min_dist_dest, { select_indc_event });
-            }
             auto final_event = this->output_responses(bounds,
                                                       indices_,
                                                       distances_,
-                                                      { select_indc_event, copy_sqrt_event });
+                                                      { select_indc_event });
             return final_event;
         }
         return select_indc_event;


### PR DESCRIPTION
# Description
Removes unnecessary duplicate sqrt of distances
This fixes issues identified during mpi-pytest integration in sklearnex