### PR TITLE
chore(workflows): add `editorconfig-checker`

### DIFF
--- a/.ci/env/editorconfig-checker.sh
+++ b/.ci/env/editorconfig-checker.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+#===============================================================================
+# Copyright contributors to the oneDAL project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#===============================================================================
+
+VERSION=v3.0.3
+NAME=ec-linux-amd64
+ASSET=$NAME.tar.gz
+
+# Download
+export SHA256="fc698b0bf5bca0d42e28dd59d72e25487a51f645ca242c5f74bae975369f16aa  $ASSET"
+wget https://github.com/editorconfig-checker/editorconfig-checker/releases/download/$VERSION/$ASSET
+echo "${SHA256}" | sha256sum --check
+
+# Install
+tar -xzf $ASSET
+mv bin/$NAME /usr/local/bin/editorconfig-checker
+
+# Clean up the downloaded archive
+rm $ASSET

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -30,7 +30,7 @@ variables:
   SYSROOT_OS: 'jammy'
 
 jobs:
-- job: 'FormattersChecks'
+- job: 'FormatterChecks'
   pool:
     vmImage: '$(VM_IMAGE)'
   steps:

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -30,16 +30,21 @@ variables:
   SYSROOT_OS: 'jammy'
 
 jobs:
-- job: 'ClangFormat'
+- job: 'FormattersChecks'
   pool:
     vmImage: '$(VM_IMAGE)'
   steps:
     - script: |
         .ci/env/apt.sh clang-format
-      displayName: 'apt-get'
+        .ci/env/editorconfig-checker.sh
+      displayName: 'Install Dependencies'
     - script: |
         .ci/scripts/clang-format.sh
       displayName: 'clang-format check'
+      failOnStderr: true
+    - script: |
+        editorconfig-checker
+      displayName: 'editorconfig-checker'
       failOnStderr: true
 
 - job: 'LinuxMakeGNU_MKL'

--- a/.ecrc
+++ b/.ecrc
@@ -1,0 +1,17 @@
+{
+  "Verbose": false,
+  "Debug": false,
+  "IgnoreDefaults": false,
+  "SpacesAftertabs": false,
+  "NoColor": false,
+  "AllowedContentTypes": [],
+  "PassedFiles": [],
+  "Disable": {
+    "EndOfLine": false,
+    "Indentation": false,
+    "InsertFinalNewline": false,
+    "TrimTrailingWhitespace": false,
+    "IndentSize": true,
+    "MaxLineLength": false
+  }
+}

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*.{py,pl,pm,i,inc,c,cpp,h,hpp,s,f,f77,f90,fi,java}]
+indent_style = space
+trim_trailing_whitespace = true
+insert_final_newline = true
+# max_line_length = 150

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,15 +10,24 @@
   },
   "packageRules": [
     {
-    "groupName": "Doc packages",
-    "matchUpdateTypes": ["patch", "minor"],
-    "schedule": ["before 2am on the first day of the month"],
-    "matchFileNames": ["docs/requirements.txt"]
+      "groupName": "Doc packages",
+      "matchUpdateTypes": ["patch", "minor"],
+      "schedule": ["before 2am on the first day of the month"],
+      "matchFileNames": ["docs/requirements.txt"]
     },
     {
-    "groupName": "Dockerfile",
-    "schedule": ["before 2am on the first day of the month"],
-    "matchFileNames": ["**/*.Dockerfile"]
+      "groupName": "Dockerfile",
+      "schedule": ["before 2am on the first day of the month"],
+      "matchFileNames": ["**/*.Dockerfile"]
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^\\.ci\\/env\\/editorconfig-checker\\.sh$"],
+      "matchStrings": ["VERSION=(?<currentValue>v\\d+\\.\\d+\\.\\d+)"],
+      "depNameTemplate": "editorconfig-checker/editorconfig-checker",
+      "datasourceTemplate": "github-releases"
     }
   ]
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ Refer to our guidelines on [pull requests](#pull-requests) and [issues](#issues)
 
 ## Contacting maintainers
 You may reach out to Intel project maintainers privately at onedal.maintainers@intel.com.
-[Codeowners](https://github.com/oneapi-src/oneDAL/blob/main/.github/CODEOWNERS) configuration defines specific maintainers for corresponding code sections, however it's currently limited to Intel members. With further migration to UXL we will be changing this, but here are non-Intel contacts: 
+[Codeowners](https://github.com/oneapi-src/oneDAL/blob/main/.github/CODEOWNERS) configuration defines specific maintainers for corresponding code sections, however it's currently limited to Intel members. With further migration to UXL we will be changing this, but here are non-Intel contacts:
 
 For ARM specifics you may contact: [@rakshithgb-fujitsu](https://github.com/rakshithgb-fujitsu/)
 
@@ -64,6 +64,20 @@ clang-format style=file <your file>
 ```
 
 Refer to [ClangFormat documentation](https://clang.llvm.org/docs/ClangFormat.html) for more information.
+
+### editorconfig-checker
+
+We also recommend using [editorconfig-checker](https://github.com/editorconfig-checker/editorconfig-checker) to ensure your code adheres to the project's coding style. EditorConfig-Checker is a command-line tool that checks your code against the rules defined in the [.editorconfig](https://github.com/oneapi-src/oneDAL/blob/main/.editorconfig) file.
+
+To use it, follow these steps:
+
+1. Install the tool by following the instructions in the [official documentation](https://github.com/editorconfig-checker/editorconfig-checker#installation).
+2. Navigate to the root directory of your project.
+3. Run the following command to check your code:
+
+```
+editorconfig-checker
+```
 
 ### Coding Guidelines
 


### PR DESCRIPTION
# Description

This Pull Request adds an [editorconfig-checker](https://github.com/editorconfig-checker/editorconfig-checker) to CI pipeline.


## Changes
- In [ci.yml](https://github.com/oneapi-src/oneDAL/blob/main/.ci/pipeline/ci.yml) the job previously known as `ClangFormat` has been renamed to `FormattersChecks` to better reflect the expanded scope of formatting checks.
-  `editorconfig-checker` has been added to the list of checks. This tool will verify that all submitted code follows the rules specified in `.editorconfig` file.
- The `.editorconfig` file has been added with the following configurations to maintain code quality and consistency across different file types including Python, Perl, C, C++, Java, and Fortran among others (`max_line_length` temporary disabled):

```ini
root = true

[*.{py,pl,pm,i,inc,c,cpp,h,hpp,s,f,f77,f90,fi,java}]
indent_style = space
trim_trailing_whitespace = true
insert_final_newline = true
# max_line_length = 150
```

In case an error is found, the log will look like this:
![image](https://github.com/user-attachments/assets/5b00f904-9af7-4204-9ee0-a0a117dec7cf)
