### PR TITLE
Increase timeout for failing test jobs

### DIFF
--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -620,7 +620,7 @@ jobs:
       conda activate CB
       source $(Pipeline.Workspace)/daal/latest/env/vars.sh
       ./sklearnex/conda-recipe/run_test.sh
-    timeoutInMinutes: 15
+    timeoutInMinutes: 20
     displayName: sklearnex test
   - script: |
       source /usr/share/miniconda/etc/profile.d/conda.sh


### PR DESCRIPTION
# Description
This PR increases the timeout for limit for `sklearnex test`, which is currently failing due to timeout in some PRs:
https://dev.azure.com/daal/DAAL/_build/results?buildId=37981&view=logs&j=a8904dfb-edc6-5d1f-0634-80e20164e44d&t=83005eef-67ab-5840-33d4-72889c553a31
https://dev.azure.com/daal/DAAL/_build/results?buildId=37978&view=logs&j=a8904dfb-edc6-5d1f-0634-80e20164e44d&t=83005eef-67ab-5840-33d4-72889c553a31
