### PR TITLE
[bug, CI] fix error handling in windows builds

### DIFF
--- a/.ci/scripts/build.bat
+++ b/.ci/scripts/build.bat
@@ -19,7 +19,7 @@ rem %1 - Make target
 rem %2 - Compiler
 rem %3 - Instruction set
 
-set exitcode=0
+set errorcode=0
 for /f "tokens=*" %%i in ('python -c "from multiprocessing import cpu_count; print(cpu_count())"') do set CPUCOUNT=%%i
 echo CPUCOUNT=%CPUCOUNT%
 
@@ -27,19 +27,19 @@ echo PATH=C:\msys64\usr\bin;%PATH%
 set PATH=C:\msys64\usr\bin;%PATH%
 
 echo pacman -S --noconfirm msys/make msys/dos2unix
-pacman -S --noconfirm msys/make msys/dos2unix || set exitcode=1
+pacman -S --noconfirm msys/make msys/dos2unix || set errorcode=1
 
 echo call .ci\env\tbb.bat
-call .ci\env\tbb.bat || set exitcode=1
+call .ci\env\tbb.bat || set errorcode=1
 
 echo call .\dev\download_micromkl.bat
-call .\dev\download_micromkl.bat || set exitcode=1
+call .\dev\download_micromkl.bat || set errorcode=1
 
 echo call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall" x64
-call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall" x64 || set exitcode=1
+call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall" x64 || set errorcode=1
 
 echo make %1 -j%CPUCOUNT% COMPILER=%2 PLAT=win32e REQCPU=%3
-make %1 -j%CPUCOUNT% COMPILER=%2 PLAT=win32e REQCPU=%3 || set exitcode=1
+make %1 -j%CPUCOUNT% COMPILER=%2 PLAT=win32e REQCPU=%3 || set errorcode=1
 
-cmake -DINSTALL_DIR=__release_win_vc\daal\latest\lib\cmake\oneDAL -DARCH_DIR=intel64 -P cmake\scripts\generate_config.cmake || set exitcode=1
-EXIT /B %exitcode%
+cmake -DINSTALL_DIR=__release_win_vc\daal\latest\lib\cmake\oneDAL -DARCH_DIR=intel64 -P cmake\scripts\generate_config.cmake || set errorcode=1
+EXIT /B %errorcode%

--- a/.ci/scripts/build.bat
+++ b/.ci/scripts/build.bat
@@ -19,6 +19,7 @@ rem %1 - Make target
 rem %2 - Compiler
 rem %3 - Instruction set
 
+set exitcode=0
 for /f "tokens=*" %%i in ('python -c "from multiprocessing import cpu_count; print(cpu_count())"') do set CPUCOUNT=%%i
 echo CPUCOUNT=%CPUCOUNT%
 
@@ -26,18 +27,19 @@ echo PATH=C:\msys64\usr\bin;%PATH%
 set PATH=C:\msys64\usr\bin;%PATH%
 
 echo pacman -S --noconfirm msys/make msys/dos2unix
-pacman -S --noconfirm msys/make msys/dos2unix
+pacman -S --noconfirm msys/make msys/dos2unix || set exitcode=1
 
 echo call .ci\env\tbb.bat
-call .ci\env\tbb.bat
+call .ci\env\tbb.bat || set exitcode=1
 
 echo call .\dev\download_micromkl.bat
-call .\dev\download_micromkl.bat
+call .\dev\download_micromkl.bat || set exitcode=1
 
 echo call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall" x64
-call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall" x64
+call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall" x64 || set exitcode=1
 
 echo make %1 -j%CPUCOUNT% COMPILER=%2 PLAT=win32e REQCPU=%3
-make %1 -j%CPUCOUNT% COMPILER=%2 PLAT=win32e REQCPU=%3
+make %1 -j%CPUCOUNT% COMPILER=%2 PLAT=win32e REQCPU=%3 || set exitcode=1
 
-cmake -DINSTALL_DIR=__release_win_vc\daal\latest\lib\cmake\oneDAL -DARCH_DIR=intel64 -P cmake\scripts\generate_config.cmake
+cmake -DINSTALL_DIR=__release_win_vc\daal\latest\lib\cmake\oneDAL -DARCH_DIR=intel64 -P cmake\scripts\generate_config.cmake || set exitcode=1
+EXIT /B %exitcode%

