### PR TITLE
Fix "loop not vectorized" warning when running with newer icpx compiler

### DIFF
--- a/cpp/oneapi/dal/table/backend/csr_kernels.cpp
+++ b/cpp/oneapi/dal/table/backend/csr_kernels.cpp
@@ -416,7 +416,7 @@ bool is_sorted(sycl::queue& queue,
     const auto wg_size = dal::backend::device_max_wg_size(queue);
     const size_t count_m1_unsigned = static_cast<size_t>(count_m1);
 
-    const size_t wg_count = (count_m1 % wg_size) ? count_m1 / wg_size + 1 : count_m1 / wg_size;
+    const size_t wg_count = (count_m1 + wg_size - 1) / wg_size;
 
     // count the number of pairs of the subsequent elements in the data array that are sorted
     // in desccending order using sycl::reduction

--- a/cpp/oneapi/dal/table/backend/csr_kernels.cpp
+++ b/cpp/oneapi/dal/table/backend/csr_kernels.cpp
@@ -428,7 +428,7 @@ bool is_sorted(sycl::queue& queue,
                              count_descending_reduction,
                              [=](sycl::nd_item<1> idx, auto& count_descending) {
                                  const auto i = idx.get_global_id(0);
-                                 if (data[i] > data[i + 1])
+                                 if (i < count_m1 && data[i + 1] < data[i])
                                      count_descending.combine(1);
                              });
         })


### PR DESCRIPTION
The warning stared to appear after PR https://github.com/oneapi-src/oneDAL/pull/2794 was merged.

SYCL `parallel_for` in `is_sorted` function was re-written to fix the warning.