### PR TITLE
[bug] fix nightly-build regression caused by #2712

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: __release_lnx
-          path: ./__release_lnx_icx
+          path: ./__release_lnx
 
   build_win:
     name: oneDAL Windows nightly build


### PR DESCRIPTION
# Description
```__release_*_icx``` was changed to ```__release_*``` in #2712 this broke the artifact upload step in the GitHub Actions nightly build.  This PR solves the issue by now pointing the Linux release upload directory at ```___release_lnx``` instead of ```__release_lnx_icx```
Changes proposed in this pull request:
- Change nightly-build.yml linux artifact upload directory