### PR TITLE
Update Docker file

### DIFF
--- a/.ci/env/apt.sh
+++ b/.ci/env/apt.sh
@@ -23,17 +23,15 @@ function update {
 }
 
 function add_repo {
-    wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
-    sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
-    rm GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
-    echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
-    sudo add-apt-repository -y "deb https://apt.repos.intel.com/oneapi all main"
-    sudo apt-get update
+    wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | \
+        gpg --dearmor | sudo tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null
+    echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" \
+        | sudo tee /etc/apt/sources.list.d/oneAPI.list
+    sudo apt update
 }
 
 function install_dpcpp {
-    sudo apt-get install -y intel-oneapi-compiler-dpcpp-cpp-2024.2
-    sudo bash -c 'echo libintelocl.so > /etc/OpenCL/vendors/intel-cpu.icd'
+    sudo apt-get install -y intel-oneapi-compiler-dpcpp-cpp intel-oneapi-runtime-libs
 }
 
 function install_mkl {
@@ -49,7 +47,7 @@ function install_dev-base {
 }
 
 function install_dev-base-conda {
-    conda env create -f .ci/env/environment.yml
+    mamba env create -f .ci/env/environment.yml
 }
 
 function install_gnu-cross-compilers {

--- a/.ci/env/apt.sh
+++ b/.ci/env/apt.sh
@@ -47,7 +47,7 @@ function install_dev-base {
 }
 
 function install_dev-base-conda {
-    mamba env create -f .ci/env/environment.yml
+    conda env create -f .ci/env/environment.yml
 }
 
 function install_gnu-cross-compilers {

--- a/.ci/env/environment.yml
+++ b/.ci/env/environment.yml
@@ -1,6 +1,5 @@
 name: ci-env
 channels:
   - conda-forge
-  - defaults
 dependencies:
   - impi-devel=2021.12.0

--- a/dev/docker/README.md
+++ b/dev/docker/README.md
@@ -16,13 +16,18 @@
 *******************************************************************************/-->
 
 # Docker Development Environment
+
 ## How To Use
+
 There is a simple docker dev environment for the oneDAL development and build process.
 It includes dependencies for building all oneDAL components with ``make`` and ``bazel``
 
-Note: The docker setup assumes that it is executed from the oneDAL repo and copies repo files inside the container
+Note: The docker setup assumes that it is executed from the oneDAL repo and copies repo files inside the container. In order to build the container locally from the root of the `oneDAL` repository, execute the following:
+```shell
+docker build -t onedal-dev -f dev/docker/onedal-dev.Dockerfile .
+```
 
-For that, run:
-   ```sh
-   docker run -it onedal-dev /bin/bash
-   ```
+Then, in order to use the container interactively, run:
+```shell
+docker run -it onedal-dev /bin/bash
+```

--- a/dev/docker/onedal-dev.Dockerfile
+++ b/dev/docker/onedal-dev.Dockerfile
@@ -17,9 +17,6 @@
 FROM ubuntu:22.04@sha256:adbb90115a21969d2fe6fa7f9af4253e16d45f8d4c1e930182610c4731962658
 
 ARG workdirectory="/sources/oneDAL"
-
-COPY . ${workdirectory}
-
 WORKDIR ${workdirectory}
 
 #Env setup
@@ -35,6 +32,13 @@ RUN wget --quiet \
 # Put conda in path to use conda activate
 ENV PATH $CONDA_DIR/bin:$PATH
 
+# Installing environment for bazel
+RUN wget https://github.com/bazelbuild/bazelisk/releases/download/v1.18.0/bazelisk-linux-amd64 && \
+    chmod 755 bazelisk-linux-amd64 && \
+    mv bazelisk-linux-amd64 /usr/bin/bazel
+
+COPY . ${workdirectory}
+
 # Installing environment for base development dependencies
 RUN .ci/env/apt.sh dev-base
 
@@ -44,11 +48,6 @@ RUN .ci/env/apt.sh dpcpp
 # Installing environment for clang-format
 RUN .ci/env/apt.sh clang-format
 
-# Installing environment for bazel
-RUN wget https://github.com/bazelbuild/bazelisk/releases/download/v1.18.0/bazelisk-linux-amd64 && \
-    chmod 755 bazelisk-linux-amd64 && \
-    mv bazelisk-linux-amd64 /usr/bin/bazel
-
 # Installing openBLAS dependency
 RUN .ci/env/openblas.sh
 
@@ -57,4 +56,3 @@ RUN ./dev/download_micromkl.sh
 
 # Installing oneTBB dependency
 RUN ./dev/download_tbb.sh
-

--- a/dev/docker/onedal-dev.Dockerfile
+++ b/dev/docker/onedal-dev.Dockerfile
@@ -24,12 +24,13 @@ WORKDIR ${workdirectory}
 
 #Env setup
 RUN apt-get update && \
-      apt-get -y install sudo wget gnupg git make python3-setuptools doxygen
+      apt-get -y install sudo wget gnupg git make python3-setuptools doxygen software-properties-common
 
 # Install miniconda
 ENV CONDA_DIR /opt/conda
-RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh && \
-    /bin/bash ~/miniconda.sh -b -p /opt/conda
+RUN wget --quiet \
+    "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh" && \
+    bash Miniforge3* -b -p /opt/conda
 
 # Put conda in path to use conda activate
 ENV PATH=$CONDA_DIR/bin:$PATH

--- a/dev/docker/onedal-dev.Dockerfile
+++ b/dev/docker/onedal-dev.Dockerfile
@@ -33,7 +33,7 @@ RUN wget --quiet \
     bash Miniforge3* -b -p /opt/conda
 
 # Put conda in path to use conda activate
-ENV PATH=$CONDA_DIR/bin:$PATH
+ENV PATH $CONDA_DIR/bin:$PATH
 
 # Installing environment for base development dependencies
 RUN .ci/env/apt.sh dev-base

--- a/dev/docker/onedal-dev.Dockerfile
+++ b/dev/docker/onedal-dev.Dockerfile
@@ -42,17 +42,17 @@ COPY . ${workdirectory}
 # Installing environment for base development dependencies
 RUN .ci/env/apt.sh dev-base
 
-# # Installing environment for DPCPP development dependencies
-# RUN .ci/env/apt.sh dpcpp
+# Installing environment for DPCPP development dependencies
+RUN .ci/env/apt.sh dpcpp
 
-# # Installing environment for clang-format
-# RUN .ci/env/apt.sh clang-format
+# Installing environment for clang-format
+RUN .ci/env/apt.sh clang-format
 
-# # Installing openBLAS dependency
-# RUN .ci/env/openblas.sh
+# Installing openBLAS dependency
+RUN .ci/env/openblas.sh
 
-# # Installing MKL dependency
-# RUN ./dev/download_micromkl.sh
+# Installing MKL dependency
+RUN ./dev/download_micromkl.sh
 
-# # Installing oneTBB dependency
-# RUN ./dev/download_tbb.sh
+# Installing oneTBB dependency
+RUN ./dev/download_tbb.sh

--- a/dev/docker/onedal-dev.Dockerfile
+++ b/dev/docker/onedal-dev.Dockerfile
@@ -24,13 +24,13 @@ RUN apt-get update && \
       apt-get -y install sudo wget gnupg git make python3-setuptools doxygen software-properties-common
 
 # Install miniconda
-ENV CONDA_DIR /opt/conda
+ENV CONDA_DIR=/opt/conda
 RUN wget --quiet \
     "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh" && \
     bash Miniforge3* -b -p /opt/conda
 
 # Put conda in path to use conda activate
-ENV PATH $CONDA_DIR/bin:$PATH
+ENV PATH=$CONDA_DIR/bin:$PATH
 
 # Installing environment for bazel
 RUN wget https://github.com/bazelbuild/bazelisk/releases/download/v1.18.0/bazelisk-linux-amd64 && \
@@ -42,17 +42,17 @@ COPY . ${workdirectory}
 # Installing environment for base development dependencies
 RUN .ci/env/apt.sh dev-base
 
-# Installing environment for DPCPP development dependencies
-RUN .ci/env/apt.sh dpcpp
+# # Installing environment for DPCPP development dependencies
+# RUN .ci/env/apt.sh dpcpp
 
-# Installing environment for clang-format
-RUN .ci/env/apt.sh clang-format
+# # Installing environment for clang-format
+# RUN .ci/env/apt.sh clang-format
 
-# Installing openBLAS dependency
-RUN .ci/env/openblas.sh
+# # Installing openBLAS dependency
+# RUN .ci/env/openblas.sh
 
-# Installing MKL dependency
-RUN ./dev/download_micromkl.sh
+# # Installing MKL dependency
+# RUN ./dev/download_micromkl.sh
 
-# Installing oneTBB dependency
-RUN ./dev/download_tbb.sh
+# # Installing oneTBB dependency
+# RUN ./dev/download_tbb.sh


### PR DESCRIPTION
# Description
This PR makes some adjustments to the Docker file provided under `/dev`:
* Downloads `Miniforge` (hosted on GitHub) instead of `Miniconda` (hosted on Anaconda).
* ~Replaces usage of `conda` with the newer `mamba`.~ Did not work in the CI.
* Pulls everything from `mamba` from the `conda-forge` repository.
* Uses the [latest version of the instructions](https://www.intel.com/content/www/us/en/developer/tools/oneapi/base-toolkit-download.html?operatingsystem=linux&linux-install-type=apt) for adding the intel APT repository, which requires some additional packages.
* Changes the fixed version of `dpcpp` towards the last version instead, as it comes from a non-ubuntu repository which is subject to changes and might at some point no longer host the specific version that was added here.
* Adds the runtime libraries for `opencl` instead of manually adding a text file entry in its place.
* Adds some short instructions for building the container locally.

I'm not 100% sure that the resulting image will end up building (haven't figured out my networking settings for Docker yet), but hopefully the CI jobs here should bring some light.