### PR TITLE
Bugfix in getIndexNumType function

### DIFF
--- a/cpp/daal/include/data_management/features/internal/helpers.h
+++ b/cpp/daal/include/data_management/features/internal/helpers.h
@@ -1,6 +1,7 @@
 /* file: helpers.h */
 /*******************************************************************************
 * Copyright 2014 Intel Corporation
+* Copyright contributors to the oneDAL project
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -225,7 +226,7 @@ inline IndexNumType getIndexNumType<unsigned long>()
 }
 #endif
 
-#if !(defined(_WIN32) || defined(_WIN64)) && defined(__x86_64__)
+#if !(defined(_WIN32) || defined(_WIN64)) && (defined(__x86_64__) || defined(TARGET_ARM) || defined(TARGET_RISCV64))
 template <>
 inline IndexNumType getIndexNumType<size_t>()
 {

--- a/examples/daal/cpp/target_excludes.cmake
+++ b/examples/daal/cpp/target_excludes.cmake
@@ -42,30 +42,16 @@ elseif((CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64") AND
        (CMAKE_C_COMPILER MATCHES "gcc"))
     set(EXCLUDE_LIST
         ${EXCLUDE_LIST}
-        "assoc_rules_apriori_batch"
-        "cd_dense_batch"
         "cholesky_dense_batch"
         "cor_csr_distr"
         "cor_csr_online"
-        "cor_dense_distr"
-        "cor_dense_online"
         "cov_csr_distr"
         "cov_csr_online"
-        "cov_dense_distr"
-        "cov_dense_online"
-        "elastic_net_dense_batch"
         "enable_thread_pinning"
-        "lasso_reg_dense_batch"
         "lin_reg_metrics_dense_batch"
         "lin_reg_qr_dense_batch"
         "lin_reg_qr_dense_online"
-        "low_order_moms_csr_distr"
-        "low_order_moms_csr_online"
-        "low_order_moms_dense_distr"
-        "low_order_moms_dense_online"
         "out_detect_mult_dense_batch"
-        "pca_metrics_dense_batch"
-        "pivoted_qr_dense_batch"
     )
 elseif((CMAKE_SYSTEM_PROCESSOR STREQUAL "riscv64") AND
        (CMAKE_C_COMPILER MATCHES "clang"))


### PR DESCRIPTION
# Description
`daal::data_management::features::internal::getIndexNumType<unsigned long>` is used by other functions that perform type conversions. This function was disabled for non x86_64 devices (when `__x86_64__`  is not defined). This PR modifies adds more conditions in the macro to enable this for aarch64 and riscv64.

This change fixes the following examples that were failing on aarch64, when tested on Graviton3 (openblas,+gcc  build).
1. assoc_rules_apriori_batch
2. cd_dense_batch
3. cor_dense_distr
4. cor_dense_online
5. cov_dense_distr
6. cov_dense_online
7. elastic_net_dense_batch
8. lasso_reg_dense_batch
9. low_order_moms_csr_distr
10. low_order_moms_csr_online
11. low_order_moms_dense_distr
12. low_order_moms_dense_online
13. pivoted_qr_dense_batch