### PR TITLE
Add sycl headers to bazel toolchain config for DPCPP through icx

### DIFF
--- a/dev/bazel/toolchains/cc_toolchain_lnx.bzl
+++ b/dev/bazel/toolchains/cc_toolchain_lnx.bzl
@@ -129,7 +129,7 @@ def _preapre_builtin_include_directory_paths(repo_ctx, tools):
             "-xc++",
             get_no_canonical_prefixes_opt(repo_ctx, tools.dpcc) +
             _add_gcc_toolchain_if_needed(repo_ctx, tools.dpcc) +
-            _add_sycl_linkage(repo_ctx, tools.dpcc),
+            _add_sycl_linkage(repo_ctx, tools.dpcc) if tools.is_dpc_found else [],
         ) +
         required_tmp_includes,
     )

--- a/dev/bazel/toolchains/cc_toolchain_lnx.bzl
+++ b/dev/bazel/toolchains/cc_toolchain_lnx.bzl
@@ -128,7 +128,8 @@ def _preapre_builtin_include_directory_paths(repo_ctx, tools):
             tools.dpcc,
             "-xc++",
             get_no_canonical_prefixes_opt(repo_ctx, tools.dpcc) +
-            _add_gcc_toolchain_if_needed(repo_ctx, tools.dpcc),
+            _add_gcc_toolchain_if_needed(repo_ctx, tools.dpcc) +
+            _add_sycl_linkage(repo_ctx, tools.dpcc),
         ) +
         required_tmp_includes,
     )
@@ -151,6 +152,12 @@ def _get_gcc_toolchain_path(repo_ctx):
 def _add_gcc_toolchain_if_needed(repo_ctx, cc):
     if ("clang" in cc) or ("icpx" in cc):
         return ["--gcc-toolchain=" + _get_gcc_toolchain_path(repo_ctx)]
+    else:
+        return []
+
+def _add_sycl_linkage(repo_ctx, cc):
+    if ("icx" in cc) or ("icpx" in cc):
+        return ["-fsycl"]
     else:
         return []
 


### PR DESCRIPTION
# Description
There is a step in the bazel test pipeline for `//cpp/oneapi/dal:tests` in which it probes the compiler for include paths of headers to add to the toolchain config:
https://github.com/oneapi-src/oneDAL/blob/b6b6a65a59b46d6770198abfc11cfa476c1338a2/dev/bazel/toolchains/cc_toolchain_lnx.bzl#L103

It does so by requesting the default paths from the compiler with this command:
```shell
<compiler> -E -xc++ - -v
```

In the case of DPCPP, this resolves to:
```shell
icx -E -xc++ - -v
```

By default, `icx` doesn't include sycl linkage, thus the command above does not return the paths of SYCL headers. Under the default `icx` factory settings, that leads to observing an error:
```
the source file 'cpp/oneapi/dal/algo/pca/test/serialization.cpp' includes the following non-builtin files with absolute paths (if these are builtin files, make sure these paths are in your toolchain):
  '/opt/intel/oneapi/compiler/2024.2/include/sycl/sycl.hpp'
```

This PR should address it by adding the necessary `-fsycl` flag when probing the compiler for its header paths.