### PR TITLE
DOC: Fix link to example that was moved

### DIFF
--- a/docs/source/daal/algorithms/logistic_regression/logistic-regression.rst
+++ b/docs/source/daal/algorithms/logistic_regression/logistic-regression.rst
@@ -120,7 +120,7 @@ Examples
 
   .. tab:: Python*
 
-    - :daal4py_example:`log_reg_model_builder.py`
+    - :daal4py_example:`log_reg_model_builder.py <https://github.com/intel/scikit-learn-intelex/blob/main/examples/mb/log_reg_model_builder.py>`
 
 Batch Processing
 ****************


### PR DESCRIPTION
## Description

This PR fixes a broken link in the docs to an example file from the sklearnex repository that was moved to a different folder:
https://github.com/intel/scikit-learn-intelex/blob/main/examples/mb/log_reg_model_builder.py

The move from the previous path which broke the link in the docs happened as part of this PR:
https://github.com/intel/scikit-learn-intelex/pull/1399

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

**Performance**

Not applicable.
