### PR TITLE
[enhancement] Add a label checker to GitHub Actions

### DIFF
--- a/.github/workflows/label-enforcement.yml
+++ b/.github/workflows/label-enforcement.yml
@@ -14,4 +14,8 @@ jobs:
 
     steps:
       - name: test
-        run: if [[ "${{ env.LABELS }}" == "[]" ]]; then exit 1; fi
+        run: |
+          if [[ "${{ env.LABELS }}" == "[]" ]]; then
+            echo "::error::No label set on the pull request"
+            exit 1
+          fi

--- a/.github/workflows/label-enforcement.yml
+++ b/.github/workflows/label-enforcement.yml
@@ -3,9 +3,6 @@ on:
   pull_request:
     branches: [ "main" ]
 
-env:
-  LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
-
 jobs:
   label_checker:
     name: Please include labels on your pull request
@@ -15,7 +12,11 @@ jobs:
     steps:
       - name: test
         run: |
-          if [[ "${{ env.LABELS }}" == "[]" ]]; then
+          LABELS=`gh api -H "Accept: application/vnd.github+json" /repos/oneapi-src/oneDAL/issues/${{ github.event.pull_request.number }}/labels | jq '[.[].name]'`
+          echo $LABELS
+          if [[ $LABELS == "[]" ]]; then
             echo "::error::No label set on the pull request"
             exit 1
           fi
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/label-enforcement.yml
+++ b/.github/workflows/label-enforcement.yml
@@ -14,7 +14,7 @@ jobs:
         run: |
           LABELS=`gh api -H "Accept: application/vnd.github+json" /repos/oneapi-src/oneDAL/issues/${{ github.event.pull_request.number }}/labels | jq '[.[].name]'`
           echo $LABELS
-          if [[ $LABELS == "[]" ]]; then
+          if [[ $LABELS == "[]" ]] || [[ $LABELS == "[\"RFC\"]" ]]; then
             echo "::error::No label set on the pull request"
             exit 1
           fi

--- a/.github/workflows/label_enforcement.yml
+++ b/.github/workflows/label_enforcement.yml
@@ -8,12 +8,10 @@ env:
 
 jobs:
   label_checker:
-    strategy:
-      fail-fast: false
     name: Please include labels on your pull request
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 5
 
     steps:
       - name: test
-        run: echo "${{ env.LABELS }}"
+        run: if [[ "${{ env.LABELS }}" == "[]" ]]; then exit 1; fi

--- a/.github/workflows/label_enforcement.yml
+++ b/.github/workflows/label_enforcement.yml
@@ -1,0 +1,19 @@
+name: Enforce Labels
+on:
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+
+jobs:
+  label_checker:
+    strategy:
+      fail-fast: false
+    name: Please include labels on your pull request
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+
+    steps:
+      - name: test
+        run: echo "${{ env.LABELS }}"


### PR DESCRIPTION
# Description
PR rules related to labeling are currently not enforced. Labels are required by the development guideline for oneDAL. This adds a GitHub Action to PRs to verify that at least some label has been set to guide reviewers.

Changes proposed in this pull request:
- Add a Github Action check for pull requests which checks the labels.