### PR TITLE
CI fixes in OpenBLAS builds

### DIFF
--- a/.ci/env/apt.sh
+++ b/.ci/env/apt.sh
@@ -63,10 +63,12 @@ function install_qemu_emulation_apt {
 }
 
 function install_qemu_emulation_deb {
-    qemu_deb=qemu-user-static_8.2.2+ds-2+b1_amd64.deb
-    wget http://ftp.de.debian.org/debian/pool/main/q/qemu/${qemu_deb}
+    qemu_deb=qemu-user-static_8.2.3+ds-2_amd64.deb
+    set -eo pipefail
+    wget http://ftp.debian.org/debian/pool/main/q/qemu/${qemu_deb}
     sudo dpkg -i ${qemu_deb}
     sudo systemctl restart systemd-binfmt.service
+    set +eo pipefail
 }
 
 function install_llvm_version {

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -363,7 +363,7 @@ jobs:
     displayName: 'System info'
   - task: Cache@2
     inputs:
-      key: '"gnu" | "x86_64" | "openblas" | "$(OPENBLAS_VERSION)" | "$(VM_IMAGE)"'
+      key: '"gcc" | "x86_64" | "openblas" | "$(OPENBLAS_VERSION)" | "$(VM_IMAGE)"'
       path: $(OPENBLAS_CACHE_DIR)
       cacheHitVar: OPENBLAS_RESTORED
   - script: |


### PR DESCRIPTION
# Description
The riscv64 and x86_64 OpenBLAS builds have been failing. For the riscv64 build, the location of the qemu debian package changed. We update the URL to obtain, as well as making sure that failing to obtain the right QEMU will cause an error in CI.

For the x86_64 build, illegal instructions are being reported, which I can't reproduce locally. My intuition is that there is something wrong with the cached build, so we update the key for the build. The naming in the key now matches that of the aarch64 and riscv64 builds.


Changes proposed in this pull request:
- Error in CI if QEMU is not installed properly
- Update the QEMU debian package to download for riscv64
- Update the key in the cache for x86_64 OpenBLAS builds