### PR TITLE
Update deprecated functions in RF and GBT Examples

### DIFF
--- a/cpp/daal/include/algorithms/decision_forest/decision_forest_classification_model_builder.h
+++ b/cpp/daal/include/algorithms/decision_forest/decision_forest_classification_model_builder.h
@@ -119,14 +119,6 @@ public:
     }
 
     /**
-    *  \DAAL_DEPRECATED
-    */
-    DAAL_DEPRECATED NodeId addLeafNode(const TreeId treeId, const NodeId parentId, const size_t position, const size_t classLabel)
-    {
-        return addLeafNode(treeId, parentId, position, classLabel, 0);
-    }
-
-    /**
     *  Create Leaf node and add it to certain tree
     *  \param[in] treeId          Tree to which new node is added
     *  \param[in] parentId        Parent node to which new node is added (use noParent for root node)
@@ -141,14 +133,6 @@ public:
         _status |= addLeafNodeByProbaInternal(treeId, parentId, position, proba, cover, resId);
         services::throwIfPossible(_status);
         return resId;
-    }
-
-    /**
-    *  \DAAL_DEPRECATED
-    */
-    DAAL_DEPRECATED NodeId addLeafNodeByProba(const TreeId treeId, const NodeId parentId, const size_t position, const double * const proba)
-    {
-        return addLeafNodeByProba(treeId, parentId, position, proba, 0);
     }
 
     /**
@@ -169,15 +153,6 @@ public:
         _status |= addSplitNodeInternal(treeId, parentId, position, featureIndex, featureValue, defaultLeft, cover, resId);
         services::throwIfPossible(_status);
         return resId;
-    }
-
-    /**
-     * \DAAL_DEPRECATED
-     */
-    DAAL_DEPRECATED NodeId addSplitNode(const TreeId treeId, const NodeId parentId, const size_t position, const size_t featureIndex,
-                                        const double featureValue)
-    {
-        return addSplitNode(treeId, parentId, position, featureIndex, featureValue, 0, 0);
     }
 
     void setNFeatures(size_t nFeatures)

--- a/cpp/daal/include/algorithms/decision_forest/decision_forest_classification_model_builder.h
+++ b/cpp/daal/include/algorithms/decision_forest/decision_forest_classification_model_builder.h
@@ -110,7 +110,7 @@ public:
     *  \param[in] cover           Cover (Hessian sum) of the node
     *  \return Node identifier
     */
