### PR TITLE
[fix] pin github actions upload-artifact to v4.4.0 to preserve linux symlinks

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -57,7 +57,7 @@ jobs:
           source /opt/intel/oneapi/compiler/latest/env/vars.sh
           .ci/scripts/build.sh --compiler icx  --optimizations avx2 --target onedal
       - name: Archive build
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: __release_lnx
           path: ./__release_lnx
@@ -109,7 +109,7 @@ jobs:
           call .\oneapi\compiler\latest\bin\sycl-ls.exe
           call .\.ci\scripts\build.bat onedal_dpc vc avx2
       - name: Archive build
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: __release_win
           path: .\__release_win_vc
@@ -118,12 +118,12 @@ jobs:
         run: |
           tar -cvzf icx.zip .\oneapi
       - name: Archive DPC++
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: icx_compiler
           path: .\icx.zip
       - name: Archive Intel OpenCL CPU runtime
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: opencl_rt_installer
           path: .\opencl_rt.msi


### PR DESCRIPTION
## Description

changes introduced in actions/upload-artifact#625 remove symlink preservation.  This locks to the last symlink-preserving version until an update to the repos can be made in tandem.

Valid run can be found here with the pinned version: https://github.com/icfaust/oneDAL/actions/runs/11230234430/job/31217199566

---

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance has changed or why changes are not expected.
- [x] I have provided justification why quality metrics have changed or why changes are not expected.
- [x] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
