### PR TITLE
FIX: `Kmeans` timeouts issue on GPU for sparse inputs

### DIFF
--- a/cpp/oneapi/dal/algo/kmeans/backend/gpu/kernels_csr_impl.hpp
+++ b/cpp/oneapi/dal/algo/kmeans/backend/gpu/kernels_csr_impl.hpp
@@ -371,7 +371,7 @@ sycl::event handle_empty_clusters(const dal::backend::context_gpu& ctx,
     auto event = queue.submit([&](sycl::handler& cgh) {
         cgh.depends_on(deps);
         cgh.parallel_for(range, [=](auto it) {
-            const auto local_id = it.get_local_id(1);
+            const auto local_id = it.get_local_id()[1];
             for (std::int64_t cluster_id = rank; cluster_id < num_clusters;
                  cluster_id += rank_count) {
                 // no need to handle non-empty clusters


### PR DESCRIPTION
# Description
Migration to the new icx compiler from icc caused timeouts for Kmeans sparse GPU inputs.
Issue was in the kernel https://github.com/oneapi-src/oneDAL/blob/b6b6a65a59b46d6770198abfc11cfa476c1338a2/cpp/oneapi/dal/algo/kmeans/backend/gpu/kernels_csr_impl.hpp#L374 where iterator wrongly gets id.


