### PR TITLE
[CI] store .ci/env as environment for sklearnex GitHub Actions CI

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -65,7 +65,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: apt.sh
-          path: ./.ci/env/apt.sh
+          path: .ci/env/apt.sh
 
   build_win:
     name: oneDAL Windows nightly build

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -61,10 +61,10 @@ jobs:
         with:
           name: __release_lnx
           path: ./__release_lnx
-      - name: Archive oneAPI env script
+      - name: Archive oneDAL environment
         uses: actions/upload-artifact@v4
         with:
-          name: lnx_oneDAL_env
+          name: oneDAL_env
           path: .ci/env
 
   build_win:

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -61,6 +61,11 @@ jobs:
         with:
           name: __release_lnx
           path: ./__release_lnx
+      - name: Archive oneAPI env script
+        uses: actions/upload-artifact@v4
+        with:
+          name: apt.sh
+          path: ./.ci/env/apt.sh
 
   build_win:
     name: oneDAL Windows nightly build

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -64,8 +64,8 @@ jobs:
       - name: Archive oneAPI env script
         uses: actions/upload-artifact@v4
         with:
-          name: apt.sh
-          path: .ci/env/apt.sh
+          name: lnx_oneDAL_env
+          path: .ci/env
 
   build_win:
     name: oneDAL Windows nightly build


### PR DESCRIPTION
## Description


Windows uploads the basekit to provide and pin the compiler and oneAPI components to sklearnex GitHub Actions CI for building and testing.  Linux was using either a local version to sklearnex or referencing the dpcpp version in oneDAL main, this breaks CI on upgrades. Sklearnex should actually reference what was used for the build itself. To do this on linux, store the install scripts from ```.ci/env``` in an artifact which can be downloaded and used in sklearnex to pin the oneAPI component versions.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance has changed or why changes are not expected.
- [x] I have provided justification why quality metrics have changed or why changes are not expected.
- [x] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
