### PR TITLE
[enhancement] Store windows basekit with symlink-preserving compression for nightly-build

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -115,7 +115,7 @@ jobs:
         shell: cmd
         run: |
           # change absolute symlinks to relative symlinks for reuse (fix issue in Intel BaseKit)
-          # iterate through all dirs in basekit (%%s), use dir to find symlinks target which have name 'latest' (%%H)
+          # iterate through all dirs in basekit (%%s), use dir to find the symlink target for symlinks named 'latest' (%%H)
           # delete the symlink, and make a new symlink using the last foldername (%%~nxH) in a relative fashion
           for /D %%s in (.\oneapi\*) do for /f "tokens=2 delims=[]" %%H in ('dir /al %%s\ ^| findstr /i /c:"latest"') do rmdir %%s\latest & mklink /D %%s\latest .\%%~nxH
           tar -cvzf oneapi.tar.gz .\oneapi

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -60,7 +60,7 @@ jobs:
         run: |
           tar -cvzf __release_lnx.tar.gz __release_lnx
       - name: Archive build
-        uses: actions/upload-artifact@v4.4.0
+        uses: actions/upload-artifact@v4
         with:
           name: __release_lnx
           path: ./__release_lnx.tar.gz

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -56,14 +56,11 @@ jobs:
         run: |
           source /opt/intel/oneapi/compiler/latest/env/vars.sh
           .ci/scripts/build.sh --compiler icx  --optimizations avx2 --target onedal
-      - name: Compress build
-        run: |
-          tar -cvzf __release_lnx.tar.gz __release_lnx
       - name: Archive build
         uses: actions/upload-artifact@v4
         with:
           name: __release_lnx
-          path: ./__release_lnx.tar.gz
+          path: ./__release_lnx
 
   build_win:
     name: oneDAL Windows nightly build
@@ -115,16 +112,11 @@ jobs:
           # delete the symlink, and make a new symlink using the last foldername (%%~nxH) in a relative fashion
           for /D %%s in (.\oneapi\*) do for /f "tokens=2 delims=[]" %%H in ('dir /al %%s\ ^| findstr /i /c:"latest"') do rmdir %%s\latest & mklink /D %%s\latest .\%%~nxH
           tar -cvzf oneapi.tar.gz .\oneapi
-      - name: Compress build
-        shell: cmd
-        run: |
-          ren __release_win_vc __release_win
-          tar -cvzf __release_win.tar.gz __release_win
       - name: Archive build
         uses: actions/upload-artifact@v4
         with:
           name: __release_win
-          path: .\__release_win.tar.gz
+          path: .\__release_win
       - name: Archive Intel BaseKit
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           source /opt/intel/oneapi/compiler/latest/env/vars.sh
           .ci/scripts/build.sh --compiler icx  --optimizations avx2 --target onedal
-      - name: Compress items
+      - name: Compress build
         run: |
           tar -cvzf __release_lnx.tar.gz .\__release_lnx
       - name: Archive build
@@ -111,10 +111,13 @@ jobs:
           call .\oneapi\setvars.bat
           call .\oneapi\compiler\latest\bin\sycl-ls.exe
           call .\.ci\scripts\build.bat onedal_dpc vc avx2
-      - name: Compress items
+      - name: Compress Intel BaseKit
         shell: cmd
         run: |
           tar -cvzf oneapi.tar.gz .\oneapi
+      - name: Compress build
+        shell: cmd
+        run: |
           ren .\__release_win_vc .\__release_win
           tar -cvzf __release_win.tar.gz .\__release_win
       - name: Archive build

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -114,14 +114,18 @@ jobs:
       - name: Compress Intel BaseKit
         shell: cmd
         run: |
+          # change absolute symlinks to relative symlinks for reuse (fix issue in Intel BaseKit)
+          # iterate through all dirs in basekit (%%s), use dir to find symlinks target which have name 'latest' (%%H)
+          # delete the symlink, and make a new symlink using the last foldername (%%~nxH) in a relative fashion
+          for /D %%s in (.\oneapi\*) do for /f "tokens=2 delims=[]" %%H in ('dir /al %%s\ ^| findstr /i /c:"latest"') do rmdir %%s\latest & mklink /D %%s\latest .\%%~nxH
           tar -cvzf oneapi.tar.gz .\oneapi
       - name: Compress build
         shell: cmd
         run: |
-          ren .\__release_win_vc .\__release_win
-          tar -cvzf __release_win.tar.gz .\__release_win
+          ren __release_win_vc __release_win
+          tar -cvzf __release_win.tar.gz __release_win
       - name: Archive build
