### PR TITLE
fix: workaround for Knn KD tree 

### DIFF
--- a/cpp/daal/src/algorithms/k_nearest_neighbors/kdtree_knn_classification_train_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/k_nearest_neighbors/kdtree_knn_classification_train_dense_default_impl.i
@@ -162,7 +162,8 @@ Status KNNClassificationTrainBatchKernel<algorithmFpType, training::defaultDense
     BBox * bboxQ    = nullptr;
     auto oldThreads = services::Environment::getInstance()->getNumberOfThreads();
     DAAL_CHECK_STATUS(status, buildFirstPartOfKDTree(q, bboxQ, *x, *r, indexes, engine));
-    // We have an issue with threading version of `buildSecondPartOfKDTree`
+    // Temporary workaround for threading issues in `buildSecondPartOfKDTree()`
+    // Fix to be provided in https://github.com/oneapi-src/oneDAL/pull/2925
     services::Environment::getInstance()->setNumberOfThreads(1);
     DAAL_CHECK_STATUS(status, buildSecondPartOfKDTree(q, bboxQ, *x, *r, indexes, engine));
     services::Environment::getInstance()->setNumberOfThreads(oldThreads);

--- a/cpp/daal/src/algorithms/k_nearest_neighbors/kdtree_knn_classification_train_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/k_nearest_neighbors/kdtree_knn_classification_train_dense_default_impl.i
@@ -189,7 +189,8 @@ Status KNNClassificationTrainBatchKernel<algorithmFpType, training::defaultDense
     typedef BoundingBox<algorithmFpType> BBox;
 
     const algorithmFpType base = 2.0;
-    // The queue size was incorrectly set
+    // The queue size is not impacted by number of threads.
+    // All operations with the queue are done not in the threader_for primitives.
     const size_t queueSize = 2 * Math::sPowx(base, Math::sCeil(Math::sLog(__KDTREE_FIRST_PART_LEAF_NODES_PER_THREAD) / Math::sLog(base)));
     const size_t firstPartLeafNodeCount = queueSize / 2;
     q.init(queueSize);

--- a/cpp/daal/src/algorithms/k_nearest_neighbors/kdtree_knn_classification_train_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/k_nearest_neighbors/kdtree_knn_classification_train_dense_default_impl.i
@@ -159,7 +159,7 @@ Status KNNClassificationTrainBatchKernel<algorithmFpType, training::defaultDense
     size_t * const indexes = static_cast<data_management::HomogenNumericTable<size_t> *>(r->impl()->getIndices().get())->getArray();
 
     Queue<BuildNode, cpu> q;
-    BBox * bboxQ = nullptr;
+    BBox * bboxQ    = nullptr;
     auto oldThreads = services::Environment::getInstance()->getNumberOfThreads();
     DAAL_CHECK_STATUS(status, buildFirstPartOfKDTree(q, bboxQ, *x, *r, indexes, engine));
     // We have an issue with threading version of `buildSecondPartOfKDTree`
@@ -189,8 +189,7 @@ Status KNNClassificationTrainBatchKernel<algorithmFpType, training::defaultDense
 
     const algorithmFpType base = 2.0;
     // The queue size was incorrectly set
-    const size_t queueSize =
-        2 * Math::sPowx(base, Math::sCeil(Math::sLog(__KDTREE_FIRST_PART_LEAF_NODES_PER_THREAD) / Math::sLog(base)));
+    const size_t queueSize = 2 * Math::sPowx(base, Math::sCeil(Math::sLog(__KDTREE_FIRST_PART_LEAF_NODES_PER_THREAD) / Math::sLog(base)));
     const size_t firstPartLeafNodeCount = queueSize / 2;
     q.init(queueSize);
     const size_t xColumnCount = x.getNumberOfColumns();


### PR DESCRIPTION
## Description

The pull request introduces a workaround for the K-Nearest Neighbors (KNN) algorithm. This fix addresses issues related to the algorithm's execution in threading part of KNN KD-tree. Additionally, the memory usage has improved. With these fix we will observe temporary performance degradations. The fix will be done in https://github.com/oneapi-src/oneDAL/pull/2925

---

Checklist to comply with **before moving PR from draft**:

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

**Performance**

- [x] I have provided justification why performance has changed or why changes are not expected.