--- a/.ci/scripts/build.bat
+++ b/.ci/scripts/build.bat
@@ -29,10 +29,10 @@ echo pacman -S --noconfirm msys/make msys/dos2unix
 pacman -S --noconfirm msys/make msys/dos2unix
 
 echo call .ci\env\tbb.bat
-if "%TBBROOT%"=="" if not exist %~dp0..\..\__deps\tbb\win\tbb call .ci\env\tbb.bat || set errorcode=1
+if "%TBBROOT%"=="" if not exist .\__deps\tbb\win\tbb call .ci\env\tbb.bat || set errorcode=1
 
 echo call .\dev\download_micromkl.bat
-if "%MKLGPUFPKROOT%"=="" if not exist %~dp0..\..\__deps\mklgpufpk\win call .\dev\download_micromkl.bat || set errorcode=1
+if "%MKLGPUFPKROOT%"=="" if not exist .\__deps\mklgpufpk\win call .\dev\download_micromkl.bat || set errorcode=1
 
 echo call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall" x64
 if "%VISUALSTUDIOVERSION%"=="" call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall" x64 || set errorcode=1

--- a/.ci/scripts/build.bat
+++ b/.ci/scripts/build.bat
@@ -29,10 +29,10 @@ echo pacman -S --noconfirm msys/make msys/dos2unix
 pacman -S --noconfirm msys/make msys/dos2unix
 
 echo call .ci\env\tbb.bat
-if "%TBBROOT%"=="" if not exist %~dp0\__deps\tbb\win\tbb call .ci\env\tbb.bat || set errorcode=1
+if "%TBBROOT%"=="" if not exist %~dp0..\..\__deps\tbb\win\tbb call .ci\env\tbb.bat || set errorcode=1
 
 echo call .\dev\download_micromkl.bat
-if "%MKLGPUFPKROOT%"=="" if not exist %~dp0\__deps\mklgpufpk\win call .\dev\download_micromkl.bat || set errorcode=1
+if "%MKLGPUFPKROOT%"=="" if not exist %~dp0..\..\__deps\mklgpufpk\win call .\dev\download_micromkl.bat || set errorcode=1
 
 echo call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall" x64
 if "%VISUALSTUDIOVERSION%"=="" call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall" x64 || set errorcode=1

--- a/.ci/scripts/build.bat
+++ b/.ci/scripts/build.bat
@@ -30,13 +30,13 @@ echo pacman -S --noconfirm msys/make msys/dos2unix
 pacman -S --noconfirm msys/make msys/dos2unix
 
 echo call .ci\env\tbb.bat
-call .ci\env\tbb.bat
+if "%TBBROOT%"=="" if not exist %~dp0\__deps\tbb\win\tbb call .ci\env\tbb.bat || set errorcode=1
 
 echo call .\dev\download_micromkl.bat
-call .\dev\download_micromkl.bat
+if "%MKLGPUFPKROOT%"=="" if not exist %~dp0\__deps\mklgpufpk\win call .\dev\download_micromkl.bat || set errorcode=1
 
 echo call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall" x64
-call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall" x64
+if "%VISUALSTUDIOVERSION%"=="" call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall" x64 || set errorcode=1
 
 echo make %1 -j%CPUCOUNT% COMPILER=%2 PLAT=win32e REQCPU=%3
 make %1 -j%CPUCOUNT% COMPILER=%2 PLAT=win32e REQCPU=%3 || set errorcode=1

--- a/.ci/scripts/build.bat
+++ b/.ci/scripts/build.bat
@@ -27,16 +27,16 @@ echo PATH=C:\msys64\usr\bin;%PATH%
 set PATH=C:\msys64\usr\bin;%PATH%
 
 echo pacman -S --noconfirm msys/make msys/dos2unix
-pacman -S --noconfirm msys/make msys/dos2unix || set errorcode=1
+pacman -S --noconfirm msys/make msys/dos2unix
 
 echo call .ci\env\tbb.bat
-call .ci\env\tbb.bat || set errorcode=1
+call .ci\env\tbb.bat
 
 echo call .\dev\download_micromkl.bat
-call .\dev\download_micromkl.bat || set errorcode=1
+call .\dev\download_micromkl.bat
 
 echo call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall" x64
-call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall" x64 || set errorcode=1
+call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall" x64
 
 echo make %1 -j%CPUCOUNT% COMPILER=%2 PLAT=win32e REQCPU=%3
 make %1 -j%CPUCOUNT% COMPILER=%2 PLAT=win32e REQCPU=%3 || set errorcode=1

