### PR TITLE
[CI] make Nightly-build CI run on changes to CI

### DIFF
--- a/.ci/env/apt.sh
+++ b/.ci/env/apt.sh
@@ -66,7 +66,7 @@ function install_qemu_emulation_deb {
     found_version=""
     for version in ${versions[@]}; do
         for suffix in ${suffixes[@]}; do
-            qemu_deb="qemu-user-static_${version}+ds-2${suffix}_amd64.deb"
+            qemu_deb="$1_${version}+ds-2${suffix}_amd64.deb"
             echo "Checking for http://ftp.debian.org/debian/pool/main/q/qemu/${qemu_deb}"
             if wget -q --method=HEAD http://ftp.debian.org/debian/pool/main/q/qemu/${qemu_deb} &> /dev/null;
             then
@@ -140,7 +140,9 @@ elif [ "${component}" == "qemu-apt" ]; then
     install_qemu_emulation_apt
 elif [ "${component}" == "qemu-deb" ]; then
     update
-    install_qemu_emulation_deb
+    install_qemu_emulation_deb qemu-user
+    install_qemu_emulation_deb qemu-user-binfmt
+    install_qemu_emulation_deb qemu-user-static
 elif [ "${component}" == "llvm-version" ] ; then
     update
     install_llvm_version "$2"

--- a/.ci/env/apt.sh
+++ b/.ci/env/apt.sh
@@ -59,36 +59,10 @@ function install_qemu_emulation_apt {
 }
 
 function install_qemu_emulation_deb {
-    set +e
-
-    versions=(9.1.1 9.0.2 8.2.4)
-    suffixes=("" "~bpo12+1")
-    found_version=""
-    for version in ${versions[@]}; do
-        for suffix in ${suffixes[@]}; do
-            qemu_deb="$1_${version}+ds-2${suffix}_amd64.deb"
-            echo "Checking for http://ftp.debian.org/debian/pool/main/q/qemu/${qemu_deb}"
-            if wget -q --method=HEAD http://ftp.debian.org/debian/pool/main/q/qemu/${qemu_deb} &> /dev/null;
-            then
-                echo "Found qemu version ${version}"
-                found_version=${qemu_deb}
-                break 2
-            fi
-        done
-    done
-
-    set -eo pipefail
-    if [[ -z "${found_version}" ]] ; then
-        # If nothing is found, error out and fail
-        echo "None of the requested qemu versions ${versions[*]} are available."
-        false
-    fi
-
+    found_version=`wget -q http://ftp.debian.org/debian/pool/main/q/qemu/ -O - | grep -oP "(?<=\")$1_.*_amd64.deb(?=\")" | tail -1`
     wget http://ftp.debian.org/debian/pool/main/q/qemu/${found_version}
     sudo dpkg -i ${found_version}
-
     sudo systemctl restart systemd-binfmt.service
-    set +eo pipefail
 }
 
 function install_llvm_version {

--- a/.ci/env/apt.sh
+++ b/.ci/env/apt.sh
@@ -61,12 +61,12 @@ function install_qemu_emulation_apt {
 function install_qemu_emulation_deb {
     set +e
 
-    versions=(9.0.2 9.0.1 8.2.4)
+    versions=(9.1.1 9.0.2 8.2.4)
     suffixes=("" "~bpo12+1")
     found_version=""
     for version in ${versions[@]}; do
         for suffix in ${suffixes[@]}; do
-            qemu_deb="qemu-user-static_${version}+ds-1${suffix}_amd64.deb"
+            qemu_deb="qemu-user-static_${version}+ds-2${suffix}_amd64.deb"
             echo "Checking for http://ftp.debian.org/debian/pool/main/q/qemu/${qemu_deb}"
             if wget -q --method=HEAD http://ftp.debian.org/debian/pool/main/q/qemu/${qemu_deb} &> /dev/null;
             then

--- a/.ci/env/apt.sh
+++ b/.ci/env/apt.sh
@@ -59,7 +59,8 @@ function install_qemu_emulation_apt {
 }
 
 function install_qemu_emulation_deb {
-    found_version=`wget -q http://ftp.debian.org/debian/pool/main/q/qemu/ -O - | grep -oP "(?<=\")$1_.*_amd64.deb(?=\")" | tail -1`
+    # get last version of qemu listed on debian, changes may need to occur to this with version 10 of qemu
+    found_version=$(wget -q http://ftp.debian.org/debian/pool/main/q/qemu/ -O - | grep -oP "(?<=\")$1_.*_amd64.deb(?=\")" | tail -1)
     wget http://ftp.debian.org/debian/pool/main/q/qemu/${found_version}
     sudo dpkg -i ${found_version}
     sudo systemctl restart systemd-binfmt.service

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -25,8 +25,12 @@ on:
     paths:
       - .github/workflows/nightly-build.yml
       - .ci/pipeline/ci.yml
+      - makefile
       - '.ci/env/**'
       - '.ci/scripts/**'
+      - 'dev/make/**'
+      - 'dev/make/compiler_definitions/**'
+      - 'dev/make/function_defintions/**'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -19,6 +19,14 @@ name: Nightly-build
 on:
   schedule:
     - cron: '0 21 * * *'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/nightly-build.yml
+      - .ci/pipeline/ci.yml
+      - '.ci/env/**'
+      - '.ci/scripts/**'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -30,7 +30,7 @@ on:
       - '.ci/scripts/**'
       - 'dev/make/**'
       - 'dev/make/compiler_definitions/**'
-      - 'dev/make/function_defintions/**'
+      - 'dev/make/function_definitions/**'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -36,6 +36,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref_name }}-${{ github.event.number || github.sha }}
+  cancel-in-progress: true
+
 env:
   WINDOWS_ALL_COMPONENTS: 'intel.oneapi.win.cpp-dpcpp-common:intel.oneapi.win.mkl.devel:intel.oneapi.win.tbb.devel'
 

--- a/dev/make/compiler_definitions/dpcpp.mk
+++ b/dev/make/compiler_definitions/dpcpp.mk
@@ -25,7 +25,7 @@ CMPLRDIRSUFF.dpcpp = _dpcpp
 
 CORE.SERV.COMPILER.dpcpp = generic
 
--Zl.dpcpp = $(if $(OS_is_win),-Zl,) $(-Q)no-intel-lib
+-Zl.dpcpp = $(if $(OS_is_win),-Zl -Q,-)no-intel-lib
 -DEBC.dpcpp = $(if $(OS_is_win),-debug:all -Z7,-g) -fno-system-debug
 
 COMPILER.lnx.dpcpp = icpx -fsycl -m64 -stdlib=libstdc++ -fgnu-runtime -fwrapv \

--- a/dev/make/compiler_definitions/icx.mkl.32e.mk
+++ b/dev/make/compiler_definitions/icx.mkl.32e.mk
@@ -25,7 +25,7 @@ CMPLRDIRSUFF.icx =
 CORE.SERV.COMPILER.icx = generic
 
 
--Zl.icx = $(if $(OS_is_win),-Zl,) $(-Q)no-intel-lib
+-Zl.icx = $(if $(OS_is_win),-Zl -Qno-intel-lib,-no-intel-lib)
 -DEBC.icx = $(if $(OS_is_win),-debug:all -Z7,-g) -fno-system-debug
 
 -Qopt = $(if $(OS_is_win),-Qopt-,-qopt-)

--- a/dev/make/compiler_definitions/icx.mkl.32e.mk
+++ b/dev/make/compiler_definitions/icx.mkl.32e.mk
@@ -25,7 +25,7 @@ CMPLRDIRSUFF.icx =
 CORE.SERV.COMPILER.icx = generic
 
 
--Zl.icx = $(if $(OS_is_win),-Zl -Qno-intel-lib,-no-intel-lib)
+-Zl.icx = $(if $(OS_is_win),-Zl,) $(-Q)no-intel-lib
 -DEBC.icx = $(if $(OS_is_win),-debug:all -Z7,-g) -fno-system-debug
 
 -Qopt = $(if $(OS_is_win),-Qopt-,-qopt-)


### PR DESCRIPTION
## Description

With the merge of intel/scikit-learn-intelex#2147, runs of Nightly-build are only taken from scheduled or workflow dispatches.  This allows for testing the nightly without disrupting sklearnex CI when changes to CI, make system, or the nightly are made in PRs. This will make it less blind, and verification by reviewers easier/less by faith.  If changes are made to CI, then nightly-build will run on the PR.  This will not be run on main push.

NOTE: This PR fixes two CI issues which have shown up:

1) A qemu install from deb package issue, which the version and dependencies have changed
2) An issue in building the nightly on windows with a VS/DPCPP hybrid build caused by changes introduced in #2946 


---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance has changed or why changes are not expected.
- [x] I have provided justification why quality metrics have changed or why changes are not expected.
- [x] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
