### PR TITLE
Perf. fix for decision forest classifier inference

### DIFF
--- a/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_predict_dense_default_batch_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_predict_dense_default_batch_impl.i
@@ -1045,7 +1045,9 @@ Status PredictClassificationTask<algorithmFPType, cpu>::predictAllPointsByAllTre
     ReadRows<algorithmFPType, cpu> xBD(const_cast<NumericTable *>(_data), 0, nRowsOfRes);
     DAAL_CHECK_BLOCK_STATUS(xBD);
     const algorithmFPType * const aX = xBD.get();
-    if (numberOfTrees > _minTreesForThreading)
+    // TODO: investigate why higher level parallelism for trees causes performance degradation
+    // (excessive memory and CPU resources usage), especially on systems with high number of cores
+    if (false)
     {
         daal::static_tls<algorithmFPType *> tlsData([=]() { return service_scalable_calloc<algorithmFPType, cpu>(_nClasses * nRowsOfRes); });
 


### PR DESCRIPTION
# Description

Disables ensemble level parallelism in classifier inference to avoid excessive memory and CPU usage on machines with higher number of cores.