### PR TITLE
[fix] address unwritten Python dependency in oneDAL building

### DIFF
--- a/deploy/pkg-config/generate_pkgconfig.py
+++ b/deploy/pkg-config/generate_pkgconfig.py
@@ -33,8 +33,8 @@ def detect_cpu_architecture():
     elif architecture.startswith('arm') or architecture == 'aarch64':
         return 'aarch64'
     else:
-        sys.stderr.write(f"Unknown Architecture {architecture} Detected. " \
-                         "Only 'x86_64', 'AMD64' and 'aarch64' supported.\n")
+        sys.stderr.write("Unknown Architecture {} Detected. " \
+                         "Only 'x86_64', 'AMD64' and 'aarch64' supported.\n".format(architecture))
         sys.exit(1)
 
 LIBS_PAR_STAT, LIBS_PAR_DYN = [], []
@@ -72,7 +72,7 @@ if platform in ["linux2", "linux"]:
     elif ARCH == 'aarch64':
         LIBDIR = 'lib/arm'
     else:
-        sys.stderr.write(f"Unknown CPU architecture '{ARCH}'\n")
+        sys.stderr.write("Unknown CPU architecture '{}'\n".format(ARCH))
 
     SUFF_DYN_LIB = ".so"
     SUFF_STAT_LIB = ".a"


### PR DESCRIPTION
## Description

Building on older ubuntu versions failed due to ```dev/deploy/generate_pkgconfig.py``` being Python 3.6+ dependent.  This was not standard until Ubuntu 22. These changes make it buildable on Ubuntu versions which maintain a python version (not explicitly Python3)

---

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [ ] I have reviewed my changes thoroughly before submitting this pull request.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [ ] I have added a respective label(s) to PR if I have a permission for that.
- [ ] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [ ] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.
- [ ] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [ ] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [ ] I have provided justification why performance has changed or why changes are not expected.
- [ ] I have provided justification why quality metrics have changed or why changes are not expected.
- [ ] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
