### PR TITLE
Workaround to sparse primitives failures in private CI

### DIFF
--- a/cpp/oneapi/dal/backend/primitives/sparse_blas/test/gemm_dpc.cpp
+++ b/cpp/oneapi/dal/backend/primitives/sparse_blas/test/gemm_dpc.cpp
@@ -32,7 +32,8 @@ TEMPLATE_LIST_TEST_M(sparse_blas_test, "ones matrix sparse CSR gemm", "[csr][gem
     SKIP_IF(this->get_policy().is_cpu());
 
     // Test takes too long time if HW emulates float64
-    SKIP_IF(this->not_float64_friendly());
+    // Temporary workaround: skip tests on architectures that do not support native float64
+    SKIP_IF(!this->get_policy().has_native_float64());
 
     this->generate_dimensions();
     this->test_gemm();

--- a/cpp/oneapi/dal/backend/primitives/sparse_blas/test/gemv_dpc.cpp
+++ b/cpp/oneapi/dal/backend/primitives/sparse_blas/test/gemv_dpc.cpp
@@ -31,7 +31,8 @@ TEMPLATE_LIST_TEST_M(sparse_blas_test, "ones matrix sparse CSR gemv", "[csr][gem
     SKIP_IF(this->get_policy().is_cpu());
 
     // Test takes too long time if HW emulates float64
-    SKIP_IF(this->not_float64_friendly());
+    // Temporary workaround: skip tests on architectures that do not support native float64
+    SKIP_IF(!this->get_policy().has_native_float64());
 
     this->generate_dimensions_gemv();
     this->test_gemv();


### PR DESCRIPTION
Sparse SYCL primitives testing disabled on the architectures that do not have native float64