### PR TITLE
[fix] nightly-build.yml to look at the correct directory, and name proper artifact for sklearnex

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -115,8 +115,8 @@ jobs:
       - name: Archive build
         uses: actions/upload-artifact@v4
         with:
-          name: __release_win_vc
-          path: .\__release_win
+          name: __release_win
+          path: .\__release_win_vc
       - name: Archive Intel BaseKit
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Mistakes in #2947 did not correct the issue about the naming scheme of the nightly, this is the correct solution.

I apologize for the mistakes.
