### PR TITLE
feature: adding -fsycl-max-parallel-link-jobs in bazel

### DIFF
--- a/dev/bazel/deps/mkl.tpl.BUILD
+++ b/dev/bazel/deps/mkl.tpl.BUILD
@@ -42,6 +42,12 @@ cc_library(
 
 cc_library(
     name = "mkl_dpc",
+    # TODO: add a mechanism to get attr from bazel command(it's not available for now)
+    linkopts = [
+        # Currently its hardcoded to 16 to get the best trade-off between linking speedup and resources used.
+        # If the number of processors on machine is below 16 it will be defaulted to `nproc`.
+        "-fsycl-max-parallel-link-jobs=16",
+    ],
     srcs = [
         "lib/libmkl_sycl.a",
     ],


### PR DESCRIPTION
## Description

Adding linking flag to improve linking of onedal_sycl lib in oneDAL(bazel)

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

