### PR TITLE
Update to newer docker env syntax

### DIFF
--- a/dev/docker/onedal-dev.Dockerfile
+++ b/dev/docker/onedal-dev.Dockerfile
@@ -32,7 +32,7 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86
     /bin/bash ~/miniconda.sh -b -p /opt/conda
 
 # Put conda in path to use conda activate
-ENV PATH=$CONDA_DIR/bin:$PATH
+ENV PATH $CONDA_DIR/bin:$PATH
 
 # Installing environment for base development dependencies
 RUN .ci/env/apt.sh dev-base


### PR DESCRIPTION
# Description
This PR modifies the example Dockerfile to use the newer syntax for defining environment variables, since the older form `ENV K=V` is deprecated.