### PR TITLE
Disable Intel libs link for icx compiler

### DIFF
--- a/dev/make/compiler_definitions/icx.mkl.32e.mk
+++ b/dev/make/compiler_definitions/icx.mkl.32e.mk
@@ -24,14 +24,14 @@ CMPLRDIRSUFF.icx = _icx
 
 CORE.SERV.COMPILER.icx = generic
 
--Zl.icx =  -no-intel-lib=libirc
+-Zl.icx = -no-intel-lib
 -DEBC.icx = -g
 
 COMPILER.lnx.icx = icpx -m64 \
                      -Werror -Wreturn-type
 
 
-link.dynamic.lnx.icx = icpx -m64
+link.dynamic.lnx.icx = icpx -m64 -no-intel-lib
 
 pedantic.opts.icx = -pedantic \
                       -Wall \


### PR DESCRIPTION
# Description

Disable unnecessary linking to Intel libs by `icx` compiler.

Solves https://github.com/intel/scikit-learn-intelex/issues/1981.