-    NodeId addLeafNode(const TreeId treeId, const NodeId parentId, const size_t position, const size_t classLabel, const double cover = 0.0)
+    NodeId addLeafNode(const TreeId treeId, const NodeId parentId, const size_t position, const size_t classLabel, const double cover)
     {
         NodeId resId;
         _status |= addLeafNodeInternal(treeId, parentId, position, classLabel, cover, resId);
@@ -127,7 +127,7 @@ public:
     *  \param[in] cover           Cover (Hessian sum) of the node
     *  \return Node identifier
     */
-    NodeId addLeafNodeByProba(const TreeId treeId, const NodeId parentId, const size_t position, const double * const proba, const double cover = 0.0)
+    NodeId addLeafNodeByProba(const TreeId treeId, const NodeId parentId, const size_t position, const double * const proba, const double cover)
     {
         NodeId resId;
         _status |= addLeafNodeByProbaInternal(treeId, parentId, position, proba, cover, resId);
@@ -147,7 +147,7 @@ public:
     *  \return Node identifier
     */
     NodeId addSplitNode(const TreeId treeId, const NodeId parentId, const size_t position, const size_t featureIndex, const double featureValue,
-                        const int defaultLeft = 0, const double cover = 0.0)
+                        const int defaultLeft, const double cover)
     {
         NodeId resId;
         _status |= addSplitNodeInternal(treeId, parentId, position, featureIndex, featureValue, defaultLeft, cover, resId);

--- a/cpp/daal/include/algorithms/decision_forest/decision_forest_classification_model_builder.h
+++ b/cpp/daal/include/algorithms/decision_forest/decision_forest_classification_model_builder.h
@@ -110,7 +110,7 @@ public:
     *  \param[in] cover           Cover (Hessian sum) of the node
     *  \return Node identifier
     */
-    NodeId addLeafNode(const TreeId treeId, const NodeId parentId, const size_t position, const size_t classLabel, const double cover)
+    NodeId addLeafNode(const TreeId treeId, const NodeId parentId, const size_t position, const size_t classLabel, const double cover = 0.0)
     {
         NodeId resId;
         _status |= addLeafNodeInternal(treeId, parentId, position, classLabel, cover, resId);
@@ -127,7 +127,7 @@ public:
     *  \param[in] cover           Cover (Hessian sum) of the node
     *  \return Node identifier
     */
-    NodeId addLeafNodeByProba(const TreeId treeId, const NodeId parentId, const size_t position, const double * const proba, const double cover)
+    NodeId addLeafNodeByProba(const TreeId treeId, const NodeId parentId, const size_t position, const double * const proba, const double cover = 0.0)
     {
         NodeId resId;
         _status |= addLeafNodeByProbaInternal(treeId, parentId, position, proba, cover, resId);
@@ -147,7 +147,7 @@ public:
     *  \return Node identifier
     */
     NodeId addSplitNode(const TreeId treeId, const NodeId parentId, const size_t position, const size_t featureIndex, const double featureValue,
-                        const int defaultLeft, const double cover)
+                        const int defaultLeft = 0, const double cover = 0.0)
     {
         NodeId resId;
         _status |= addSplitNodeInternal(treeId, parentId, position, featureIndex, featureValue, defaultLeft, cover, resId);

--- a/cpp/daal/include/algorithms/gradient_boosted_trees/gbt_classification_model_builder.h
+++ b/cpp/daal/include/algorithms/gradient_boosted_trees/gbt_classification_model_builder.h
@@ -131,7 +131,8 @@ public:
     *  \param[in] cover           Cover (Hessian sum) of the node
     *  \return Node identifier
     */
-    NodeId addSplitNode(TreeId treeId, NodeId parentId, size_t position, size_t featureIndex, double featureValue, int defaultLeft = 0, double cover = 0.0)
+    NodeId addSplitNode(TreeId treeId, NodeId parentId, size_t position, size_t featureIndex, double featureValue, int defaultLeft = 0,
+                        double cover = 0.0)
     {
         NodeId resId;
         _status |= addSplitNodeInternal(treeId, parentId, position, featureIndex, featureValue, defaultLeft, cover, resId);

--- a/cpp/daal/include/algorithms/gradient_boosted_trees/gbt_classification_model_builder.h
+++ b/cpp/daal/include/algorithms/gradient_boosted_trees/gbt_classification_model_builder.h
@@ -121,14 +121,6 @@ public:
     }
 
     /**
-    *  \DAAL_DEPRECATED
-    */
-    DAAL_DEPRECATED NodeId addLeafNode(TreeId treeId, NodeId parentId, size_t position, double response)
-    {
-        return addLeafNode(treeId, parentId, position, response, 0);
-    }
-
-    /**
     *  Create Split node and add it to certain tree
     *  \param[in] treeId          Tree to which new node is added
     *  \param[in] parentId        Parent node to which new node is added (use noParent for root node)
@@ -145,14 +137,6 @@ public:
         _status |= addSplitNodeInternal(treeId, parentId, position, featureIndex, featureValue, defaultLeft, cover, resId);
         services::throwIfPossible(_status);
         return resId;
-    }
-
-    /**
-    *  \DAAL_DEPRECATED
-    */
-    DAAL_DEPRECATED NodeId addSplitNode(TreeId treeId, NodeId parentId, size_t position, size_t featureIndex, double featureValue)
-    {
-        return addSplitNode(treeId, parentId, position, featureIndex, featureValue, 0, 0);
     }
 
     /**

--- a/cpp/daal/include/algorithms/gradient_boosted_trees/gbt_classification_model_builder.h
+++ b/cpp/daal/include/algorithms/gradient_boosted_trees/gbt_classification_model_builder.h
@@ -112,7 +112,7 @@ public:
     *  \param[in] cover           Cover (Hessian sum) of the node
     *  \return Node identifier
     */
-    NodeId addLeafNode(TreeId treeId, NodeId parentId, size_t position, double response, double cover)
+    NodeId addLeafNode(TreeId treeId, NodeId parentId, size_t position, double response, double cover = 0.0)
     {
         NodeId resId;
         _status |= addLeafNodeInternal(treeId, parentId, position, response, cover, resId);
@@ -131,7 +131,7 @@ public:
     *  \param[in] cover           Cover (Hessian sum) of the node
     *  \return Node identifier
     */
-    NodeId addSplitNode(TreeId treeId, NodeId parentId, size_t position, size_t featureIndex, double featureValue, int defaultLeft, double cover)
+    NodeId addSplitNode(TreeId treeId, NodeId parentId, size_t position, size_t featureIndex, double featureValue, int defaultLeft = 0, double cover = 0.0)
     {
         NodeId resId;
         _status |= addSplitNodeInternal(treeId, parentId, position, featureIndex, featureValue, defaultLeft, cover, resId);

--- a/cpp/daal/include/algorithms/gradient_boosted_trees/gbt_classification_model_builder.h
+++ b/cpp/daal/include/algorithms/gradient_boosted_trees/gbt_classification_model_builder.h
@@ -112,7 +112,7 @@ public:
     *  \param[in] cover           Cover (Hessian sum) of the node
     *  \return Node identifier
     */
-    NodeId addLeafNode(TreeId treeId, NodeId parentId, size_t position, double response, double cover = 0.0)
+    NodeId addLeafNode(TreeId treeId, NodeId parentId, size_t position, double response, double cover)
     {
         NodeId resId;
         _status |= addLeafNodeInternal(treeId, parentId, position, response, cover, resId);
@@ -131,8 +131,7 @@ public:
     *  \param[in] cover           Cover (Hessian sum) of the node
     *  \return Node identifier
     */
-    NodeId addSplitNode(TreeId treeId, NodeId parentId, size_t position, size_t featureIndex, double featureValue, int defaultLeft = 0,
-                        double cover = 0.0)
+    NodeId addSplitNode(TreeId treeId, NodeId parentId, size_t position, size_t featureIndex, double featureValue, int defaultLeft, double cover)
     {
         NodeId resId;
         _status |= addSplitNodeInternal(treeId, parentId, position, featureIndex, featureValue, defaultLeft, cover, resId);

--- a/cpp/daal/include/algorithms/gradient_boosted_trees/gbt_regression_model_builder.h
+++ b/cpp/daal/include/algorithms/gradient_boosted_trees/gbt_regression_model_builder.h
@@ -129,7 +129,8 @@ public:
     *  \param[in] cover           Cover of the node (sum_hess)
     *  \return Node identifier
     */
-    NodeId addSplitNode(TreeId treeId, NodeId parentId, size_t position, size_t featureIndex, double featureValue, int defaultLeft = 0, double cover = 0.0)
+    NodeId addSplitNode(TreeId treeId, NodeId parentId, size_t position, size_t featureIndex, double featureValue, int defaultLeft = 0,
+                        double cover = 0.0)
     {
         NodeId resId;
         _status |= addSplitNodeInternal(treeId, parentId, position, featureIndex, featureValue, defaultLeft, cover, resId);

--- a/cpp/daal/include/algorithms/gradient_boosted_trees/gbt_regression_model_builder.h
+++ b/cpp/daal/include/algorithms/gradient_boosted_trees/gbt_regression_model_builder.h
@@ -110,7 +110,7 @@ public:
     *  \param[in] cover           Cover of the node (sum_hess)
     *  \return Node identifier
     */
-    NodeId addLeafNode(TreeId treeId, NodeId parentId, size_t position, double response, double cover = 0.0)
+    NodeId addLeafNode(TreeId treeId, NodeId parentId, size_t position, double response, double cover)
     {
         NodeId resId;
         _status |= addLeafNodeInternal(treeId, parentId, position, response, cover, resId);
@@ -129,8 +129,7 @@ public:
     *  \param[in] cover           Cover of the node (sum_hess)
     *  \return Node identifier
     */
-    NodeId addSplitNode(TreeId treeId, NodeId parentId, size_t position, size_t featureIndex, double featureValue, int defaultLeft = 0,
-                        double cover = 0.0)
+    NodeId addSplitNode(TreeId treeId, NodeId parentId, size_t position, size_t featureIndex, double featureValue, int defaultLeft, double cover)
     {
         NodeId resId;
         _status |= addSplitNodeInternal(treeId, parentId, position, featureIndex, featureValue, defaultLeft, cover, resId);

--- a/cpp/daal/include/algorithms/gradient_boosted_trees/gbt_regression_model_builder.h
+++ b/cpp/daal/include/algorithms/gradient_boosted_trees/gbt_regression_model_builder.h
@@ -119,14 +119,6 @@ public:
     }
 
     /**
-    *  \DAAL_DEPRECATED
-    */
-    DAAL_DEPRECATED NodeId addLeafNode(TreeId treeId, NodeId parentId, size_t position, double response)
-    {
-        return addLeafNode(treeId, parentId, position, response, 0);
-    }
-
-    /**
     *  Create Split node and add it to certain tree
     *  \param[in] treeId          Tree to which new node is added
     *  \param[in] parentId        Parent node to which new node is added (use noParent for root node)
@@ -143,14 +135,6 @@ public:
         _status |= addSplitNodeInternal(treeId, parentId, position, featureIndex, featureValue, defaultLeft, cover, resId);
         services::throwIfPossible(_status);
         return resId;
-    }
-
-    /**
-    *  \DAAL_DEPRECATED
-    */
-    DAAL_DEPRECATED NodeId addSplitNode(TreeId treeId, NodeId parentId, size_t position, size_t featureIndex, double featureValue)
-    {
-        return addSplitNode(treeId, parentId, position, featureIndex, featureValue, 0, 0);
     }
 
     /**

--- a/cpp/daal/include/algorithms/gradient_boosted_trees/gbt_regression_model_builder.h
+++ b/cpp/daal/include/algorithms/gradient_boosted_trees/gbt_regression_model_builder.h
@@ -110,7 +110,7 @@ public:
     *  \param[in] cover           Cover of the node (sum_hess)
     *  \return Node identifier
     */
-    NodeId addLeafNode(TreeId treeId, NodeId parentId, size_t position, double response, double cover)
+    NodeId addLeafNode(TreeId treeId, NodeId parentId, size_t position, double response, double cover = 0.0)
     {
         NodeId resId;
         _status |= addLeafNodeInternal(treeId, parentId, position, response, cover, resId);
@@ -129,7 +129,7 @@ public:
     *  \param[in] cover           Cover of the node (sum_hess)
     *  \return Node identifier
     */
-    NodeId addSplitNode(TreeId treeId, NodeId parentId, size_t position, size_t featureIndex, double featureValue, int defaultLeft, double cover)
+    NodeId addSplitNode(TreeId treeId, NodeId parentId, size_t position, size_t featureIndex, double featureValue, int defaultLeft = 0, double cover = 0.0)
     {
         NodeId resId;
         _status |= addSplitNodeInternal(treeId, parentId, position, featureIndex, featureValue, defaultLeft, cover, resId);

--- a/examples/daal/cpp/source/decision_forest/df_cls_dense_batch_model_builder.cpp
+++ b/examples/daal/cpp/source/decision_forest/df_cls_dense_batch_model_builder.cpp
@@ -66,22 +66,33 @@ decision_forest::classification::ModelPtr buildModel() {
     ModelBuilder modelBuilder(nClasses, nTrees);
     ModelBuilder::TreeId tree1 = modelBuilder.createTree(nNodes);
     ModelBuilder::NodeId root1 =
-        modelBuilder.addSplitNode(tree1, ModelBuilder::noParent, 0, 0, 0.174108, defaultLeft, cover);
+        modelBuilder
+            .addSplitNode(tree1, ModelBuilder::noParent, 0, 0, 0.174108, defaultLeft, cover);
     /* ModelBuilder::NodeId child12 = */ modelBuilder.addLeafNode(tree1, root1, 1, 4, cover);
     double proba11[] = { 0.8, 0.1, 0.0, 0.1, 0.0 };
-    /* ModelBuilder::NodeId child11 = */ modelBuilder.addLeafNodeByProba(tree1, root1, 0, proba11, cover);
+    /* ModelBuilder::NodeId child11 = */ modelBuilder.addLeafNodeByProba(tree1,
+                                                                         root1,
+                                                                         0,
+                                                                         proba11,
+                                                                         cover);
 
     ModelBuilder::TreeId tree2 = modelBuilder.createTree(nNodes);
     ModelBuilder::NodeId root2 =
-        modelBuilder.addSplitNode(tree2, ModelBuilder::noParent, 0, 1, 0.571184, defaultLeft, cover);
+        modelBuilder
+            .addSplitNode(tree2, ModelBuilder::noParent, 0, 1, 0.571184, defaultLeft, cover);
     /* ModelBuilder::NodeId child22 = */ modelBuilder.addLeafNode(tree2, root2, 1, 4, cover);
     /* ModelBuilder::NodeId child21 = */ modelBuilder.addLeafNode(tree2, root2, 0, 2, cover);
 
     ModelBuilder::TreeId tree3 = modelBuilder.createTree(nNodes);
     ModelBuilder::NodeId root3 =
-        modelBuilder.addSplitNode(tree3, ModelBuilder::noParent, 0, 0, 0.303995, defaultLeft, cover);
+        modelBuilder
+            .addSplitNode(tree3, ModelBuilder::noParent, 0, 0, 0.303995, defaultLeft, cover);
     double proba32[] = { 0.05, 0.1, 0.0, 0.1, 0.75 };
-    /* ModelBuilder::NodeId child32 = */ modelBuilder.addLeafNodeByProba(tree3, root3, 1, proba32, cover);
+    /* ModelBuilder::NodeId child32 = */ modelBuilder.addLeafNodeByProba(tree3,
+                                                                         root3,
+                                                                         1,
+                                                                         proba32,
+                                                                         cover);
     /* ModelBuilder::NodeId child31 = */ modelBuilder.addLeafNode(tree3, root3, 0, 2, cover);
     modelBuilder.setNFeatures(nFeatures);
     return modelBuilder.getModel();

--- a/examples/daal/cpp/source/decision_forest/df_cls_dense_batch_model_builder.cpp
+++ b/examples/daal/cpp/source/decision_forest/df_cls_dense_batch_model_builder.cpp
@@ -60,27 +60,29 @@ int main(int argc, char* argv[]) {
 
 decision_forest::classification::ModelPtr buildModel() {
     const size_t nNodes = 3;
+    const int defaultLeft = 0;
+    const double cover = 0.0;
 
     ModelBuilder modelBuilder(nClasses, nTrees);
     ModelBuilder::TreeId tree1 = modelBuilder.createTree(nNodes);
     ModelBuilder::NodeId root1 =
-        modelBuilder.addSplitNode(tree1, ModelBuilder::noParent, 0, 0, 0.174108);
-    /* ModelBuilder::NodeId child12 = */ modelBuilder.addLeafNode(tree1, root1, 1, 4);
+        modelBuilder.addSplitNode(tree1, ModelBuilder::noParent, 0, 0, 0.174108, defaultLeft, cover);
+    /* ModelBuilder::NodeId child12 = */ modelBuilder.addLeafNode(tree1, root1, 1, 4, cover);
     double proba11[] = { 0.8, 0.1, 0.0, 0.1, 0.0 };
-    /* ModelBuilder::NodeId child11 = */ modelBuilder.addLeafNodeByProba(tree1, root1, 0, proba11);
+    /* ModelBuilder::NodeId child11 = */ modelBuilder.addLeafNodeByProba(tree1, root1, 0, proba11, cover);
 
     ModelBuilder::TreeId tree2 = modelBuilder.createTree(nNodes);
     ModelBuilder::NodeId root2 =
-        modelBuilder.addSplitNode(tree2, ModelBuilder::noParent, 0, 1, 0.571184);
-    /* ModelBuilder::NodeId child22 = */ modelBuilder.addLeafNode(tree2, root2, 1, 4);
-    /* ModelBuilder::NodeId child21 = */ modelBuilder.addLeafNode(tree2, root2, 0, 2);
+        modelBuilder.addSplitNode(tree2, ModelBuilder::noParent, 0, 1, 0.571184, defaultLeft, cover);
+    /* ModelBuilder::NodeId child22 = */ modelBuilder.addLeafNode(tree2, root2, 1, 4, cover);
+    /* ModelBuilder::NodeId child21 = */ modelBuilder.addLeafNode(tree2, root2, 0, 2, cover);
 
     ModelBuilder::TreeId tree3 = modelBuilder.createTree(nNodes);
     ModelBuilder::NodeId root3 =
-        modelBuilder.addSplitNode(tree3, ModelBuilder::noParent, 0, 0, 0.303995);
+        modelBuilder.addSplitNode(tree3, ModelBuilder::noParent, 0, 0, 0.303995, defaultLeft, cover);
     double proba32[] = { 0.05, 0.1, 0.0, 0.1, 0.75 };
-    /* ModelBuilder::NodeId child32 = */ modelBuilder.addLeafNodeByProba(tree3, root3, 1, proba32);
-    /* ModelBuilder::NodeId child31 = */ modelBuilder.addLeafNode(tree3, root3, 0, 2);
+    /* ModelBuilder::NodeId child32 = */ modelBuilder.addLeafNodeByProba(tree3, root3, 1, proba32, cover);
+    /* ModelBuilder::NodeId child31 = */ modelBuilder.addLeafNode(tree3, root3, 0, 2, cover);
     modelBuilder.setNFeatures(nFeatures);
     return modelBuilder.getModel();
 }

--- a/examples/daal/cpp/source/decision_forest/df_cls_traversed_model_builder.cpp
+++ b/examples/daal/cpp/source/decision_forest/df_cls_traversed_model_builder.cpp
@@ -138,13 +138,17 @@ bool buildTree(size_t treeId,
                bool &isRoot,
                ModelBuilder &builder,
                std::map<Node *, ParentPlace> &parentMap) {
+    const int defaultLeft = 0;
+    const double cover = 0.0;
     if (node->left != NULL && node->right != NULL) {
         if (isRoot) {
             ModelBuilder::NodeId parent = builder.addSplitNode(treeId,
                                                                ModelBuilder::noParent,
                                                                0,
                                                                node->featureIndex,
-                                                               node->featureValue);
+                                                               node->featureValue,
+                                                               defaultLeft,
+                                                               cover);
 
             parentMap[node->left] = ParentPlace(parent, 0);
             ;
@@ -158,7 +162,9 @@ bool buildTree(size_t treeId,
                                                                p.parentId,
                                                                p.place,
                                                                node->featureIndex,
-                                                               node->featureValue);
+                                                               node->featureValue,
+                                                               defaultLeft,
+                                                               cover);
 
             parentMap[node->left] = ParentPlace(parent, 0);
             ;
@@ -168,12 +174,12 @@ bool buildTree(size_t treeId,
     }
     else {
         if (isRoot) {
-            builder.addLeafNode(treeId, ModelBuilder::noParent, 0, node->classLabel);
+            builder.addLeafNode(treeId, ModelBuilder::noParent, 0, node->classLabel, cover);
             isRoot = false;
         }
         else {
             ParentPlace p = parentMap[node];
-            builder.addLeafNode(treeId, p.parentId, p.place, node->classLabel);
+            builder.addLeafNode(treeId, p.parentId, p.place, node->classLabel, cover);
         }
         return true;
     }

--- a/examples/daal/cpp/source/gradient_boosted_trees/gbt_cls_traversed_model_builder.cpp
+++ b/examples/daal/cpp/source/gradient_boosted_trees/gbt_cls_traversed_model_builder.cpp
@@ -253,7 +253,11 @@ bool buildTree(size_t treeId,
             isRoot = false;
         }
         else {
-            builder.addLeafNode(treeId, parentPlace.parentId, parentPlace.place, node->response, cover);
+            builder.addLeafNode(treeId,
+                                parentPlace.parentId,
+                                parentPlace.place,
+                                node->response,
+                                cover);
         }
     }
 

--- a/examples/daal/cpp/source/gradient_boosted_trees/gbt_cls_traversed_model_builder.cpp
+++ b/examples/daal/cpp/source/gradient_boosted_trees/gbt_cls_traversed_model_builder.cpp
@@ -218,13 +218,17 @@ bool buildTree(size_t treeId,
                bool &isRoot,
                ModelBuilder &builder,
                const ParentPlace &parentPlace) {
+    const int defaultLeft = 0;
+    const double cover = 0.0;
     if (node->left != NULL && node->right != NULL) {
         if (isRoot) {
             ModelBuilder::NodeId parent = builder.addSplitNode(treeId,
                                                                ModelBuilder::noParent,
                                                                0,
                                                                node->featureIndex,
-                                                               node->featureValue);
+                                                               node->featureValue,
+                                                               defaultLeft,
+                                                               cover);
 
             isRoot = false;
             buildTree(treeId, node->left, isRoot, builder, ParentPlace(parent, 0));
@@ -235,7 +239,9 @@ bool buildTree(size_t treeId,
                                                                parentPlace.parentId,
                                                                parentPlace.place,
                                                                node->featureIndex,
-                                                               node->featureValue);
+                                                               node->featureValue,
+                                                               defaultLeft,
+                                                               cover);
 
             buildTree(treeId, node->left, isRoot, builder, ParentPlace(parent, 0));
             buildTree(treeId, node->right, isRoot, builder, ParentPlace(parent, 1));
@@ -243,11 +249,11 @@ bool buildTree(size_t treeId,
     }
     else {
         if (isRoot) {
-            builder.addLeafNode(treeId, ModelBuilder::noParent, 0, node->response);
+            builder.addLeafNode(treeId, ModelBuilder::noParent, 0, node->response, cover);
             isRoot = false;
         }
         else {
-            builder.addLeafNode(treeId, parentPlace.parentId, parentPlace.place, node->response);
+            builder.addLeafNode(treeId, parentPlace.parentId, parentPlace.place, node->response, cover);
         }
     }
 

--- a/examples/daal/cpp/source/gradient_boosted_trees/gbt_reg_traversed_model_builder.cpp
+++ b/examples/daal/cpp/source/gradient_boosted_trees/gbt_reg_traversed_model_builder.cpp
@@ -216,13 +216,18 @@ bool buildTree(size_t treeId,
                bool &isRoot,
                ModelBuilder &builder,
                const ParentPlace &parentPlace) {
+
+    const int defaultLeft = 0;
+    const double cover = 0.0;
     if (node->left != NULL && node->right != NULL) {
         if (isRoot) {
             ModelBuilder::NodeId parent = builder.addSplitNode(treeId,
                                                                ModelBuilder::noParent,
                                                                0,
                                                                node->featureIndex,
-                                                               node->featureValue);
+                                                               node->featureValue,
+                                                               defaultLeft,
+                                                               cover);
 
             isRoot = false;
             buildTree(treeId, node->left, isRoot, builder, ParentPlace(parent, 0));
@@ -233,7 +238,9 @@ bool buildTree(size_t treeId,
                                                                parentPlace.parentId,
                                                                parentPlace.place,
                                                                node->featureIndex,
-                                                               node->featureValue);
+                                                               node->featureValue,
+                                                               defaultLeft,
+                                                               cover);
 
             buildTree(treeId, node->left, isRoot, builder, ParentPlace(parent, 0));
             buildTree(treeId, node->right, isRoot, builder, ParentPlace(parent, 1));
@@ -241,11 +248,11 @@ bool buildTree(size_t treeId,
     }
     else {
         if (isRoot) {
-            builder.addLeafNode(treeId, ModelBuilder::noParent, 0, node->response);
+            builder.addLeafNode(treeId, ModelBuilder::noParent, 0, node->response, cover);
             isRoot = false;
         }
         else {
-            builder.addLeafNode(treeId, parentPlace.parentId, parentPlace.place, node->response);
+            builder.addLeafNode(treeId, parentPlace.parentId, parentPlace.place, node->response, cover);
         }
     }
 

--- a/examples/daal/cpp/source/gradient_boosted_trees/gbt_reg_traversed_model_builder.cpp
+++ b/examples/daal/cpp/source/gradient_boosted_trees/gbt_reg_traversed_model_builder.cpp
@@ -216,7 +216,6 @@ bool buildTree(size_t treeId,
                bool &isRoot,
                ModelBuilder &builder,
                const ParentPlace &parentPlace) {
-
     const int defaultLeft = 0;
     const double cover = 0.0;
     if (node->left != NULL && node->right != NULL) {
@@ -252,7 +251,11 @@ bool buildTree(size_t treeId,
             isRoot = false;
         }
         else {
-            builder.addLeafNode(treeId, parentPlace.parentId, parentPlace.place, node->response, cover);
+            builder.addLeafNode(treeId,
+                                parentPlace.parentId,
+                                parentPlace.place,
+                                node->response,
+                                cover);
         }
     }
 


### PR DESCRIPTION
# Description
There are a few functions in Random Forest and Gradient Boosted tree in DAAL that have been deprecated and replaced by newer definitions which expects one or two parameters more. Because of the deprecation flags CI throws warnings on windows. The deprecated functions are being used from examples and some tests on ci. This PR modifies the examples to use newer definitions. Public CI failure will be addressed on https://github.com/oneapi-src/oneDAL/pull/2891