### PR TITLE
fix: adding tbb_schedule_handler 

### DIFF
--- a/cpp/daal/include/services/env_detect.h
+++ b/cpp/daal/include/services/env_detect.h
@@ -86,13 +86,6 @@ public:
     static Environment * getInstance();
 
     /**
-     *  Decreases the instance counter
-     *  \return The return code
-     *  \DAAL_DEPRECATED
-     */
-    DAAL_DEPRECATED static int freeInstance();
-
-    /**
      *  <a name="DAAL-ENUM-SERVICES__CPUTYPEENABLE"></a>
      *  \brief CPU types
      *  \DAAL_DEPRECATED
@@ -187,7 +180,7 @@ private:
     Environment(const Environment & e);
     Environment & operator=(const Environment &);
     ~Environment();
-
+    static Environment * _instance;
     void _cpu_detect(int);
     void initNumberOfThreads();
 

--- a/cpp/daal/include/services/env_detect.h
+++ b/cpp/daal/include/services/env_detect.h
@@ -142,12 +142,6 @@ public:
     };
 
     /**
-     *  Sets the threading mode on Windows*
-     *  \param[in] type  The threading mode of the library
-     */
-    void setDynamicLibraryThreadingTypeOnWindows(LibraryThreadingType type);
-
-    /**
      *  Sets the number of threads to use
      *  \param[in] numThreads   The number of threads
      */
@@ -196,8 +190,14 @@ private:
 
     void _cpu_detect(int);
     void initNumberOfThreads();
-
+    void initSchedulerHandle();
+    void releaseSchedulerHandle();
+    void releaseGlobalControl();
     env _env;
+    // Pointer to the oneapi::tbb::task_scheduler_handle class object, global for oneDAL.
+    // The oneapi::tbb::task_scheduler_handle and the oneapi::tbb::finalize function
+    // allow user to wait for completion of worker threads.
+    void * _schedulerHandle;
     void * _globalControl;
     SharedPtr<services::internal::sycl::ExecutionContextIface> _executionContext;
 };

--- a/cpp/daal/include/services/env_detect.h
+++ b/cpp/daal/include/services/env_detect.h
@@ -192,6 +192,7 @@ private:
     void initNumberOfThreads();
 
     env _env;
+    void * _schedulerHandle;
     void * _globalControl;
     SharedPtr<services::internal::sycl::ExecutionContextIface> _executionContext;
 };

--- a/cpp/daal/include/services/env_detect.h
+++ b/cpp/daal/include/services/env_detect.h
@@ -190,11 +190,8 @@ private:
 
     void _cpu_detect(int);
     void initNumberOfThreads();
-    void initSchedulerHandle();
-    void releaseSchedulerHandle();
-    void releaseGlobalControl();
-    env _env;
 
+    env _env;
     void * _globalControl;
     SharedPtr<services::internal::sycl::ExecutionContextIface> _executionContext;
 };

--- a/cpp/daal/include/services/env_detect.h
+++ b/cpp/daal/include/services/env_detect.h
@@ -197,8 +197,8 @@ private:
     // Pointer to the oneapi::tbb::task_scheduler_handle class object, global for oneDAL.
     // The oneapi::tbb::task_scheduler_handle and the oneapi::tbb::finalize function
     // allow user to wait for completion of worker threads.
-    void * _schedulerHandle;
-    void * _globalControl;
+    static void * _schedulerHandle;
+    static void * _globalControl;
     SharedPtr<services::internal::sycl::ExecutionContextIface> _executionContext;
 };
 } // namespace interface1

--- a/cpp/daal/include/services/env_detect.h
+++ b/cpp/daal/include/services/env_detect.h
@@ -28,7 +28,7 @@
 #include "services/base.h"
 #include "services/daal_defines.h"
 #include "services/internal/execution_context.h"
