### PR TITLE
[fix] directly define ```__int32``` and ```__int64``` for Coverity scans using icpx

### DIFF
--- a/cpp/daal/include/services/daal_defines.h
+++ b/cpp/daal/include/services/daal_defines.h
@@ -45,8 +45,11 @@
     #define DAAL_INTEL_CPP_COMPILER
 #endif
 
-#if !(defined(_MSC_VER) || defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER))
+#if !defined(__int32)
     #define __int32 int
+#endif
+
+#if !defined(__int64)
     #define __int64 long long int
 #endif
 


### PR DESCRIPTION
## Description

Coverity logs show that while building some of oneDAL is possible, some of the macros associated with the ```__INTEL_LLVM_COMPILER``` are not being properly handled and may be causing failures.  This directly defines ```__int32``` and ```__int64``` if not previously defined and solves the most occurring error for linux. This is a more direct approach instead of querying for the compiler.

---

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance has changed or why changes are not expected.
- [x] I have provided justification why quality metrics have changed or why changes are not expected.
- [x] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