-        uses: actions/upload-artifact@v4.4.0
+        uses: actions/upload-artifact@v4
         with:
           name: __release_win
           path: .\__release_win.tar.gz
@@ -131,7 +135,7 @@ jobs:
           name: intel_oneapi_basekit
           path: .\oneapi.tar.gz
       - name: Archive Intel OpenCL CPU runtime
-        uses: actions/upload-artifact@v4.4.0
+        uses: actions/upload-artifact@v4
         with:
           name: opencl_rt_installer
           path: .\opencl_rt.msi

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -58,7 +58,7 @@ jobs:
           .ci/scripts/build.sh --compiler icx  --optimizations avx2 --target onedal
       - name: Compress build
         run: |
-          tar -cvzf __release_lnx.tar.gz .\__release_lnx
+          tar -cvzf __release_lnx.tar.gz __release_lnx
       - name: Archive build
         uses: actions/upload-artifact@v4.4.0
         with:

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -31,6 +31,7 @@ env:
 jobs:
   build_lnx:
     name: oneDAL Linux nightly build
+    if: github.repository == 'oneapi-src/oneDAL'
     runs-on: ubuntu-22.04
     timeout-minutes: 120
 
@@ -66,6 +67,7 @@ jobs:
 
   build_win:
     name: oneDAL Windows nightly build
+    if: github.repository == 'oneapi-src/oneDAL'
     runs-on: windows-2022
     timeout-minutes: 120
 

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -56,11 +56,14 @@ jobs:
         run: |
           source /opt/intel/oneapi/compiler/latest/env/vars.sh
           .ci/scripts/build.sh --compiler icx  --optimizations avx2 --target onedal
+      - name: Compress items
+        run: |
+          tar -cvzf __release_lnx.tar.gz .\__release_lnx
       - name: Archive build
         uses: actions/upload-artifact@v4
         with:
           name: __release_lnx
-          path: ./__release_lnx
+          path: ./__release_lnx.tar.gz
 
   build_win:
     name: oneDAL Windows nightly build
@@ -108,20 +111,22 @@ jobs:
           call .\oneapi\setvars.bat
           call .\oneapi\compiler\latest\bin\sycl-ls.exe
           call .\.ci\scripts\build.bat onedal_dpc vc avx2
+      - name: Compress items
+        shell: cmd
+        run: |
+          tar -cvzf oneapi.tar.gz .\oneapi
+          ren .\__release_win_vc .\__release_win
+          tar -cvzf __release_win.tar.gz .\__release_win
       - name: Archive build
         uses: actions/upload-artifact@v4
         with:
           name: __release_win
-          path: .\__release_win_vc
-      - name: Compress DPC++
-        shell: cmd
-        run: |
-          tar -cvzf icx.zip .\oneapi
-      - name: Archive DPC++
+          path: .\__release_win.tar.gz
+      - name: Archive Intel BaseKit
         uses: actions/upload-artifact@v4
         with:
-          name: icx_compiler
-          path: .\icx.zip
+          name: intel_oneapi_basekit
+          path: .\oneapi.tar.gz
       - name: Archive Intel OpenCL CPU runtime
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -31,7 +31,6 @@ env:
 jobs:
   build_lnx:
     name: oneDAL Linux nightly build
-    if: github.repository == 'oneapi-src/oneDAL'
     runs-on: ubuntu-22.04
     timeout-minutes: 120
 
@@ -67,7 +66,6 @@ jobs:
 
   build_win:
     name: oneDAL Windows nightly build
-    if: github.repository == 'oneapi-src/oneDAL'
     runs-on: windows-2022
     timeout-minutes: 120
 


### PR DESCRIPTION
## Description

actions/upload-artifact#625 included in 4.4.1 fixes an issue to not preserve symlinks (since fixed in later versions). The Windows Intel oneAPI BaseKit installer uses absolute paths in symlinks rather than relative ones for the ```latest``` folders of various oneAPI components.  This makes a maintenance burden on sklearnex-side since they are unusable. Therefore the fully path must be known and maintained to the compiler and tbb version```vars.bat``` files. A rather long and complicated batch script line was added to force these to be relative.  This removed the maintenance burden by fixing the ```latest``` symlink to work in sklearnex out-of-the-box.  Since it is only one line and fixes what hopefully will only be a temporary issue  I don't think necessitates its own script.  Because of the complication of it, comments were added for future understanding.

This will reduce maintenance burden on sklearnex side by making the CI pipeline run independent of the tbb/mkl/compiler versions

---

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance has changed or why changes are not expected.
- [x] I have provided justification why quality metrics have changed or why changes are not expected.
- [x] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
