### PR TITLE
Rename min/max functions to resolve naming conflicts with windows.h 

### DIFF
--- a/cpp/daal/src/algorithms/dbscan/dbscan_dense_default_batch_impl.i
+++ b/cpp/daal/src/algorithms/dbscan/dbscan_dense_default_batch_impl.i
@@ -77,7 +77,7 @@ Status DBSCANBatchKernel<algorithmFPType, method, cpu>::processNeighborhoodParal
         size_t total_elems = 0;
 
         size_t begin = iBlock * blockSize;
-        size_t end   = services::internal::min<cpu, size_t>(begin + blockSize, neigh.size());
+        size_t end   = services::internal::serviceMin<cpu, size_t>(begin + blockSize, neigh.size());
 
         total_elems += end - begin;
 
@@ -270,7 +270,7 @@ Status DBSCANBatchKernel<algorithmFPType, method, cpu>::computeNoMemSave(const N
     const size_t blockSize = neighs.size() / nBlocks + !!(neighs.size() % nBlocks);
     daal::threader_for(nBlocks, nBlocks, [&](size_t iBlock) {
         size_t begin = iBlock * blockSize;
-        size_t end   = services::internal::min<cpu, size_t>(begin + blockSize, neighs.size());
+        size_t end   = services::internal::serviceMin<cpu, size_t>(begin + blockSize, neighs.size());
 
         for (size_t i = begin; i < end; ++i)
         {

--- a/cpp/daal/src/algorithms/dbscan/dbscan_dense_default_distr_impl.i
+++ b/cpp/daal/src/algorithms/dbscan/dbscan_dense_default_distr_impl.i
@@ -111,8 +111,8 @@ Status DBSCANDistrStep2Kernel<algorithmFPType, method, cpu>::compute(const DataC
             {
                 for (size_t j = 0; j < nFeatures; j++)
                 {
-                    boundingBox[j]             = min<cpu, algorithmFPType>(boundingBox[j], data[i * nFeatures + j]);
-                    boundingBox[j + nFeatures] = max<cpu, algorithmFPType>(boundingBox[j + nFeatures], data[i * nFeatures + j]);
+                    boundingBox[j]             = serviceMin<cpu, algorithmFPType>(boundingBox[j], data[i * nFeatures + j]);
+                    boundingBox[j + nFeatures] = serviceMax<cpu, algorithmFPType>(boundingBox[j + nFeatures], data[i * nFeatures + j]);
                 }
             }
         }
@@ -154,8 +154,8 @@ Status DBSCANDistrStep3Kernel<algorithmFPType, method, cpu>::compute(const DataC
 
         for (size_t i = 0; i < nFeatures; i++)
         {
-            boundingBox[i]             = min<cpu, algorithmFPType>(boundingBox[i], partialBoundingBox[i]);
-            boundingBox[i + nFeatures] = max<cpu, algorithmFPType>(boundingBox[i + nFeatures], partialBoundingBox[i + nFeatures]);
+            boundingBox[i]             = serviceMin<cpu, algorithmFPType>(boundingBox[i], partialBoundingBox[i]);
+            boundingBox[i + nFeatures] = serviceMax<cpu, algorithmFPType>(boundingBox[i + nFeatures], partialBoundingBox[i + nFeatures]);
         }
     }
 

--- a/cpp/daal/src/algorithms/decision_tree/decision_tree_classification_predict_dense_default_batch_impl.i
+++ b/cpp/daal/src/algorithms/decision_tree/decision_tree_classification_predict_dense_default_batch_impl.i
@@ -81,7 +81,7 @@ services::Status DecisionTreePredictKernel<algorithmFPType, defaultDense, cpu>::
 
     daal::threader_for(blockCount, blockCount, [=, &featureTypesCache, &treeTable, &modelImpl](int iBlock) {
         const size_t first = iBlock * rowsPerBlock;
-        const size_t last  = min<cpu>(static_cast<decltype(xRowCount)>(first + rowsPerBlock), xRowCount);
+        const size_t last  = serviceMin<cpu>(static_cast<decltype(xRowCount)>(first + rowsPerBlock), xRowCount);
 
         BlockDescriptor<algorithmFPType> xBD;
         const_cast<NumericTable &>(*x).getBlockOfRows(first, last - first, readOnly, xBD);

--- a/cpp/daal/src/algorithms/decision_tree/decision_tree_classification_train_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/decision_tree/decision_tree_classification_train_dense_default_impl.i
@@ -59,7 +59,7 @@ class REPPruningData : public PruningData<cpu, int>
 
 public:
     REPPruningData(size_t size, size_t numberOfClasses)
-        : BaseType(size), _numberOfClasses(numberOfClasses), _counters(daal_alloc<size_t>(max<cpu, size_t>(1, size * numberOfClasses)))
+        : BaseType(size), _numberOfClasses(numberOfClasses), _counters(daal_alloc<size_t>(serviceMax<cpu, size_t>(1, size * numberOfClasses)))
     {
         resetCounters();
     }

--- a/cpp/daal/src/algorithms/decision_tree/decision_tree_regression_predict_dense_default_batch_impl.i
+++ b/cpp/daal/src/algorithms/decision_tree/decision_tree_regression_predict_dense_default_batch_impl.i
@@ -78,7 +78,7 @@ services::Status DecisionTreePredictKernel<algorithmFPType, defaultDense, cpu>::
     const auto blockCount   = (xRowCount + rowsPerBlock - 1) / rowsPerBlock;
     daal::threader_for(blockCount, blockCount, [=, &featureTypesCache, &treeTable](int iBlock) {
         const size_t first = iBlock * rowsPerBlock;
-        const size_t last  = min<cpu>(static_cast<decltype(xRowCount)>(first + rowsPerBlock), xRowCount);
+        const size_t last  = serviceMin<cpu>(static_cast<decltype(xRowCount)>(first + rowsPerBlock), xRowCount);
 
         BlockDescriptor<algorithmFPType> xBD;
         const_cast<NumericTable &>(*x).getBlockOfRows(first, last - first, readOnly, xBD);

--- a/cpp/daal/src/algorithms/decision_tree/decision_tree_train_impl.i
+++ b/cpp/daal/src/algorithms/decision_tree/decision_tree_train_impl.i
@@ -754,7 +754,7 @@ public:
             for (size_t iBlock = 0; iBlock < blockCount; iBlock++)
             {
                 const size_t first = iBlock * rowsPerBlock;
-                const size_t last  = min<cpu>(first + rowsPerBlock, xRowCount);
+                const size_t last  = serviceMin<cpu>(first + rowsPerBlock, xRowCount);
 
                 for (size_t i = first; i < last; ++i)
                 {
@@ -1042,7 +1042,7 @@ protected:
         status = services::Status();
         if (_nodeCount >= _nodeCapacity)
         {
-            status = reserve(max<cpu>(_nodeCount + 1, _nodeCapacity * 2));
+            status = reserve(serviceMax<cpu>(_nodeCount + 1, _nodeCapacity * 2));
         }
 
         return _nodeCount++;
@@ -1177,7 +1177,7 @@ protected:
             for (size_t iBlock = 0; iBlock < blockCount; iBlock++)
             {
                 const size_t first = iBlock * rowsPerBlock;
-                const size_t last  = min<cpu>(first + rowsPerBlock, indexCount);
+                const size_t last  = serviceMin<cpu>(first + rowsPerBlock, indexCount);
 
                 for (size_t i = first; i < last; ++i)
                 {
@@ -1360,7 +1360,7 @@ protected:
 
         typename SplitCriterion::DependentVariableType leafDependentVariableValue;
         const size_t maxThreads                   = threader_get_threads_number();
-        const size_t workItemCountForDataParallel = max<cpu, size_t>(maxThreads / 4, 2);
+        const size_t workItemCountForDataParallel = serviceMax<cpu, size_t>(maxThreads / 4, 2);
         while (workQueue.size() < workItemCountForDataParallel)
         {
             if (workQueue.size() == 1)
@@ -1625,7 +1625,7 @@ protected:
             const size_t blockCount   = (workSize + rowsPerBlock - 1) / rowsPerBlock;
             daal::threader_for(blockCount, blockCount, [=, &workArray, &indexes, &mutex, &indexCount, &context, &statPush, &safeStat](int iBlock) {
                 const size_t first = iBlock * rowsPerBlock;
-                const size_t last  = min<cpu>(first + rowsPerBlock, workSize);
+                const size_t last  = serviceMin<cpu>(first + rowsPerBlock, workSize);
 
                 SplitCriterion localSplitCriterion(context.splitCriterion);
                 typename SplitCriterion::DependentVariableType leafDependentVariableValue;
@@ -1844,7 +1844,7 @@ protected:
                 for (size_t iBlock = 0; iBlock < blockCount; iBlock++)
                 {
                     const size_t first = iBlock * rowsPerBlock;
-                    const size_t last  = min<cpu>(first + rowsPerBlock, indexCount);
+                    const size_t last  = serviceMin<cpu>(first + rowsPerBlock, indexCount);
 
                     for (size_t i = first; i < last; ++i)
                     {

--- a/cpp/daal/src/algorithms/dtrees/dtrees_feature_type_helper.h
+++ b/cpp/daal/src/algorithms/dtrees/dtrees_feature_type_helper.h
@@ -138,7 +138,7 @@ public:
     }
 
     //returns right border of the bin if the feature is a binned one
-    ModelFPType min(size_t iCol) const
+    ModelFPType featureMin(size_t iCol) const
     {
         DAAL_ASSERT(isBinned(iCol));
         return _entries[iCol].min;

--- a/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_predict_dense_default_batch_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_predict_dense_default_batch_impl.i
@@ -1063,7 +1063,7 @@ Status PredictClassificationTask<algorithmFPType, cpu>::predictAllPointsByAllTre
 
         daal::threader_for(nBlocks, nBlocks, [&](const size_t iBlock) {
             const size_t begin = iBlock * localBlockSize;
-            const size_t end   = services::internal::min<cpu, size_t>(nRowsOfRes, begin + localBlockSize);
+            const size_t end   = services::internal::serviceMin<cpu, size_t>(nRowsOfRes, begin + localBlockSize);
 
             services::internal::service_memset_seq<algorithmFPType, cpu>(commonBufVal + begin * _nClasses, algorithmFPType(0),
                                                                          (end - begin) * _nClasses);
@@ -1127,7 +1127,7 @@ Status PredictClassificationTask<algorithmFPType, cpu>::predictAllPointsByAllTre
 
             daal::threader_for(nBlocks, nBlocks, [&, nCols](const size_t iBlock) {
                 const size_t begin = iBlock * localBlockSize;
-                const size_t end   = services::internal::min<cpu, size_t>(nRowsOfRes, begin + localBlockSize);
+                const size_t end   = services::internal::serviceMin<cpu, size_t>(nRowsOfRes, begin + localBlockSize);
 
                 if (prob != nullptr)
                 {

--- a/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_train_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_train_dense_default_impl.i
@@ -1652,7 +1652,7 @@ Status TreeThreadCtx<algorithmFPType, cpu>::finalizeOOBError(const NumericTable 
             for (size_t j = 0; j < _nClasses; ++j)
             {
                 resDecisionFunction[i * _nClasses + j] =
-                    static_cast<algorithmFPType>(ptr[j]) / services::internal::max<cpu, algorithmFPType>(sum, eps);
+                    static_cast<algorithmFPType>(ptr[j]) / services::internal::serviceMax<cpu, algorithmFPType>(sum, eps);
             }
         }
         if (maxVal == 0)

--- a/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_train_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_train_dense_default_impl.i
@@ -1010,7 +1010,7 @@ size_t UnorderedRespHelperRandom<algorithmFPType, cpu>::genRandomBinIdx(const In
 {
     //randomly select a histogram split index
     algorithmFPType fidx   = 0;
-    algorithmFPType minval = minidx ? this->indexedFeatures().binRightBorder(iFeature, minidx - 1) : this->indexedFeatures().min(iFeature);
+    algorithmFPType minval = minidx ? this->indexedFeatures().binRightBorder(iFeature, minidx - 1) : this->indexedFeatures().featureMin(iFeature);
     algorithmFPType maxval = this->indexedFeatures().binRightBorder(iFeature, maxidx);
     size_t mid;
     size_t l   = minidx;

--- a/cpp/daal/src/algorithms/dtrees/forest/regression/df_regression_train_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/regression/df_regression_train_dense_default_impl.i
@@ -857,7 +857,7 @@ size_t OrderedRespHelperRandom<algorithmFPType, cpu>::genRandomBinIdx(const Inde
 {
     //randomly select a histogram split index
     algorithmFPType fidx   = 0;
-    algorithmFPType minval = minidx ? this->indexedFeatures().binRightBorder(iFeature, minidx - 1) : this->indexedFeatures().min(iFeature);
+    algorithmFPType minval = minidx ? this->indexedFeatures().binRightBorder(iFeature, minidx - 1) : this->indexedFeatures().featureMin(iFeature);
     algorithmFPType maxval = this->indexedFeatures().binRightBorder(iFeature, maxidx);
     size_t mid;
     size_t l   = minidx;

--- a/cpp/daal/src/algorithms/dtrees/gbt/gbt_train_hist_kernel.i
+++ b/cpp/daal/src/algorithms/dtrees/gbt/gbt_train_hist_kernel.i
@@ -232,8 +232,8 @@ struct ComputeGHSumByRows
         const size_t prefetchOffset      = 10; // heuristic, prefetch on 10 rows ahead
         const size_t elementsInCacheLine = cacheLineSize / sizeof(BinIndexType);
 
-        const size_t noPrefetchSize              = services::internal::min<cpu, size_t>(prefetchOffset + elementsInCacheLine, nRows);
-        const size_t iEndWithPrefetch            = services::internal::min<cpu, size_t>(nRows - noPrefetchSize, iEnd);
+        const size_t noPrefetchSize              = services::internal::serviceMin<cpu, size_t>(prefetchOffset + elementsInCacheLine, nRows);
+        const size_t iEndWithPrefetch            = services::internal::serviceMin<cpu, size_t>(nRows - noPrefetchSize, iEnd);
         const size_t nCacheLinesToPrefetchOneRow = nFeatures / elementsInCacheLine + !!(nFeatures % elementsInCacheLine);
 
         RowIndexType i = iStart;
@@ -330,8 +330,8 @@ struct ComputeGHSumByRows<RowIndexType, BinIndexType, float, SSE42_ALL>
         const size_t prefetchOffset      = 10; // heuristic, prefetch on 10 rows ahead
         const size_t elementsInCacheLine = cacheLineSize / sizeof(IndexType);
 
-        const size_t noPrefetchSize              = services::internal::min<SSE42_ALL, size_t>(prefetchOffset + elementsInCacheLine, nRows);
-        const size_t iEndWithPrefetch            = services::internal::min<SSE42_ALL, size_t>(nRows - noPrefetchSize, iEnd);
+        const size_t noPrefetchSize              = services::internal::serviceMin<SSE42_ALL, size_t>(prefetchOffset + elementsInCacheLine, nRows);
+        const size_t iEndWithPrefetch            = services::internal::serviceMin<SSE42_ALL, size_t>(nRows - noPrefetchSize, iEnd);
         const size_t nCacheLinesToPrefetchOneRow = nFeatures / elementsInCacheLine + !!(nFeatures % elementsInCacheLine);
 
         __m128 adds;

--- a/cpp/daal/src/algorithms/k_nearest_neighbors/kdtree_knn_classification_predict_dense_default_batch_impl.i
+++ b/cpp/daal/src/algorithms/k_nearest_neighbors/kdtree_knn_classification_predict_dense_default_batch_impl.i
@@ -216,7 +216,7 @@ Status KNNClassificationPredictKernel<algorithmFpType, defaultDense, cpu>::compu
             services::Status s;
 
             const size_t first = iBlock * rowsPerBlock;
-            const size_t last  = min<cpu>(static_cast<decltype(xRowCount)>(first + rowsPerBlock), xRowCount);
+            const size_t last  = serviceMin<cpu>(static_cast<decltype(xRowCount)>(first + rowsPerBlock), xRowCount);
 
             const algorithmFpType radius = MaxVal::get();
             data_management::BlockDescriptor<algorithmFpType> xBD;

--- a/cpp/daal/src/algorithms/k_nearest_neighbors/kdtree_knn_classification_train_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/k_nearest_neighbors/kdtree_knn_classification_train_dense_default_impl.i
@@ -337,7 +337,7 @@ Status KNNClassificationTrainBatchKernel<algorithmFpType, training::defaultDense
             if (bboxLocal)
             {
                 const size_t first = iBlock * rowsPerBlock;
-                const size_t last  = min<cpu>(static_cast<decltype(xRowCount)>(first + rowsPerBlock), xRowCount);
+                const size_t last  = serviceMin<cpu>(static_cast<decltype(xRowCount)>(first + rowsPerBlock), xRowCount);
 
                 if (first < last)
                 {
@@ -396,7 +396,7 @@ size_t KNNClassificationTrainBatchKernel<algorithmFpType, training::defaultDense
     size_t start, size_t end, size_t * sampleIndexes, algorithmFpType * sampleValues, size_t sampleCount, const NumericTable & x,
     const size_t * indexes, engines::BatchBase * engine)
 {
-    const size_t elementCount = min<cpu>(end - start, sampleCount);
+    const size_t elementCount = serviceMin<cpu>(end - start, sampleCount);
     const size_t xColumnCount = x.getNumberOfColumns();
     const size_t xRowCount    = x.getNumberOfRows();
 
@@ -562,7 +562,7 @@ algorithmFpType KNNClassificationTrainBatchKernel<algorithmFpType, training::def
         if (hist)
         {
             const size_t first = start + iBlock * rowsPerBlock;
-            const size_t last  = min<cpu>(first + rowsPerBlock, end);
+            const size_t last  = serviceMin<cpu>(first + rowsPerBlock, end);
 
             for (size_t l = first; l < last; ++l)
             {
@@ -724,7 +724,7 @@ size_t KNNClassificationTrainBatchKernel<algorithmFpType, training::defaultDense
 
     daal::threader_for(blockCount, blockCount, [=, &leftSegmentStartPerBlock, &rightSegmentStartPerBlock](int iBlock) {
         const size_t first = start + iBlock * rowsPerBlock;
-        const size_t last  = min<cpu>(first + rowsPerBlock, end);
+        const size_t last  = serviceMin<cpu>(first + rowsPerBlock, end);
 
         size_t left  = first;
         size_t right = last - 1;
@@ -860,7 +860,7 @@ Status KNNClassificationTrainBatchKernel<algorithmFpType, training::defaultDense
 
         daal::threader_for(blockCount, blockCount, [=](int iBlock) {
             const size_t first = iBlock * rowsPerBlock;
-            const size_t last  = min<cpu>(static_cast<decltype(xRowCount)>(first + rowsPerBlock), xRowCount);
+            const size_t last  = serviceMin<cpu>(static_cast<decltype(xRowCount)>(first + rowsPerBlock), xRowCount);
 
             size_t j = first;
             if (last > 4)
@@ -882,7 +882,7 @@ Status KNNClassificationTrainBatchKernel<algorithmFpType, training::defaultDense
         {
             daal::threader_for(blockCount, blockCount, [=](int iBlock) {
                 const size_t first = iBlock * rowsPerBlock;
-                const size_t last  = min<cpu>(static_cast<decltype(xRowCount)>(first + rowsPerBlock), xRowCount);
+                const size_t last  = serviceMin<cpu>(static_cast<decltype(xRowCount)>(first + rowsPerBlock), xRowCount);
 
                 auto j = first;
                 if (last > 4)
@@ -1028,7 +1028,7 @@ Status KNNClassificationTrainBatchKernel<algorithmFpType, training::defaultDense
             if (local)
             {
                 const size_t first = iBlock * rowsPerBlock;
-                const size_t last  = min<cpu>(first + rowsPerBlock, posQ);
+                const size_t last  = serviceMin<cpu>(first + rowsPerBlock, posQ);
 
                 BuildNode bn, bnLeft, bnRight;
                 BBox *bboxCur = nullptr, *bboxLeft = nullptr, *bboxRight = nullptr;
@@ -1122,7 +1122,7 @@ Status KNNClassificationTrainBatchKernel<algorithmFpType, training::defaultDense
                                 {
                                     if (extraIndex >= local->extraKDTreeNodesCapacity)
                                     {
-                                        const size_t newCapacity = max<cpu>(
+                                        const size_t newCapacity = serviceMax<cpu>(
                                             local->extraKDTreeNodesCapacity > 0 ? local->extraKDTreeNodesCapacity * 2 : static_cast<size_t>(1024),
                                             extraIndex + 1);
                                         KDTreeNode * const newNodes =
@@ -1142,7 +1142,7 @@ Status KNNClassificationTrainBatchKernel<algorithmFpType, training::defaultDense
                                 }
                                 else
                                 {
-                                    local->extraKDTreeNodesCapacity = max<cpu>(extraIndex + 1, static_cast<size_t>(1024));
+                                    local->extraKDTreeNodesCapacity = serviceMax<cpu>(extraIndex + 1, static_cast<size_t>(1024));
                                     local->extraKDTreeNodes         = static_cast<KDTreeNode *>(
                                         service_malloc<KDTreeNode, cpu>(local->extraKDTreeNodesCapacity * sizeof(KDTreeNode)));
 
@@ -1347,8 +1347,8 @@ algorithmFpType KNNClassificationTrainBatchKernel<algorithmFpType, training::def
         return approximatedMedian;
     } // if (end - start < sortValueCount)
 
-    size_t sampleCount = min<cpu>(static_cast<size_t>(static_cast<algorithmFpType>(end - start) * __KDTREE_SAMPLES_PERCENT / 100),
-                                  static_cast<size_t>(__KDTREE_MAX_SAMPLES + 1));
+    size_t sampleCount = serviceMin<cpu>(static_cast<size_t>(static_cast<algorithmFpType>(end - start) * __KDTREE_SAMPLES_PERCENT / 100),
+                                         static_cast<size_t>(__KDTREE_MAX_SAMPLES + 1));
 
     if (sampleCount < __KDTREE_MIN_SAMPLES)
     {

--- a/cpp/daal/src/algorithms/k_nearest_neighbors/kdtree_knn_impl.i
+++ b/cpp/daal/src/algorithms/k_nearest_neighbors/kdtree_knn_impl.i
@@ -51,18 +51,6 @@ namespace internal
 
 #define __KDTREE_NULLDIMENSION (static_cast<size_t>(-1))
 
-template <CpuType cpu, typename T>
-inline const T & min(const T & a, const T & b)
-{
-    return !(b < a) ? a : b;
-}
-
-template <CpuType cpu, typename T>
-inline const T & max(const T & a, const T & b)
-{
-    return (a < b) ? b : a;
-}
-
 template <typename T, CpuType cpu>
 class Stack
 {

--- a/cpp/daal/src/algorithms/kmeans/kmeans_plusplus_init_impl.i
+++ b/cpp/daal/src/algorithms/kmeans/kmeans_plusplus_init_impl.i
@@ -209,7 +209,7 @@ public:
                 dist2 *= aWeights[iRow];
             }
 
-            pDistSq[iRow] = daal::services::internal::min<cpu, algorithmFPType>(pDistSqBest[iRow], dist2);
+            pDistSq[iRow] = daal::services::internal::serviceMin<cpu, algorithmFPType>(pDistSqBest[iRow], dist2);
             sumOfDist2 += pDistSq[iRow];
         }
 
@@ -320,7 +320,7 @@ public:
                 dist2 *= aWeights[iRow];
             }
 
-            pDistSq[iRow] = daal::services::internal::min<cpu, algorithmFPType>(pDistSqBest[iRow], dist2);
+            pDistSq[iRow] = daal::services::internal::serviceMin<cpu, algorithmFPType>(pDistSqBest[iRow], dist2);
             sumOfDist2 += pDistSq[iRow];
         }
 

--- a/cpp/daal/src/algorithms/linear_model/linear_model_train_qr_common_impl.i
+++ b/cpp/daal/src/algorithms/linear_model/linear_model_train_qr_common_impl.i
@@ -61,7 +61,7 @@ Status CommonKernel<algorithmFPType, cpu>::computeWorkSize(DAAL_INT nRows, DAAL_
     DAAL_CHECK(info == 0, services::ErrorLinearRegressionInternal);
 
     lwork2 = (DAAL_INT)workLocal;
-    lwork  = daal::services::internal::max<cpu, DAAL_INT>(lwork1, lwork2);
+    lwork  = daal::services::internal::serviceMax<cpu, DAAL_INT>(lwork1, lwork2);
 
     return Status();
 }
@@ -80,7 +80,7 @@ Status CommonKernel<algorithmFPType, cpu>::computeQRForBlock(DAAL_INT p, DAAL_IN
     /* Copy result into matrix R */
     const DAAL_INT xOffset             = (n > p ? (n - p) * p : 0);
     const DAAL_INT rOffset             = (n > p ? 0 : (p - n) * p);
-    const DAAL_INT nRowsInR            = daal::services::internal::min<cpu, DAAL_INT>(p, n);
+    const DAAL_INT nRowsInR            = daal::services::internal::serviceMin<cpu, DAAL_INT>(p, n);
     const DAAL_INT jOffset             = (n > p ? 0 : p - n);
     const algorithmFPType * const xPtr = x + xOffset;
     algorithmFPType * const rPtr       = r + rOffset;

--- a/cpp/daal/src/algorithms/service_kernel_math.h
+++ b/cpp/daal/src/algorithms/service_kernel_math.h
@@ -199,13 +199,13 @@ public:
         for (size_t iBlock = 0; iBlock < nBlocks; ++iBlock)
         {
             const size_t begin = iBlock * blockSize;
-            const size_t end   = services::internal::min<cpu, size_t>(begin + blockSize, n);
+            const size_t end   = services::internal::serviceMin<cpu, size_t>(begin + blockSize, n);
             const size_t count = end - begin;
 
             // max(0, d) to remove negative distances before Sqrt
             for (size_t i = begin; i < end; ++i)
             {
-                a[i] = services::internal::max<cpu, FPType>(FPType(0), a[i]);
+                a[i] = services::internal::serviceMax<cpu, FPType>(FPType(0), a[i]);
             }
             MathInst<FPType, cpu>::vSqrt(count, a + begin, a + begin);
         }
@@ -262,7 +262,7 @@ protected:
 
         daal::threader_for(nBlocks, nBlocks, [&](size_t iBlock) {
             size_t begin = iBlock * blockSize;
-            size_t end   = services::internal::min<cpu, size_t>(begin + blockSize, nRows);
+            size_t end   = services::internal::serviceMin<cpu, size_t>(begin + blockSize, nRows);
 
             ReadRows<FPType, cpu> dataRows(const_cast<NumericTable &>(ntData), begin, end - begin);
             DAAL_CHECK_BLOCK_STATUS_THR(dataRows);

--- a/cpp/daal/src/algorithms/svd/svd_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/svd/svd_dense_default_impl.i
@@ -161,9 +161,9 @@ Status compute_QR_on_one_node(DAAL_INT m, DAAL_INT n, algorithmFPType * a_q, DAA
     LapackInst<algorithmFPType, cpu>::xgeqrf(m, n, a_q, lda_q, tau, workQuery, workDim, &mklStatus);
 
     // a bug in Intel(R) MKL with XORGQR workDim query, to be fixed
-    const DAAL_INT nColumnsInQ = daal::services::internal::min<cpu, DAAL_INT>(m, n);
+    const DAAL_INT nColumnsInQ = daal::services::internal::serviceMin<cpu, DAAL_INT>(m, n);
     LapackInst<algorithmFPType, cpu>::xorgqr(m, nColumnsInQ, nColumnsInQ, a_q, lda_q, tau, &workQuery[1], workDim, &mklStatus);
-    workDim = daal::services::internal::max<cpu, algorithmFPType>(workQuery[0], workQuery[1]);
+    workDim = daal::services::internal::serviceMax<cpu, algorithmFPType>(workQuery[0], workQuery[1]);
 
     // allocate buffer
     TArray<algorithmFPType, cpu> workPtr(workDim);

--- a/cpp/daal/src/algorithms/svm/svm_train_boser_impl.i
+++ b/cpp/daal/src/algorithms/svm/svm_train_boser_impl.i
@@ -303,8 +303,8 @@ inline void SVMTrainTask<algorithmFPType, cpu>::updateAlpha(int Bi, int Bj, algo
     const algorithmFPType cwj       = _cw[Bj];
 
     const algorithmFPType alphaBiDelta = (yi > 0.0f) ? cwi - oldAlphai : oldAlphai;
-    const algorithmFPType alphaBjDelta = services::internal::min<cpu, algorithmFPType>((yj > 0.0f) ? oldAlphaj : cwj - oldAlphaj, delta);
-    delta                              = services::internal::min<cpu, algorithmFPType>(alphaBiDelta, alphaBjDelta);
+    const algorithmFPType alphaBjDelta = services::internal::serviceMin<cpu, algorithmFPType>((yj > 0.0f) ? oldAlphaj : cwj - oldAlphaj, delta);
+    delta                              = services::internal::serviceMin<cpu, algorithmFPType>(alphaBiDelta, alphaBjDelta);
 
     algorithmFPType newAlphai = oldAlphai + yi * delta;
     algorithmFPType newAlphaj = oldAlphaj - yj * delta;

--- a/cpp/daal/src/algorithms/svm/svm_train_result.h
+++ b/cpp/daal/src/algorithms/svm/svm_train_result.h
@@ -312,11 +312,11 @@ protected:
             }
             if (HelperTrainSVM<algorithmFPType, cpu>::isUpper(yi, ai, cwi, signNuType))
             {
-                ub = services::internal::min<cpu, algorithmFPType>(ub, gradi);
+                ub = services::internal::serviceMin<cpu, algorithmFPType>(ub, gradi);
             }
             if (HelperTrainSVM<algorithmFPType, cpu>::isLower(yi, ai, cwi, signNuType))
             {
-                lb = services::internal::max<cpu, algorithmFPType>(lb, gradi);
+                lb = services::internal::serviceMax<cpu, algorithmFPType>(lb, gradi);
             }
         }
 

--- a/cpp/daal/src/algorithms/svm/svm_train_thunder_impl.i
+++ b/cpp/daal/src/algorithms/svm/svm_train_thunder_impl.i
@@ -134,8 +134,8 @@ services::Status SVMTrainImpl<thunder, algorithmFPType, cpu>::compute(const Nume
     TArray<char, cpu> I(nWS);
     DAAL_CHECK_MALLOC(I.get());
 
-    size_t defaultCacheSize = services::internal::min<cpu, size_t>(nVectors, cacheSize / nVectors / sizeof(algorithmFPType));
-    defaultCacheSize        = services::internal::max<cpu, size_t>(nWS, defaultCacheSize);
+    size_t defaultCacheSize = services::internal::serviceMin<cpu, size_t>(nVectors, cacheSize / nVectors / sizeof(algorithmFPType));
+    defaultCacheSize        = services::internal::serviceMax<cpu, size_t>(nWS, defaultCacheSize);
     auto cachePtr           = SVMCache<thunder, lruCache, algorithmFPType, cpu>::create(defaultCacheSize, nWS, nVectors, xTable, kernel, status);
     DAAL_CHECK_STATUS_VAR(status);
 
@@ -240,12 +240,12 @@ services::Status SVMTrainImpl<thunder, algorithmFPType, cpu>::classificationInit
         {
             if (y[i] > 0)
             {
-                alpha[i] = services::internal::min<cpu, algorithmFPType>(sumPos, cw[i]);
+                alpha[i] = services::internal::serviceMin<cpu, algorithmFPType>(sumPos, cw[i]);
                 sumPos -= alpha[i];
             }
             else
             {
-                alpha[i] = services::internal::min<cpu, algorithmFPType>(sumNeg, cw[i]);
+                alpha[i] = services::internal::serviceMin<cpu, algorithmFPType>(sumNeg, cw[i]);
                 sumNeg -= alpha[i];
             }
         }
@@ -320,7 +320,7 @@ services::Status SVMTrainImpl<thunder, algorithmFPType, cpu>::regressionInit(Num
         algorithmFPType sum = nu * cwSum / algorithmFPType(2);
         for (size_t i = 0; i < nVectors; ++i)
         {
-            alpha[i] = alpha[i + nVectors] = services::internal::min<cpu, algorithmFPType>(sum, cw[i]);
+            alpha[i] = alpha[i + nVectors] = services::internal::serviceMin<cpu, algorithmFPType>(sum, cw[i]);
             sum -= alpha[i];
         }
     }
@@ -352,7 +352,7 @@ services::Status SVMTrainImpl<thunder, algorithmFPType, cpu>::SMOBlockSolver(
         SafeStatus safeStat;
 
         /* Gather data to local buffers */
-        const size_t blockSizeWS = services::internal::min<cpu, algorithmFPType>(nWS, 16);
+        const size_t blockSizeWS = services::internal::serviceMin<cpu, algorithmFPType>(nWS, 16);
         const size_t nBlocks     = nWS / blockSizeWS;
         daal::threader_for(nBlocks, nBlocks, [&](const size_t iBlock) {
             const size_t startRow = iBlock * blockSizeWS;
@@ -453,7 +453,7 @@ services::Status SVMTrainImpl<thunder, algorithmFPType, cpu>::SMOBlockSolver(
                 KBiBlock = KBiBlockNeg;
             }
 
-            localDiff = services::internal::max<cpu, algorithmFPType>(GMax2Pos - GMinPos, GMax2Neg - GMinNeg);
+            localDiff = services::internal::serviceMax<cpu, algorithmFPType>(GMax2Pos - GMinPos, GMax2Neg - GMinNeg);
         }
         else
         {
@@ -469,7 +469,7 @@ services::Status SVMTrainImpl<thunder, algorithmFPType, cpu>::SMOBlockSolver(
 
         if (iter == 0)
         {
-            localEps  = services::internal::max<cpu, algorithmFPType>(accuracyThreshold, localDiff * algorithmFPType(1e-1));
+            localEps  = services::internal::serviceMax<cpu, algorithmFPType>(accuracyThreshold, localDiff * algorithmFPType(1e-1));
             firstDiff = localDiff;
         }
         if (localDiff < localEps)
@@ -485,8 +485,8 @@ services::Status SVMTrainImpl<thunder, algorithmFPType, cpu>::SMOBlockSolver(
         /* Update coefficients */
         const algorithmFPType alphaBiDelta = (yBi > zero) ? cwBi - alphaLocal[Bi] : alphaLocal[Bi];
         const algorithmFPType alphaBjDelta =
-            services::internal::min<cpu, algorithmFPType>((yBj > zero) ? alphaLocal[Bj] : cwBj - alphaLocal[Bj], delta);
-        delta = services::internal::min<cpu, algorithmFPType>(alphaBiDelta, alphaBjDelta);
+            services::internal::serviceMin<cpu, algorithmFPType>((yBj > zero) ? alphaLocal[Bj] : cwBj - alphaLocal[Bj], delta);
+        delta = services::internal::serviceMin<cpu, algorithmFPType>(alphaBiDelta, alphaBjDelta);
 
         /* Update alpha */
         alphaLocal[Bi] += delta * yBi;

--- a/cpp/daal/src/algorithms/svm/svm_train_thunder_workset.h
+++ b/cpp/daal/src/algorithms/svm/svm_train_thunder_workset.h
@@ -60,7 +60,7 @@ struct TaskWorkingSet
         DAAL_CHECK_MALLOC(_indicator.get());
         services::internal::service_memset_seq<bool, cpu>(_indicator.get(), false, _nVectors);
 
-        _nWS       = services::internal::min<cpu, algorithmFPType>(maxPowTwo(_nNonZeroWeights), _maxWS);
+        _nWS       = services::internal::serviceMin<cpu, algorithmFPType>(maxPowTwo(_nNonZeroWeights), _maxWS);
         _nSelected = 0;
 
         _wsIndices.reset(_nWS);

--- a/cpp/daal/src/algorithms/tsne/tsne_gradient_descent_avx512_impl.i
+++ b/cpp/daal/src/algorithms/tsne/tsne_gradient_descent_avx512_impl.i
@@ -57,12 +57,12 @@ struct AttractiveKernel<DivComp, IdxType, float, avx512>
         });
 
         const IdxType nThreads    = threader_get_threads_number();
-        const IdxType sizeOfBlock = services::internal::min<avx512, size_t>(256, N / nThreads + 1);
+        const IdxType sizeOfBlock = services::internal::serviceMin<avx512, size_t>(256, N / nThreads + 1);
         const IdxType nBlocks     = N / sizeOfBlock + bool(N % sizeOfBlock);
 
         daal::threader_for(nBlocks, nBlocks, [&](IdxType iBlock) {
             const IdxType iStart = iBlock * sizeOfBlock;
-            const IdxType iEnd   = services::internal::min<avx512, IdxType>(N, iStart + sizeOfBlock);
+            const IdxType iEnd   = services::internal::serviceMin<avx512, IdxType>(N, iStart + sizeOfBlock);
             float * logLocal     = logTlsData.local();
             if (logLocal == nullptr) return;
 
@@ -144,7 +144,7 @@ struct AttractiveKernel<DivComp, IdxType, float, avx512>
 
                         y1d    = row_point.x - mem._pos[iCol].x;
                         y2d    = row_point.y - mem._pos[iCol].y;
-                        sqDist = services::internal::max<avx512, float>(0.f, y1d * y1d + y2d * y2d);
+                        sqDist = services::internal::serviceMax<avx512, float>(0.f, y1d * y1d + y2d * y2d);
                         PQ     = val[index] / (sqDist + 1.f);
 
                         // Apply forces
@@ -206,12 +206,12 @@ struct AttractiveKernel<DivComp, IdxType, double, avx512>
         });
 
         const IdxType nThreads    = threader_get_threads_number();
-        const IdxType sizeOfBlock = services::internal::min<avx512, size_t>(256, N / nThreads + 1);
+        const IdxType sizeOfBlock = services::internal::serviceMin<avx512, size_t>(256, N / nThreads + 1);
         const IdxType nBlocks     = N / sizeOfBlock + bool(N % sizeOfBlock);
 
         daal::threader_for(nBlocks, nBlocks, [&](IdxType iBlock) {
             const IdxType iStart = iBlock * sizeOfBlock;
-            const IdxType iEnd   = services::internal::min<avx512, IdxType>(N, iStart + sizeOfBlock);
+            const IdxType iEnd   = services::internal::serviceMin<avx512, IdxType>(N, iStart + sizeOfBlock);
             double * logLocal    = logTlsData.local();
             if (logLocal == nullptr) return;
 
@@ -294,7 +294,7 @@ struct AttractiveKernel<DivComp, IdxType, double, avx512>
 
                         y1d    = row_point.x - mem._pos[iCol].x;
                         y2d    = row_point.y - mem._pos[iCol].y;
-                        sqDist = services::internal::max<avx512, double>(double(0), y1d * y1d + y2d * y2d);
+                        sqDist = services::internal::serviceMax<avx512, double>(double(0), y1d * y1d + y2d * y2d);
                         PQ     = val[index] / (sqDist + 1.);
 
                         // Apply forces

--- a/cpp/daal/src/algorithms/tsne/tsne_gradient_descent_impl.i
+++ b/cpp/daal/src/algorithms/tsne/tsne_gradient_descent_impl.i
@@ -65,7 +65,7 @@ public:
             }
             else
             {
-                for (size_t i = 0; i < n; ++i) res[i] = services::internal::max<cpu, DataType>(res[i], ptr[i]);
+                for (size_t i = 0; i < n; ++i) res[i] = services::internal::serviceMax<cpu, DataType>(res[i], ptr[i]);
             }
         });
     }
@@ -190,18 +190,18 @@ services::Status maxRowElementsImpl(const size_t * row, const IdxType N, IdxType
 {
     TlsMax<IdxType, cpu> maxTlsData(1);
     const IdxType nThreads    = threader_get_threads_number();
-    const IdxType sizeOfBlock = services::internal::min<cpu, IdxType>(blockOfRows, N / nThreads + 1);
+    const IdxType sizeOfBlock = services::internal::serviceMin<cpu, IdxType>(blockOfRows, N / nThreads + 1);
     const IdxType nBlocks     = N / sizeOfBlock + bool(N % sizeOfBlock);
 
     SafeStatus safeStat;
     daal::threader_for(nBlocks, nBlocks, [&](IdxType iBlock) {
         const IdxType iStart = iBlock * sizeOfBlock;
-        const IdxType iEnd   = services::internal::min<cpu, IdxType>(N, iStart + sizeOfBlock);
+        const IdxType iEnd   = services::internal::serviceMin<cpu, IdxType>(N, iStart + sizeOfBlock);
         IdxType * localMax   = maxTlsData.local();
         DAAL_CHECK_MALLOC_THR(localMax);
         for (IdxType i = iStart; i < iEnd; ++i)
         {
-            localMax[0] = services::internal::max<cpu, IdxType>(localMax[0], IdxType((row[i + 1] - row[i])));
+            localMax[0] = services::internal::serviceMax<cpu, IdxType>(localMax[0], IdxType((row[i + 1] - row[i])));
         }
     });
     DAAL_CHECK_SAFE_STATUS();
@@ -237,23 +237,23 @@ services::Status boundingBoxKernelImpl(xyType<DataType> * pos, const IdxType N, 
     });
 
     const IdxType nThreads = tlsBox.nthreads();
-    // const IdxType sizeOfBlock = services::internal::min<cpu, IdxType>(256, (N + nThreads - 1) / nThreads);
+    // const IdxType sizeOfBlock = services::internal::serviceMin<cpu, IdxType>(256, (N + nThreads - 1) / nThreads);
     // const IdxType nBlocks     = (N + sizeOfBlock - 1) / sizeOfBlock;
-    const IdxType sizeOfBlock = services::internal::min<cpu, IdxType>(256, N / nThreads + 1);
+    const IdxType sizeOfBlock = services::internal::serviceMin<cpu, IdxType>(256, N / nThreads + 1);
     const IdxType nBlocks     = N / sizeOfBlock + bool(N % sizeOfBlock);
 
     daal::static_threader_for(nBlocks, [&](IdxType iBlock, IdxType tid) {
         DataType * localBox = tlsBox.local(tid);
         if (localBox == nullptr) return;
         const IdxType iStart = iBlock * sizeOfBlock;
-        const IdxType iEnd   = services::internal::min<cpu, IdxType>(N, iStart + sizeOfBlock);
+        const IdxType iEnd   = services::internal::serviceMin<cpu, IdxType>(N, iStart + sizeOfBlock);
 
         for (IdxType i = iStart; i < iEnd; ++i)
         {
-            localBox[0] = services::internal::min<cpu, DataType>(localBox[0], pos[i].x);
-            localBox[1] = services::internal::max<cpu, DataType>(localBox[1], pos[i].x);
-            localBox[2] = services::internal::min<cpu, DataType>(localBox[2], pos[i].y);
-            localBox[3] = services::internal::max<cpu, DataType>(localBox[3], pos[i].y);
+            localBox[0] = services::internal::serviceMin<cpu, DataType>(localBox[0], pos[i].x);
+            localBox[1] = services::internal::serviceMax<cpu, DataType>(localBox[1], pos[i].x);
+            localBox[2] = services::internal::serviceMin<cpu, DataType>(localBox[2], pos[i].y);
+            localBox[3] = services::internal::serviceMax<cpu, DataType>(localBox[3], pos[i].y);
         }
     });
     DAAL_CHECK_SAFE_STATUS();
@@ -261,10 +261,10 @@ services::Status boundingBoxKernelImpl(xyType<DataType> * pos, const IdxType N, 
     tlsBox.reduce([&](DataType * ptr) -> void {
         if (ptr == nullptr) return;
 
-        box[0] = services::internal::min<cpu, DataType>(box[0], ptr[0]);
-        box[1] = services::internal::max<cpu, DataType>(box[1], ptr[1]);
-        box[2] = services::internal::min<cpu, DataType>(box[2], ptr[2]);
-        box[3] = services::internal::max<cpu, DataType>(box[3], ptr[3]);
+        box[0] = services::internal::serviceMin<cpu, DataType>(box[0], ptr[0]);
+        box[1] = services::internal::serviceMax<cpu, DataType>(box[1], ptr[1]);
+        box[2] = services::internal::serviceMin<cpu, DataType>(box[2], ptr[2]);
+        box[3] = services::internal::serviceMax<cpu, DataType>(box[3], ptr[3]);
 
         services::internal::service_free<DataType, cpu>(ptr);
     });
@@ -272,7 +272,7 @@ services::Status boundingBoxKernelImpl(xyType<DataType> * pos, const IdxType N, 
     //save results
     centerx = (box[0] + box[1]) * DataType(0.5);
     centery = (box[2] + box[3]) * DataType(0.5);
-    radius  = services::internal::max<cpu, DataType>(box[1] - box[0], box[3] - box[2]) * scale;
+    radius  = services::internal::serviceMax<cpu, DataType>(box[1] - box[0], box[3] - box[2]) * scale;
 
     return services::Status();
 }
@@ -393,7 +393,7 @@ services::Status qTreeBuildingKernelImpl(MemoryCtxType<IdxType, DataType, cpu> &
 
     const IdxType nThreads    = tlsHist1024.nthreads();
     const int capacity        = mem._capacity;
-    const IdxType sizeOfBlock = services::internal::min<cpu, IdxType>(256, (capacity + nThreads - 1) / nThreads);
+    const IdxType sizeOfBlock = services::internal::serviceMin<cpu, IdxType>(256, (capacity + nThreads - 1) / nThreads);
     const IdxType nBlocks     = (capacity + sizeOfBlock - 1) / sizeOfBlock;
 
     daal::static_threader_for(nBlocks, [&](IdxType iBlock, IdxType tid) {
@@ -401,7 +401,7 @@ services::Status qTreeBuildingKernelImpl(MemoryCtxType<IdxType, DataType, cpu> &
         if (hist == nullptr) return;
 
         const IdxType iStart = iBlock * sizeOfBlock;
-        const IdxType iEnd   = services::internal::min<cpu, IdxType>(capacity, iStart + sizeOfBlock);
+        const IdxType iEnd   = services::internal::serviceMin<cpu, IdxType>(capacity, iStart + sizeOfBlock);
         const DataType rootx = centerx - radius;
         const DataType rooty = centery - radius;
 
@@ -643,12 +643,12 @@ services::Status summarizationKernelImpl(MemoryCtxType<IdxType, DataType, cpu> &
     }
 
     nThreads    = threader_get_threads_number();
-    sizeOfBlock = services::internal::min<cpu, IdxType>(256, (qTree.size + nThreads - 1) / nThreads);
+    sizeOfBlock = services::internal::serviceMin<cpu, IdxType>(256, (qTree.size + nThreads - 1) / nThreads);
     nBlocks     = (qTree.size + sizeOfBlock - 1) / sizeOfBlock;
 
     daal::static_threader_for(nBlocks, [&](IdxType iBlock, IdxType tid) {
         const IdxType iStart = iBlock * sizeOfBlock;
-        const IdxType iEnd   = services::internal::min<cpu, IdxType>(qTree.size, iStart + sizeOfBlock);
+        const IdxType iEnd   = services::internal::serviceMin<cpu, IdxType>(qTree.size, iStart + sizeOfBlock);
         for (IdxType i = iStart; i < iEnd; ++i)
         {
             DataType iMass = DataType(1) / qTree.tree[i].cnt;
@@ -677,7 +677,7 @@ services::Status repulsionKernelImpl(MemoryCtxType<IdxType, DataType, cpu> & mem
 
     const int capacity        = mem._capacity;
     const IdxType nThreads    = sumTlsData.nthreads();
-    const IdxType sizeOfBlock = services::internal::min<cpu, IdxType>(256, (capacity + nThreads - 1) / nThreads);
+    const IdxType sizeOfBlock = services::internal::serviceMin<cpu, IdxType>(256, (capacity + nThreads - 1) / nThreads);
     const IdxType nBlocks     = (capacity + sizeOfBlock - 1) / sizeOfBlock;
 
     TArray<IdxType, cpu> nStackArr(nThreads * TSNE_Q_TREE_MAX_LEVEL * 4);
@@ -690,7 +690,7 @@ services::Status repulsionKernelImpl(MemoryCtxType<IdxType, DataType, cpu> & mem
 
     daal::static_threader_for(nBlocks, [&](IdxType iBlock, IdxType tid) {
         const IdxType iStart = iBlock * sizeOfBlock;
-        const IdxType iEnd   = services::internal::min<cpu, IdxType>(capacity, iStart + sizeOfBlock);
+        const IdxType iEnd   = services::internal::serviceMin<cpu, IdxType>(capacity, iStart + sizeOfBlock);
         DataType * lSum      = sumTlsData.local(tid);
         DAAL_CHECK_MALLOC_THR(lSum);
 
@@ -813,12 +813,12 @@ struct AttractiveKernel
         });
 
         const IdxType nThreads    = threader_get_threads_number();
-        const IdxType sizeOfBlock = services::internal::min<cpu, size_t>(256, N / nThreads + 1);
+        const IdxType sizeOfBlock = services::internal::serviceMin<cpu, size_t>(256, N / nThreads + 1);
         const IdxType nBlocks     = N / sizeOfBlock + bool(N % sizeOfBlock);
 
         daal::threader_for(nBlocks, nBlocks, [&](IdxType iBlock) {
             const IdxType iStart = iBlock * sizeOfBlock;
-            const IdxType iEnd   = services::internal::min<cpu, IdxType>(N, iStart + sizeOfBlock);
+            const IdxType iEnd   = services::internal::serviceMin<cpu, IdxType>(N, iStart + sizeOfBlock);
             DataType * logLocal  = logTlsData.local();
             if (logLocal == nullptr) return;
             DataType * divLocal = divTlsData.local();
@@ -844,7 +844,7 @@ struct AttractiveKernel
 
                     y1d = row_point.x - mem._pos[iCol].x; // 1*NNZ Flop, 4*N + 4*NNZ byte
                     y2d = row_point.y - mem._pos[iCol].y; // 1*NNZ Flop, 4*N + 4*NNZ byte
-                    // const DataType sqDist = services::internal::max<cpu, DataType>(DataType(0), y1d * y1d + y2d * y2d); // To deal with NaNs     // 4*NNZ Flop
+                    // const DataType sqDist = services::internal::serviceMax<cpu, DataType>(DataType(0), y1d * y1d + y2d * y2d); // To deal with NaNs     // 4*NNZ Flop
                     // const DataType PQ     = val[index] / (sqDist + 1.);            // 1*NNZ div, 1*NNZ flop, 4*NNZ byte
                     sqDist = 1.0 + y1d * y1d + y2d * y2d;
                     PQ     = val[index] / sqDist;
@@ -891,7 +891,7 @@ services::Status integrationKernelImpl(const DataType eta, const DataType moment
                                        const IdxType & blockOfRows)
 {
     const IdxType nThreads    = threader_get_threads_number();
-    const IdxType sizeOfBlock = services::internal::min<cpu, IdxType>(256, N / nThreads + 1);
+    const IdxType sizeOfBlock = services::internal::serviceMin<cpu, IdxType>(256, N / nThreads + 1);
     const IdxType nBlocks     = N / sizeOfBlock + bool(N % sizeOfBlock);
 
     daal::StaticTlsSum<DataType, cpu> sumTlsData(1);
@@ -900,7 +900,7 @@ services::Status integrationKernelImpl(const DataType eta, const DataType moment
     SafeStatus safeStat;
     daal::static_threader_for(nBlocks, [&](IdxType iBlock, IdxType tid) {
         const IdxType iStart = iBlock * sizeOfBlock;
-        const IdxType iEnd   = services::internal::min<cpu, IdxType>(N, iStart + sizeOfBlock);
+        const IdxType iEnd   = services::internal::serviceMin<cpu, IdxType>(N, iStart + sizeOfBlock);
         DataType ux, uy, gx, gy;
         DataType * localSum = sumTlsData.local(tid);
         DAAL_CHECK_MALLOC_THR(localSum);

--- a/cpp/daal/src/data_management/service_numeric_table.h
+++ b/cpp/daal/src/data_management/service_numeric_table.h
@@ -663,7 +663,7 @@ private:
 
     void initialize()
     {
-        size_t startsSize = daal::services::internal::max<cpu, size_t>(_nRowBlocks, _nColBlocks);
+        size_t startsSize = daal::services::internal::serviceMax<cpu, size_t>(_nRowBlocks, _nColBlocks);
         algorithmFPAccessType ** dataStarts =
             static_cast<algorithmFPAccessType **>(daal::services::internal::service_malloc<algorithmFPAccessType *, cpu>(
                 startsSize)); // TODO allocate more memory to eliminate cache false sharings in threading version

--- a/cpp/daal/src/data_management/train_test_split.cpp
+++ b/cpp/daal/src/data_management/train_test_split.cpp
@@ -120,7 +120,7 @@ services::Status generateShuffledIndicesImpl(const NumericTablePtr & idxTable, c
     {
         daal::threader_for(nRngBlocks, nRngBlocks, [&](size_t iBlock) {
             const size_t start = iBlock * rngBlockSize;
-            const size_t end   = daal::services::internal::min<cpu, size_t>(start + rngBlockSize, nRandomUInts);
+            const size_t end   = daal::services::internal::serviceMin<cpu, size_t>(start + rngBlockSize, nRandomUInts);
 
             s |= generateRandomNumbers<cpu>(rngState, randomUInts, start, end - start);
         });
@@ -191,7 +191,7 @@ services::Status assignColumnSubset(const DataType * origDataPtr, const NumericT
 
         daal::threader_for(nBlocks, nBlocks, [&](size_t iBlock) {
             const size_t start = iBlock * BLOCK_CONST;
-            const size_t end   = daal::services::internal::min<cpu, size_t>(start + BLOCK_CONST, nRows);
+            const size_t end   = daal::services::internal::serviceMin<cpu, size_t>(start + BLOCK_CONST, nRows);
 
             s |= assignColumnValues<DataType, IdxType, cpu>(origDataPtr, dataTable, idxPtr, start, end - start, iCol);
         });
@@ -254,7 +254,7 @@ services::Status assignRowsSubset(const DataType * origDataPtr, const NumericTab
 
         daal::threader_for(nBlocks, nBlocks, [&](size_t iBlock) {
             const size_t start = iBlock * blockSize;
-            const size_t end   = daal::services::internal::min<cpu, size_t>(start + blockSize, nRows);
+            const size_t end   = daal::services::internal::serviceMin<cpu, size_t>(start + blockSize, nRows);
 
             s |= assignRows<DataType, IdxType, cpu>(origDataPtr, dataTable, idxTable, start, end - start, nColumns);
         });
@@ -272,7 +272,7 @@ services::Status splitRows(const NumericTablePtr & inputTable, const NumericTabl
                            const size_t nTestRows, const size_t nColumns, const size_t nThreads)
 {
     services::Status s;
-    const size_t blockSize = daal::services::internal::max<cpu, size_t>(BLOCK_CONST / nColumns, 1);
+    const size_t blockSize = daal::services::internal::serviceMax<cpu, size_t>(BLOCK_CONST / nColumns, 1);
     daal::internal::ReadRows<DataType, cpu> origBlock(*inputTable, 0, inputTable->getNumberOfRows());
     const DataType * origDataPtr = origBlock.get();
     DAAL_CHECK_MALLOC(origDataPtr);

--- a/cpp/daal/src/services/service_utils.h
+++ b/cpp/daal/src/services/service_utils.h
@@ -201,13 +201,13 @@ inline float infToBigValue(float arg)
 }
 
 template <CpuType cpu, typename T>
-inline const T & min(const T & a, const T & b)
+inline const T & serviceMin(const T & a, const T & b)
 {
     return !(b < a) ? a : b;
 }
 
 template <CpuType cpu, typename T>
-inline const T & max(const T & a, const T & b)
+inline const T & serviceMax(const T & a, const T & b)
 {
     return (a < b) ? b : a;
 }


### PR DESCRIPTION
This PR resolves naming conflicts in oneDAL codes and <windows.h> header.

Following changes were made:
- `min` and `max` functions  renamed into `serviceMin` and `serviceMax` in "service_utils.h";
- `min` method renamed into `featureMin` in `IndexedFeatures` class in dtrees_feature_type_helper.h.

This PR is related to #2865.

