### PR TITLE
Fix usage of sequential execution branches

### DIFF
--- a/cpp/daal/BUILD
+++ b/cpp/daal/BUILD
@@ -143,7 +143,6 @@ daal_module(
     name = "threading_tbb",
     srcs = glob(["src/threading/**/*.cpp"]),
     local_defines = [
-        "__DO_TBB_LAYER__",
         "__TBB_NO_IMPLICIT_LINKAGE",
         "__TBB_LEGACY_MODE",
         "TBB_SUPPRESS_DEPRECATED_MESSAGES",

--- a/cpp/daal/src/algorithms/linear_model/linear_model_train_normeq_merge_impl.i
+++ b/cpp/daal/src/algorithms/linear_model/linear_model_train_normeq_merge_impl.i
@@ -43,22 +43,6 @@ using namespace daal::data_management;
 using namespace daal::internal;
 using namespace daal::services::internal;
 
-template <CpuType cpu, typename F>
-void conditional_threader_for(bool condition, size_t n, size_t threadsRequest, const F & processIteration)
-{
-    if (condition)
-    {
-        daal::threader_for(n, threadsRequest, processIteration);
-    }
-    else
-    {
-        for (size_t i = 0; i < n; i++)
-        {
-            processIteration(i);
-        }
-    }
-}
-
 template <typename algorithmFPType, CpuType cpu>
 Status MergeKernel<algorithmFPType, cpu>::merge(const NumericTable & partialTable, algorithmFPType * result, bool threadingCondition)
 {
@@ -69,7 +53,7 @@ Status MergeKernel<algorithmFPType, cpu>::merge(const NumericTable & partialTabl
     algorithmFPType * partialResult = const_cast<algorithmFPType *>(block.get());
 
     size_t resultSize = nRows * partialTable.getNumberOfColumns();
-    conditional_threader_for<cpu>(threadingCondition, resultSize, resultSize, [=](size_t i) { result[i] += partialResult[i]; });
+    daal::conditional_threader_for(threadingCondition, resultSize, [=](size_t i) { result[i] += partialResult[i]; });
     return Status();
 }
 

--- a/cpp/daal/src/threading/service_thread_pinner.cpp
+++ b/cpp/daal/src/threading/service_thread_pinner.cpp
@@ -27,39 +27,37 @@
     #include "services/daal_memory.h"
     #include "src/threading/threading.h"
 
-    #if defined(__DO_TBB_LAYER__)
+    #define USE_TASK_ARENA_CURRENT_SLOT 1
+    #define LOG_PINNING                 1
+    #define TBB_PREVIEW_TASK_ARENA      1
+    #define TBB_PREVIEW_LOCAL_OBSERVER  1
 
-        #define USE_TASK_ARENA_CURRENT_SLOT 1
-        #define LOG_PINNING                 1
-        #define TBB_PREVIEW_TASK_ARENA      1
-        #define TBB_PREVIEW_LOCAL_OBSERVER  1
-
-        #include "tbb/tbb.h"
-        #include <tbb/task_arena.h>
-        #include <tbb/task_scheduler_observer.h>
-        #include <tbb/parallel_reduce.h>
-        #include <tbb/blocked_range.h>
-        #include <tbb/tick_count.h>
-        #include <tbb/scalable_allocator.h>
-        #include "services/daal_atomic_int.h"
+    #include "tbb/tbb.h"
+    #include <tbb/task_arena.h>
+    #include <tbb/task_scheduler_observer.h>
+    #include <tbb/parallel_reduce.h>
+    #include <tbb/blocked_range.h>
+    #include <tbb/tick_count.h>
+    #include <tbb/scalable_allocator.h>
+    #include "services/daal_atomic_int.h"
 using namespace daal::services;
 
-        #if defined(_WIN32) || defined(_WIN64)
-            #include <Windows.h>
-            #define __PINNER_WINDOWS__
+    #if defined(_WIN32) || defined(_WIN64)
+        #include <Windows.h>
+        #define __PINNER_WINDOWS__
 
-            #if defined(_WIN64)
-                #define MASK_WIDTH 64
-            #else
-                #define MASK_WIDTH 32
-            #endif
+        #if defined(_WIN64)
+            #define MASK_WIDTH 64
+        #else
+            #define MASK_WIDTH 32
+        #endif
 
-        #else // LINUX
-            #include <sched.h>
-            #define __PINNER_LINUX__
+    #else // LINUX
+        #include <sched.h>
+        #define __PINNER_LINUX__
 
-            #ifdef __FreeBSD__
-                #include <pthread_np.h>
+        #ifdef __FreeBSD__
+            #include <pthread_np.h>
 
 cpu_set_t * __sched_cpualloc(size_t count)
 {
@@ -73,25 +71,25 @@ int sched_getaffinity(pid_t pid, size_t cpusetsize, cpu_set_t * mask)
 {
     return cpuset_getaffinity(CPU_LEVEL_WHICH, CPU_WHICH_PID, pid == 0 ? -1 : pid, cpusetsize, mask);
 }
-            #endif
-
         #endif
+
+    #endif
 
 struct cpu_mask_t
 {
     int status;
-        #if defined(_WIN32) || defined(_WIN64)
+    #if defined(_WIN32) || defined(_WIN64)
     GROUP_AFFINITY ga;
-        #else
+    #else
     int ncpus;
     int bit_parts_size;
     cpu_set_t * cpu_set;
-        #endif
+    #endif
     cpu_mask_t()
     {
         status = 0;
 
-        #if defined __PINNER_LINUX__
+    #if defined __PINNER_LINUX__
 
         ncpus          = 0;
         bit_parts_size = 0;
@@ -113,10 +111,10 @@ struct cpu_mask_t
         }
 
         if (cpu_set == NULL)
-        #else // defined __PINNER_WINDOWS__
+    #else // defined __PINNER_WINDOWS__
         bool retval = GetThreadGroupAffinity(GetCurrentThread(), &ga);
         if (!retval)
-        #endif
+    #endif
         {
             status--;
         }
@@ -128,13 +126,13 @@ struct cpu_mask_t
     {
         if (status == 0)
         {
-        #if defined __PINNER_LINUX__
+    #if defined __PINNER_LINUX__
             int err = pthread_getaffinity_np(pthread_self(), bit_parts_size, cpu_set);
             if (err)
-        #else // defined __PINNER_WINDOWS__
+    #else // defined __PINNER_WINDOWS__
             bool retval = GetThreadGroupAffinity(GetCurrentThread(), &ga);
             if (!retval)
-        #endif
+    #endif
             {
                 status--;
             }
@@ -147,15 +145,15 @@ struct cpu_mask_t
     {
         if (status == 0)
         {
-        #if defined __PINNER_LINUX__
+    #if defined __PINNER_LINUX__
 
             int err = pthread_setaffinity_np(pthread_self(), bit_parts_size, cpu_set);
             if (err)
-        #else // defined __PINNER_WINDOWS__
+    #else // defined __PINNER_WINDOWS__
 
             bool retval = SetThreadGroupAffinity(GetCurrentThread(), &ga, NULL);
             if (!retval)
-        #endif
+    #endif
             {
                 status--;
             }
@@ -168,13 +166,13 @@ struct cpu_mask_t
     {
         if (status == 0)
         {
-        #if defined __PINNER_LINUX__
+    #if defined __PINNER_LINUX__
             CPU_ZERO_S(bit_parts_size, cpu_set);
             CPU_SET_S(cpu_idx, bit_parts_size, cpu_set);
-        #else // defined __PINNER_WINDOWS__
+    #else // defined __PINNER_WINDOWS__
             ga.Group = cpu_idx / MASK_WIDTH;
             ga.Mask  = cpu_idx % MASK_WIDTH;
-        #endif
+    #endif
         }
 
         return status;
@@ -184,12 +182,12 @@ struct cpu_mask_t
 
     ~cpu_mask_t()
     {
-        #if defined __PINNER_LINUX__
+    #if defined __PINNER_LINUX__
         if (cpu_set != NULL)
         {
             CPU_FREE(cpu_set);
         }
-        #endif
+    #endif
 
         return;
     } // ~cpu_mask_t()
@@ -387,35 +385,5 @@ DAAL_EXPORT void _thread_pinner_on_scheduler_exit(bool p)
 {
     IMPL->on_scheduler_exit(p);
 }
-
-    #else /* if __DO_TBB_LAYER__ is not defined */
-
-DAAL_EXPORT void * _getThreadPinner(bool create_pinner, void (*read_topo)(int &, int &, int &, int **), void (*deleter)(void *))
-{
-    return NULL;
-}
-
-DAAL_EXPORT void _thread_pinner_thread_pinner_init(void (*f)(int &, int &, int &, int **), void (*deleter)(void *)) {}
-DAAL_EXPORT void _thread_pinner_execute(daal::services::internal::thread_pinner_task_t & task)
-{
-    task();
-}
-DAAL_EXPORT bool _thread_pinner_get_pinning()
-{
-    return false;
-}
-DAAL_EXPORT bool _thread_pinner_set_pinning(bool p)
-{
-    return true;
-}
-DAAL_EXPORT int _thread_pinner_get_status()
-{
-    return 0;
-}
-
-DAAL_EXPORT void _thread_pinner_on_scheduler_entry(bool p) {}
-DAAL_EXPORT void _thread_pinner_on_scheduler_exit(bool p) {}
-
-    #endif /* if __DO_TBB_LAYER__ is not defined */
 
 #endif /* #if !defined (DAAL_THREAD_PINNING_DISABLED) */

--- a/cpp/daal/src/threading/threading.cpp
+++ b/cpp/daal/src/threading/threading.cpp
@@ -399,7 +399,8 @@ DAAL_EXPORT void _daal_parallel_reduce_tls(void * tlsPtr, void * a, daal::tls_re
     size_t n                                    = 0;
     tbb::enumerable_thread_specific<void *> * p = static_cast<tbb::enumerable_thread_specific<void *> *>(tlsPtr);
 
-    for (auto it = p->begin(); it != p->end(); ++it, ++n);
+    for (auto it = p->begin(); it != p->end(); ++it, ++n)
+        ;
     if (n)
     {
         typedef void * mptr;

--- a/makefile
+++ b/makefile
@@ -489,7 +489,6 @@ $(CORE.objs_a): COPT += -D__TBB_NO_IMPLICIT_LINKAGE -DDAAL_NOTHROW_EXCEPTIONS \
                         -DDAAL_HIDE_DEPRECATED -DTBB_USE_ASSERT=0 -D_ENABLE_ATOMIC_ALIGNMENT_FIX \
                         $(if $(CHECK_DLL_SIG),-DDAAL_CHECK_DLL_SIG)
 $(CORE.objs_a): COPT += @$(CORE.tmpdir_a)/inc_a_folders.txt
-$(filter %threading.$o, $(CORE.objs_a)): COPT += -D__DO_TBB_LAYER__
 
 $(eval $(call append_uarch_copt,$(CORE.objs_a)))
 
@@ -500,7 +499,6 @@ $(CORE.objs_y): COPT += -D__DAAL_IMPLEMENTATION \
                         -DDAAL_HIDE_DEPRECATED -DTBB_USE_ASSERT=0 -D_ENABLE_ATOMIC_ALIGNMENT_FIX \
                         $(if $(CHECK_DLL_SIG),-DDAAL_CHECK_DLL_SIG)
 $(CORE.objs_y): COPT += @$(CORE.tmpdir_y)/inc_y_folders.txt
-$(filter %threading.$o, $(CORE.objs_y)): COPT += -D__DO_TBB_LAYER__
 
 $(eval $(call append_uarch_copt,$(CORE.objs_y)))
 
@@ -842,7 +840,6 @@ THR_TBB.objs := $(THR_TBB.objs_a) $(THR_TBB.objs_y)
 THR.objs := $(THR.objs_a) $(THR.objs_y)
 
 $(THR.objs): COPT += $(-fPIC) $(-cxx11) $(-Zl) $(-DEBC) -DDAAL_HIDE_DEPRECATED -DTBB_USE_ASSERT=0 -D_ENABLE_ATOMIC_ALIGNMENT_FIX
-$(THR_TBB.objs): COPT += -D__DO_TBB_LAYER__
 
 $(THR.objs_a): $(THR.tmpdir_a)/thr_inc_a_folders.txt
 $(THR.objs_a): COPT += @$(THR.tmpdir_a)/thr_inc_a_folders.txt


### PR DESCRIPTION
Changes:
- Remove `__DO_TBB_LAYER__` and `__DO_SEQ_LAYER__` usage
- Use part of sequential branches for running with 1 thread to avoid TBB overheads