### PR TITLE
Correct PCA nComponents description

### DIFF
--- a/cpp/daal/include/algorithms/pca/pca_types.h
+++ b/cpp/daal/include/algorithms/pca/pca_types.h
@@ -670,7 +670,7 @@ public:
     BaseBatchParameter();
 
     DAAL_UINT64 resultsToCompute; /*!< 64 bit integer flag that indicates the results to compute */
-    size_t nComponents;           /*!< number of components for reduced implementation */
+    size_t nComponents;           /*!< number of components for reduced implementation (applicable for batch mode only) */
     bool isDeterministic;         /*!< sign flip if required */
     bool doScale;                 /*!< scaling if required */
     bool isCorrelation;           /*!< correlation is provided */


### PR DESCRIPTION
# Description
PCA's nComponents parameter description didn't mention it works for batch mode only. This doc string is reused in [daal4py docs](https://intelpython.github.io/daal4py/algorithms.html#daal4py.pca) resulting in confusion that parameter is supported for all modes.

Addresses https://github.com/intel/scikit-learn-intelex/issues/759.