### PR TITLE
[enhancement] Add new issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/RFC.md
+++ b/.github/ISSUE_TEMPLATE/RFC.md
@@ -1,0 +1,20 @@
+---
+name: RFC for new interface
+about: Use this template to request new functionality or change the behavior of the library
+title: ''
+labels: 'RFC'
+assignees: ''
+---
+
+**Summary**
+Include a short summary of the request. Sections below provide guidance on
+what factors are considered important. 
+
+**Problem statement**
+Describe the problem you are trying to solve with a reasonable level of detail.
+
+**Details**
+* The definition of the function including interface and semantics. How this
+interface will be extendable for different hardware implementations.
+* What existing libraries have implementation of this function and can be used
+under oneDAL interface.

--- a/.github/ISSUE_TEMPLATE/RFC.md
+++ b/.github/ISSUE_TEMPLATE/RFC.md
@@ -14,7 +14,7 @@ what factors are considered important.
 Describe the problem you are trying to solve with a reasonable level of detail.
 
 **Details**
-* The definition of the function including interface and semantics. How this
+* The definition of the function including interface and semantics. Please include how this
 interface will be extendable for different hardware implementations.
 * What existing libraries have implementation of this function and can be used
 under oneDAL interface.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,6 +24,6 @@ Describe what your are expecting from steps above
 If applicable, add output/screenshots to help explain your problem.
 
 **Environment:**
- - OS: [e.g. Ubuntu 18.04]
- - Compiler: [e.g. GCC9.2]
- - Version: [e.g. 2019 Update 4]
+ - OS: [e.g. Ubuntu 22.04]
+ - Compiler: [e.g. GCC12.1]
+ - Version: [e.g. 2025 Update 1]

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -26,4 +26,4 @@ If applicable, add output/screenshots to help explain your problem.
 **Environment:**
  - OS: [e.g. Ubuntu 22.04]
  - Compiler: [e.g. GCC12.1]
- - Version: [e.g. 2025 Update 1]
+ - Version: [e.g. 2025.1]

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,19 @@
+---
+name: Request a documentation change
+about: Use this template to report documentation issue or request documentation changes
+title: ''
+labels: 'documentation'
+assignees: ''
+---
+
+**Summary**
+Include a short summary of the issue or request. Sections below provide
+guidance on what factors are considered important for a documentation
+issue.
+
+**URLs**
+Include pointers to documents that are impacted.
+
+**Additional details**
+Provide detailed description of the expected changes in documentation
+and suggestions you have.

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -15,5 +15,5 @@ issue.
 Include pointers to documents that are impacted.
 
 **Additional details**
-Provide detailed description of the expected changes in documentation
-and suggestions you have.
+Please provide a detailed description of the expected changes in documentation
+and any suggestions that you may have.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,18 @@
+---
+name: Request a feature
+about: Use this template to request new functionality or change the behavior of the library
+title: ''
+labels: 'new feature'
+assignees: ''
+---
+
+**Summary**
+Include a short summary of the request. 
+
+See the sections below for factors important for a feature request.
+
+**Problem Statement**
+Describe the problem you want to solve with a reasonable level of detail.
+
+**Preferred Solution**
+Provide your ideas regarding problem solutions.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,7 @@
+---
+name: Ask a question
+about: Use this template for any questions
+title: ''
+labels: 'question'
+assignees: ''
+---

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,7 +1,0 @@
----
-name: Ask a question
-about: Use this template for any questions
-title: ''
-labels: 'question'
-assignees: ''
----


### PR DESCRIPTION
# Description
This PR adds issue templates to make external contribution and communication simpler and easier.  Users of oneDAL will be able to submit issues for a range of problems outside of bug reports.  These files follow the standard set by oneDAL's bug_report.md, and are based off of oneapi-src/oneMKL#10 and oneapi-src/oneTBB#1400 .  This addresses uxlfoundation/open-source-working-group#40

Changes proposed in this pull request:
- add documentation.md
- add RFC.md
- add feature_request.md
- add question.md