### PR TITLE
Add missing ONEDAL_EXPORT for sparse Logistic Regression

### DIFF
--- a/cpp/oneapi/dal/algo/logistic_regression/detail/infer_ops.cpp
+++ b/cpp/oneapi/dal/algo/logistic_regression/detail/infer_ops.cpp
@@ -40,5 +40,8 @@ struct infer_ops_dispatcher<host_policy, Float, Method, Task> {
 INSTANTIATE(float, method::dense_batch, task::classification)
 INSTANTIATE(double, method::dense_batch, task::classification)
 
+INSTANTIATE(float, method::sparse, task::classification)
+INSTANTIATE(double, method::sparse, task::classification)
+
 } // namespace v1
 } // namespace oneapi::dal::logistic_regression::detail

--- a/cpp/oneapi/dal/algo/logistic_regression/detail/train_ops.cpp
+++ b/cpp/oneapi/dal/algo/logistic_regression/detail/train_ops.cpp
@@ -64,6 +64,8 @@ private:
 
 INSTANTIATE(float, method::dense_batch, task::classification)
 INSTANTIATE(double, method::dense_batch, task::classification)
+INSTANTIATE(float, method::sparse, task::classification)
+INSTANTIATE(double, method::sparse, task::classification)
 
 } // namespace v1
 } // namespace oneapi::dal::logistic_regression::detail

--- a/cpp/oneapi/dal/algo/logistic_regression/detail/train_ops.cpp
+++ b/cpp/oneapi/dal/algo/logistic_regression/detail/train_ops.cpp
@@ -64,6 +64,7 @@ private:
 
 INSTANTIATE(float, method::dense_batch, task::classification)
 INSTANTIATE(double, method::dense_batch, task::classification)
+
 INSTANTIATE(float, method::sparse, task::classification)
 INSTANTIATE(double, method::sparse, task::classification)
 


### PR DESCRIPTION
# Description
Add ONEDAL_EXPORT to sparse method for logistic regression algorithm to enable sparse computations on sklearnex side