### PR TITLE
Changed openblas build to ILP64

### DIFF
--- a/.ci/env/apt.sh
+++ b/.ci/env/apt.sh
@@ -63,7 +63,7 @@ function install_qemu_emulation_apt {
 }
 
 function install_qemu_emulation_deb {
-    qemu_deb=qemu-user-static_8.2.3+ds-2_amd64.deb
+    qemu_deb=qemu-user-static_8.2.1+ds-1~bpo12+1_amd64.deb
     set -eo pipefail
     wget http://ftp.debian.org/debian/pool/main/q/qemu/${qemu_deb}
     sudo dpkg -i ${qemu_deb}

--- a/.ci/env/openblas.sh
+++ b/.ci/env/openblas.sh
@@ -37,6 +37,7 @@ show_help() {
 --prefix:The path where OpenBLAS will be installed
 --version:The version of OpenBLAS to install. This is a git reference from the OpenBLAS repo, and defaults to ${BLAS_DEFAULT_VERSION}
 --sysroot:If cross-compiling with LLVM, determines the location of the target architecture sysroot
+--ilp64 <on/off>: whether or not to use the ILP64 build
 '
 }
 
@@ -74,6 +75,9 @@ while [[ $# -gt 0 ]]; do
         --sysroot)
         sysroot="$2"
         shift;;
+        --ilp64)
+        ilp64=on
+        shift;;
         --help)
         show_help
         exit 0
@@ -89,6 +93,7 @@ done
 target=${target:-ARMV8}
 host_compiler=${host_compiler:-gcc}
 compiler=${compiler:-aarch64-linux-gnu-gcc}
+openblas_ilp64=${ilp64:-on}
 
 target_arch=${target_arch:-$(uname -m)}
 OPENBLAS_DEFAULT_PREFIX="${ONEDAL_DIR}/__deps/openblas_${target_arch}"
@@ -159,6 +164,9 @@ pushd "${blas_src_dir}"
         USE_OPENMP=0
         USE_THREAD=0
         USE_LOCKING=1)
+  fi
+  if [ "${openblas_ilp64}" == "on" ]; then
+      make_options+=( 'BINARY=64' 'INTERFACE64=1' )
   fi
   # Clean
   echo make "${make_options[@]}" clean

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -114,7 +114,7 @@ jobs:
     displayName: 'System info'
   - task: Cache@2
     inputs:
-      key: '"gcc" | "aarch64" | "openblas" | "$(OPENBLAS_VERSION)" | "$(VM_IMAGE)"'
+      key: '"gcc" | "aarch64" | "openblas" | "$(OPENBLAS_VERSION)" | "$(VM_IMAGE)" | "ILP64"'
       path: $(OPENBLAS_CACHE_DIR)
       cacheHitVar: OPENBLAS_RESTORED
   - script: |
@@ -363,7 +363,7 @@ jobs:
     displayName: 'System info'
   - task: Cache@2
     inputs:
-      key: '"gcc" | "x86_64" | "openblas" | "$(OPENBLAS_VERSION)" | "$(VM_IMAGE)"'
+      key: '"gcc" | "x86_64" | "openblas" | "$(OPENBLAS_VERSION)" | "$(VM_IMAGE)" | "ILP64"'
       path: $(OPENBLAS_CACHE_DIR)
       cacheHitVar: OPENBLAS_RESTORED
   - script: |

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -201,7 +201,7 @@ jobs:
     displayName: 'System info'
   - task: Cache@2
     inputs:
-      key: '"clang" | "18" | "aarch64" | "openblas" | "$(OPENBLAS_VERSION)" | "$(VM_IMAGE)"'
+      key: '"clang" | "18" | "aarch64" | "openblas" | "$(OPENBLAS_VERSION)" | "$(VM_IMAGE)" | "ILP64"'
       path: $(OPENBLAS_CACHE_DIR)
       cacheHitVar: OPENBLAS_RESTORED
   - script: |
@@ -293,7 +293,7 @@ jobs:
     displayName: 'System info'
   - task: Cache@2
     inputs:
-      key: '"clang" | "riscv64" | "openblas" | "$(OPENBLAS_VERSION)"'
+      key: '"clang" | "riscv64" | "openblas" | "$(OPENBLAS_VERSION)" | "ILP64"'
       path: $(OPENBLAS_CACHE_DIR)
       cacheHitVar: OPENBLAS_RESTORED
   - script: |

--- a/examples/daal/cpp/CMakeLists.txt
+++ b/examples/daal/cpp/CMakeLists.txt
@@ -44,10 +44,7 @@ if(REF_BACKEND)
         ${EXCLUDE_LIST}
         "source/boosting/brownboost_dense_batch.cpp"
         "source/em/em_gmm_dense_batch.cpp"
-        "source/linear_regression/lin_reg_qr_dense_distr.cpp"
-        "source/pca/pca_cor*"
-        "source/qr/qr_dense*"
-        "source/svd/svd_dense_batch.cpp"
+        "source/pca/pca_cor_csr*"
     )
 endif()
 

--- a/examples/daal/cpp/target_excludes.cmake
+++ b/examples/daal/cpp/target_excludes.cmake
@@ -42,16 +42,11 @@ elseif((CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64") AND
        (CMAKE_C_COMPILER MATCHES "gcc"))
     set(EXCLUDE_LIST
         ${EXCLUDE_LIST}
-        "cholesky_dense_batch"
         "cor_csr_distr"
         "cor_csr_online"
         "cov_csr_distr"
         "cov_csr_online"
         "enable_thread_pinning"
-        "lin_reg_metrics_dense_batch"
-        "lin_reg_qr_dense_batch"
-        "lin_reg_qr_dense_online"
-        "out_detect_mult_dense_batch"
     )
 elseif((CMAKE_SYSTEM_PROCESSOR STREQUAL "riscv64") AND
        (CMAKE_C_COMPILER MATCHES "clang"))


### PR DESCRIPTION
# Issue
OpenBLAS uses 32-bit integers by default . But DAAL_INT is 64-bit integer type. This causes errors during LAPACK calls, where the argument is expected to be a pointer to 32-bit integer, but a pointer to 64-bit integer is given. This causes many examples that use LAPACK to fail.

# Fix
Build openBLAS with ILP64 interface by adding `BINARY=64` and `INTERFACE64=1` while building. An option to switch ILP64 interface has been added to the openblas build script (by default ILP64 interface is built). 

This change fixes the following examples which have been removed from the exclude list.

1. out_detect_mult_dense_batch
2. pca_cor_dense_batch
3. pca_cor_dense_distr
4. pca_cor_dense_online
5. qr_dense_batch
6. qr_dense_distr
7. qr_dense_online
8. svd_dense_batch

Changes were tested on Graviton3 (openblas+gcc build).