### PR TITLE
[maint] Update docker ubuntu version to 24.04

### DIFF
--- a/cpp/oneapi/dal/algo/knn/detail/distance.hpp
+++ b/cpp/oneapi/dal/algo/knn/detail/distance.hpp
@@ -96,7 +96,7 @@ struct distance_accessor {
 
 template <typename Descriptor>
 distance_impl* get_distance_impl(Descriptor&& desc) {
-    const auto& distance = distance_accessor{}.get_distance_impl(std::forward<Descriptor>(desc));
+    const auto distance = distance_accessor{}.get_distance_impl(std::forward<Descriptor>(desc));
     return distance ? distance->get_impl() : nullptr;
 }
 

--- a/cpp/oneapi/dal/algo/objective_function/detail/objective.hpp
+++ b/cpp/oneapi/dal/algo/objective_function/detail/objective.hpp
@@ -71,7 +71,7 @@ struct objective_accessor {
 
 template <typename Descriptor>
 objective_impl* get_objective_impl(Descriptor&& desc) {
-    const auto& objective = objective_accessor{}.get_objective_impl(std::forward<Descriptor>(desc));
+    const auto objective = objective_accessor{}.get_objective_impl(std::forward<Descriptor>(desc));
     return objective ? objective->get_impl() : nullptr;
 }
 

--- a/cpp/oneapi/dal/algo/svm/detail/kernel_function.hpp
+++ b/cpp/oneapi/dal/algo/svm/detail/kernel_function.hpp
@@ -143,7 +143,7 @@ struct kernel_function_accessor {
 
 template <typename Descriptor>
 kernel_function_impl* get_kernel_function_impl(Descriptor&& desc) {
-    const auto& kernel = kernel_function_accessor{}.get_kernel_impl(std::forward<Descriptor>(desc));
+    const auto kernel = kernel_function_accessor{}.get_kernel_impl(std::forward<Descriptor>(desc));
     return kernel ? kernel->get_impl() : nullptr;
 }
 

--- a/dev/docker/onedal-dev.Dockerfile
+++ b/dev/docker/onedal-dev.Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #===============================================================================
 
-FROM ubuntu:22.04@sha256:adbb90115a21969d2fe6fa7f9af4253e16d45f8d4c1e930182610c4731962658
+FROM ubuntu:24.04@sha256:77d57fd89366f7d16615794a5b53e124d742404e20f035c22032233f1826bd6a
 
 ARG workdirectory="/sources/oneDAL"
 WORKDIR ${workdirectory}


### PR DESCRIPTION
# Description
Currently there is a failure due to the 22.04 sha256 seems invalid.  This upgrades the ubuntu version of the dockerfile to 24.04 (falls in line with #2918)

Solves errors raised by gcc bazel build in 24.04 associated with ```error: possibly dangling reference to a temporary [-Werror=dangling-reference]```