--- a/.ci/scripts/build.bat
+++ b/.ci/scripts/build.bat
@@ -20,8 +20,7 @@ rem %2 - Compiler
 rem %3 - Instruction set
 
 set errorcode=0
-for /f "tokens=*" %%i in ('python -c "from multiprocessing import cpu_count; print(cpu_count())"') do set CPUCOUNT=%%i
-echo CPUCOUNT=%CPUCOUNT%
+echo CPUCOUNT=%NUMBER_OF_PROCESSORS%
 
 echo PATH=C:\msys64\usr\bin;%PATH%
 set PATH=C:\msys64\usr\bin;%PATH%
@@ -38,8 +37,8 @@ if "%MKLGPUFPKROOT%"=="" if not exist %~dp0\__deps\mklgpufpk\win call .\dev\down
 echo call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall" x64
 if "%VISUALSTUDIOVERSION%"=="" call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall" x64 || set errorcode=1
 
-echo make %1 -j%CPUCOUNT% COMPILER=%2 PLAT=win32e REQCPU=%3
-make %1 -j%CPUCOUNT% COMPILER=%2 PLAT=win32e REQCPU=%3 || set errorcode=1
+echo make %1 -j%NUMBER_OF_PROCESSORS% COMPILER=%2 PLAT=win32e REQCPU=%3
+make %1 -j%NUMBER_OF_PROCESSORS% COMPILER=%2 PLAT=win32e REQCPU=%3 || set errorcode=1
 
 cmake -DINSTALL_DIR=__release_win_vc\daal\latest\lib\cmake\oneDAL -DARCH_DIR=intel64 -P cmake\scripts\generate_config.cmake || set errorcode=1
 EXIT /B %errorcode%

--- a/.ci/scripts/test.bat
+++ b/.ci/scripts/test.bat
@@ -35,10 +35,10 @@ echo PATH=C:\msys64\usr\bin;%PATH%
 set PATH=C:\msys64\usr\bin;%PATH%
 
 echo call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall" x64
-call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall" x64
+call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall" x64 || set errorcode=1
 
 echo call __release_win_vc\daal\latest\env\vars.bat
-call __release_win_vc\daal\latest\env\vars.bat
+call __release_win_vc\daal\latest\env\vars.bat || set errorcode=1
 
 echo set LIB=%~dp0..\..\__release_win_vc\tbb\latest\lib\intel64\vc_mt;%LIB%
 set LIB=%~dp0..\..\__release_win_vc\tbb\latest\lib\intel64\vc_mt;%LIB%
@@ -69,9 +69,9 @@ if "%build_system%"=="cmake" (
 
     set results_dir=_cmake_results\intel_intel64_%cmake_link_mode_short%\Release
     echo cmake -B Build -S . -DONEDAL_LINK=%cmake_link_mode% -DTBB_DIR=%TBB_DIR%
-    cmake -B Build -S . -DONEDAL_LINK=%cmake_link_mode% -DTBB_DIR=%TBB_DIR%
+    cmake -B Build -S . -DONEDAL_LINK=%cmake_link_mode% -DTBB_DIR=%TBB_DIR% || set errorcode=1
     set solution_name=%examples:\=_%
-    msbuild.exe "Build\!solution_name!_examples.sln" /p:Configuration=Release
+    msbuild.exe "Build\!solution_name!_examples.sln" /p:Configuration=Release || set errorcode=1
 
     for /f "delims=." %%F in ('dir /B !results_dir!\*.exe 2^> nul') do (
         set example=%%F
@@ -100,3 +100,4 @@ if "%build_system%"=="cmake" (
     if "%examples%"=="daal\cpp" nmake %linking% compiler=%compiler%
     if "%examples%"=="oneapi\cpp" nmake %linking% compiler=%compiler%
 )
+EXIT /B %errorcode%


### PR DESCRIPTION
# Description
Current Azure Pipelines public CI steps do not properly show errors. This issue is similar to intel/scikit-learn-intelex#1609 , for .bat files, the error code must be set and propagated to the end to properly show a failure in Azure Pipelines.

This PR will first require fixes to a bug introduced into LinearRegression Algos in #2565 (possibly)

Changes proposed in this pull request:
- Add errorcodes to .ci/scripts/build.bat
- Extend errorcodes in .ci/scripts/test.bat