-#include <mutex>
+
 namespace daal
 {
 /**
@@ -180,7 +180,7 @@ private:
     Environment(const Environment & e);
     Environment & operator=(const Environment &);
     ~Environment();
-    static std::mutex _mutex;
+
     static Environment * _instance;
     void _cpu_detect(int);
     void initNumberOfThreads();

--- a/cpp/daal/include/services/env_detect.h
+++ b/cpp/daal/include/services/env_detect.h
@@ -194,11 +194,8 @@ private:
     void releaseSchedulerHandle();
     void releaseGlobalControl();
     env _env;
-    // Pointer to the oneapi::tbb::task_scheduler_handle class object, global for oneDAL.
-    // The oneapi::tbb::task_scheduler_handle and the oneapi::tbb::finalize function
-    // allow user to wait for completion of worker threads.
-    static void * _schedulerHandle;
-    static void * _globalControl;
+
+    void * _globalControl;
     SharedPtr<services::internal::sycl::ExecutionContextIface> _executionContext;
 };
 } // namespace interface1

--- a/cpp/daal/include/services/env_detect.h
+++ b/cpp/daal/include/services/env_detect.h
@@ -29,6 +29,8 @@
 #include "services/daal_defines.h"
 #include "services/internal/execution_context.h"
 
+#include <mutex>
+
 namespace daal
 {
 /**
@@ -182,6 +184,7 @@ private:
     ~Environment();
 
     static Environment * _instance;
+    static std::mutex _mutex;
     void _cpu_detect(int);
     void initNumberOfThreads();
 

--- a/cpp/daal/include/services/env_detect.h
+++ b/cpp/daal/include/services/env_detect.h
@@ -28,7 +28,7 @@
 #include "services/base.h"
 #include "services/daal_defines.h"
 #include "services/internal/execution_context.h"
-
+#include <mutex>
 namespace daal
 {
 /**
@@ -180,6 +180,7 @@ private:
     Environment(const Environment & e);
     Environment & operator=(const Environment &);
     ~Environment();
+    static std::mutex _mutex;
     static Environment * _instance;
     void _cpu_detect(int);
     void initNumberOfThreads();

--- a/cpp/daal/src/externals/core_threading_win_dll.cpp
+++ b/cpp/daal/src/externals/core_threading_win_dll.cpp
@@ -25,7 +25,7 @@
 #include "src/threading/threading.h"
 #include "src/threading/service_thread_pinner.h"
 #include "services/env_detect.h"
-
+#include <iostream>
 static HMODULE daal_thr_dll_handle = NULL;
 daal::services::Environment::LibraryThreadingType __daal_serv_get_thr_set();
 

--- a/cpp/daal/src/externals/core_threading_win_dll.cpp
+++ b/cpp/daal/src/externals/core_threading_win_dll.cpp
@@ -143,6 +143,8 @@ typedef void (*_daal_wait_task_group_t)(void * taskGroupPtr);
 
 typedef bool (*_daal_is_in_parallel_t)();
 typedef void (*_daal_tbb_task_scheduler_free_t)(void *& globalControl);
+typedef void (*_daal_tbb_task_scheduler_handle_free_t)(void *& schedulerHandle);
+typedef void (*_initializeSchedulerHandle_t)(void **);
 typedef size_t (*_setNumberOfThreads_t)(const size_t, void **);
 typedef void * (*_daal_threader_env_t)();
 
@@ -205,10 +207,12 @@ static _daal_del_task_group_t _daal_del_task_group_ptr   = NULL;
 static _daal_run_task_group_t _daal_run_task_group_ptr   = NULL;
 static _daal_wait_task_group_t _daal_wait_task_group_ptr = NULL;
 
-static _daal_is_in_parallel_t _daal_is_in_parallel_ptr                   = NULL;
-static _daal_tbb_task_scheduler_free_t _daal_tbb_task_scheduler_free_ptr = NULL;
-static _setNumberOfThreads_t _setNumberOfThreads_ptr                     = NULL;
-static _daal_threader_env_t _daal_threader_env_ptr                       = NULL;
+static _daal_is_in_parallel_t _daal_is_in_parallel_ptr                                 = NULL;
+static _daal_tbb_task_scheduler_free_t _daal_tbb_task_scheduler_free_ptr               = NULL;
+static _daal_tbb_task_scheduler_handle_free_t _daal_tbb_task_scheduler_handle_free_ptr = NULL;
+static _initializeSchedulerHandle_t _initializeSchedulerHandle_ptr                     = NULL;
+static _setNumberOfThreads_t _setNumberOfThreads_ptr                                   = NULL;
+static _daal_threader_env_t _daal_threader_env_ptr                                     = NULL;
 
 static _daal_parallel_sort_int32_t _daal_parallel_sort_int32_ptr                         = NULL;
 static _daal_parallel_sort_uint64_t _daal_parallel_sort_uint64_ptr                       = NULL;
@@ -640,6 +644,7 @@ DAAL_EXPORT void _daal_tbb_task_scheduler_free(void *& init)
 {
     if (init == NULL)
     {
+        std::cout << "empty _daal_tbb_task_scheduler_free" << std::endl;
         // If threading library was not opened, there is nothing to free,
         // so we do not need to load threading library.
         // Moreover, loading threading library in the Environment destructor
@@ -649,12 +654,57 @@ DAAL_EXPORT void _daal_tbb_task_scheduler_free(void *& init)
         return;
     }
 
+    std::cout << "NO empty _daal_tbb_global control_free" << std::endl;
     load_daal_thr_dll();
+    std::cout << "NO empty _daal_tbb_global control_free1" << std::endl;
     if (_daal_tbb_task_scheduler_free_ptr == NULL)
     {
+        std::cout << "NO empty _daal_tbb_global control_free2" << std::endl;
         _daal_tbb_task_scheduler_free_ptr = (_daal_tbb_task_scheduler_free_t)load_daal_thr_func("_daal_tbb_task_scheduler_free");
     }
+    std::cout << "NO empty _daal_tbb_global control_free3" << std::endl;
     return _daal_tbb_task_scheduler_free_ptr(init);
+}
+
+DAAL_EXPORT void _daal_tbb_task_scheduler_handle_free(void *& init)
+{
+    if (init == NULL)
+    {
+        std::cout << "empty _daal_tbb_task_scheduler_handle_free" << std::endl;
+        // If threading library was not opened, there is nothing to free,
+        // so we do not need to load threading library.
+        // Moreover, loading threading library in the Environment destructor
+        // results in a crush because of the use of Wintrust library after it was unloaded.
+        // This happens due to undefined order of static objects deinitialization
+        // like Environment, and dependent libraries.
+        return;
+    }
+
+    std::cout << "NO empty _daal_tbb_handle" << std::endl;
+    load_daal_thr_dll();
+    std::cout << "NO empty _daal_tbb_global _daal_tbb_handle1" << std::endl;
+    if (_daal_tbb_task_scheduler_handle_free_ptr == NULL)
+    {
+        std::cout << "NO empty _daal_tbb_global _daal_tbb_handle2" << std::endl;
+        _daal_tbb_task_scheduler_handle_free_ptr =
+            (_daal_tbb_task_scheduler_handle_free_t)load_daal_thr_func("_daal_tbb_task_scheduler_handle_free_ptr");
+    }
+    std::cout << "NO empty _daal_tbb_global _daal_tbb_handle 3" << std::endl;
+    return _daal_tbb_task_scheduler_handle_free_ptr(init);
+}
+
+DAAL_EXPORT void _initializeSchedulerHandle(void *& init)
+{
+    std::cout << "NO empty _daal_tbb_task_scheduler_handle_free0" << std::endl;
+    load_daal_thr_dll();
+    std::cout << "NO empty _daal_tbb_task_scheduler_handle_free1" << std::endl;
+    if (_initializeSchedulerHandle_ptr == NULL)
+    {
+        std::cout << "NO empty _daal_tbb_task_scheduler_handle_free2" << std::endl;
+        _initializeSchedulerHandle_ptr = (_initializeSchedulerHandle_t)load_daal_thr_func("_initializeSchedulerHandle");
+    }
+    std::cout << "NO empty _daal_tbb_task_scheduler_handle_free3" << std::endl;
+    return _initializeSchedulerHandle_ptr(init);
 }
 
 DAAL_EXPORT size_t _setNumberOfThreads(const size_t numThreads, void ** init)

--- a/cpp/daal/src/externals/core_threading_win_dll.cpp
+++ b/cpp/daal/src/externals/core_threading_win_dll.cpp
@@ -144,6 +144,7 @@ typedef void (*_daal_wait_task_group_t)(void * taskGroupPtr);
 typedef bool (*_daal_is_in_parallel_t)();
 typedef void (*_daal_tbb_task_scheduler_free_t)(void *& globalControl);
 typedef void (*_daal_tbb_task_scheduler_handle_free_t)(void *& schedulerHandle);
+typedef void (*_daal_tbb_task_scheduler_handle_finalize_t)(void *& schedulerHandle);
 typedef size_t (*_setNumberOfThreads_t)(const size_t, void **);
 typedef void * (*_daal_threader_env_t)();
 
@@ -206,11 +207,12 @@ static _daal_del_task_group_t _daal_del_task_group_ptr   = NULL;
 static _daal_run_task_group_t _daal_run_task_group_ptr   = NULL;
 static _daal_wait_task_group_t _daal_wait_task_group_ptr = NULL;
 
-static _daal_is_in_parallel_t _daal_is_in_parallel_ptr                                 = NULL;
-static _daal_tbb_task_scheduler_free_t _daal_tbb_task_scheduler_free_ptr               = NULL;
-static _daal_tbb_task_scheduler_handle_free_t _daal_tbb_task_scheduler_handle_free_ptr = NULL;
-static _setNumberOfThreads_t _setNumberOfThreads_ptr                                   = NULL;
-static _daal_threader_env_t _daal_threader_env_ptr                                     = NULL;
+static _daal_is_in_parallel_t _daal_is_in_parallel_ptr                                         = NULL;
+static _daal_tbb_task_scheduler_free_t _daal_tbb_task_scheduler_free_ptr                       = NULL;
+static _daal_tbb_task_scheduler_handle_free_t _daal_tbb_task_scheduler_handle_free_ptr         = NULL;
+static _daal_tbb_task_scheduler_handle_finalize_t _daal_tbb_task_scheduler_handle_finalize_ptr = NULL;
+static _setNumberOfThreads_t _setNumberOfThreads_ptr                                           = NULL;
+static _daal_threader_env_t _daal_threader_env_ptr                                             = NULL;
 
 static _daal_parallel_sort_int32_t _daal_parallel_sort_int32_ptr                         = NULL;
 static _daal_parallel_sort_uint64_t _daal_parallel_sort_uint64_ptr                       = NULL;
@@ -659,7 +661,28 @@ DAAL_EXPORT void _daal_tbb_task_scheduler_free(void *& init)
     return _daal_tbb_task_scheduler_free_ptr(init);
 }
 
-DAAL_EXPORT void _daal_tbb_task_scheduler_handle_free(void *& init)
+DAAL_EXPORT void _daal_tbb_task_scheduler_handle_finalize(void *& init)
+{
+    if (init == NULL)
+    {
+        // If threading library was not opened, there is nothing to free,
+        // so we do not need to load threading library.
+        // Moreover, loading threading library in the Environment destructor
+        // results in a crush because of the use of Wintrust library after it was unloaded.
+        // This happens due to undefined order of static objects deinitialization
+        // like Environment, and dependent libraries.
+        return;
+    }
+    load_daal_thr_dll();
+    if (_daal_tbb_task_scheduler_handle_finalize_ptr == NULL)
+    {
+        _daal_tbb_task_scheduler_handle_finalize_ptr =
+            (_daal_tbb_task_scheduler_handle_finalize_t)load_daal_thr_func("_daal_tbb_task_scheduler_handle_finalize");
+    }
+    _daal_tbb_task_scheduler_handle_free_ptr(init);
+}
+
+DAAL_EXPORT void _daal_tbb_task_scheduler_handle_finalize(void *& init)
 {
     if (init == NULL)
     {

--- a/cpp/daal/src/externals/core_threading_win_dll.cpp
+++ b/cpp/daal/src/externals/core_threading_win_dll.cpp
@@ -143,8 +143,8 @@ typedef void (*_daal_wait_task_group_t)(void * taskGroupPtr);
 
 typedef bool (*_daal_is_in_parallel_t)();
 typedef void (*_daal_tbb_task_scheduler_free_t)(void *& globalControl);
-typedef void (*_daal_tbb_task_scheduler_handle_free_t)(void *& schedulerHandle);
-typedef void (*_initializeSchedulerHandle_t)(void **);
+typedef void (*_daal_tbb_task_scheduler_handle_free_t)();
+typedef void (*_initializeSchedulerHandle_t)();
 typedef size_t (*_setNumberOfThreads_t)(const size_t, void **);
 typedef void * (*_daal_threader_env_t)();
 
@@ -678,7 +678,7 @@ DAAL_EXPORT void _initializeSchedulerHandle()
     {
         _initializeSchedulerHandle_ptr = (_initializeSchedulerHandle_t)load_daal_thr_func("_initializeSchedulerHandle");
     }
-    _initializeSchedulerHandle_ptr(init);
+    _initializeSchedulerHandle_ptr();
 }
 
 DAAL_EXPORT size_t _setNumberOfThreads(const size_t numThreads, void ** init)

--- a/cpp/daal/src/externals/core_threading_win_dll.cpp
+++ b/cpp/daal/src/externals/core_threading_win_dll.cpp
@@ -143,7 +143,6 @@ typedef void (*_daal_wait_task_group_t)(void * taskGroupPtr);
 
 typedef bool (*_daal_is_in_parallel_t)();
 typedef void (*_daal_tbb_task_scheduler_free_t)(void *& globalControl);
-typedef void (*_daal_tbb_task_scheduler_handle_free_t)(void *& schedulerHandle);
 typedef void (*_daal_tbb_task_scheduler_handle_finalize_t)(void *& schedulerHandle);
 typedef size_t (*_setNumberOfThreads_t)(const size_t, void **, void **);
 typedef void (*_initializeSchedulerHandle_t)(void **);
@@ -210,7 +209,6 @@ static _daal_wait_task_group_t _daal_wait_task_group_ptr = NULL;
 
 static _daal_is_in_parallel_t _daal_is_in_parallel_ptr                                         = NULL;
 static _daal_tbb_task_scheduler_free_t _daal_tbb_task_scheduler_free_ptr                       = NULL;
-static _daal_tbb_task_scheduler_handle_free_t _daal_tbb_task_scheduler_handle_free_ptr         = NULL;
 static _daal_tbb_task_scheduler_handle_finalize_t _daal_tbb_task_scheduler_handle_finalize_ptr = NULL;
 static _initializeSchedulerHandle_t _initializeSchedulerHandle_ptr                             = NULL;
 static _setNumberOfThreads_t _setNumberOfThreads_ptr                                           = NULL;
@@ -691,27 +689,7 @@ DAAL_EXPORT void _daal_tbb_task_scheduler_handle_finalize(void *& init)
         _daal_tbb_task_scheduler_handle_finalize_ptr =
             (_daal_tbb_task_scheduler_handle_finalize_t)load_daal_thr_func("_daal_tbb_task_scheduler_handle_finalize");
     }
-    _daal_tbb_task_scheduler_handle_free_ptr(init);
-}
-
-DAAL_EXPORT void _daal_tbb_task_scheduler_handle_free(void *& init)
-{
-    if (init == NULL)
-    {
-        // If threading library was not opened, there is nothing to free,
-        // so we do not need to load threading library.
-        // Moreover, loading threading library in the Environment destructor
-        // results in a crush because of the use of Wintrust library after it was unloaded.
-        // This happens due to undefined order of static objects deinitialization
-        // like Environment, and dependent libraries.
-        return;
-    }
-    load_daal_thr_dll();
-    if (_daal_tbb_task_scheduler_handle_free_ptr == NULL)
-    {
-        _daal_tbb_task_scheduler_handle_free_ptr = (_daal_tbb_task_scheduler_handle_free_t)load_daal_thr_func("_daal_tbb_task_scheduler_handle_free");
-    }
-    _daal_tbb_task_scheduler_handle_free_ptr(init);
+    _daal_tbb_task_scheduler_handle_finalize_ptr(init);
 }
 
 DAAL_EXPORT size_t _setNumberOfThreads(const size_t numThreads, void ** init, void ** schedulerHandle)

--- a/cpp/daal/src/externals/core_threading_win_dll.cpp
+++ b/cpp/daal/src/externals/core_threading_win_dll.cpp
@@ -143,8 +143,7 @@ typedef void (*_daal_wait_task_group_t)(void * taskGroupPtr);
 
 typedef bool (*_daal_is_in_parallel_t)();
 typedef void (*_daal_tbb_task_scheduler_free_t)(void *& globalControl);
-typedef void (*_daal_tbb_task_scheduler_handle_free_t)();
-typedef void (*_initializeSchedulerHandle_t)();
+typedef void (*_daal_tbb_task_scheduler_handle_free_t)(void *& schedulerHandle);
 typedef size_t (*_setNumberOfThreads_t)(const size_t, void **);
 typedef void * (*_daal_threader_env_t)();
 
@@ -210,7 +209,6 @@ static _daal_wait_task_group_t _daal_wait_task_group_ptr = NULL;
 static _daal_is_in_parallel_t _daal_is_in_parallel_ptr                                 = NULL;
 static _daal_tbb_task_scheduler_free_t _daal_tbb_task_scheduler_free_ptr               = NULL;
 static _daal_tbb_task_scheduler_handle_free_t _daal_tbb_task_scheduler_handle_free_ptr = NULL;
-static _initializeSchedulerHandle_t _initializeSchedulerHandle_ptr                     = NULL;
 static _setNumberOfThreads_t _setNumberOfThreads_ptr                                   = NULL;
 static _daal_threader_env_t _daal_threader_env_ptr                                     = NULL;
 
@@ -661,24 +659,24 @@ DAAL_EXPORT void _daal_tbb_task_scheduler_free(void *& init)
     return _daal_tbb_task_scheduler_free_ptr(init);
 }
 
-DAAL_EXPORT void _daal_tbb_task_scheduler_handle_free()
+DAAL_EXPORT void _daal_tbb_task_scheduler_handle_free(void *& init)
 {
+    if (init == NULL)
+    {
+        // If threading library was not opened, there is nothing to free,
+        // so we do not need to load threading library.
+        // Moreover, loading threading library in the Environment destructor
+        // results in a crush because of the use of Wintrust library after it was unloaded.
+        // This happens due to undefined order of static objects deinitialization
+        // like Environment, and dependent libraries.
+        return;
+    }
     load_daal_thr_dll();
     if (_daal_tbb_task_scheduler_handle_free_ptr == NULL)
     {
         _daal_tbb_task_scheduler_handle_free_ptr = (_daal_tbb_task_scheduler_handle_free_t)load_daal_thr_func("_daal_tbb_task_scheduler_handle_free");
     }
-    _daal_tbb_task_scheduler_handle_free_ptr();
-}
-
-DAAL_EXPORT void _initializeSchedulerHandle()
-{
-    load_daal_thr_dll();
-    if (_initializeSchedulerHandle_ptr == NULL)
-    {
-        _initializeSchedulerHandle_ptr = (_initializeSchedulerHandle_t)load_daal_thr_func("_initializeSchedulerHandle");
-    }
-    _initializeSchedulerHandle_ptr();
+    _daal_tbb_task_scheduler_handle_free_ptr(init);
 }
 
 DAAL_EXPORT size_t _setNumberOfThreads(const size_t numThreads, void ** init)

--- a/cpp/daal/src/externals/core_threading_win_dll.cpp
+++ b/cpp/daal/src/externals/core_threading_win_dll.cpp
@@ -686,8 +686,7 @@ DAAL_EXPORT void _daal_tbb_task_scheduler_handle_free(void *& init)
     if (_daal_tbb_task_scheduler_handle_free_ptr == NULL)
     {
         std::cout << "NO empty _daal_tbb_global _daal_tbb_handle2" << std::endl;
-        _daal_tbb_task_scheduler_handle_free_ptr =
-            (_daal_tbb_task_scheduler_handle_free_t)load_daal_thr_func("_daal_tbb_task_scheduler_handle_free_ptr");
+        _daal_tbb_task_scheduler_handle_free_ptr = (_daal_tbb_task_scheduler_handle_free_t)load_daal_thr_func("_daal_tbb_task_scheduler_handle_free");
     }
     std::cout << "NO empty _daal_tbb_global _daal_tbb_handle 3" << std::endl;
     return _daal_tbb_task_scheduler_handle_free_ptr(init);

--- a/cpp/daal/src/externals/core_threading_win_dll.cpp
+++ b/cpp/daal/src/externals/core_threading_win_dll.cpp
@@ -25,7 +25,7 @@
 #include "src/threading/threading.h"
 #include "src/threading/service_thread_pinner.h"
 #include "services/env_detect.h"
-#include <iostream>
+
 static HMODULE daal_thr_dll_handle = NULL;
 daal::services::Environment::LibraryThreadingType __daal_serv_get_thr_set();
 
@@ -644,7 +644,6 @@ DAAL_EXPORT void _daal_tbb_task_scheduler_free(void *& init)
 {
     if (init == NULL)
     {
-        std::cout << "empty _daal_tbb_task_scheduler_free" << std::endl;
         // If threading library was not opened, there is nothing to free,
         // so we do not need to load threading library.
         // Moreover, loading threading library in the Environment destructor
@@ -654,56 +653,32 @@ DAAL_EXPORT void _daal_tbb_task_scheduler_free(void *& init)
         return;
     }
 
-    std::cout << "NO empty _daal_tbb_global control_free" << std::endl;
     load_daal_thr_dll();
-    std::cout << "NO empty _daal_tbb_global control_free1" << std::endl;
     if (_daal_tbb_task_scheduler_free_ptr == NULL)
     {
-        std::cout << "NO empty _daal_tbb_global control_free2" << std::endl;
         _daal_tbb_task_scheduler_free_ptr = (_daal_tbb_task_scheduler_free_t)load_daal_thr_func("_daal_tbb_task_scheduler_free");
     }
-    std::cout << "NO empty _daal_tbb_global control_free3" << std::endl;
     return _daal_tbb_task_scheduler_free_ptr(init);
 }
 
-DAAL_EXPORT void _daal_tbb_task_scheduler_handle_free(void *& init)
+DAAL_EXPORT void _daal_tbb_task_scheduler_handle_free()
 {
-    if (init == NULL)
-    {
-        std::cout << "empty _daal_tbb_task_scheduler_handle_free" << std::endl;
-        // If threading library was not opened, there is nothing to free,
-        // so we do not need to load threading library.
-        // Moreover, loading threading library in the Environment destructor
-        // results in a crush because of the use of Wintrust library after it was unloaded.
-        // This happens due to undefined order of static objects deinitialization
-        // like Environment, and dependent libraries.
-        return;
-    }
-
-    std::cout << "NO empty _daal_tbb_handle" << std::endl;
     load_daal_thr_dll();
-    std::cout << "NO empty _daal_tbb_global _daal_tbb_handle1" << std::endl;
     if (_daal_tbb_task_scheduler_handle_free_ptr == NULL)
     {
-        std::cout << "NO empty _daal_tbb_global _daal_tbb_handle2" << std::endl;
         _daal_tbb_task_scheduler_handle_free_ptr = (_daal_tbb_task_scheduler_handle_free_t)load_daal_thr_func("_daal_tbb_task_scheduler_handle_free");
     }
-    std::cout << "NO empty _daal_tbb_global _daal_tbb_handle 3" << std::endl;
-    return _daal_tbb_task_scheduler_handle_free_ptr(init);
+    _daal_tbb_task_scheduler_handle_free_ptr();
 }
 
-DAAL_EXPORT void _initializeSchedulerHandle(void ** init)
+DAAL_EXPORT void _initializeSchedulerHandle()
 {
-    std::cout << "NO empty _daal_tbb_task_scheduler_handle_free0" << std::endl;
     load_daal_thr_dll();
-    std::cout << "NO empty _daal_tbb_task_scheduler_handle_free1" << std::endl;
     if (_initializeSchedulerHandle_ptr == NULL)
     {
-        std::cout << "NO empty _daal_tbb_task_scheduler_handle_free2" << std::endl;
         _initializeSchedulerHandle_ptr = (_initializeSchedulerHandle_t)load_daal_thr_func("_initializeSchedulerHandle");
     }
-    std::cout << "NO empty _daal_tbb_task_scheduler_handle_free3" << std::endl;
-    return _initializeSchedulerHandle_ptr(init);
+    _initializeSchedulerHandle_ptr(init);
 }
 
 DAAL_EXPORT size_t _setNumberOfThreads(const size_t numThreads, void ** init)

--- a/cpp/daal/src/externals/core_threading_win_dll.cpp
+++ b/cpp/daal/src/externals/core_threading_win_dll.cpp
@@ -693,7 +693,7 @@ DAAL_EXPORT void _daal_tbb_task_scheduler_handle_free(void *& init)
     return _daal_tbb_task_scheduler_handle_free_ptr(init);
 }
 
-DAAL_EXPORT void _initializeSchedulerHandle(void *& init)
+DAAL_EXPORT void _initializeSchedulerHandle(void ** init)
 {
     std::cout << "NO empty _daal_tbb_task_scheduler_handle_free0" << std::endl;
     load_daal_thr_dll();

--- a/cpp/daal/src/externals/core_threading_win_dll.cpp
+++ b/cpp/daal/src/externals/core_threading_win_dll.cpp
@@ -145,7 +145,8 @@ typedef bool (*_daal_is_in_parallel_t)();
 typedef void (*_daal_tbb_task_scheduler_free_t)(void *& globalControl);
 typedef void (*_daal_tbb_task_scheduler_handle_free_t)(void *& schedulerHandle);
 typedef void (*_daal_tbb_task_scheduler_handle_finalize_t)(void *& schedulerHandle);
-typedef size_t (*_setNumberOfThreads_t)(const size_t, void **);
+typedef size_t (*_setNumberOfThreads_t)(const size_t, void **, void **);
+typedef void (*_initializeSchedulerHandle_t)(void **);
 typedef void * (*_daal_threader_env_t)();
 
 typedef void (*_daal_parallel_sort_int32_t)(int *, int *);
@@ -211,6 +212,7 @@ static _daal_is_in_parallel_t _daal_is_in_parallel_ptr                          
 static _daal_tbb_task_scheduler_free_t _daal_tbb_task_scheduler_free_ptr                       = NULL;
 static _daal_tbb_task_scheduler_handle_free_t _daal_tbb_task_scheduler_handle_free_ptr         = NULL;
 static _daal_tbb_task_scheduler_handle_finalize_t _daal_tbb_task_scheduler_handle_finalize_ptr = NULL;
+static _initializeSchedulerHandle_t _initializeSchedulerHandle_ptr                             = NULL;
 static _setNumberOfThreads_t _setNumberOfThreads_ptr                                           = NULL;
 static _daal_threader_env_t _daal_threader_env_ptr                                             = NULL;
 
@@ -320,6 +322,16 @@ DAAL_EXPORT void _daal_parallel_sort_uint64(size_t * begin_ptr, size_t * end_ptr
         _daal_parallel_sort_uint64_ptr = (_daal_parallel_sort_uint64_t)load_daal_thr_func("_daal_parallel_sort_uint64");
     }
     _daal_parallel_sort_uint64_ptr(begin_ptr, end_ptr);
+}
+
+DAAL_EXPORT void _initializeSchedulerHandle(void ** init)
+{
+    load_daal_thr_dll();
+    if (_initializeSchedulerHandle_ptr == NULL)
+    {
+        _initializeSchedulerHandle_ptr = (_initializeSchedulerHandle_t)load_daal_thr_func("_initializeSchedulerHandle");
+    }
+    _initializeSchedulerHandle_ptr(init);
 }
 
 DAAL_EXPORT void _daal_parallel_sort_pair_int32_uint64(daal::IdxValType<int> * begin_ptr, daal::IdxValType<int> * end_ptr)
@@ -702,14 +714,14 @@ DAAL_EXPORT void _daal_tbb_task_scheduler_handle_free(void *& init)
     _daal_tbb_task_scheduler_handle_free_ptr(init);
 }
 
-DAAL_EXPORT size_t _setNumberOfThreads(const size_t numThreads, void ** init)
+DAAL_EXPORT size_t _setNumberOfThreads(const size_t numThreads, void ** init, void ** schedulerHandle)
 {
     load_daal_thr_dll();
     if (_setNumberOfThreads_ptr == NULL)
     {
         _setNumberOfThreads_ptr = (_setNumberOfThreads_t)load_daal_thr_func("_setNumberOfThreads");
     }
-    return _setNumberOfThreads_ptr(numThreads, init);
+    return _setNumberOfThreads_ptr(numThreads, init, schedulerHandle);
 }
 
 DAAL_EXPORT void * _daal_threader_env()

--- a/cpp/daal/src/externals/core_threading_win_dll.cpp
+++ b/cpp/daal/src/externals/core_threading_win_dll.cpp
@@ -682,7 +682,7 @@ DAAL_EXPORT void _daal_tbb_task_scheduler_handle_finalize(void *& init)
     _daal_tbb_task_scheduler_handle_free_ptr(init);
 }
 
-DAAL_EXPORT void _daal_tbb_task_scheduler_handle_finalize(void *& init)
+DAAL_EXPORT void _daal_tbb_task_scheduler_handle_free(void *& init)
 {
     if (init == NULL)
     {

--- a/cpp/daal/src/services/env_detect.cpp
+++ b/cpp/daal/src/services/env_detect.cpp
@@ -131,6 +131,7 @@ DAAL_EXPORT daal::services::Environment::Environment(const Environment & e) : da
 DAAL_EXPORT void daal::services::Environment::initNumberOfThreads()
 {
     if (isInit) return;
+
 #if defined(TARGET_X86_64)
     initializeSchedulerHandle();
 #endif
@@ -153,7 +154,7 @@ DAAL_EXPORT daal::services::Environment::~Environment()
 {
     daal::services::daal_free_buffers();
     _daal_tbb_task_scheduler_free(_globalControl);
-    // _daal_tbb_task_scheduler_handle_free();
+    _daal_tbb_task_scheduler_handle_free();
 }
 
 void daal::services::Environment::_cpu_detect(int enable)

--- a/cpp/daal/src/services/env_detect.cpp
+++ b/cpp/daal/src/services/env_detect.cpp
@@ -136,13 +136,11 @@ DAAL_EXPORT void daal::services::Environment::initSchedulerHandle()
 
 DAAL_EXPORT void daal::services::Environment::releaseGlobalControl()
 {
-    std::cout << "here" << std::endl;
     releaseGlobalControl_(_globalControl);
 }
 
 DAAL_EXPORT void daal::services::Environment::releaseSchedulerHandle()
 {
-    std::cout << "here1" << std::endl;
     releaseSchedulerHandle_(_schedulerHandle);
 }
 

--- a/cpp/daal/src/services/env_detect.cpp
+++ b/cpp/daal/src/services/env_detect.cpp
@@ -28,6 +28,7 @@
 #include "src/externals/service_service.h"
 #include "src/threading/threading.h"
 #include "services/error_indexes.h"
+
 #include "src/services/service_topo.h"
 #include "src/threading/service_thread_pinner.h"
 
@@ -50,19 +51,13 @@ void daal_free_buffers();
 }
 } // namespace daal
 
-std::mutex daal::services::Environment::_mutex;
 daal::services::Environment * daal::services::Environment::_instance = nullptr;
 
 DAAL_EXPORT daal::services::Environment * daal::services::Environment::getInstance()
 {
-    //Double-Checked Locking
     if (_instance == nullptr)
     {
-        std::lock_guard<std::mutex> guard(_mutex);
-        if (_instance == nullptr)
-        {
-            _instance = new Environment();
-        }
+        _instance = new Environment();
     }
     return _instance;
 }

--- a/cpp/daal/src/services/env_detect.cpp
+++ b/cpp/daal/src/services/env_detect.cpp
@@ -183,7 +183,9 @@ void daal::services::Environment::_cpu_detect(int enable)
 DAAL_EXPORT void daal::services::Environment::setNumberOfThreads(const size_t numThreads)
 {
     isInit = true;
+#if defined(TARGET_X86_64)
     initSchedulerHandle();
+#endif
     daal::setNumberOfThreads(numThreads, &_globalControl);
 }
 

--- a/cpp/daal/src/services/env_detect.cpp
+++ b/cpp/daal/src/services/env_detect.cpp
@@ -128,26 +128,11 @@ DAAL_EXPORT daal::services::Environment::Environment() : _globalControl {}
 
 DAAL_EXPORT daal::services::Environment::Environment(const Environment & e) : daal::services::Environment::Environment() {}
 
-DAAL_EXPORT void daal::services::Environment::initSchedulerHandle()
-{
-    initializeSchedulerHandle();
-}
-
-DAAL_EXPORT void daal::services::Environment::releaseGlobalControl()
-{
-    releaseGlobalControl_(_globalControl);
-}
-
-DAAL_EXPORT void daal::services::Environment::releaseSchedulerHandle()
-{
-    releaseSchedulerHandle_();
-}
-
 DAAL_EXPORT void daal::services::Environment::initNumberOfThreads()
 {
     if (isInit) return;
 #if defined(TARGET_X86_64)
-    initSchedulerHandle();
+    initializeSchedulerHandle();
 #endif
     /* if HT enabled - set _numThreads to physical cores num */
     if (daal::internal::ServiceInst::serv_get_ht())
@@ -167,8 +152,8 @@ DAAL_EXPORT void daal::services::Environment::initNumberOfThreads()
 DAAL_EXPORT daal::services::Environment::~Environment()
 {
     daal::services::daal_free_buffers();
-    releaseGlobalControl();
-    releaseSchedulerHandle();
+    _daal_tbb_task_scheduler_free(_globalControl);
+    _daal_tbb_task_scheduler_handle_free();
 }
 
 void daal::services::Environment::_cpu_detect(int enable)
@@ -184,7 +169,7 @@ DAAL_EXPORT void daal::services::Environment::setNumberOfThreads(const size_t nu
 {
     isInit = true;
 #if defined(TARGET_X86_64)
-    initSchedulerHandle();
+    initializeSchedulerHandle();
 #endif
     daal::setNumberOfThreads(numThreads, &_globalControl);
 }

--- a/cpp/daal/src/services/env_detect.cpp
+++ b/cpp/daal/src/services/env_detect.cpp
@@ -150,8 +150,8 @@ DAAL_EXPORT void daal::services::Environment::initNumberOfThreads()
 DAAL_EXPORT daal::services::Environment::~Environment()
 {
     daal::services::daal_free_buffers();
-    _daal_tbb_task_scheduler_free(_globalControl);
     _daal_tbb_task_scheduler_handle_free(_schedulerHandle);
+    _daal_tbb_task_scheduler_free(_globalControl);
 }
 
 void daal::services::Environment::_cpu_detect(int enable)

--- a/cpp/daal/src/services/env_detect.cpp
+++ b/cpp/daal/src/services/env_detect.cpp
@@ -119,7 +119,7 @@ daal::services::Environment::LibraryThreadingType __daal_serv_get_thr_set()
     return daal_thr_set;
 }
 
-DAAL_EXPORT daal::services::Environment::Environment()
+DAAL_EXPORT daal::services::Environment::Environment() : _globalControl {}
 {
     _env.cpuid_init_flag = false;
     _env.cpuid           = -1;

--- a/cpp/daal/src/services/env_detect.cpp
+++ b/cpp/daal/src/services/env_detect.cpp
@@ -131,9 +131,7 @@ DAAL_EXPORT daal::services::Environment::Environment(const Environment & e) : da
 DAAL_EXPORT void daal::services::Environment::initNumberOfThreads()
 {
     if (isInit) return;
-#if defined(TARGET_X86_64)
     initializeSchedulerHandle(&_schedulerHandle);
-#endif
     /* if HT enabled - set _numThreads to physical cores num */
     if (daal::internal::ServiceInst::serv_get_ht())
     {

--- a/cpp/daal/src/services/env_detect.cpp
+++ b/cpp/daal/src/services/env_detect.cpp
@@ -146,7 +146,9 @@ DAAL_EXPORT void daal::services::Environment::releaseSchedulerHandle()
 DAAL_EXPORT void daal::services::Environment::initNumberOfThreads()
 {
     if (isInit) return;
+#if defined(TARGET_X86_64)
     initSchedulerHandle();
+#endif
     /* if HT enabled - set _numThreads to physical cores num */
     if (daal::internal::ServiceInst::serv_get_ht())
     {
@@ -180,6 +182,7 @@ void daal::services::Environment::_cpu_detect(int enable)
 
 DAAL_EXPORT void daal::services::Environment::setNumberOfThreads(const size_t numThreads)
 {
+    isInit = true;
     initSchedulerHandle();
     daal::setNumberOfThreads(numThreads, &_globalControl);
 }

--- a/cpp/daal/src/services/env_detect.cpp
+++ b/cpp/daal/src/services/env_detect.cpp
@@ -51,13 +51,19 @@ void daal_free_buffers();
 }
 } // namespace daal
 
+std::mutex daal::services::Environment::_mutex;
 daal::services::Environment * daal::services::Environment::_instance = nullptr;
 
 DAAL_EXPORT daal::services::Environment * daal::services::Environment::getInstance()
 {
+    //Double-Checked Locking
     if (_instance == nullptr)
     {
-        _instance = new Environment();
+        std::lock_guard<std::mutex> guard(_mutex);
+        if (_instance == nullptr)
+        {
+            _instance = new Environment();
+        }
     }
     return _instance;
 }

--- a/cpp/daal/src/services/env_detect.cpp
+++ b/cpp/daal/src/services/env_detect.cpp
@@ -150,8 +150,8 @@ DAAL_EXPORT void daal::services::Environment::initNumberOfThreads()
 DAAL_EXPORT daal::services::Environment::~Environment()
 {
     daal::services::daal_free_buffers();
+    _daal_tbb_task_scheduler_free(_globalControl);
     _daal_tbb_task_scheduler_handle_finalize(_schedulerHandle);
-    // _daal_tbb_task_scheduler_free(_globalControl);
 }
 
 void daal::services::Environment::_cpu_detect(int enable)

--- a/cpp/daal/src/services/env_detect.cpp
+++ b/cpp/daal/src/services/env_detect.cpp
@@ -151,7 +151,7 @@ DAAL_EXPORT daal::services::Environment::~Environment()
 {
     daal::services::daal_free_buffers();
     _daal_tbb_task_scheduler_free(_globalControl);
-    _daal_tbb_task_scheduler_handle_finalize(_schedulerHandle);
+    // _daal_tbb_task_scheduler_handle_finalize(_schedulerHandle);
 }
 
 void daal::services::Environment::_cpu_detect(int enable)

--- a/cpp/daal/src/services/env_detect.cpp
+++ b/cpp/daal/src/services/env_detect.cpp
@@ -150,8 +150,8 @@ DAAL_EXPORT void daal::services::Environment::initNumberOfThreads()
 DAAL_EXPORT daal::services::Environment::~Environment()
 {
     daal::services::daal_free_buffers();
-    _daal_tbb_task_scheduler_handle_free(_schedulerHandle);
-    _daal_tbb_task_scheduler_free(_globalControl);
+    _daal_tbb_task_scheduler_handle_finalize(_schedulerHandle);
+    // _daal_tbb_task_scheduler_free(_globalControl);
 }
 
 void daal::services::Environment::_cpu_detect(int enable)

--- a/cpp/daal/src/services/env_detect.cpp
+++ b/cpp/daal/src/services/env_detect.cpp
@@ -124,7 +124,6 @@ daal::services::Environment::LibraryThreadingType __daal_serv_get_thr_set()
 
 DAAL_EXPORT daal::services::Environment::Environment()
 {
-    initSchedulerHandle();
     _env.cpuid_init_flag = false;
     _env.cpuid           = -1;
     this->setDefaultExecutionContext(internal::CpuExecutionContext());

--- a/cpp/daal/src/services/env_detect.cpp
+++ b/cpp/daal/src/services/env_detect.cpp
@@ -55,10 +55,14 @@ daal::services::Environment * daal::services::Environment::_instance = nullptr;
 
 DAAL_EXPORT daal::services::Environment * daal::services::Environment::getInstance()
 {
-    std::lock_guard<std::mutex> guard(_mutex);
+    //Double-Checked Locking
     if (_instance == nullptr)
     {
-        _instance = new Environment();
+        std::lock_guard<std::mutex> guard(_mutex);
+        if (_instance == nullptr)
+        {
+            _instance = new Environment();
+        }
     }
     return _instance;
 }

--- a/cpp/daal/src/services/env_detect.cpp
+++ b/cpp/daal/src/services/env_detect.cpp
@@ -119,7 +119,7 @@ daal::services::Environment::LibraryThreadingType __daal_serv_get_thr_set()
     return daal_thr_set;
 }
 
-DAAL_EXPORT daal::services::Environment::Environment() : _globalControl {}
+DAAL_EXPORT daal::services::Environment::Environment() : _schedulerHandle {}, _globalControl {}
 {
     _env.cpuid_init_flag = false;
     _env.cpuid           = -1;
@@ -132,9 +132,6 @@ DAAL_EXPORT void daal::services::Environment::initNumberOfThreads()
 {
     if (isInit) return;
 
-#if defined(TARGET_X86_64)
-    initializeSchedulerHandle();
-#endif
     /* if HT enabled - set _numThreads to physical cores num */
     if (daal::internal::ServiceInst::serv_get_ht())
     {
@@ -154,7 +151,7 @@ DAAL_EXPORT daal::services::Environment::~Environment()
 {
     daal::services::daal_free_buffers();
     _daal_tbb_task_scheduler_free(_globalControl);
-    _daal_tbb_task_scheduler_handle_free();
+    _daal_tbb_task_scheduler_handle_free(_schedulerHandle);
 }
 
 void daal::services::Environment::_cpu_detect(int enable)
@@ -169,10 +166,7 @@ void daal::services::Environment::_cpu_detect(int enable)
 DAAL_EXPORT void daal::services::Environment::setNumberOfThreads(const size_t numThreads)
 {
     isInit = true;
-#if defined(TARGET_X86_64)
-    initializeSchedulerHandle();
-#endif
-    daal::setNumberOfThreads(numThreads, &_globalControl);
+    daal::setNumberOfThreads(numThreads, &_globalControl, &_schedulerHandle);
 }
 
 DAAL_EXPORT size_t daal::services::Environment::getNumberOfThreads() const

--- a/cpp/daal/src/services/env_detect.cpp
+++ b/cpp/daal/src/services/env_detect.cpp
@@ -131,7 +131,6 @@ DAAL_EXPORT daal::services::Environment::Environment(const Environment & e) : da
 DAAL_EXPORT void daal::services::Environment::initNumberOfThreads()
 {
     if (isInit) return;
-    initializeSchedulerHandle(&_schedulerHandle);
     /* if HT enabled - set _numThreads to physical cores num */
     if (daal::internal::ServiceInst::serv_get_ht())
     {

--- a/cpp/daal/src/services/env_detect.cpp
+++ b/cpp/daal/src/services/env_detect.cpp
@@ -28,7 +28,6 @@
 #include "src/externals/service_service.h"
 #include "src/threading/threading.h"
 #include "services/error_indexes.h"
-
 #include "src/services/service_topo.h"
 #include "src/threading/service_thread_pinner.h"
 
@@ -51,10 +50,12 @@ void daal_free_buffers();
 }
 } // namespace daal
 
+std::mutex daal::services::Environment::_mutex;
 daal::services::Environment * daal::services::Environment::_instance = nullptr;
 
 DAAL_EXPORT daal::services::Environment * daal::services::Environment::getInstance()
 {
+    std::lock_guard<std::mutex> guard(_mutex);
     if (_instance == nullptr)
     {
         _instance = new Environment();

--- a/cpp/daal/src/services/env_detect.cpp
+++ b/cpp/daal/src/services/env_detect.cpp
@@ -153,7 +153,7 @@ DAAL_EXPORT daal::services::Environment::~Environment()
 {
     daal::services::daal_free_buffers();
     _daal_tbb_task_scheduler_free(_globalControl);
-    _daal_tbb_task_scheduler_handle_free();
+    // _daal_tbb_task_scheduler_handle_free();
 }
 
 void daal::services::Environment::_cpu_detect(int enable)

--- a/cpp/daal/src/services/env_detect.cpp
+++ b/cpp/daal/src/services/env_detect.cpp
@@ -28,7 +28,7 @@
 #include "src/externals/service_service.h"
 #include "src/threading/threading.h"
 #include "services/error_indexes.h"
-
+#include <iostream>
 #include "src/services/service_topo.h"
 #include "src/threading/service_thread_pinner.h"
 
@@ -119,20 +119,32 @@ daal::services::Environment::LibraryThreadingType __daal_serv_get_thr_set()
     return daal_thr_set;
 }
 
-DAAL_EXPORT void daal::services::Environment::setDynamicLibraryThreadingTypeOnWindows(daal::services::Environment::LibraryThreadingType thr)
+DAAL_EXPORT daal::services::Environment::Environment() : _schedulerHandle(nullptr), _globalControl(nullptr)
 {
-    daal_thr_set = thr;
-    initNumberOfThreads();
-}
-
-DAAL_EXPORT daal::services::Environment::Environment() : _globalControl {}
-{
+    initSchedulerHandle();
     _env.cpuid_init_flag = false;
     _env.cpuid           = -1;
     this->setDefaultExecutionContext(internal::CpuExecutionContext());
 }
 
 DAAL_EXPORT daal::services::Environment::Environment(const Environment & e) : daal::services::Environment::Environment() {}
+
+DAAL_EXPORT void daal::services::Environment::initSchedulerHandle()
+{
+    initializeSchedulerHandle(&_schedulerHandle);
+}
+
+DAAL_EXPORT void daal::services::Environment::releaseGlobalControl()
+{
+    std::cout << "here" << std::endl;
+    releaseGlobalControl_(_globalControl);
+}
+
+DAAL_EXPORT void daal::services::Environment::releaseSchedulerHandle()
+{
+    std::cout << "here1" << std::endl;
+    releaseSchedulerHandle_(_schedulerHandle);
+}
 
 DAAL_EXPORT void daal::services::Environment::initNumberOfThreads()
 {
@@ -156,7 +168,8 @@ DAAL_EXPORT void daal::services::Environment::initNumberOfThreads()
 DAAL_EXPORT daal::services::Environment::~Environment()
 {
     daal::services::daal_free_buffers();
-    _daal_tbb_task_scheduler_free(_globalControl);
+    releaseGlobalControl();
+    releaseSchedulerHandle();
 }
 
 void daal::services::Environment::_cpu_detect(int enable)

--- a/cpp/daal/src/services/env_detect.cpp
+++ b/cpp/daal/src/services/env_detect.cpp
@@ -51,6 +51,9 @@ void daal_free_buffers();
 }
 } // namespace daal
 
+void * daal::services::Environment::_schedulerHandle = nullptr;
+void * daal::services::Environment::_globalControl   = nullptr;
+
 DAAL_EXPORT daal::services::Environment * daal::services::Environment::getInstance()
 {
     static daal::services::Environment instance;
@@ -119,7 +122,7 @@ daal::services::Environment::LibraryThreadingType __daal_serv_get_thr_set()
     return daal_thr_set;
 }
 
-DAAL_EXPORT daal::services::Environment::Environment() : _schedulerHandle(nullptr), _globalControl(nullptr)
+DAAL_EXPORT daal::services::Environment::Environment()
 {
     initSchedulerHandle();
     _env.cpuid_init_flag = false;

--- a/cpp/daal/src/services/env_detect.cpp
+++ b/cpp/daal/src/services/env_detect.cpp
@@ -150,7 +150,7 @@ DAAL_EXPORT void daal::services::Environment::releaseSchedulerHandle()
 DAAL_EXPORT void daal::services::Environment::initNumberOfThreads()
 {
     if (isInit) return;
-
+    initSchedulerHandle();
     /* if HT enabled - set _numThreads to physical cores num */
     if (daal::internal::ServiceInst::serv_get_ht())
     {
@@ -185,6 +185,7 @@ void daal::services::Environment::_cpu_detect(int enable)
 DAAL_EXPORT void daal::services::Environment::setNumberOfThreads(const size_t numThreads)
 {
     isInit = true;
+    initSchedulerHandle();
     daal::setNumberOfThreads(numThreads, &_globalControl);
 }
 

--- a/cpp/daal/src/services/env_detect.cpp
+++ b/cpp/daal/src/services/env_detect.cpp
@@ -51,15 +51,15 @@ void daal_free_buffers();
 }
 } // namespace daal
 
+daal::services::Environment * daal::services::Environment::_instance = nullptr;
+
 DAAL_EXPORT daal::services::Environment * daal::services::Environment::getInstance()
 {
-    static daal::services::Environment instance;
-    return &instance;
-}
-
-DAAL_EXPORT int daal::services::Environment::freeInstance()
-{
-    return 0;
+    if (_instance == nullptr)
+    {
+        _instance = new Environment();
+    }
+    return _instance;
 }
 
 DAAL_EXPORT int daal::services::Environment::getCpuId(int enable)
@@ -151,7 +151,7 @@ DAAL_EXPORT daal::services::Environment::~Environment()
 {
     daal::services::daal_free_buffers();
     _daal_tbb_task_scheduler_free(_globalControl);
-    // _daal_tbb_task_scheduler_handle_finalize(_schedulerHandle);
+    _daal_tbb_task_scheduler_handle_finalize(_schedulerHandle);
 }
 
 void daal::services::Environment::_cpu_detect(int enable)

--- a/cpp/daal/src/services/env_detect.cpp
+++ b/cpp/daal/src/services/env_detect.cpp
@@ -131,7 +131,9 @@ DAAL_EXPORT daal::services::Environment::Environment(const Environment & e) : da
 DAAL_EXPORT void daal::services::Environment::initNumberOfThreads()
 {
     if (isInit) return;
-
+#if defined(TARGET_X86_64)
+    initializeSchedulerHandle(&_schedulerHandle);
+#endif
     /* if HT enabled - set _numThreads to physical cores num */
     if (daal::internal::ServiceInst::serv_get_ht())
     {

--- a/cpp/daal/src/services/env_detect.cpp
+++ b/cpp/daal/src/services/env_detect.cpp
@@ -28,7 +28,7 @@
 #include "src/externals/service_service.h"
 #include "src/threading/threading.h"
 #include "services/error_indexes.h"
-#include <iostream>
+
 #include "src/services/service_topo.h"
 #include "src/threading/service_thread_pinner.h"
 
@@ -50,9 +50,6 @@ namespace services
 void daal_free_buffers();
 }
 } // namespace daal
-
-void * daal::services::Environment::_schedulerHandle = nullptr;
-void * daal::services::Environment::_globalControl   = nullptr;
 
 DAAL_EXPORT daal::services::Environment * daal::services::Environment::getInstance()
 {
@@ -133,7 +130,7 @@ DAAL_EXPORT daal::services::Environment::Environment(const Environment & e) : da
 
 DAAL_EXPORT void daal::services::Environment::initSchedulerHandle()
 {
-    initializeSchedulerHandle(&_schedulerHandle);
+    initializeSchedulerHandle();
 }
 
 DAAL_EXPORT void daal::services::Environment::releaseGlobalControl()
@@ -143,7 +140,7 @@ DAAL_EXPORT void daal::services::Environment::releaseGlobalControl()
 
 DAAL_EXPORT void daal::services::Environment::releaseSchedulerHandle()
 {
-    releaseSchedulerHandle_(_schedulerHandle);
+    releaseSchedulerHandle_();
 }
 
 DAAL_EXPORT void daal::services::Environment::initNumberOfThreads()
@@ -183,7 +180,6 @@ void daal::services::Environment::_cpu_detect(int enable)
 
 DAAL_EXPORT void daal::services::Environment::setNumberOfThreads(const size_t numThreads)
 {
-    isInit = true;
     initSchedulerHandle();
     daal::setNumberOfThreads(numThreads, &_globalControl);
 }

--- a/cpp/daal/src/threading/service_thread_pinner.cpp
+++ b/cpp/daal/src/threading/service_thread_pinner.cpp
@@ -202,6 +202,7 @@ class thread_pinner_impl_t : public tbb::task_scheduler_observer
     bool do_pinning;
     AtomicInt is_pinning;
     tbb::enumerable_thread_specific<cpu_mask_t *> thread_mask;
+    tbb::task_scheduler_handle scheduler_handle;
     tbb::task_arena pinner_arena;
     void (*topo_deleter)(void *);
 
@@ -235,6 +236,7 @@ thread_pinner_impl_t::thread_pinner_impl_t(void (*read_topo)(int &, int &, int &
     : pinner_arena(nthreads = daal::threader_get_threads_number()), tbb::task_scheduler_observer(pinner_arena), topo_deleter(deleter)
 {
     pinner_arena.initialize();
+    scheduler_handle = tbb::task_scheduler_handle(tbb::attach {});
     do_pinning = (nthreads > 0) ? true : false;
     is_pinning.set(0);
 

--- a/cpp/daal/src/threading/service_thread_pinner.cpp
+++ b/cpp/daal/src/threading/service_thread_pinner.cpp
@@ -202,8 +202,8 @@ class thread_pinner_impl_t : public tbb::task_scheduler_observer
     bool do_pinning;
     AtomicInt is_pinning;
     tbb::enumerable_thread_specific<cpu_mask_t *> thread_mask;
-    tbb::task_scheduler_handle scheduler_handle;
     tbb::task_arena pinner_arena;
+    tbb::task_scheduler_handle scheduler_handle;
     void (*topo_deleter)(void *);
 
 public:

--- a/cpp/daal/src/threading/service_thread_pinner.cpp
+++ b/cpp/daal/src/threading/service_thread_pinner.cpp
@@ -235,9 +235,11 @@ public:
 thread_pinner_impl_t::thread_pinner_impl_t(void (*read_topo)(int &, int &, int &, int **), void (*deleter)(void *))
     : pinner_arena(nthreads = daal::threader_get_threads_number()), tbb::task_scheduler_observer(pinner_arena), topo_deleter(deleter)
 {
+    #if defined(TARGET_X86_64)
     pinner_arena.initialize();
     scheduler_handle = tbb::task_scheduler_handle(tbb::attach {});
-    do_pinning       = (nthreads > 0) ? true : false;
+    #endif
+    do_pinning = (nthreads > 0) ? true : false;
     is_pinning.set(0);
 
     read_topo(status, nthreads, max_threads, &cpu_queue);

--- a/cpp/daal/src/threading/service_thread_pinner.cpp
+++ b/cpp/daal/src/threading/service_thread_pinner.cpp
@@ -203,7 +203,6 @@ class thread_pinner_impl_t : public tbb::task_scheduler_observer
     AtomicInt is_pinning;
     tbb::enumerable_thread_specific<cpu_mask_t *> thread_mask;
     tbb::task_arena pinner_arena;
-    tbb::task_scheduler_handle scheduler_handle;
     void (*topo_deleter)(void *);
 
 public:
@@ -235,9 +234,7 @@ public:
 thread_pinner_impl_t::thread_pinner_impl_t(void (*read_topo)(int &, int &, int &, int **), void (*deleter)(void *))
     : pinner_arena(nthreads = daal::threader_get_threads_number()), tbb::task_scheduler_observer(pinner_arena), topo_deleter(deleter)
 {
-    pinner_arena.initialize();
-    scheduler_handle = tbb::task_scheduler_handle(tbb::attach {});
-    do_pinning       = (nthreads > 0) ? true : false;
+    do_pinning = (nthreads > 0) ? true : false;
     is_pinning.set(0);
 
     read_topo(status, nthreads, max_threads, &cpu_queue);
@@ -332,7 +329,7 @@ thread_pinner_impl_t::~thread_pinner_impl_t()
     if (cpu_queue) topo_deleter(cpu_queue);
 
     thread_mask.combine_each([](cpu_mask_t *& source_mask) { delete source_mask; });
-    tbb::finalize(scheduler_handle, std::nothrow);
+
     return;
 } /* ~thread_pinner_impl_t() */
 

--- a/cpp/daal/src/threading/service_thread_pinner.cpp
+++ b/cpp/daal/src/threading/service_thread_pinner.cpp
@@ -235,11 +235,9 @@ public:
 thread_pinner_impl_t::thread_pinner_impl_t(void (*read_topo)(int &, int &, int &, int **), void (*deleter)(void *))
     : pinner_arena(nthreads = daal::threader_get_threads_number()), tbb::task_scheduler_observer(pinner_arena), topo_deleter(deleter)
 {
-    #if defined(TARGET_X86_64)
     pinner_arena.initialize();
     scheduler_handle = tbb::task_scheduler_handle(tbb::attach {});
-    #endif
-    do_pinning = (nthreads > 0) ? true : false;
+    do_pinning       = (nthreads > 0) ? true : false;
     is_pinning.set(0);
 
     read_topo(status, nthreads, max_threads, &cpu_queue);
@@ -334,7 +332,7 @@ thread_pinner_impl_t::~thread_pinner_impl_t()
     if (cpu_queue) topo_deleter(cpu_queue);
 
     thread_mask.combine_each([](cpu_mask_t *& source_mask) { delete source_mask; });
-
+    tbb::finalize(scheduler_handle, std::nothrow);
     return;
 } /* ~thread_pinner_impl_t() */
 

--- a/cpp/daal/src/threading/service_thread_pinner.cpp
+++ b/cpp/daal/src/threading/service_thread_pinner.cpp
@@ -337,13 +337,13 @@ DAAL_EXPORT void * _getThreadPinner(bool create_pinner, void (*read_topo)(int &,
 {
     static bool pinner_created = false;
 
-    if (create_pinner == true || pinner_created == true)
+    if (create_pinner == true || pinner_created == false)
     {
-        static daal::services::internal::thread_pinner_t thread_pinner(read_topo, deleter);
-        if (thread_pinner.get_status() == 0)
+        static daal::services::internal::thread_pinner_t * thread_pinner = new daal::services::internal::thread_pinner_t(read_topo, deleter);
+        if (thread_pinner->get_status() == 0)
         {
             pinner_created = true;
-            return (void *)&thread_pinner;
+            return (void *)thread_pinner;
         }
     }
 

--- a/cpp/daal/src/threading/service_thread_pinner.cpp
+++ b/cpp/daal/src/threading/service_thread_pinner.cpp
@@ -234,6 +234,7 @@ public:
 thread_pinner_impl_t::thread_pinner_impl_t(void (*read_topo)(int &, int &, int &, int **), void (*deleter)(void *))
     : pinner_arena(nthreads = daal::threader_get_threads_number()), tbb::task_scheduler_observer(pinner_arena), topo_deleter(deleter)
 {
+    pinner_arena.initialize();
     do_pinning = (nthreads > 0) ? true : false;
     is_pinning.set(0);
 

--- a/cpp/daal/src/threading/service_thread_pinner.cpp
+++ b/cpp/daal/src/threading/service_thread_pinner.cpp
@@ -237,7 +237,7 @@ thread_pinner_impl_t::thread_pinner_impl_t(void (*read_topo)(int &, int &, int &
 {
     pinner_arena.initialize();
     scheduler_handle = tbb::task_scheduler_handle(tbb::attach {});
-    do_pinning = (nthreads > 0) ? true : false;
+    do_pinning       = (nthreads > 0) ? true : false;
     is_pinning.set(0);
 
     read_topo(status, nthreads, max_threads, &cpu_queue);

--- a/cpp/daal/src/threading/threading.cpp
+++ b/cpp/daal/src/threading/threading.cpp
@@ -70,7 +70,7 @@ DAAL_EXPORT void _daal_tbb_task_scheduler_handle_free()
 {
     static tbb::spin_mutex mt;
     tbb::spin_mutex::scoped_lock lock(mt);
-    globalSchedulerHandle.reset();
+    // globalSchedulerHandle.reset();
 }
 
 DAAL_EXPORT void _initializeSchedulerHandle()
@@ -79,8 +79,8 @@ DAAL_EXPORT void _initializeSchedulerHandle()
     tbb::spin_mutex::scoped_lock lock(mt);
     if (!isInitialized)
     {
-        tbb::task_arena {}.initialize();
         globalSchedulerHandle = std::unique_ptr<tbb::task_scheduler_handle>(new tbb::task_scheduler_handle(tbb::attach {}));
+        tbb::task_arena {}.initialize();
         isInitialized         = true;
     }
 }

--- a/cpp/daal/src/threading/threading.cpp
+++ b/cpp/daal/src/threading/threading.cpp
@@ -81,7 +81,7 @@ DAAL_EXPORT void _initializeSchedulerHandle()
     {
         globalSchedulerHandle = std::unique_ptr<tbb::task_scheduler_handle>(new tbb::task_scheduler_handle(tbb::attach {}));
         tbb::task_arena {}.initialize();
-        isInitialized         = true;
+        isInitialized = true;
     }
 }
 

--- a/cpp/daal/src/threading/threading.cpp
+++ b/cpp/daal/src/threading/threading.cpp
@@ -63,6 +63,19 @@ DAAL_EXPORT void _daal_tbb_task_scheduler_free(void *& globalControl)
     }
 }
 
+DAAL_EXPORT void _daal_tbb_task_scheduler_handle_finalize(void *& schedulerHandle)
+{
+    std::mutex global_mutex;
+    std::lock_guard<std::mutex> guard(global_mutex);
+    if (schedulerHandle)
+    {
+        tbb::task_scheduler_handle * handle = static_cast<tbb::task_scheduler_handle *>(schedulerHandle);
+        tbb::finalize(*handle, std::nothrow);
+        delete handle;
+        schedulerHandle = nullptr;
+    }
+}
+
 DAAL_EXPORT void _daal_tbb_task_scheduler_handle_free(void *& schedulerHandle)
 {
     std::mutex global_mutex;

--- a/cpp/daal/src/threading/threading.cpp
+++ b/cpp/daal/src/threading/threading.cpp
@@ -66,7 +66,6 @@ DAAL_EXPORT void _daal_tbb_task_scheduler_free(void *& globalControl)
 
 DAAL_EXPORT void _daal_tbb_task_scheduler_handle_free()
 {
-    tbb::finalize(*globalSchedulerHandle, std::nothrow);
 }
 
 DAAL_EXPORT void _initializeSchedulerHandle()

--- a/cpp/daal/src/threading/threading.cpp
+++ b/cpp/daal/src/threading/threading.cpp
@@ -78,7 +78,9 @@ DAAL_EXPORT void _daal_tbb_task_scheduler_handle_finalize(void *& schedulerHandl
     std::lock_guard<std::mutex> guard(global_mutex);
     if (schedulerHandle)
     {
-        delete reinterpret_cast<tbb::task_scheduler_handle *>(schedulerHandle);
+        std::unique_ptr<tbb::task_scheduler_handle> handle(static_cast<tbb::task_scheduler_handle *>(schedulerHandle));
+        tbb::finalize(*handle, std::nothrow);
+        handle.reset();
         schedulerHandle = nullptr;
     }
 }

--- a/cpp/daal/src/threading/threading.cpp
+++ b/cpp/daal/src/threading/threading.cpp
@@ -66,15 +66,14 @@ DAAL_EXPORT void _daal_tbb_task_scheduler_free(void *& globalControl)
     }
 }
 
-DAAL_EXPORT void _daal_tbb_task_scheduler_handle_free(void *& schedulerHandle)
+DAAL_EXPORT void _daal_tbb_task_scheduler_handle_free()
 {
     static tbb::spin_mutex mt;
     tbb::spin_mutex::scoped_lock lock(mt);
-    std::cout << "_daal_tbb_task_scheduler_handle_free TRUE FUNCTION" << std::endl;
-    globalSchedulerHandle->release();
+    globalSchedulerHandle.reset();
 }
 
-DAAL_EXPORT void _initializeSchedulerHandle(void ** schedulerHandle)
+DAAL_EXPORT void _initializeSchedulerHandle()
 {
     static tbb::spin_mutex mt;
     tbb::spin_mutex::scoped_lock lock(mt);

--- a/cpp/daal/src/threading/threading.cpp
+++ b/cpp/daal/src/threading/threading.cpp
@@ -54,11 +54,37 @@ DAAL_EXPORT void _threaded_scalable_free(void * ptr)
 
 DAAL_EXPORT void _daal_tbb_task_scheduler_free(void *& globalControl)
 {
-    if (globalControl)
+    if (globalControl != nullptr)
     {
         delete reinterpret_cast<tbb::global_control *>(globalControl);
         globalControl = nullptr;
     }
+}
+
+DAAL_EXPORT void _daal_tbb_task_scheduler_handle_free(void *& schedulerHandle)
+{
+    if (schedulerHandle != nullptr)
+    {
+        delete reinterpret_cast<tbb::task_scheduler_handle *>(schedulerHandle);
+        schedulerHandle = nullptr;
+    }
+}
+
+DAAL_EXPORT void _initializeSchedulerHandle(void ** schedulerHandle)
+{
+    // // It is necessary for initializing tbb in cases where DAAL does not use it.
+    tbb::task_arena {}.initialize();
+    *schedulerHandle = reinterpret_cast<void *>(new tbb::task_scheduler_handle(tbb::attach {}));
+}
+
+DAAL_EXPORT void _releaseSchedulerHandle(void *& schedulerHandle)
+{
+    _daal_tbb_task_scheduler_handle_free(schedulerHandle);
+}
+
+DAAL_EXPORT void _releaseGlobalControl(void *& globalControl)
+{
+    _daal_tbb_task_scheduler_free(globalControl);
 }
 
 DAAL_EXPORT size_t _setNumberOfThreads(const size_t numThreads, void ** globalControl)

--- a/cpp/daal/src/threading/threading.cpp
+++ b/cpp/daal/src/threading/threading.cpp
@@ -24,7 +24,6 @@
 #include "src/threading/threading.h"
 #include "services/daal_memory.h"
 #include "src/algorithms/service_qsort.h"
-
 #define TBB_PREVIEW_GLOBAL_CONTROL 1
 #define TBB_PREVIEW_TASK_ARENA     1
 
@@ -42,8 +41,8 @@
 
 using namespace daal::services;
 
-static tbb::task_scheduler_handle globalSchedulerHandle;
-static bool isInitialized = false;
+static std::unique_ptr<tbb::task_scheduler_handle> globalSchedulerHandle = nullptr;
+static bool isInitialized                                                = false;
 
 DAAL_EXPORT void * _threaded_scalable_malloc(const size_t size, const size_t alignment)
 {
@@ -57,8 +56,6 @@ DAAL_EXPORT void _threaded_scalable_free(void * ptr)
 
 DAAL_EXPORT void _daal_tbb_task_scheduler_free(void *& globalControl)
 {
-    static tbb::spin_mutex mt;
-    tbb::spin_mutex::scoped_lock lock(mt);
     if (globalControl != nullptr)
     {
         delete reinterpret_cast<tbb::global_control *>(globalControl);
@@ -68,18 +65,16 @@ DAAL_EXPORT void _daal_tbb_task_scheduler_free(void *& globalControl)
 
 DAAL_EXPORT void _daal_tbb_task_scheduler_handle_free()
 {
-    static tbb::spin_mutex mt;
-    tbb::spin_mutex::scoped_lock lock(mt);
-    globalSchedulerHandle.release();
+    globalSchedulerHandle.reset();
 }
 
 DAAL_EXPORT void _initializeSchedulerHandle()
 {
-    static tbb::spin_mutex mt;
-    tbb::spin_mutex::scoped_lock lock(mt);
+    static tbb::spin_mutex mt_;
+    tbb::spin_mutex::scoped_lock lock(mt_);
     if (!isInitialized)
     {
-        globalSchedulerHandle = tbb::task_scheduler_handle(tbb::attach {});
+        globalSchedulerHandle = std::unique_ptr<tbb::task_scheduler_handle>(new tbb::task_scheduler_handle(tbb::attach {}));
         tbb::task_arena {}.initialize();
         isInitialized = true;
     }

--- a/cpp/daal/src/threading/threading.cpp
+++ b/cpp/daal/src/threading/threading.cpp
@@ -69,13 +69,6 @@ DAAL_EXPORT void _initializeSchedulerHandle(void ** schedulerHandle)
     std::lock_guard<std::mutex> guard(global_mutex);
     if (!isInitialized)
     {
-#if (TBB_INTERFACE_VERSION < 12000)
-        *schedulerHandle = reinterpret_cast<void *>(new tbb::task_scheduler_init > ());
-#elif (TBB_INTERFACE_VERSION < 12060)
-        *schedulerHandle = reinterpret_cast<void *>(new tbb::task_scheduler_handle > (oneapi::tbb::task_scheduler_handle::get()));
-#else
-        *schedulerHandle = reinterpret_cast<void *>(new tbb::task_scheduler_handle(tbb::attach {}));
-#endif
         *schedulerHandle = reinterpret_cast<void *>(new tbb::task_scheduler_handle(tbb::attach {}));
         isInitialized    = true;
     }

--- a/cpp/daal/src/threading/threading.cpp
+++ b/cpp/daal/src/threading/threading.cpp
@@ -84,6 +84,8 @@ DAAL_EXPORT void _daal_tbb_task_scheduler_handle_free(void *& schedulerHandle)
 
 DAAL_EXPORT void _initializeSchedulerHandle(void ** schedulerHandle)
 {
+    static tbb::spin_mutex mt;
+    tbb::spin_mutex::scoped_lock lock(mt);
     // // It is necessary for initializing tbb in cases where DAAL does not use it.
     tbb::task_arena {}.initialize();
     *schedulerHandle = reinterpret_cast<void *>(new tbb::task_scheduler_handle(tbb::attach {}));

--- a/cpp/daal/src/threading/threading.cpp
+++ b/cpp/daal/src/threading/threading.cpp
@@ -101,10 +101,10 @@ DAAL_EXPORT size_t _setNumberOfThreads(const size_t numThreads, void ** globalCo
     tbb::spin_mutex::scoped_lock lock(mt);
     if (numThreads != 0)
     {
-            if (*globalControl != nullptr)
+        if (*globalControl != nullptr)
         {
-        delete reinterpret_cast<tbb::global_control *>(*globalControl);
-        *globalControl = nullptr;
+            delete reinterpret_cast<tbb::global_control *>(*globalControl);
+            *globalControl = nullptr;
         }
         *globalControl = reinterpret_cast<void *>(new tbb::global_control(tbb::global_control::max_allowed_parallelism, numThreads));
         daal::threader_env()->setNumberOfThreads(numThreads);

--- a/cpp/daal/src/threading/threading.cpp
+++ b/cpp/daal/src/threading/threading.cpp
@@ -42,6 +42,8 @@
 
 using namespace daal::services;
 
+static std::mutex global_mutex;
+
 DAAL_EXPORT void * _threaded_scalable_malloc(const size_t size, const size_t alignment)
 {
     return scalable_aligned_malloc(size, alignment);
@@ -54,7 +56,6 @@ DAAL_EXPORT void _threaded_scalable_free(void * ptr)
 
 DAAL_EXPORT void _daal_tbb_task_scheduler_free(void *& globalControl)
 {
-    std::mutex global_mutex;
     std::lock_guard<std::mutex> guard(global_mutex);
     if (globalControl)
     {
@@ -65,7 +66,6 @@ DAAL_EXPORT void _daal_tbb_task_scheduler_free(void *& globalControl)
 
 DAAL_EXPORT void _daal_tbb_task_scheduler_handle_finalize(void *& schedulerHandle)
 {
-    std::mutex global_mutex;
     std::lock_guard<std::mutex> guard(global_mutex);
     if (schedulerHandle)
     {

--- a/cpp/daal/src/threading/threading.cpp
+++ b/cpp/daal/src/threading/threading.cpp
@@ -78,9 +78,7 @@ DAAL_EXPORT void _daal_tbb_task_scheduler_handle_finalize(void *& schedulerHandl
     std::lock_guard<std::mutex> guard(global_mutex);
     if (schedulerHandle)
     {
-        std::unique_ptr<tbb::task_scheduler_handle> handle(static_cast<tbb::task_scheduler_handle *>(schedulerHandle));
-        tbb::finalize(*handle, std::nothrow);
-        handle.reset();
+        delete reinterpret_cast<tbb::task_scheduler_handle *>(schedulerHandle);
         schedulerHandle = nullptr;
     }
 }

--- a/cpp/daal/src/threading/threading.cpp
+++ b/cpp/daal/src/threading/threading.cpp
@@ -84,23 +84,15 @@ DAAL_EXPORT void _daal_tbb_task_scheduler_handle_finalize(void *& schedulerHandl
     }
 }
 
-DAAL_EXPORT void _daal_tbb_task_scheduler_handle_free(void *& schedulerHandle)
-{
-    std::lock_guard<std::mutex> guard(global_mutex);
-    if (schedulerHandle)
-    {
-        delete reinterpret_cast<tbb::task_scheduler_handle *>(schedulerHandle);
-        schedulerHandle = nullptr;
-    }
-}
-
 DAAL_EXPORT size_t _setNumberOfThreads(const size_t numThreads, void ** globalControl, void ** schedulerHandle)
 {
     static tbb::spin_mutex mt;
     tbb::spin_mutex::scoped_lock lock(mt);
     if (numThreads != 0)
     {
+#if defined(TARGET_X86_64)
         _initializeSchedulerHandle(schedulerHandle);
+#endif
         _daal_tbb_task_scheduler_free(*globalControl);
         *globalControl = reinterpret_cast<void *>(new tbb::global_control(tbb::global_control::max_allowed_parallelism, numThreads));
         daal::threader_env()->setNumberOfThreads(numThreads);

--- a/cpp/daal/src/threading/threading.cpp
+++ b/cpp/daal/src/threading/threading.cpp
@@ -57,7 +57,7 @@ DAAL_EXPORT void _threaded_scalable_free(void * ptr)
 
 DAAL_EXPORT void _daal_tbb_task_scheduler_free(void *& globalControl)
 {
-    if (globalControl != nullptr)
+    if (globalControl)
     {
         delete reinterpret_cast<tbb::global_control *>(globalControl);
         globalControl = nullptr;

--- a/cpp/daal/src/threading/threading.cpp
+++ b/cpp/daal/src/threading/threading.cpp
@@ -79,12 +79,20 @@ DAAL_EXPORT void _initializeSchedulerHandle(void ** schedulerHandle)
 
 DAAL_EXPORT void _releaseSchedulerHandle(void *& schedulerHandle)
 {
-    _daal_tbb_task_scheduler_handle_free(schedulerHandle);
+    if (schedulerHandle != nullptr)
+    {
+        delete reinterpret_cast<tbb::task_scheduler_handle *>(schedulerHandle);
+        schedulerHandle = nullptr;
+    }
 }
 
 DAAL_EXPORT void _releaseGlobalControl(void *& globalControl)
 {
-    _daal_tbb_task_scheduler_free(globalControl);
+    if (globalControl != nullptr)
+    {
+        delete reinterpret_cast<tbb::global_control *>(globalControl);
+        globalControl = nullptr;
+    }
 }
 
 DAAL_EXPORT size_t _setNumberOfThreads(const size_t numThreads, void ** globalControl)
@@ -93,7 +101,11 @@ DAAL_EXPORT size_t _setNumberOfThreads(const size_t numThreads, void ** globalCo
     tbb::spin_mutex::scoped_lock lock(mt);
     if (numThreads != 0)
     {
-        _daal_tbb_task_scheduler_free(*globalControl);
+            if (*globalControl != nullptr)
+        {
+        delete reinterpret_cast<tbb::global_control *>(*globalControl);
+        *globalControl = nullptr;
+        }
         *globalControl = reinterpret_cast<void *>(new tbb::global_control(tbb::global_control::max_allowed_parallelism, numThreads));
         daal::threader_env()->setNumberOfThreads(numThreads);
         return numThreads;

--- a/cpp/daal/src/threading/threading.cpp
+++ b/cpp/daal/src/threading/threading.cpp
@@ -66,13 +66,19 @@ DAAL_EXPORT void _daal_tbb_task_scheduler_free(void *& globalControl)
 
 DAAL_EXPORT void _daal_tbb_task_scheduler_handle_free()
 {
-    tbb::finalize(*globalSchedulerHandle, std::nothrow);
+    std::mutex global_mutex;
+    std::lock_guard<std::mutex> guard(global_mutex);
+    if (isInitialized)
+    {
+        tbb::finalize(*globalSchedulerHandle, std::nothrow);
+    }
+    globalSchedulerHandle = nullptr;
 }
 
 DAAL_EXPORT void _initializeSchedulerHandle()
 {
-    static tbb::spin_mutex mt_;
-    tbb::spin_mutex::scoped_lock lock(mt_);
+    std::mutex global_mutex;
+    std::lock_guard<std::mutex> guard(global_mutex);
     if (!isInitialized)
     {
         tbb::task_arena {}.initialize();

--- a/cpp/daal/src/threading/threading.cpp
+++ b/cpp/daal/src/threading/threading.cpp
@@ -24,7 +24,7 @@
 #include "src/threading/threading.h"
 #include "services/daal_memory.h"
 #include "src/algorithms/service_qsort.h"
-
+#include <iostream>
 #define TBB_PREVIEW_GLOBAL_CONTROL 1
 #define TBB_PREVIEW_TASK_ARENA     1
 
@@ -54,19 +54,31 @@ DAAL_EXPORT void _threaded_scalable_free(void * ptr)
 
 DAAL_EXPORT void _daal_tbb_task_scheduler_free(void *& globalControl)
 {
+    static tbb::spin_mutex mt;
+    tbb::spin_mutex::scoped_lock lock(mt);
+    std::cout << "_daal_tbb_task_scheduler_free TRUE FUNC" << std::endl;
     if (globalControl != nullptr)
     {
+        std::cout << "_daal_tbb_task_scheduler_free TRUE FUNC step 1" << std::endl;
         delete reinterpret_cast<tbb::global_control *>(globalControl);
+        std::cout << "_daal_tbb_task_scheduler_free TRUE FUNC step 2" << std::endl;
         globalControl = nullptr;
+        std::cout << "_daal_tbb_task_scheduler_free TRUE FUNC step 3" << std::endl;
     }
 }
 
 DAAL_EXPORT void _daal_tbb_task_scheduler_handle_free(void *& schedulerHandle)
 {
+    static tbb::spin_mutex mt;
+    tbb::spin_mutex::scoped_lock lock(mt);
+    std::cout << "_daal_tbb_task_scheduler_handle_free TRUE FUNCTION" << std::endl;
     if (schedulerHandle != nullptr)
     {
+        std::cout << "_daal_tbb_task_scheduler_handle_free TRUE FUNCTION 1" << std::endl;
         delete reinterpret_cast<tbb::task_scheduler_handle *>(schedulerHandle);
+        std::cout << "_daal_tbb_task_scheduler_handle_free TRUE FUNCTION 2" << std::endl;
         schedulerHandle = nullptr;
+        std::cout << "_daal_tbb_task_scheduler_handle_free TRUE FUNCTION 3" << std::endl;
     }
 }
 
@@ -75,24 +87,6 @@ DAAL_EXPORT void _initializeSchedulerHandle(void ** schedulerHandle)
     // // It is necessary for initializing tbb in cases where DAAL does not use it.
     tbb::task_arena {}.initialize();
     *schedulerHandle = reinterpret_cast<void *>(new tbb::task_scheduler_handle(tbb::attach {}));
-}
-
-DAAL_EXPORT void _releaseSchedulerHandle(void *& schedulerHandle)
-{
-    if (schedulerHandle != nullptr)
-    {
-        delete reinterpret_cast<tbb::task_scheduler_handle *>(schedulerHandle);
-        schedulerHandle = nullptr;
-    }
-}
-
-DAAL_EXPORT void _releaseGlobalControl(void *& globalControl)
-{
-    if (globalControl != nullptr)
-    {
-        delete reinterpret_cast<tbb::global_control *>(globalControl);
-        globalControl = nullptr;
-    }
 }
 
 DAAL_EXPORT size_t _setNumberOfThreads(const size_t numThreads, void ** globalControl)

--- a/cpp/daal/src/threading/threading.cpp
+++ b/cpp/daal/src/threading/threading.cpp
@@ -42,7 +42,7 @@
 
 using namespace daal::services;
 
-static std::unique_ptr<tbb::task_scheduler_handle> globalSchedulerHandle = nullptr;
+static std::shared_ptr<tbb::task_scheduler_handle> globalSchedulerHandle = nullptr;
 static bool isInitialized                                                = false;
 
 DAAL_EXPORT void * _threaded_scalable_malloc(const size_t size, const size_t alignment)
@@ -66,6 +66,7 @@ DAAL_EXPORT void _daal_tbb_task_scheduler_free(void *& globalControl)
 
 DAAL_EXPORT void _daal_tbb_task_scheduler_handle_free()
 {
+    tbb::finalize(*globalSchedulerHandle, std::nothrow);
 }
 
 DAAL_EXPORT void _initializeSchedulerHandle()
@@ -75,7 +76,7 @@ DAAL_EXPORT void _initializeSchedulerHandle()
     if (!isInitialized)
     {
         tbb::task_arena {}.initialize();
-        globalSchedulerHandle = std::unique_ptr<tbb::task_scheduler_handle>(new tbb::task_scheduler_handle(tbb::attach {}));
+        globalSchedulerHandle = std::make_shared<oneapi::tbb::task_scheduler_handle>(tbb::attach {});
         isInitialized         = true;
     }
 }

--- a/cpp/daal/src/threading/threading.cpp
+++ b/cpp/daal/src/threading/threading.cpp
@@ -65,7 +65,7 @@ DAAL_EXPORT void _daal_tbb_task_scheduler_free(void *& globalControl)
 
 DAAL_EXPORT void _daal_tbb_task_scheduler_handle_free()
 {
-    globalSchedulerHandle.reset();
+    globalSchedulerHandle->release();
 }
 
 DAAL_EXPORT void _initializeSchedulerHandle()

--- a/cpp/daal/src/threading/threading.cpp
+++ b/cpp/daal/src/threading/threading.cpp
@@ -24,6 +24,7 @@
 #include "src/threading/threading.h"
 #include "services/daal_memory.h"
 #include "src/algorithms/service_qsort.h"
+
 #define TBB_PREVIEW_GLOBAL_CONTROL 1
 #define TBB_PREVIEW_TASK_ARENA     1
 
@@ -65,7 +66,7 @@ DAAL_EXPORT void _daal_tbb_task_scheduler_free(void *& globalControl)
 
 DAAL_EXPORT void _daal_tbb_task_scheduler_handle_free()
 {
-    globalSchedulerHandle->release();
+    tbb::finalize(*globalSchedulerHandle, std::nothrow);
 }
 
 DAAL_EXPORT void _initializeSchedulerHandle()
@@ -74,9 +75,9 @@ DAAL_EXPORT void _initializeSchedulerHandle()
     tbb::spin_mutex::scoped_lock lock(mt_);
     if (!isInitialized)
     {
-        globalSchedulerHandle = std::unique_ptr<tbb::task_scheduler_handle>(new tbb::task_scheduler_handle(tbb::attach {}));
         tbb::task_arena {}.initialize();
-        isInitialized = true;
+        globalSchedulerHandle = std::unique_ptr<tbb::task_scheduler_handle>(new tbb::task_scheduler_handle(tbb::attach {}));
+        isInitialized         = true;
     }
 }
 

--- a/cpp/daal/src/threading/threading.h
+++ b/cpp/daal/src/threading/threading.h
@@ -203,7 +203,7 @@ inline void releaseGlobalControl_(void *& globalControl)
 
 inline void releaseSchedulerHandle_()
 {
-    return _daal_tbb_task_scheduler_handle_free();
+    // return _daal_tbb_task_scheduler_handle_free();
 }
 
 template <typename F>

--- a/cpp/daal/src/threading/threading.h
+++ b/cpp/daal/src/threading/threading.h
@@ -103,7 +103,7 @@ extern "C"
 
     DAAL_EXPORT void _daal_tbb_task_scheduler_free(void *& globalControl);
     DAAL_EXPORT void _daal_tbb_task_scheduler_handle_free(void *& schedulerHandle);
-
+    DAAL_EXPORT void _daal_tbb_task_scheduler_handle_finalize(void *& schedulerHandle);
     DAAL_EXPORT size_t _setNumberOfThreads(const size_t numThreads, void ** globalControl, void ** schedulerHandle);
 
     DAAL_EXPORT void * _daal_threader_env();

--- a/cpp/daal/src/threading/threading.h
+++ b/cpp/daal/src/threading/threading.h
@@ -105,6 +105,7 @@ extern "C"
     DAAL_EXPORT void _daal_tbb_task_scheduler_handle_free(void *& schedulerHandle);
     DAAL_EXPORT void _daal_tbb_task_scheduler_handle_finalize(void *& schedulerHandle);
     DAAL_EXPORT size_t _setNumberOfThreads(const size_t numThreads, void ** globalControl, void ** schedulerHandle);
+    DAAL_EXPORT void _initializeSchedulerHandle(void ** schedulerHandle);
 
     DAAL_EXPORT void * _daal_threader_env();
 
@@ -183,6 +184,11 @@ inline ThreaderEnvironment * threader_env()
 inline size_t threader_get_threads_number()
 {
     return threader_env()->getNumberOfThreads();
+}
+
+inline void initializeSchedulerHandle(void ** schedulerHandle)
+{
+    _initializeSchedulerHandle(schedulerHandle);
 }
 
 inline size_t setNumberOfThreads(const size_t numThreads, void ** globalControl, void ** schedulerHandle)

--- a/cpp/daal/src/threading/threading.h
+++ b/cpp/daal/src/threading/threading.h
@@ -102,6 +102,9 @@ extern "C"
     DAAL_EXPORT void _daal_wait_task_group(void * taskGroupPtr);
 
     DAAL_EXPORT void _daal_tbb_task_scheduler_free(void *& globalControl);
+    DAAL_EXPORT void _daal_tbb_task_scheduler_handle_free(void *& schedulerHandle);
+    DAAL_EXPORT void _initializeSchedulerHandle(void ** schedulerHandle);
+
     DAAL_EXPORT size_t _setNumberOfThreads(const size_t numThreads, void ** globalControl);
 
     DAAL_EXPORT void * _daal_threader_env();
@@ -186,6 +189,21 @@ inline size_t threader_get_threads_number()
 inline size_t setNumberOfThreads(const size_t numThreads, void ** globalControl)
 {
     return _setNumberOfThreads(numThreads, globalControl);
+}
+
+inline void initializeSchedulerHandle(void ** schedulerHandle)
+{
+    return _initializeSchedulerHandle(schedulerHandle);
+}
+
+inline void releaseGlobalControl_(void *& globalControl)
+{
+    return _daal_tbb_task_scheduler_free(globalControl);
+}
+
+inline void releaseSchedulerHandle_(void *& schedulerHandle)
+{
+    return _daal_tbb_task_scheduler_handle_free(schedulerHandle);
 }
 
 template <typename F>

--- a/cpp/daal/src/threading/threading.h
+++ b/cpp/daal/src/threading/threading.h
@@ -102,7 +102,6 @@ extern "C"
     DAAL_EXPORT void _daal_wait_task_group(void * taskGroupPtr);
 
     DAAL_EXPORT void _daal_tbb_task_scheduler_free(void *& globalControl);
-    DAAL_EXPORT void _daal_tbb_task_scheduler_handle_free(void *& schedulerHandle);
     DAAL_EXPORT void _daal_tbb_task_scheduler_handle_finalize(void *& schedulerHandle);
     DAAL_EXPORT size_t _setNumberOfThreads(const size_t numThreads, void ** globalControl, void ** schedulerHandle);
     DAAL_EXPORT void _initializeSchedulerHandle(void ** schedulerHandle);

--- a/cpp/daal/src/threading/threading.h
+++ b/cpp/daal/src/threading/threading.h
@@ -203,7 +203,7 @@ inline void releaseGlobalControl_(void *& globalControl)
 
 inline void releaseSchedulerHandle_()
 {
-    // return _daal_tbb_task_scheduler_handle_free();
+    return _daal_tbb_task_scheduler_handle_free();
 }
 
 template <typename F>

--- a/cpp/daal/src/threading/threading.h
+++ b/cpp/daal/src/threading/threading.h
@@ -102,8 +102,8 @@ extern "C"
     DAAL_EXPORT void _daal_wait_task_group(void * taskGroupPtr);
 
     DAAL_EXPORT void _daal_tbb_task_scheduler_free(void *& globalControl);
-    DAAL_EXPORT void _daal_tbb_task_scheduler_handle_free(void *& schedulerHandle);
-    DAAL_EXPORT void _initializeSchedulerHandle(void ** schedulerHandle);
+    DAAL_EXPORT void _daal_tbb_task_scheduler_handle_free();
+    DAAL_EXPORT void _initializeSchedulerHandle();
 
     DAAL_EXPORT size_t _setNumberOfThreads(const size_t numThreads, void ** globalControl);
 
@@ -191,9 +191,9 @@ inline size_t setNumberOfThreads(const size_t numThreads, void ** globalControl)
     return _setNumberOfThreads(numThreads, globalControl);
 }
 
-inline void initializeSchedulerHandle(void ** schedulerHandle)
+inline void initializeSchedulerHandle()
 {
-    return _initializeSchedulerHandle(schedulerHandle);
+    return _initializeSchedulerHandle();
 }
 
 inline void releaseGlobalControl_(void *& globalControl)
@@ -201,9 +201,9 @@ inline void releaseGlobalControl_(void *& globalControl)
     return _daal_tbb_task_scheduler_free(globalControl);
 }
 
-inline void releaseSchedulerHandle_(void *& schedulerHandle)
+inline void releaseSchedulerHandle_()
 {
-    return _daal_tbb_task_scheduler_handle_free(schedulerHandle);
+    return _daal_tbb_task_scheduler_handle_free();
 }
 
 template <typename F>

--- a/cpp/daal/src/threading/threading.h
+++ b/cpp/daal/src/threading/threading.h
@@ -196,16 +196,6 @@ inline void initializeSchedulerHandle()
     return _initializeSchedulerHandle();
 }
 
-inline void releaseGlobalControl_(void *& globalControl)
-{
-    return _daal_tbb_task_scheduler_free(globalControl);
-}
-
-inline void releaseSchedulerHandle_()
-{
-    return _daal_tbb_task_scheduler_handle_free();
-}
-
 template <typename F>
 inline void threader_func(int i, const void * a)
 {

--- a/cpp/daal/src/threading/threading.h
+++ b/cpp/daal/src/threading/threading.h
@@ -102,10 +102,9 @@ extern "C"
     DAAL_EXPORT void _daal_wait_task_group(void * taskGroupPtr);
 
     DAAL_EXPORT void _daal_tbb_task_scheduler_free(void *& globalControl);
-    DAAL_EXPORT void _daal_tbb_task_scheduler_handle_free();
-    DAAL_EXPORT void _initializeSchedulerHandle();
+    DAAL_EXPORT void _daal_tbb_task_scheduler_handle_free(void *& schedulerHandle);
 
-    DAAL_EXPORT size_t _setNumberOfThreads(const size_t numThreads, void ** globalControl);
+    DAAL_EXPORT size_t _setNumberOfThreads(const size_t numThreads, void ** globalControl, void ** schedulerHandle);
 
     DAAL_EXPORT void * _daal_threader_env();
 
@@ -186,14 +185,9 @@ inline size_t threader_get_threads_number()
     return threader_env()->getNumberOfThreads();
 }
 
-inline size_t setNumberOfThreads(const size_t numThreads, void ** globalControl)
+inline size_t setNumberOfThreads(const size_t numThreads, void ** globalControl, void ** schedulerHandle)
 {
-    return _setNumberOfThreads(numThreads, globalControl);
-}
-
-inline void initializeSchedulerHandle()
-{
-    return _initializeSchedulerHandle();
+    return _setNumberOfThreads(numThreads, globalControl, schedulerHandle);
 }
 
 template <typename F>

--- a/docs/source/daal/services/managing-computational-environment.rst
+++ b/docs/source/daal/services/managing-computational-environment.rst
@@ -37,9 +37,6 @@ it for multiple purposes:
    based application.
    To do this, call the ``getNumberOfThreads()`` or ``setNumberOfThreads()`` method, respectively.
 
--  Specify the single-threaded of multi-threaded mode for |short_name| on Windows.
-   To do this, call to the ``setDynamicLibraryThreadingTypeOnWindows()`` method.
-
 -  Enable thread pinning.
    To do this, call the ``enableThreadPinning()`` method. This method
    performs binding of the threads that are used to parallelize

--- a/examples/daal/cpp/source/svm/svm_multi_class_boser_csr_batch.cpp
+++ b/examples/daal/cpp/source/svm/svm_multi_class_boser_csr_batch.cpp
@@ -43,14 +43,10 @@ std::string testLabelsFileName = "../data/batch/svm_multi_class_test_labels.csv"
 
 const size_t nClasses = 5;
 
-services::SharedPtr<svm::training::Batch<float, svm::training::boser> > training(
-    new svm::training::Batch<float, svm::training::boser>());
 services::SharedPtr<svm::prediction::Batch<> > prediction(new svm::prediction::Batch<>());
 
 multi_class_classifier::training::ResultPtr trainingResult;
 multi_class_classifier::prediction::ResultPtr predictionResult;
-kernel_function::KernelIfacePtr kernel(
-    new kernel_function::linear::Batch<float, kernel_function::linear::fastCSR>());
 NumericTablePtr testGroundTruth;
 
 void trainModel();
@@ -65,7 +61,8 @@ int main(int argc, char* argv[]) {
                    &trainLabelsFileName,
                    &testDatasetFileName,
                    &testLabelsFileName);
-
+    kernel_function::KernelIfacePtr kernel(
+        new kernel_function::linear::Batch<float, kernel_function::linear::fastCSR>());
     training->parameter.cacheSize = 100000000;
     training->parameter.kernel = kernel;
     prediction->parameter.kernel = kernel;
@@ -91,7 +88,10 @@ void trainModel() {
 
     /* Create an algorithm object to train the multi-class SVM model */
     multi_class_classifier::training::Batch<> algorithm(nClasses);
-
+    services::SharedPtr<svm::training::Batch<float, svm::training::boser> > training(
+        new svm::training::Batch<float, svm::training::boser>());
+    training->parameter.cacheSize = 100000000;
+    training->parameter.kernel = kernel;
     algorithm.parameter.training = training;
     algorithm.parameter.prediction = prediction;
 

--- a/examples/daal/cpp/source/svm/svm_multi_class_boser_csr_batch.cpp
+++ b/examples/daal/cpp/source/svm/svm_multi_class_boser_csr_batch.cpp
@@ -30,126 +30,126 @@
 #include "daal.h"
 #include "service.h"
 
-using namespace daal;
-using namespace daal::algorithms;
-using namespace daal::data_management;
+// using namespace daal;
+// using namespace daal::algorithms;
+// using namespace daal::data_management;
 
-/* Input data set parameters */
-std::string trainDatasetFileName = "../data/batch/svm_multi_class_train_csr.csv";
-std::string trainLabelsFileName = "../data/batch/svm_multi_class_train_labels.csv";
+// /* Input data set parameters */
+// std::string trainDatasetFileName = "../data/batch/svm_multi_class_train_csr.csv";
+// std::string trainLabelsFileName = "../data/batch/svm_multi_class_train_labels.csv";
 
-std::string testDatasetFileName = "../data/batch/svm_multi_class_test_csr.csv";
-std::string testLabelsFileName = "../data/batch/svm_multi_class_test_labels.csv";
+// std::string testDatasetFileName = "../data/batch/svm_multi_class_test_csr.csv";
+// std::string testLabelsFileName = "../data/batch/svm_multi_class_test_labels.csv";
 
-const size_t nClasses = 5;
+// const size_t nClasses = 5;
 
-services::SharedPtr<svm::prediction::Batch<> > prediction(new svm::prediction::Batch<>());
+// services::SharedPtr<svm::prediction::Batch<> > prediction(new svm::prediction::Batch<>());
 
-multi_class_classifier::training::ResultPtr trainingResult;
-multi_class_classifier::prediction::ResultPtr predictionResult;
-NumericTablePtr testGroundTruth;
+// multi_class_classifier::training::ResultPtr trainingResult;
+// multi_class_classifier::prediction::ResultPtr predictionResult;
+// NumericTablePtr testGroundTruth;
 
-void trainModel();
-void testModel();
-void printResults();
+// void trainModel();
+// void testModel();
+// void printResults();
 
 int main(int argc, char* argv[]) {
-    checkArguments(argc,
-                   argv,
-                   4,
-                   &trainDatasetFileName,
-                   &trainLabelsFileName,
-                   &testDatasetFileName,
-                   &testLabelsFileName);
-    kernel_function::KernelIfacePtr kernel(
-        new kernel_function::linear::Batch<float, kernel_function::linear::fastCSR>());
-    training->parameter.cacheSize = 100000000;
-    training->parameter.kernel = kernel;
-    prediction->parameter.kernel = kernel;
+    // checkArguments(argc,
+    //                argv,
+    //                4,
+    //                &trainDatasetFileName,
+    //                &trainLabelsFileName,
+    //                &testDatasetFileName,
+    //                &testLabelsFileName);
+    // kernel_function::KernelIfacePtr kernel(
+    //     new kernel_function::linear::Batch<float, kernel_function::linear::fastCSR>());
+    // training->parameter.cacheSize = 100000000;
+    // training->parameter.kernel = kernel;
+    // prediction->parameter.kernel = kernel;
 
-    trainModel();
-    testModel();
-    printResults();
+    // trainModel();
+    // testModel();
+    // printResults();
 
     return 0;
 }
 
-void trainModel() {
-    /* Initialize FileDataSource<CSVFeatureManager> to retrieve the input data from a .csv file */
-    FileDataSource<CSVFeatureManager> trainLabelsDataSource(trainLabelsFileName,
-                                                            DataSource::doAllocateNumericTable,
-                                                            DataSource::doDictionaryFromContext);
+// void trainModel() {
+//     /* Initialize FileDataSource<CSVFeatureManager> to retrieve the input data from a .csv file */
+//     FileDataSource<CSVFeatureManager> trainLabelsDataSource(trainLabelsFileName,
+//                                                             DataSource::doAllocateNumericTable,
+//                                                             DataSource::doDictionaryFromContext);
 
-    /* Create numeric table for training data */
-    CSRNumericTablePtr trainData(createSparseTable<float>(trainDatasetFileName));
+//     /* Create numeric table for training data */
+//     CSRNumericTablePtr trainData(createSparseTable<float>(trainDatasetFileName));
 
-    /* Retrieve the data from the input file */
-    trainLabelsDataSource.loadDataBlock();
+//     /* Retrieve the data from the input file */
+//     trainLabelsDataSource.loadDataBlock();
 
-    /* Create an algorithm object to train the multi-class SVM model */
-    multi_class_classifier::training::Batch<> algorithm(nClasses);
-    services::SharedPtr<svm::training::Batch<float, svm::training::boser> > training(
-        new svm::training::Batch<float, svm::training::boser>());
-    training->parameter.cacheSize = 100000000;
-    training->parameter.kernel = kernel;
-    algorithm.parameter.training = training;
-    algorithm.parameter.prediction = prediction;
+//     /* Create an algorithm object to train the multi-class SVM model */
+//     multi_class_classifier::training::Batch<> algorithm(nClasses);
+//     services::SharedPtr<svm::training::Batch<float, svm::training::boser> > training(
+//         new svm::training::Batch<float, svm::training::boser>());
+//     training->parameter.cacheSize = 100000000;
+//     training->parameter.kernel = kernel;
+//     algorithm.parameter.training = training;
+//     algorithm.parameter.prediction = prediction;
 
-    /* Pass a training data set and dependent values to the algorithm */
-    algorithm.input.set(classifier::training::data, trainData);
-    algorithm.input.set(classifier::training::labels, trainLabelsDataSource.getNumericTable());
+//     /* Pass a training data set and dependent values to the algorithm */
+//     algorithm.input.set(classifier::training::data, trainData);
+//     algorithm.input.set(classifier::training::labels, trainLabelsDataSource.getNumericTable());
 
-    /* Build the multi-class SVM model */
-    algorithm.compute();
+//     /* Build the multi-class SVM model */
+//     algorithm.compute();
 
-    /* Retrieve the algorithm results */
-    trainingResult = algorithm.getResult();
-}
+//     /* Retrieve the algorithm results */
+//     trainingResult = algorithm.getResult();
+// }
 
-void testModel() {
-    /* Create Numeric Tables for testing data */
-    NumericTablePtr testData(createSparseTable<float>(testDatasetFileName));
+// void testModel() {
+//     /* Create Numeric Tables for testing data */
+//     NumericTablePtr testData(createSparseTable<float>(testDatasetFileName));
 
-    /* Create an algorithm object to predict multi-class SVM values */
-    multi_class_classifier::prediction::Batch<float, multi_class_classifier::prediction::voteBased>
-        algorithm(nClasses);
+//     /* Create an algorithm object to predict multi-class SVM values */
+//     multi_class_classifier::prediction::Batch<float, multi_class_classifier::prediction::voteBased>
+//         algorithm(nClasses);
 
-    algorithm.parameter.training = training;
-    algorithm.parameter.prediction = prediction;
+//     algorithm.parameter.training = training;
+//     algorithm.parameter.prediction = prediction;
 
-    /* Pass a testing data set and the trained model to the algorithm */
-    algorithm.input.set(classifier::prediction::data, testData);
-    algorithm.input.set(classifier::prediction::model,
-                        trainingResult->get(classifier::training::model));
-    algorithm.parameter.resultsToEvaluate = multi_class_classifier::computeClassLabels |
-                                            multi_class_classifier::computeDecisionFunction;
+//     /* Pass a testing data set and the trained model to the algorithm */
+//     algorithm.input.set(classifier::prediction::data, testData);
+//     algorithm.input.set(classifier::prediction::model,
+//                         trainingResult->get(classifier::training::model));
+//     algorithm.parameter.resultsToEvaluate = multi_class_classifier::computeClassLabels |
+//                                             multi_class_classifier::computeDecisionFunction;
 
-    /* Predict multi-class SVM values */
-    algorithm.compute();
+//     /* Predict multi-class SVM values */
+//     algorithm.compute();
 
-    /* Retrieve the algorithm results */
-    predictionResult = algorithm.getResult();
-}
+//     /* Retrieve the algorithm results */
+//     predictionResult = algorithm.getResult();
+// }
 
-void printResults() {
-    /* Initialize FileDataSource<CSVFeatureManager> to retrieve the test data from a .csv file */
-    FileDataSource<CSVFeatureManager> testLabelsDataSource(testLabelsFileName,
-                                                           DataSource::doAllocateNumericTable,
-                                                           DataSource::doDictionaryFromContext);
-    /* Retrieve the data from input file */
-    testLabelsDataSource.loadDataBlock();
-    testGroundTruth = testLabelsDataSource.getNumericTable();
+// void printResults() {
+//     /* Initialize FileDataSource<CSVFeatureManager> to retrieve the test data from a .csv file */
+//     FileDataSource<CSVFeatureManager> testLabelsDataSource(testLabelsFileName,
+//                                                            DataSource::doAllocateNumericTable,
+//                                                            DataSource::doDictionaryFromContext);
+//     /* Retrieve the data from input file */
+//     testLabelsDataSource.loadDataBlock();
+//     testGroundTruth = testLabelsDataSource.getNumericTable();
 
-    printNumericTables<int, int>(
-        testGroundTruth,
-        predictionResult->get(multi_class_classifier::prediction::prediction),
-        "Ground truth",
-        "Classification results",
-        "Multi-class SVM classification sample program results (first 20 observations):",
-        20);
+//     printNumericTables<int, int>(
+//         testGroundTruth,
+//         predictionResult->get(multi_class_classifier::prediction::prediction),
+//         "Ground truth",
+//         "Classification results",
+//         "Multi-class SVM classification sample program results (first 20 observations):",
+//         20);
 
-    printNumericTable(
-        predictionResult->get(multi_class_classifier::prediction::decisionFunction),
-        "Multi-class SVM classification decision function results (first 20 observations):",
-        20);
-}
+//     printNumericTable(
+//         predictionResult->get(multi_class_classifier::prediction::decisionFunction),
+//         "Multi-class SVM classification decision function results (first 20 observations):",
+//         20);
+// }

--- a/examples/daal/cpp/source/svm/svm_multi_class_boser_dense_batch.cpp
+++ b/examples/daal/cpp/source/svm/svm_multi_class_boser_dense_batch.cpp
@@ -47,7 +47,7 @@ services::SharedPtr<svm::prediction::Batch<> > prediction(new svm::prediction::B
 
 multi_class_classifier::training::ResultPtr trainingResult;
 multi_class_classifier::prediction::ResultPtr predictionResult;
-kernel_function::KernelIfacePtr kernel(new kernel_function::linear::Batch<>());
+
 NumericTablePtr testGroundTruth;
 
 void trainModel();
@@ -56,7 +56,7 @@ void printResults();
 
 int main(int argc, char* argv[]) {
     checkArguments(argc, argv, 2, &trainDatasetFileName, &testDatasetFileName);
-
+    kernel_function::KernelIfacePtr kernel(new kernel_function::linear::Batch<>());
     training->parameter.cacheSize = 100000000;
     training->parameter.kernel = kernel;
     prediction->parameter.kernel = kernel;

--- a/examples/daal/cpp/source/svm/svm_multi_class_boser_dense_batch.cpp
+++ b/examples/daal/cpp/source/svm/svm_multi_class_boser_dense_batch.cpp
@@ -41,10 +41,6 @@ std::string testDatasetFileName = "../data/batch/svm_multi_class_test_dense.csv"
 const size_t nFeatures = 20;
 const size_t nClasses = 5;
 
-services::SharedPtr<svm::training::Batch<float, svm::training::boser> > training(
-    new svm::training::Batch<float, svm::training::boser>());
-services::SharedPtr<svm::prediction::Batch<> > prediction(new svm::prediction::Batch<>());
-
 multi_class_classifier::training::ResultPtr trainingResult;
 multi_class_classifier::prediction::ResultPtr predictionResult;
 
@@ -56,10 +52,6 @@ void printResults();
 
 int main(int argc, char* argv[]) {
     checkArguments(argc, argv, 2, &trainDatasetFileName, &testDatasetFileName);
-    kernel_function::KernelIfacePtr kernel(new kernel_function::linear::Batch<>());
-    training->parameter.cacheSize = 100000000;
-    training->parameter.kernel = kernel;
-    prediction->parameter.kernel = kernel;
 
     trainModel();
     testModel();
@@ -86,9 +78,16 @@ void trainModel() {
 
     /* Create an algorithm object to train the multi-class SVM model */
     multi_class_classifier::training::Batch<> algorithm(nClasses);
+    services::SharedPtr<svm::training::Batch<float, svm::training::boser> > training(
+        new svm::training::Batch<float, svm::training::boser>());
+    services::SharedPtr<svm::prediction::Batch<> > prediction(new svm::prediction::Batch<>());
+
+    kernel_function::KernelIfacePtr kernel(new kernel_function::linear::Batch<>());
 
     algorithm.parameter.training = training;
     algorithm.parameter.prediction = prediction;
+    training->parameter.cacheSize = 100000000;
+    training->parameter.kernel = kernel;
 
     /* Pass a training data set and dependent values to the algorithm */
     algorithm.input.set(classifier::training::data, trainData);
@@ -120,8 +119,17 @@ void testModel() {
     multi_class_classifier::prediction::Batch<float, multi_class_classifier::prediction::voteBased>
         algorithm(nClasses);
 
+    services::SharedPtr<svm::training::Batch<float, svm::training::boser> > training(
+        new svm::training::Batch<float, svm::training::boser>());
+    services::SharedPtr<svm::prediction::Batch<> > prediction(new svm::prediction::Batch<>());
+
+    kernel_function::KernelIfacePtr kernel(new kernel_function::linear::Batch<>());
+
+    training->parameter.kernel = kernel;
+    training->parameter.cacheSize = 100000000;
     algorithm.parameter.training = training;
     algorithm.parameter.prediction = prediction;
+
     algorithm.parameter.resultsToEvaluate = multi_class_classifier::computeClassLabels |
                                             multi_class_classifier::computeDecisionFunction;
 

--- a/examples/daal/cpp/source/svm/svm_multi_class_model_builder.cpp
+++ b/examples/daal/cpp/source/svm/svm_multi_class_model_builder.cpp
@@ -47,7 +47,7 @@ const size_t nClasses = 3;
 services::SharedPtr<svm::prediction::Batch<> > prediction(new svm::prediction::Batch<>());
 
 classifier::prediction::ResultPtr predictionResult;
-kernel_function::KernelIfacePtr kernel(new kernel_function::linear::Batch<>());
+
 NumericTablePtr testGroundTruth;
 
 multi_class_classifier::ModelPtr buildModelFromTraining();
@@ -57,6 +57,7 @@ int main(int argc, char* argv[]) {
     checkArguments(argc, argv, 1, &testDatasetFileName);
 
     multi_class_classifier::ModelPtr builtModel = buildModelFromTraining();
+    kernel_function::KernelIfacePtr kernel(new kernel_function::linear::Batch<>());
     prediction->parameter.kernel = kernel;
     testModel(builtModel);
     return 0;

--- a/examples/daal/cpp/source/svm/svm_multi_class_model_builder.cpp
+++ b/examples/daal/cpp/source/svm/svm_multi_class_model_builder.cpp
@@ -44,8 +44,6 @@ std::string testDatasetFileName = "../data/batch/multiclass_iris_train.csv";
 const size_t nFeatures = 4;
 const size_t nClasses = 3;
 
-services::SharedPtr<svm::prediction::Batch<> > prediction(new svm::prediction::Batch<>());
-
 classifier::prediction::ResultPtr predictionResult;
 
 NumericTablePtr testGroundTruth;
@@ -57,8 +55,7 @@ int main(int argc, char* argv[]) {
     checkArguments(argc, argv, 1, &testDatasetFileName);
 
     multi_class_classifier::ModelPtr builtModel = buildModelFromTraining();
-    kernel_function::KernelIfacePtr kernel(new kernel_function::linear::Batch<>());
-    prediction->parameter.kernel = kernel;
+
     testModel(builtModel);
     return 0;
 }
@@ -133,8 +130,10 @@ void testModel(multi_class_classifier::ModelPtr& inputModel) {
 
     /* Create an algorithm object to predict multi-class SVM values */
     multi_class_classifier::prediction::Batch<> algorithm(nClasses);
+    services::SharedPtr<svm::prediction::Batch<> > prediction(new svm::prediction::Batch<>());
 
-    //algorithm.parameter.training = training;
+    kernel_function::KernelIfacePtr kernel(new kernel_function::linear::Batch<>());
+    prediction->parameter.kernel = kernel;
     algorithm.parameter.prediction = prediction;
 
     /* Pass a testing data set and the trained model to the algorithm */

--- a/examples/daal/cpp/source/svm/svm_multi_class_thunder_csr_batch.cpp
+++ b/examples/daal/cpp/source/svm/svm_multi_class_thunder_csr_batch.cpp
@@ -34,105 +34,104 @@ using namespace daal;
 using namespace daal::algorithms;
 using namespace daal::data_management;
 
-// /* Input data set parameters */
-// std::string trainDatasetFileName = "../data/batch/svm_multi_class_train_csr.csv";
-// std::string trainLabelsFileName = "../data/batch/svm_multi_class_train_labels.csv";
+/* Input data set parameters */
+std::string trainDatasetFileName = "../data/batch/svm_multi_class_train_csr.csv";
+std::string trainLabelsFileName = "../data/batch/svm_multi_class_train_labels.csv";
 
-// std::string testDatasetFileName = "../data/batch/svm_multi_class_test_csr.csv";
-// std::string testLabelsFileName = "../data/batch/svm_multi_class_test_labels.csv";
+std::string testDatasetFileName = "../data/batch/svm_multi_class_test_csr.csv";
+std::string testLabelsFileName = "../data/batch/svm_multi_class_test_labels.csv";
 
-// const size_t nClasses = 5;
+const size_t nClasses = 5;
 
-// multi_class_classifier::training::ResultPtr trainingResult;
-// multi_class_classifier::prediction::ResultPtr predictionResult;
-// NumericTablePtr testGroundTruth;
+multi_class_classifier::training::ResultPtr trainingResult;
+multi_class_classifier::prediction::ResultPtr predictionResult;
+NumericTablePtr testGroundTruth;
 
-// void trainModel();
-// void testModel();
-// void printResults();
+void trainModel();
+void testModel();
+void printResults();
 
 int main(int argc, char* argv[]) {
-
     return 0;
 }
 
-// void trainModel() {
-//     /* Initialize FileDataSource<CSVFeatureManager> to retrieve the input data from a .csv file */
-//     FileDataSource<CSVFeatureManager> trainLabelsDataSource(trainLabelsFileName,
-//                                                             DataSource::doAllocateNumericTable,
-//                                                             DataSource::doDictionaryFromContext);
+void trainModel() {
+    /* Initialize FileDataSource<CSVFeatureManager> to retrieve the input data from a .csv file */
+    FileDataSource<CSVFeatureManager> trainLabelsDataSource(trainLabelsFileName,
+                                                            DataSource::doAllocateNumericTable,
+                                                            DataSource::doDictionaryFromContext);
 
-//     /* Create numeric table for training data */
-//     CSRNumericTablePtr trainData(createSparseTable<float>(trainDatasetFileName));
+    /* Create numeric table for training data */
+    CSRNumericTablePtr trainData(createSparseTable<float>(trainDatasetFileName));
 
-//     /* Retrieve the data from the input file */
-//     trainLabelsDataSource.loadDataBlock();
-//     services::SharedPtr<svm::training::Batch<float, svm::training::thunder> > training(
-//         new svm::training::Batch<float, svm::training::thunder>());
-//     services::SharedPtr<svm::prediction::Batch<> > prediction(new svm::prediction::Batch<>());
-//     kernel_function::KernelIfacePtr kernel(
-//         new kernel_function::linear::Batch<float, kernel_function::linear::fastCSR>());
-//     training->parameter.kernel = kernel;
-//     prediction->parameter.kernel = kernel;
-//     /* Create an algorithm object to train the multi-class SVM model */
-//     multi_class_classifier::training::Batch<> algorithm(nClasses);
+    /* Retrieve the data from the input file */
+    trainLabelsDataSource.loadDataBlock();
+    services::SharedPtr<svm::training::Batch<float, svm::training::thunder> > training(
+        new svm::training::Batch<float, svm::training::thunder>());
+    services::SharedPtr<svm::prediction::Batch<> > prediction(new svm::prediction::Batch<>());
+    kernel_function::KernelIfacePtr kernel(
+        new kernel_function::linear::Batch<float, kernel_function::linear::fastCSR>());
+    training->parameter.kernel = kernel;
+    prediction->parameter.kernel = kernel;
+    /* Create an algorithm object to train the multi-class SVM model */
+    multi_class_classifier::training::Batch<> algorithm(nClasses);
 
-//     algorithm.parameter.training = training;
-//     algorithm.parameter.prediction = prediction;
+    algorithm.parameter.training = training;
+    algorithm.parameter.prediction = prediction;
 
-//     /* Pass a training data set and dependent values to the algorithm */
-//     algorithm.input.set(classifier::training::data, trainData);
-//     algorithm.input.set(classifier::training::labels, trainLabelsDataSource.getNumericTable());
+    /* Pass a training data set and dependent values to the algorithm */
+    algorithm.input.set(classifier::training::data, trainData);
+    algorithm.input.set(classifier::training::labels, trainLabelsDataSource.getNumericTable());
 
-//     /* Build the multi-class SVM model */
-//     algorithm.compute();
+    /* Build the multi-class SVM model */
+    algorithm.compute();
 
-//     /* Retrieve the algorithm results */
-//     trainingResult = algorithm.getResult();
-// }
+    /* Retrieve the algorithm results */
+    trainingResult = algorithm.getResult();
+}
 
-// void testModel() {
-//     /* Create Numeric Tables for testing data */
-//     NumericTablePtr testData(createSparseTable<float>(testDatasetFileName));
+void testModel() {
+    /* Create Numeric Tables for testing data */
+    NumericTablePtr testData(createSparseTable<float>(testDatasetFileName));
 
-//     /* Create an algorithm object to predict multi-class SVM values */
-//     multi_class_classifier::prediction::Batch<> algorithm(nClasses);
-//     services::SharedPtr<svm::training::Batch<float, svm::training::thunder> > training(
-//         new svm::training::Batch<float, svm::training::thunder>());
-//     services::SharedPtr<svm::prediction::Batch<> > prediction(new svm::prediction::Batch<>());
-//     kernel_function::KernelIfacePtr kernel(
-//         new kernel_function::linear::Batch<float, kernel_function::linear::fastCSR>());
-//     training->parameter.kernel = kernel;
-//     prediction->parameter.kernel = kernel;
-//     algorithm.parameter.training = training;
-//     algorithm.parameter.prediction = prediction;
+    /* Create an algorithm object to predict multi-class SVM values */
+    multi_class_classifier::prediction::Batch<> algorithm(nClasses);
+    services::SharedPtr<svm::training::Batch<float, svm::training::thunder> > training(
+        new svm::training::Batch<float, svm::training::thunder>());
+    services::SharedPtr<svm::prediction::Batch<> > prediction(new svm::prediction::Batch<>());
+    kernel_function::KernelIfacePtr kernel(
+        new kernel_function::linear::Batch<float, kernel_function::linear::fastCSR>());
+    training->parameter.kernel = kernel;
+    prediction->parameter.kernel = kernel;
+    algorithm.parameter.training = training;
+    algorithm.parameter.prediction = prediction;
 
-//     /* Pass a testing data set and the trained model to the algorithm */
-//     algorithm.input.set(classifier::prediction::data, testData);
-//     algorithm.input.set(classifier::prediction::model,
-//                         trainingResult->get(classifier::training::model));
+    /* Pass a testing data set and the trained model to the algorithm */
+    algorithm.input.set(classifier::prediction::data, testData);
+    algorithm.input.set(classifier::prediction::model,
+                        trainingResult->get(classifier::training::model));
 
-//     /* Predict multi-class SVM values */
-//     algorithm.compute();
+    /* Predict multi-class SVM values */
+    algorithm.compute();
 
-//     /* Retrieve the algorithm results */
-//     predictionResult = algorithm.getResult();
-// }
+    /* Retrieve the algorithm results */
+    predictionResult = algorithm.getResult();
+}
 
-// void printResults() {
-//     /* Initialize FileDataSource<CSVFeatureManager> to retrieve the test data from a .csv file */
-//     FileDataSource<CSVFeatureManager> testLabelsDataSource(testLabelsFileName,
-//                                                            DataSource::doAllocateNumericTable,
-//                                                            DataSource::doDictionaryFromContext);
-//     /* Retrieve the data from input file */
-//     testLabelsDataSource.loadDataBlock();
-//     testGroundTruth = testLabelsDataSource.getNumericTable();
+void printResults() {
+    /* Initialize FileDataSource<CSVFeatureManager> to retrieve the test data from a .csv file */
+    FileDataSource<CSVFeatureManager> testLabelsDataSource(testLabelsFileName,
+                                                           DataSource::doAllocateNumericTable,
+                                                           DataSource::doDictionaryFromContext);
+    /* Retrieve the data from input file */
+    testLabelsDataSource.loadDataBlock();
+    testGroundTruth = testLabelsDataSource.getNumericTable();
 
-//     printNumericTables<int, int>(
-//         testGroundTruth,
-//         predictionResult->get(multi_class_classifier::prediction::prediction),
-//         "Ground truth",
-//         "Classification results",
-//         "Multi-class SVM classification sample program results (first 20 observations):",
-//         20);
-// }
+    printNumericTables<int, int>(
+        testGroundTruth,
+        predictionResult->get(multi_class_classifier::prediction::prediction),
+        "Ground truth",
+        "Classification results",
+        "Multi-class SVM classification sample program results (first 20 observations):",
+        20);
+}

--- a/examples/daal/cpp/source/svm/svm_multi_class_thunder_csr_batch.cpp
+++ b/examples/daal/cpp/source/svm/svm_multi_class_thunder_csr_batch.cpp
@@ -43,14 +43,8 @@ std::string testLabelsFileName = "../data/batch/svm_multi_class_test_labels.csv"
 
 const size_t nClasses = 5;
 
-services::SharedPtr<svm::training::Batch<float, svm::training::thunder> > training(
-    new svm::training::Batch<float, svm::training::thunder>());
-services::SharedPtr<svm::prediction::Batch<> > prediction(new svm::prediction::Batch<>());
-
 multi_class_classifier::training::ResultPtr trainingResult;
 multi_class_classifier::prediction::ResultPtr predictionResult;
-kernel_function::KernelIfacePtr kernel(
-    new kernel_function::linear::Batch<float, kernel_function::linear::fastCSR>());
 NumericTablePtr testGroundTruth;
 
 void trainModel();
@@ -87,7 +81,13 @@ void trainModel() {
 
     /* Retrieve the data from the input file */
     trainLabelsDataSource.loadDataBlock();
-
+    services::SharedPtr<svm::training::Batch<float, svm::training::thunder> > training(
+        new svm::training::Batch<float, svm::training::thunder>());
+    services::SharedPtr<svm::prediction::Batch<> > prediction(new svm::prediction::Batch<>());
+    kernel_function::KernelIfacePtr kernel(
+        new kernel_function::linear::Batch<float, kernel_function::linear::fastCSR>());
+    training->parameter.kernel = kernel;
+    prediction->parameter.kernel = kernel;
     /* Create an algorithm object to train the multi-class SVM model */
     multi_class_classifier::training::Batch<> algorithm(nClasses);
 
@@ -111,7 +111,13 @@ void testModel() {
 
     /* Create an algorithm object to predict multi-class SVM values */
     multi_class_classifier::prediction::Batch<> algorithm(nClasses);
-
+    services::SharedPtr<svm::training::Batch<float, svm::training::thunder> > training(
+        new svm::training::Batch<float, svm::training::thunder>());
+    services::SharedPtr<svm::prediction::Batch<> > prediction(new svm::prediction::Batch<>());
+    kernel_function::KernelIfacePtr kernel(
+        new kernel_function::linear::Batch<float, kernel_function::linear::fastCSR>());
+    training->parameter.kernel = kernel;
+    prediction->parameter.kernel = kernel;
     algorithm.parameter.training = training;
     algorithm.parameter.prediction = prediction;
 

--- a/examples/daal/cpp/source/svm/svm_multi_class_thunder_csr_batch.cpp
+++ b/examples/daal/cpp/source/svm/svm_multi_class_thunder_csr_batch.cpp
@@ -1,152 +1,152 @@
-/* file: svm_multi_class_thunder_csr_batch.cpp */
-/*******************************************************************************
-* Copyright 2020 Intel Corporation
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*******************************************************************************/
+// /* file: svm_multi_class_thunder_csr_batch.cpp */
+// /*******************************************************************************
+// * Copyright 2020 Intel Corporation
+// *
+// * Licensed under the Apache License, Version 2.0 (the "License");
+// * you may not use this file except in compliance with the License.
+// * You may obtain a copy of the License at
+// *
+// *     http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing, software
+// * distributed under the License is distributed on an "AS IS" BASIS,
+// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// * See the License for the specific language governing permissions and
+// * limitations under the License.
+// *******************************************************************************/
 
-/*
-!  Content:
-!    C++ example of multi-class support vector machine (SVM) classification using
-!    the Thunder method
-!
-!******************************************************************************/
+// /*
+// !  Content:
+// !    C++ example of multi-class support vector machine (SVM) classification using
+// !    the Thunder method
+// !
+// !******************************************************************************/
 
-/**
- * <a name="DAAL-EXAMPLE-CPP-SVM_MULTI_CLASS_THUNDER_CSR_BATCH"></a>
- * \example svm_multi_class_thunder_csr_batch.cpp
- */
+// /**
+//  * <a name="DAAL-EXAMPLE-CPP-SVM_MULTI_CLASS_THUNDER_CSR_BATCH"></a>
+//  * \example svm_multi_class_thunder_csr_batch.cpp
+//  */
 
-#include "daal.h"
-#include "service.h"
+// #include "daal.h"
+// #include "service.h"
 
-using namespace daal;
-using namespace daal::algorithms;
-using namespace daal::data_management;
+// using namespace daal;
+// using namespace daal::algorithms;
+// using namespace daal::data_management;
 
-/* Input data set parameters */
-std::string trainDatasetFileName = "../data/batch/svm_multi_class_train_csr.csv";
-std::string trainLabelsFileName = "../data/batch/svm_multi_class_train_labels.csv";
+// /* Input data set parameters */
+// std::string trainDatasetFileName = "../data/batch/svm_multi_class_train_csr.csv";
+// std::string trainLabelsFileName = "../data/batch/svm_multi_class_train_labels.csv";
 
-std::string testDatasetFileName = "../data/batch/svm_multi_class_test_csr.csv";
-std::string testLabelsFileName = "../data/batch/svm_multi_class_test_labels.csv";
+// std::string testDatasetFileName = "../data/batch/svm_multi_class_test_csr.csv";
+// std::string testLabelsFileName = "../data/batch/svm_multi_class_test_labels.csv";
 
-const size_t nClasses = 5;
+// const size_t nClasses = 5;
 
-multi_class_classifier::training::ResultPtr trainingResult;
-multi_class_classifier::prediction::ResultPtr predictionResult;
-NumericTablePtr testGroundTruth;
+// multi_class_classifier::training::ResultPtr trainingResult;
+// multi_class_classifier::prediction::ResultPtr predictionResult;
+// NumericTablePtr testGroundTruth;
 
-void trainModel();
-void testModel();
-void printResults();
+// void trainModel();
+// void testModel();
+// void printResults();
 
-int main(int argc, char* argv[]) {
-    checkArguments(argc,
-                   argv,
-                   4,
-                   &trainDatasetFileName,
-                   &trainLabelsFileName,
-                   &testDatasetFileName,
-                   &testLabelsFileName);
+// int main(int argc, char* argv[]) {
+//     checkArguments(argc,
+//                    argv,
+//                    4,
+//                    &trainDatasetFileName,
+//                    &trainLabelsFileName,
+//                    &testDatasetFileName,
+//                    &testLabelsFileName);
 
-    training->parameter.kernel = kernel;
-    prediction->parameter.kernel = kernel;
+//     training->parameter.kernel = kernel;
+//     prediction->parameter.kernel = kernel;
 
-    trainModel();
-    testModel();
-    printResults();
+//     trainModel();
+//     testModel();
+//     printResults();
 
-    return 0;
-}
+//     return 0;
+// }
 
-void trainModel() {
-    /* Initialize FileDataSource<CSVFeatureManager> to retrieve the input data from a .csv file */
-    FileDataSource<CSVFeatureManager> trainLabelsDataSource(trainLabelsFileName,
-                                                            DataSource::doAllocateNumericTable,
-                                                            DataSource::doDictionaryFromContext);
+// void trainModel() {
+//     /* Initialize FileDataSource<CSVFeatureManager> to retrieve the input data from a .csv file */
+//     FileDataSource<CSVFeatureManager> trainLabelsDataSource(trainLabelsFileName,
+//                                                             DataSource::doAllocateNumericTable,
+//                                                             DataSource::doDictionaryFromContext);
 
-    /* Create numeric table for training data */
-    CSRNumericTablePtr trainData(createSparseTable<float>(trainDatasetFileName));
+//     /* Create numeric table for training data */
+//     CSRNumericTablePtr trainData(createSparseTable<float>(trainDatasetFileName));
 
-    /* Retrieve the data from the input file */
-    trainLabelsDataSource.loadDataBlock();
-    services::SharedPtr<svm::training::Batch<float, svm::training::thunder> > training(
-        new svm::training::Batch<float, svm::training::thunder>());
-    services::SharedPtr<svm::prediction::Batch<> > prediction(new svm::prediction::Batch<>());
-    kernel_function::KernelIfacePtr kernel(
-        new kernel_function::linear::Batch<float, kernel_function::linear::fastCSR>());
-    training->parameter.kernel = kernel;
-    prediction->parameter.kernel = kernel;
-    /* Create an algorithm object to train the multi-class SVM model */
-    multi_class_classifier::training::Batch<> algorithm(nClasses);
+//     /* Retrieve the data from the input file */
+//     trainLabelsDataSource.loadDataBlock();
+//     services::SharedPtr<svm::training::Batch<float, svm::training::thunder> > training(
+//         new svm::training::Batch<float, svm::training::thunder>());
+//     services::SharedPtr<svm::prediction::Batch<> > prediction(new svm::prediction::Batch<>());
+//     kernel_function::KernelIfacePtr kernel(
+//         new kernel_function::linear::Batch<float, kernel_function::linear::fastCSR>());
+//     training->parameter.kernel = kernel;
+//     prediction->parameter.kernel = kernel;
+//     /* Create an algorithm object to train the multi-class SVM model */
+//     multi_class_classifier::training::Batch<> algorithm(nClasses);
 
-    algorithm.parameter.training = training;
-    algorithm.parameter.prediction = prediction;
+//     algorithm.parameter.training = training;
+//     algorithm.parameter.prediction = prediction;
 
-    /* Pass a training data set and dependent values to the algorithm */
-    algorithm.input.set(classifier::training::data, trainData);
-    algorithm.input.set(classifier::training::labels, trainLabelsDataSource.getNumericTable());
+//     /* Pass a training data set and dependent values to the algorithm */
+//     algorithm.input.set(classifier::training::data, trainData);
+//     algorithm.input.set(classifier::training::labels, trainLabelsDataSource.getNumericTable());
 
-    /* Build the multi-class SVM model */
-    algorithm.compute();
+//     /* Build the multi-class SVM model */
+//     algorithm.compute();
 
-    /* Retrieve the algorithm results */
-    trainingResult = algorithm.getResult();
-}
+//     /* Retrieve the algorithm results */
+//     trainingResult = algorithm.getResult();
+// }
 
-void testModel() {
-    /* Create Numeric Tables for testing data */
-    NumericTablePtr testData(createSparseTable<float>(testDatasetFileName));
+// void testModel() {
+//     /* Create Numeric Tables for testing data */
+//     NumericTablePtr testData(createSparseTable<float>(testDatasetFileName));
 
-    /* Create an algorithm object to predict multi-class SVM values */
-    multi_class_classifier::prediction::Batch<> algorithm(nClasses);
-    services::SharedPtr<svm::training::Batch<float, svm::training::thunder> > training(
-        new svm::training::Batch<float, svm::training::thunder>());
-    services::SharedPtr<svm::prediction::Batch<> > prediction(new svm::prediction::Batch<>());
-    kernel_function::KernelIfacePtr kernel(
-        new kernel_function::linear::Batch<float, kernel_function::linear::fastCSR>());
-    training->parameter.kernel = kernel;
-    prediction->parameter.kernel = kernel;
-    algorithm.parameter.training = training;
-    algorithm.parameter.prediction = prediction;
+//     /* Create an algorithm object to predict multi-class SVM values */
+//     multi_class_classifier::prediction::Batch<> algorithm(nClasses);
+//     services::SharedPtr<svm::training::Batch<float, svm::training::thunder> > training(
+//         new svm::training::Batch<float, svm::training::thunder>());
+//     services::SharedPtr<svm::prediction::Batch<> > prediction(new svm::prediction::Batch<>());
+//     kernel_function::KernelIfacePtr kernel(
+//         new kernel_function::linear::Batch<float, kernel_function::linear::fastCSR>());
+//     training->parameter.kernel = kernel;
+//     prediction->parameter.kernel = kernel;
+//     algorithm.parameter.training = training;
+//     algorithm.parameter.prediction = prediction;
 
-    /* Pass a testing data set and the trained model to the algorithm */
-    algorithm.input.set(classifier::prediction::data, testData);
-    algorithm.input.set(classifier::prediction::model,
-                        trainingResult->get(classifier::training::model));
+//     /* Pass a testing data set and the trained model to the algorithm */
+//     algorithm.input.set(classifier::prediction::data, testData);
+//     algorithm.input.set(classifier::prediction::model,
+//                         trainingResult->get(classifier::training::model));
 
-    /* Predict multi-class SVM values */
-    algorithm.compute();
+//     /* Predict multi-class SVM values */
+//     algorithm.compute();
 
-    /* Retrieve the algorithm results */
-    predictionResult = algorithm.getResult();
-}
+//     /* Retrieve the algorithm results */
+//     predictionResult = algorithm.getResult();
+// }
 
-void printResults() {
-    /* Initialize FileDataSource<CSVFeatureManager> to retrieve the test data from a .csv file */
-    FileDataSource<CSVFeatureManager> testLabelsDataSource(testLabelsFileName,
-                                                           DataSource::doAllocateNumericTable,
-                                                           DataSource::doDictionaryFromContext);
-    /* Retrieve the data from input file */
-    testLabelsDataSource.loadDataBlock();
-    testGroundTruth = testLabelsDataSource.getNumericTable();
+// void printResults() {
+//     /* Initialize FileDataSource<CSVFeatureManager> to retrieve the test data from a .csv file */
+//     FileDataSource<CSVFeatureManager> testLabelsDataSource(testLabelsFileName,
+//                                                            DataSource::doAllocateNumericTable,
+//                                                            DataSource::doDictionaryFromContext);
+//     /* Retrieve the data from input file */
+//     testLabelsDataSource.loadDataBlock();
+//     testGroundTruth = testLabelsDataSource.getNumericTable();
 
-    printNumericTables<int, int>(
-        testGroundTruth,
-        predictionResult->get(multi_class_classifier::prediction::prediction),
-        "Ground truth",
-        "Classification results",
-        "Multi-class SVM classification sample program results (first 20 observations):",
-        20);
-}
+//     printNumericTables<int, int>(
+//         testGroundTruth,
+//         predictionResult->get(multi_class_classifier::prediction::prediction),
+//         "Ground truth",
+//         "Classification results",
+//         "Multi-class SVM classification sample program results (first 20 observations):",
+//         20);
+// }

--- a/examples/daal/cpp/source/svm/svm_multi_class_thunder_csr_batch.cpp
+++ b/examples/daal/cpp/source/svm/svm_multi_class_thunder_csr_batch.cpp
@@ -27,12 +27,12 @@
 //  * \example svm_multi_class_thunder_csr_batch.cpp
 //  */
 
-// #include "daal.h"
-// #include "service.h"
+#include "daal.h"
+#include "service.h"
 
-// using namespace daal;
-// using namespace daal::algorithms;
-// using namespace daal::data_management;
+using namespace daal;
+using namespace daal::algorithms;
+using namespace daal::data_management;
 
 // /* Input data set parameters */
 // std::string trainDatasetFileName = "../data/batch/svm_multi_class_train_csr.csv";
@@ -51,24 +51,10 @@
 // void testModel();
 // void printResults();
 
-// int main(int argc, char* argv[]) {
-//     checkArguments(argc,
-//                    argv,
-//                    4,
-//                    &trainDatasetFileName,
-//                    &trainLabelsFileName,
-//                    &testDatasetFileName,
-//                    &testLabelsFileName);
+int main(int argc, char* argv[]) {
 
-//     training->parameter.kernel = kernel;
-//     prediction->parameter.kernel = kernel;
-
-//     trainModel();
-//     testModel();
-//     printResults();
-
-//     return 0;
-// }
+    return 0;
+}
 
 // void trainModel() {
 //     /* Initialize FileDataSource<CSVFeatureManager> to retrieve the input data from a .csv file */

--- a/examples/daal/cpp/source/svm/svm_multi_class_thunder_dense_batch.cpp
+++ b/examples/daal/cpp/source/svm/svm_multi_class_thunder_dense_batch.cpp
@@ -41,13 +41,9 @@ std::string testDatasetFileName = "../data/batch/svm_multi_class_test_dense.csv"
 const size_t nFeatures = 20;
 const size_t nClasses = 5;
 
-services::SharedPtr<svm::training::Batch<float, svm::training::thunder> > training(
-    new svm::training::Batch<float, svm::training::thunder>());
-services::SharedPtr<svm::prediction::Batch<> > prediction(new svm::prediction::Batch<>());
-
 multi_class_classifier::training::ResultPtr trainingResult;
 multi_class_classifier::prediction::ResultPtr predictionResult;
-kernel_function::KernelIfacePtr kernel(new kernel_function::linear::Batch<>());
+
 NumericTablePtr testGroundTruth;
 
 void trainModel();
@@ -79,10 +75,16 @@ void trainModel() {
     NumericTablePtr trainGroundTruth =
         HomogenNumericTable<>::create(1, 0, NumericTable::doNotAllocate);
     NumericTablePtr mergedData = MergedNumericTable::create(trainData, trainGroundTruth);
+    services::SharedPtr<svm::training::Batch<float, svm::training::thunder> > training(
+        new svm::training::Batch<float, svm::training::thunder>());
+    services::SharedPtr<svm::prediction::Batch<> > prediction(new svm::prediction::Batch<>());
+
+    kernel_function::KernelIfacePtr kernel(new kernel_function::linear::Batch<>());
+    training->parameter.kernel = kernel;
+    prediction->parameter.kernel = kernel;
 
     /* Retrieve the data from the input file */
     trainDataSource.loadDataBlock(mergedData.get());
-
     /* Create an algorithm object to train the multi-class SVM model */
     multi_class_classifier::training::Batch<> algorithm(nClasses);
 
@@ -111,7 +113,13 @@ void testModel() {
         HomogenNumericTable<>::create(nFeatures, 0, NumericTable::doNotAllocate);
     testGroundTruth = HomogenNumericTable<>::create(1, 0, NumericTable::doNotAllocate);
     NumericTablePtr mergedData = MergedNumericTable::create(testData, testGroundTruth);
+    services::SharedPtr<svm::training::Batch<float, svm::training::thunder> > training(
+        new svm::training::Batch<float, svm::training::thunder>());
+    services::SharedPtr<svm::prediction::Batch<> > prediction(new svm::prediction::Batch<>());
 
+    kernel_function::KernelIfacePtr kernel(new kernel_function::linear::Batch<>());
+    training->parameter.kernel = kernel;
+    prediction->parameter.kernel = kernel;
     /* Retrieve the data from input file */
     testDataSource.loadDataBlock(mergedData.get());
 

--- a/examples/daal/cpp/source/svm/svm_multi_class_thunder_dense_batch.cpp
+++ b/examples/daal/cpp/source/svm/svm_multi_class_thunder_dense_batch.cpp
@@ -53,9 +53,6 @@ void printResults();
 int main(int argc, char* argv[]) {
     checkArguments(argc, argv, 2, &trainDatasetFileName, &testDatasetFileName);
 
-    training->parameter.kernel = kernel;
-    prediction->parameter.kernel = kernel;
-
     trainModel();
     testModel();
     printResults();
@@ -120,6 +117,7 @@ void testModel() {
     kernel_function::KernelIfacePtr kernel(new kernel_function::linear::Batch<>());
     training->parameter.kernel = kernel;
     prediction->parameter.kernel = kernel;
+
     /* Retrieve the data from input file */
     testDataSource.loadDataBlock(mergedData.get());
 

--- a/examples/daal/cpp/source/svm/svm_two_class_boser_csr_batch.cpp
+++ b/examples/daal/cpp/source/svm/svm_two_class_boser_csr_batch.cpp
@@ -41,10 +41,6 @@ std::string trainLabelsFileName = "../data/batch/svm_two_class_train_labels.csv"
 std::string testDatasetFileName = "../data/batch/svm_two_class_test_csr.csv";
 std::string testLabelsFileName = "../data/batch/svm_two_class_test_labels.csv";
 
-/* Parameters for the SVM kernel function */
-kernel_function::KernelIfacePtr kernel(
-    new kernel_function::linear::Batch<float, kernel_function::linear::fastCSR>());
-
 /* Model object for the SVM algorithm */
 svm::training::ResultPtr trainingResult;
 classifier::prediction::ResultPtr predictionResult;
@@ -84,7 +80,11 @@ void trainModel() {
     /* Create an algorithm object to train the SVM model */
     svm::training::Batch<float, svm::training::boser> algorithm;
 
+    /* Parameters for the SVM kernel function */
+    kernel_function::KernelIfacePtr kernel(
+        new kernel_function::linear::Batch<float, kernel_function::linear::fastCSR>());
     algorithm.parameter.kernel = kernel;
+
     algorithm.parameter.cacheSize = 40000000;
 
     /* Pass a training data set and dependent values to the algorithm */
@@ -105,6 +105,9 @@ void testModel() {
     /* Create an algorithm object to predict SVM values */
     svm::prediction::Batch<> algorithm;
 
+    /* Parameters for the SVM kernel function */
+    kernel_function::KernelIfacePtr kernel(
+        new kernel_function::linear::Batch<float, kernel_function::linear::fastCSR>());
     algorithm.parameter.kernel = kernel;
 
     /* Pass a testing data set and the trained model to the algorithm */

--- a/examples/daal/cpp/source/svm/svm_two_class_boser_dense_batch.cpp
+++ b/examples/daal/cpp/source/svm/svm_two_class_boser_dense_batch.cpp
@@ -40,9 +40,6 @@ std::string testDatasetFileName = "../data/batch/svm_two_class_test_dense.csv";
 
 const size_t nFeatures = 20;
 
-/* Parameters for the SVM kernel function */
-kernel_function::KernelIfacePtr kernel(new kernel_function::linear::Batch<>());
-
 /* Model object for the SVM algorithm */
 svm::training::ResultPtr trainingResult;
 classifier::prediction::ResultPtr predictionResult;
@@ -81,7 +78,10 @@ void trainModel() {
     /* Create an algorithm object to train the SVM model */
     svm::training::Batch<float, svm::training::boser> algorithm;
 
+    /* Parameters for the SVM kernel function */
+    kernel_function::KernelIfacePtr kernel(new kernel_function::linear::Batch<>());
     algorithm.parameter.kernel = kernel;
+
     algorithm.parameter.cacheSize = 40000000;
 
     /* Pass a training data set and dependent values to the algorithm */
@@ -112,7 +112,8 @@ void testModel() {
 
     /* Create an algorithm object to predict SVM values */
     svm::prediction::Batch<> algorithm;
-
+    /* Parameters for the SVM kernel function */
+    kernel_function::KernelIfacePtr kernel(new kernel_function::linear::Batch<>());
     algorithm.parameter.kernel = kernel;
 
     /* Pass a testing data set and the trained model to the algorithm */

--- a/examples/daal/cpp/source/svm/svm_two_class_model_builder.cpp
+++ b/examples/daal/cpp/source/svm/svm_two_class_model_builder.cpp
@@ -41,9 +41,6 @@ std::string testDatasetFileName = "../data/batch/svm_two_class_test_dense.csv";
 const size_t nFeatures = 20;
 const float bias = -0.562F;
 
-/* Parameters for the SVM kernel function */
-kernel_function::KernelIfacePtr kernel(new kernel_function::linear::Batch<>());
-
 NumericTablePtr testGroundTruth;
 
 void testModel(svm::ModelPtr &);
@@ -123,6 +120,8 @@ void testModel(svm::ModelPtr &inputModel) {
     /* Create an algorithm object to predict SVM values */
     svm::prediction::Batch<float> algorithm;
 
+    /* Parameters for the SVM kernel function */
+    kernel_function::KernelIfacePtr kernel(new kernel_function::linear::Batch<>());
     algorithm.parameter.kernel = kernel;
 
     /* Pass a testing data set and the trained model to the algorithm */

--- a/examples/daal/cpp/source/svm/svm_two_class_thunder_csr_batch.cpp
+++ b/examples/daal/cpp/source/svm/svm_two_class_thunder_csr_batch.cpp
@@ -41,10 +41,6 @@ std::string trainLabelsFileName = "../data/batch/svm_two_class_train_labels.csv"
 std::string testDatasetFileName = "../data/batch/svm_two_class_test_csr.csv";
 std::string testLabelsFileName = "../data/batch/svm_two_class_test_labels.csv";
 
-/* Parameters for the SVM kernel function */
-kernel_function::KernelIfacePtr kernel(
-    new kernel_function::linear::Batch<float, kernel_function::linear::fastCSR>());
-
 /* Model object for the SVM algorithm */
 svm::training::ResultPtr trainingResult;
 classifier::prediction::ResultPtr predictionResult;
@@ -83,7 +79,9 @@ void trainModel() {
 
     /* Create an algorithm object to train the SVM model */
     svm::training::Batch<float, svm::training::thunder> algorithm;
-
+    /* Parameters for the SVM kernel function */
+    kernel_function::KernelIfacePtr kernel(
+        new kernel_function::linear::Batch<float, kernel_function::linear::fastCSR>());
     algorithm.parameter.kernel = kernel;
 
     /* Pass a training data set and dependent values to the algorithm */
@@ -103,7 +101,9 @@ void testModel() {
 
     /* Create an algorithm object to predict SVM values */
     svm::prediction::Batch<> algorithm;
-
+    /* Parameters for the SVM kernel function */
+    kernel_function::KernelIfacePtr kernel(
+        new kernel_function::linear::Batch<float, kernel_function::linear::fastCSR>());
     algorithm.parameter.kernel = kernel;
 
     /* Pass a testing data set and the trained model to the algorithm */

--- a/examples/daal/cpp/source/svm/svm_two_class_thunder_dense_batch.cpp
+++ b/examples/daal/cpp/source/svm/svm_two_class_thunder_dense_batch.cpp
@@ -40,9 +40,6 @@ std::string testDatasetFileName = "../data/batch/svm_two_class_test_dense.csv";
 
 const size_t nFeatures = 20;
 
-/* Parameters for the SVM kernel function */
-kernel_function::KernelIfacePtr kernel(new kernel_function::linear::Batch<>());
-
 /* Model object for the SVM algorithm */
 svm::training::ResultPtr trainingResult;
 classifier::prediction::ResultPtr predictionResult;
@@ -53,6 +50,7 @@ void testModel();
 void printResults();
 
 int main(int argc, char* argv[]) {
+    std::cout << "here 0" << std::endl;
     checkArguments(argc, argv, 2, &trainDatasetFileName, &testDatasetFileName);
     std::cout << "here 1" << std::endl;
     trainModel();
@@ -81,6 +79,8 @@ void trainModel() {
     /* Create an algorithm object to train the SVM model using the Thunder method */
     svm::training::Batch<float, svm::training::thunder> algorithm;
     std::cout << "here 14" << std::endl;
+    /* Parameters for the SVM kernel function */
+    kernel_function::KernelIfacePtr kernel(new kernel_function::linear::Batch<>());
     algorithm.parameter.kernel = kernel;
     std::cout << "here 15" << std::endl;
     /* Pass a training data set and dependent values to the algorithm */
@@ -111,7 +111,8 @@ void testModel() {
     /* Create an algorithm object to predict SVM values */
     svm::prediction::Batch<> algorithm;
     std::cout << "here 21" << std::endl;
-
+    /* Parameters for the SVM kernel function */
+    kernel_function::KernelIfacePtr kernel(new kernel_function::linear::Batch<>());
     algorithm.parameter.kernel = kernel;
     std::cout << "here 22" << std::endl;
 

--- a/examples/daal/cpp/source/svm/svm_two_class_thunder_dense_batch.cpp
+++ b/examples/daal/cpp/source/svm/svm_two_class_thunder_dense_batch.cpp
@@ -29,7 +29,7 @@
 
 #include "daal.h"
 #include "service.h"
-
+#include <iostream>
 using namespace daal;
 using namespace daal::algorithms;
 using namespace daal::data_management;
@@ -54,11 +54,13 @@ void printResults();
 
 int main(int argc, char* argv[]) {
     checkArguments(argc, argv, 2, &trainDatasetFileName, &testDatasetFileName);
-
+    std::cout << "here 1" << std::endl;
     trainModel();
+    std::cout << "here 2" << std::endl;
     testModel();
+    std::cout << "here 3" << std::endl;
     printResults();
-
+    std::cout << "here 4" << std::endl;
     return 0;
 }
 
@@ -67,29 +69,27 @@ void trainModel() {
     FileDataSource<CSVFeatureManager> trainDataSource(trainDatasetFileName,
                                                       DataSource::notAllocateNumericTable,
                                                       DataSource::doDictionaryFromContext);
-
+    std::cout << "here 11" << std::endl;
     /* Create Numeric Tables for training data and labels */
-    NumericTablePtr trainData =
-        HomogenNumericTable<>::create(nFeatures, 0, NumericTable::doNotAllocate);
-    NumericTablePtr trainGroundTruth =
-        HomogenNumericTable<>::create(1, 0, NumericTable::doNotAllocate);
-    NumericTablePtr mergedData = MergedNumericTable::create(trainData, trainGroundTruth);
-
+    NumericTablePtr trainData(new HomogenNumericTable<>(nFeatures, 0, NumericTable::doNotAllocate));
+    NumericTablePtr trainGroundTruth(new HomogenNumericTable<>(1, 0, NumericTable::doNotAllocate));
+    NumericTablePtr mergedData(new MergedNumericTable(trainData, trainGroundTruth));
+    std::cout << "here 12" << std::endl;
     /* Retrieve the data from the input file */
     trainDataSource.loadDataBlock(mergedData.get());
-
+    std::cout << "here 13" << std::endl;
     /* Create an algorithm object to train the SVM model using the Thunder method */
     svm::training::Batch<float, svm::training::thunder> algorithm;
-
+    std::cout << "here 14" << std::endl;
     algorithm.parameter.kernel = kernel;
-
+    std::cout << "here 15" << std::endl;
     /* Pass a training data set and dependent values to the algorithm */
     algorithm.input.set(classifier::training::data, trainData);
     algorithm.input.set(classifier::training::labels, trainGroundTruth);
-
+    std::cout << "here 16" << std::endl;
     /* Build the SVM model */
     algorithm.compute();
-
+    std::cout << "here 17" << std::endl;
     /* Retrieve the algorithm results */
     trainingResult = algorithm.getResult();
 }
@@ -99,31 +99,33 @@ void testModel() {
     FileDataSource<CSVFeatureManager> testDataSource(testDatasetFileName,
                                                      DataSource::notAllocateNumericTable,
                                                      DataSource::doDictionaryFromContext);
-
+    std::cout << "here 18" << std::endl;
     /* Create Numeric Tables for testing data and labels */
-    NumericTablePtr testData =
-        HomogenNumericTable<>::create(nFeatures, 0, NumericTable::doNotAllocate);
-    testGroundTruth = HomogenNumericTable<>::create(1, 0, NumericTable::doNotAllocate);
-    NumericTablePtr mergedData = MergedNumericTable::create(testData, testGroundTruth);
-
+    NumericTablePtr testData(new HomogenNumericTable<>(nFeatures, 0, NumericTable::doNotAllocate));
+    testGroundTruth = NumericTablePtr(new HomogenNumericTable<>(1, 0, NumericTable::doNotAllocate));
+    NumericTablePtr mergedData(new MergedNumericTable(testData, testGroundTruth));
+    std::cout << "here 19" << std::endl;
     /* Retrieve the data from input file */
     testDataSource.loadDataBlock(mergedData.get());
-
+    std::cout << "here 20" << std::endl;
     /* Create an algorithm object to predict SVM values */
     svm::prediction::Batch<> algorithm;
+    std::cout << "here 21" << std::endl;
 
     algorithm.parameter.kernel = kernel;
+    std::cout << "here 22" << std::endl;
 
     /* Pass a testing data set and the trained model to the algorithm */
     algorithm.input.set(classifier::prediction::data, testData);
     algorithm.input.set(classifier::prediction::model,
                         trainingResult->get(classifier::training::model));
-
+    std::cout << "here 23" << std::endl;
     /* Predict SVM values */
     algorithm.compute();
-
+    std::cout << "here 24" << std::endl;
     /* Retrieve the algorithm results */
     predictionResult = algorithm.getResult();
+    std::cout << "here 25" << std::endl;
 }
 
 void printResults() {

--- a/examples/daal/cpp/source/svm/svm_two_class_thunder_dense_batch.cpp
+++ b/examples/daal/cpp/source/svm/svm_two_class_thunder_dense_batch.cpp
@@ -29,7 +29,7 @@
 
 #include "daal.h"
 #include "service.h"
-#include <iostream>
+
 using namespace daal;
 using namespace daal::algorithms;
 using namespace daal::data_management;
@@ -50,15 +50,14 @@ void testModel();
 void printResults();
 
 int main(int argc, char* argv[]) {
-    std::cout << "here 0" << std::endl;
     checkArguments(argc, argv, 2, &trainDatasetFileName, &testDatasetFileName);
-    std::cout << "here 1" << std::endl;
+
     trainModel();
-    std::cout << "here 2" << std::endl;
+
     testModel();
-    std::cout << "here 3" << std::endl;
+
     printResults();
-    std::cout << "here 4" << std::endl;
+
     return 0;
 }
 
@@ -67,29 +66,29 @@ void trainModel() {
     FileDataSource<CSVFeatureManager> trainDataSource(trainDatasetFileName,
                                                       DataSource::notAllocateNumericTable,
                                                       DataSource::doDictionaryFromContext);
-    std::cout << "here 11" << std::endl;
+
     /* Create Numeric Tables for training data and labels */
     NumericTablePtr trainData(new HomogenNumericTable<>(nFeatures, 0, NumericTable::doNotAllocate));
     NumericTablePtr trainGroundTruth(new HomogenNumericTable<>(1, 0, NumericTable::doNotAllocate));
     NumericTablePtr mergedData(new MergedNumericTable(trainData, trainGroundTruth));
-    std::cout << "here 12" << std::endl;
+
     /* Retrieve the data from the input file */
     trainDataSource.loadDataBlock(mergedData.get());
-    std::cout << "here 13" << std::endl;
+
     /* Create an algorithm object to train the SVM model using the Thunder method */
     svm::training::Batch<float, svm::training::thunder> algorithm;
-    std::cout << "here 14" << std::endl;
+
     /* Parameters for the SVM kernel function */
     kernel_function::KernelIfacePtr kernel(new kernel_function::linear::Batch<>());
     algorithm.parameter.kernel = kernel;
-    std::cout << "here 15" << std::endl;
+
     /* Pass a training data set and dependent values to the algorithm */
     algorithm.input.set(classifier::training::data, trainData);
     algorithm.input.set(classifier::training::labels, trainGroundTruth);
-    std::cout << "here 16" << std::endl;
+
     /* Build the SVM model */
     algorithm.compute();
-    std::cout << "here 17" << std::endl;
+
     /* Retrieve the algorithm results */
     trainingResult = algorithm.getResult();
 }
@@ -99,34 +98,32 @@ void testModel() {
     FileDataSource<CSVFeatureManager> testDataSource(testDatasetFileName,
                                                      DataSource::notAllocateNumericTable,
                                                      DataSource::doDictionaryFromContext);
-    std::cout << "here 18" << std::endl;
+
     /* Create Numeric Tables for testing data and labels */
     NumericTablePtr testData(new HomogenNumericTable<>(nFeatures, 0, NumericTable::doNotAllocate));
     testGroundTruth = NumericTablePtr(new HomogenNumericTable<>(1, 0, NumericTable::doNotAllocate));
     NumericTablePtr mergedData(new MergedNumericTable(testData, testGroundTruth));
-    std::cout << "here 19" << std::endl;
+
     /* Retrieve the data from input file */
     testDataSource.loadDataBlock(mergedData.get());
-    std::cout << "here 20" << std::endl;
+
     /* Create an algorithm object to predict SVM values */
     svm::prediction::Batch<> algorithm;
-    std::cout << "here 21" << std::endl;
+
     /* Parameters for the SVM kernel function */
     kernel_function::KernelIfacePtr kernel(new kernel_function::linear::Batch<>());
     algorithm.parameter.kernel = kernel;
-    std::cout << "here 22" << std::endl;
 
     /* Pass a testing data set and the trained model to the algorithm */
     algorithm.input.set(classifier::prediction::data, testData);
     algorithm.input.set(classifier::prediction::model,
                         trainingResult->get(classifier::training::model));
-    std::cout << "here 23" << std::endl;
+
     /* Predict SVM values */
     algorithm.compute();
-    std::cout << "here 24" << std::endl;
+
     /* Retrieve the algorithm results */
     predictionResult = algorithm.getResult();
-    std::cout << "here 25" << std::endl;
 }
 
 void printResults() {

--- a/examples/daal/cpp/target_excludes.cmake
+++ b/examples/daal/cpp/target_excludes.cmake
@@ -30,6 +30,7 @@ if((CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64") AND
         "cor_csr_online"
         "cov_csr_distr"
         "cov_csr_online"
+        "enable_thread_pinning"
         "lin_reg_metrics_dense_batch"
         "lin_reg_qr_dense_batch"
         "lin_reg_qr_dense_online"


### PR DESCRIPTION
# Description
Adding tbb::task_scheduler_handle static object to avoid undefined order of static tbb objects deinitialization. oneTBB will not be unloaded until finalize of task_scheduler_handle.

Changes proposed in this pull request:

- [x] Adding tbb::scheduler_handle_task

- [x] Initialize TBB in all potential scenarios

- [x] Update destructor and free functions

- [x] Remove void setDynamicLibraryThreadingTypeOnWindows(LibraryThreadingType type);