### PR TITLE
Fix memory leak in hashmap

### DIFF
--- a/cpp/oneapi/dal/detail/hash_map.hpp
+++ b/cpp/oneapi/dal/detail/hash_map.hpp
@@ -71,6 +71,14 @@ public:
     }
 
     ~hash_map() {
+        for (std::int64_t i = 0; i < capacity_; i++) {
+            entry_ptr current = entries_[i];
+            while (current) {
+                entry_ptr next = current->get_next();
+                delete current;
+                current = next;
+            }
+        }
         delete[] entries_;
         entries_ = nullptr;
         capacity_ = 0;


### PR DESCRIPTION
# Description
Fixes memory leak in hashmap caught in test with valgrind for DBSCAN. 
"delete[] entries_" is not enough to deallocate the individual hash_map_entry objects.