### PR TITLE
[CI] add repository check to openssf-scorecard github action

### DIFF
--- a/.github/workflows/openssf-scorecard.yml
+++ b/.github/workflows/openssf-scorecard.yml
@@ -16,6 +16,7 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecard analysis
+    if: github.repository == 'oneapi-src/oneDAL'
     runs-on: ubuntu-latest
     permissions:
       # Needed to upload the results to code-scanning dashboard.


### PR DESCRIPTION
# Description
A new github action with a cron job was added to oneDAL (via #2753). As it is currently setup, this will run for all forks every friday at 9PM UTC.  To prevent this, a repository check will be added, and the step will be skipped for everything but the onedal-src/oneDAL repository. This matches changes made to the [docker validation nightly](https://github.com/oneapi-src/oneDAL/blob/main/.github/workflows/docker-validation-nightly.yml#L29)

Changes proposed in this pull request:
- Add repository check to openssf-scorecard github action