### PR TITLE
Change default COMPILER to icx in makefile

### DIFF
--- a/dev/make/function_definitions/32e.mk
+++ b/dev/make/function_definitions/32e.mk
@@ -20,7 +20,7 @@ ifeq ($(filter mkl ref,$(BACKEND_CONFIG)),)
 endif
 
 COMPILERs = icc icx gnu clang vc
-COMPILER ?= icc
+COMPILER ?= icx
 CPUs := sse2 sse42 avx2 avx512
 CPUs.files := nrh neh hsw skx
 


### PR DESCRIPTION
Change default COMPILER from `icc` to `icx` in makefile 32e helper.