### PR TITLE
Update oneAPI components versions in CI

### DIFF
--- a/.ci/env/apt.sh
+++ b/.ci/env/apt.sh
@@ -35,7 +35,7 @@ function install_dpcpp {
 }
 
 function install_mkl {
-    sudo apt-get install -y intel-oneapi-mkl-devel-2025.0
+    sudo apt-get install -y intel-oneapi-mkl-devel-2025.0 intel-oneapi-tbb-devel-2022.0
 }
 
 function install_clang-format {

--- a/.ci/env/apt.sh
+++ b/.ci/env/apt.sh
@@ -31,11 +31,11 @@ function add_repo {
 }
 
 function install_dpcpp {
-    sudo apt-get install -y intel-oneapi-compiler-dpcpp-cpp intel-oneapi-runtime-libs
+    sudo apt-get install -y intel-oneapi-compiler-dpcpp-cpp-2025.0 intel-oneapi-runtime-libs=2025.0.0-406
 }
 
 function install_mkl {
-    sudo apt-get install -y intel-oneapi-mkl-devel=2024.2.1-103
+    sudo apt-get install -y intel-oneapi-mkl-devel-2025.0
 }
 
 function install_clang-format {

--- a/.ci/env/tbb.sh
+++ b/.ci/env/tbb.sh
@@ -20,7 +20,7 @@ set -eo pipefail
 SCRIPT_PATH=$(readlink -f "${BASH_SOURCE[0]}")
 SCRIPT_DIR=$(dirname "${SCRIPT_PATH}")
 ONEDAL_DIR=$(readlink -f "${SCRIPT_DIR}/../..")
-TBB_DEFAULT_VERSION="v2021.10.0"
+TBB_DEFAULT_VERSION="v2022.0.0-rc1"
 
 # Function to display help
 show_help() {

--- a/.ci/env/tbb.sh
+++ b/.ci/env/tbb.sh
@@ -20,7 +20,7 @@ set -eo pipefail
 SCRIPT_PATH=$(readlink -f "${BASH_SOURCE[0]}")
 SCRIPT_DIR=$(dirname "${SCRIPT_PATH}")
 ONEDAL_DIR=$(readlink -f "${SCRIPT_DIR}/../..")
-TBB_DEFAULT_VERSION="v2022.0.0-rc1"
+TBB_DEFAULT_VERSION="v2021.10.0"
 
 # Function to display help
 show_help() {

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -65,12 +65,15 @@ jobs:
       .ci/env/apt.sh mkl
     displayName: 'mkl installation'
   - script: |
+      source /opt/intel/oneapi/setvars.sh
       .ci/scripts/describe_system.sh
     displayName: 'System info'
   - script: |
+      source /opt/intel/oneapi/setvars.sh
       .ci/scripts/build.sh --compiler gnu --optimizations avx2 --target daal --conda-env ci-env
     displayName: 'make daal'
   - script: |
+      source /opt/intel/oneapi/setvars.sh
       .ci/scripts/build.sh --compiler gnu --optimizations avx2 --target onedal_c
     displayName: 'make onedal_c'
   - task: PublishPipelineArtifact@1
@@ -80,12 +83,15 @@ jobs:
     displayName: 'Upload build artifacts'
     continueOnError: true
   - script: |
+      source /opt/intel/oneapi/setvars.sh
       .ci/scripts/test.sh --test-kind examples --build-dir $(release.dir) --compiler gnu --interface daal/cpp --build-system cmake
     displayName: 'daal/cpp examples'
   - script: |
+      source /opt/intel/oneapi/setvars.sh
       .ci/scripts/test.sh --test-kind examples --build-dir $(release.dir) --compiler gnu --interface oneapi/cpp --build-system cmake
     displayName: 'oneapi/cpp examples'
   - script: |
+      source /opt/intel/oneapi/setvars.sh
       .ci/scripts/test.sh --test-kind samples --build-dir $(release.dir) --compiler gnu --interface daal/cpp/mpi --conda-env ci-env --build-system cmake
     displayName: 'daal/cpp/mpi samples'
   - script: |
@@ -425,15 +431,15 @@ jobs:
       .ci/env/apt.sh mkl
     displayName: 'mkl installation'
   - script: |
-      source /opt/intel/oneapi/compiler/latest/env/vars.sh
+      source /opt/intel/oneapi/setvars.sh
       .ci/scripts/describe_system.sh
     displayName: 'System info'
   - script: |
-      source /opt/intel/oneapi/compiler/latest/env/vars.sh
+      source /opt/intel/oneapi/setvars.sh
       .ci/scripts/build.sh --compiler icx  --optimizations avx2 --target daal --conda-env ci-env
     displayName: 'make daal'
   - script: |
-      source /opt/intel/oneapi/compiler/latest/env/vars.sh
+      source /opt/intel/oneapi/setvars.sh
       .ci/scripts/build.sh --compiler icx  --optimizations avx2 --target onedal_dpc
     displayName: 'make onedal_dpc'
   - task: PublishPipelineArtifact@1
@@ -443,18 +449,15 @@ jobs:
     displayName: 'Upload build artifacts'
     continueOnError: true
   - script: |
-      source /opt/intel/oneapi/compiler/latest/env/vars.sh
-      source /opt/intel/oneapi/mkl/latest/env/vars.sh
+      source /opt/intel/oneapi/setvars.sh
       .ci/scripts/test.sh --test-kind examples --build-dir $(release.dir) --compiler clang --interface daal/cpp --build-system cmake
     displayName: 'daal/cpp examples'
   - script: |
-      source /opt/intel/oneapi/compiler/latest/env/vars.sh
-      source /opt/intel/oneapi/mkl/latest/env/vars.sh
+      source /opt/intel/oneapi/setvars.sh
       .ci/scripts/test.sh --test-kind examples --build-dir $(release.dir) --compiler clang --interface oneapi/cpp --build-system cmake
     displayName: 'oneapi/cpp examples'
   - script: |
-      source /opt/intel/oneapi/compiler/latest/env/vars.sh
-      source /opt/intel/oneapi/mkl/latest/env/vars.sh
+      source /opt/intel/oneapi/setvars.sh
       .ci/scripts/test.sh --test-kind samples --build-dir $(release.dir) --compiler gnu --interface daal/cpp/mpi --conda-env ci-env --build-system cmake
     displayName: 'daal/cpp/mpi samples'
   - task: PublishPipelineArtifact@1

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -606,7 +606,7 @@ jobs:
     displayName: 'System info'
   - script: |
       conda update -y -q conda
-      conda create -q -y -n CB -c conda-forge python=$(python.version) tbb mpich
+      conda create -q -y -n CB -c conda-forge python=$(python.version) mpich
     displayName: 'Conda create'
   - script: |
       git clone https://github.com/intel/scikit-learn-intelex.git sklearnex
@@ -616,6 +616,7 @@ jobs:
       conda activate CB
       pip install -r sklearnex/dependencies-dev
       pip install -r sklearnex/requirements-test.txt
+      pip install tbb==2022.*
     displayName: Create python environment
   - script: |
       source /usr/share/miniconda/etc/profile.d/conda.sh

--- a/.ci/scripts/build.sh
+++ b/.ci/scripts/build.sh
@@ -206,9 +206,8 @@ fi
 if [[ ! -z "${TBB_INSTALL_DIR}" ]] ; then
     export TBBROOT="${TBB_INSTALL_DIR}"
     export LD_LIBRARY_PATH="${TBBROOT}/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
-elif [[ "${ARCH}" == "32e" ]]; then
-    # "${ONEDAL_DIR}"/dev/download_tbb.sh
-    sudo apt-get install -y intel-oneapi-tbb-devel-2022.0
+elif [[ "${ARCH}" == "32e" ] && [ "${backend_config}" == "ref" ]]; then
+    "${ONEDAL_DIR}"/dev/download_tbb.sh
 elif [[ "${ARCH}" == "arm" || ("${ARCH}" == "riscv64") ]]; then
     if [[ "${ARCH}" == "arm" ]] ; then
         ARCH_STR=aarch64

--- a/.ci/scripts/build.sh
+++ b/.ci/scripts/build.sh
@@ -206,7 +206,7 @@ fi
 if [[ ! -z "${TBB_INSTALL_DIR}" ]] ; then
     export TBBROOT="${TBB_INSTALL_DIR}"
     export LD_LIBRARY_PATH="${TBBROOT}/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
-elif [[ "${ARCH}" == "32e" ] && [ "${backend_config}" == "ref" ]]; then
+elif [ "${ARCH}" == "32e" ] && [ "${backend_config}" == "ref" ]; then
     "${ONEDAL_DIR}"/dev/download_tbb.sh
 elif [[ "${ARCH}" == "arm" || ("${ARCH}" == "riscv64") ]]; then
     if [[ "${ARCH}" == "arm" ]] ; then

--- a/.ci/scripts/build.sh
+++ b/.ci/scripts/build.sh
@@ -207,7 +207,8 @@ if [[ ! -z "${TBB_INSTALL_DIR}" ]] ; then
     export TBBROOT="${TBB_INSTALL_DIR}"
     export LD_LIBRARY_PATH="${TBBROOT}/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
 elif [[ "${ARCH}" == "32e" ]]; then
-    "${ONEDAL_DIR}"/dev/download_tbb.sh
+    # "${ONEDAL_DIR}"/dev/download_tbb.sh
+    sudo apt-get install -y intel-oneapi-tbb-devel-2022.0
 elif [[ "${ARCH}" == "arm" || ("${ARCH}" == "riscv64") ]]; then
     if [[ "${ARCH}" == "arm" ]] ; then
         ARCH_STR=aarch64


### PR DESCRIPTION
## Description

Changes:
- Update and pin DPC++ compiler and oneAPI runtime libs to 2025
- MKL-based jobs: update oneMKL to 2025, change oneTBB installation from github to apt and pin compatible version to 2022 

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance has changed or why changes are not expected.
- [x] I have provided justification why quality metrics have changed or why changes are not expected.
- [x] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
