### PR TITLE
slack notification when PR is labelled RFC

### DIFF
--- a/.github/workflows/slack-pr-notification.yml
+++ b/.github/workflows/slack-pr-notification.yml
@@ -19,7 +19,7 @@ jobs:
     if: |
       github.event.action == 'labeled' &&
       contains(toJson(github.event.pull_request.labels.*.name), '"RFC"')
-    steps: 
+    steps:
     - name: Notify Slack
       uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
       with:

--- a/.github/workflows/slack-pr.yaml
+++ b/.github/workflows/slack-pr.yaml
@@ -1,0 +1,27 @@
+name: Slack PR Notification
+on:
+  # use pull_request_target to run on PRs from forks and have access to secrets
+  pull_request_target:
+    types: [labeled]
+
+env:
+  SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+  channel: "onedal"
+
+permissions:
+  pull-requests: read
+
+jobs:
+  rfc:
+    name: RFC Notification
+    runs-on: ubuntu-latest
+    # Trigger when labeling a PR with "RFC"
+    if: |
+      github.event.action == 'labeled' &&
+      contains(toJson(github.event.pull_request.labels.*.name), '"RFC"')
+    steps: 
+    - name: Notify Slack
+      uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
+      with:
+        channel-id: ${{ env.channel }}
+        slack-message: "${{ github.actor }} posted a RFC: ${{ github.event.pull_request.title }}. URL: ${{ github.event.pull_request.html_url }}"


### PR DESCRIPTION
# Description

Publish a notification to the onedal channel in the UXL slack space when a PR is labeled RFC. To see a sample, look at rc-test channel. They are some test messages for onednn for the same workflow. This is the same workflow as https://github.com/oneapi-src/oneDNN/pull/1900. Only the channel name and license has changed.

To enable the notification, someone with admin privileges must add a secret called SLACK_BOT_TOKEN to the repo. I can provide the value of the token in a DM. After the secret is added and this PR is merged, then new PR's with the RFC label will trigger the notification.

Addresses part of https://github.com/orgs/uxlfoundation/projects/5?pane=issue&itemId=57348837

@vbm32 @napetrov 

