### PR TITLE
fix: Set the correct CPATH for oneAPI toolkit

### DIFF
--- a/deploy/local/vars_lnx.sh
+++ b/deploy/local/vars_lnx.sh
@@ -247,11 +247,12 @@ if [ "$(basename "${my_script_path}")" = "env" ] ; then   # assume stand-alone
     export DALROOT="$__daal_tmp_dir"
     export PKG_CONFIG_PATH="$__daal_tmp_dir/lib/pkgconfig${PKG_CONFIG_PATH+:${PKG_CONFIG_PATH}}"
     export CMAKE_PREFIX_PATH="$__daal_tmp_dir${CMAKE_PREFIX_PATH+:${CMAKE_PREFIX_PATH}}"
-    export CPATH="$__daal_tmp_dir/include${CPATH+:${CPATH}}"
     if [ -d "${component_root}/include/dal" ]; then
+      export CPATH="$__daal_tmp_dir/include/dal${CPATH+:${CPATH}}"
       export LIBRARY_PATH="$__daal_tmp_dir/lib${LIBRARY_PATH+:${LIBRARY_PATH}}"
       export LD_LIBRARY_PATH="$__daal_tmp_dir/lib${LD_LIBRARY_PATH+:${LD_LIBRARY_PATH}}"
     else
+      export CPATH="$__daal_tmp_dir/include${CPATH+:${CPATH}}"
       export LIBRARY_PATH="$__daal_tmp_dir/lib/$ARCH_DIR_ONEDAL${LIBRARY_PATH+:${LIBRARY_PATH}}"
       export LD_LIBRARY_PATH="$__daal_tmp_dir/lib/$ARCH_DIR_ONEDAL${LD_LIBRARY_PATH+:${LD_LIBRARY_PATH}}"
     fi
@@ -277,7 +278,7 @@ else   # must be a consolidated layout
 
   # *"etc"*)
     export DALROOT="$ONEAPI_ROOT"
-    export CPATH="$ONEAPI_ROOT/include${CPATH+:${CPATH}}"
+    export CPATH="$ONEAPI_ROOT/include/dal${CPATH+:${CPATH}}"
   # ;;
 # esac
 fi

--- a/deploy/local/vars_lnx.sh
+++ b/deploy/local/vars_lnx.sh
@@ -247,12 +247,11 @@ if [ "$(basename "${my_script_path}")" = "env" ] ; then   # assume stand-alone
     export DALROOT="$__daal_tmp_dir"
     export PKG_CONFIG_PATH="$__daal_tmp_dir/lib/pkgconfig${PKG_CONFIG_PATH+:${PKG_CONFIG_PATH}}"
     export CMAKE_PREFIX_PATH="$__daal_tmp_dir${CMAKE_PREFIX_PATH+:${CMAKE_PREFIX_PATH}}"
+    export CPATH="$__daal_tmp_dir/include:$__daal_tmp_dir/include/dal${CPATH+:${CPATH}}"
     if [ -d "${component_root}/include/dal" ]; then
-      export CPATH="$__daal_tmp_dir/include/dal${CPATH+:${CPATH}}"
       export LIBRARY_PATH="$__daal_tmp_dir/lib${LIBRARY_PATH+:${LIBRARY_PATH}}"
       export LD_LIBRARY_PATH="$__daal_tmp_dir/lib${LD_LIBRARY_PATH+:${LD_LIBRARY_PATH}}"
     else
-      export CPATH="$__daal_tmp_dir/include${CPATH+:${CPATH}}"
       export LIBRARY_PATH="$__daal_tmp_dir/lib/$ARCH_DIR_ONEDAL${LIBRARY_PATH+:${LIBRARY_PATH}}"
       export LD_LIBRARY_PATH="$__daal_tmp_dir/lib/$ARCH_DIR_ONEDAL${LD_LIBRARY_PATH+:${LD_LIBRARY_PATH}}"
     fi
@@ -278,7 +277,7 @@ else   # must be a consolidated layout
 
   # *"etc"*)
     export DALROOT="$ONEAPI_ROOT"
-    export CPATH="$ONEAPI_ROOT/include/dal${CPATH+:${CPATH}}"
+    export CPATH="$ONEAPI_ROOT/include:$ONEAPI_ROOT/include/dal${CPATH+:${CPATH}}"
   # ;;
 # esac
 fi

--- a/deploy/local/vars_win.bat
+++ b/deploy/local/vars_win.bat
@@ -35,7 +35,7 @@ if "%SCRIPT_PATH%"=="%DAAL%\env\" (
 ) else (
   set "DALROOT=%ONEAPI_ROOT%"
   set "INCLUDE=%ONEAPI_ROOT%\include\dal;%INCLUDE%"
-  set "CPATH=%ONEAPI_ROOT%\include;%CPATH%"
+  set "CPATH=%ONEAPI_ROOT%\include\dal;%CPATH%"
   goto :GoodArgs2024
 )
 
@@ -53,14 +53,15 @@ exit /b 0
 
 :GoodArgs
 set "DALROOT=%DAAL%"
-set "CPATH=%DAAL%\include;%CPATH%"
 if exist "%DAAL%\include\dal" (
   set "INCLUDE=%DAAL%\include\dal;%INCLUDE%"
+  set "CPATH=%DAAL%\include\dal;%CPATH%"
   set "LIB=%DAAL%\lib;%LIB%"
   set "CLASSPATH=%DAAL%\share\java\onedal.jar;%CLASSPATH%"
   set "PATH=%DAAL%\bin;%PATH%"
 ) else (
   set "INCLUDE=%DAAL%\include;%INCLUDE%"
+  set "CPATH=%DAAL%\include;%CPATH%"
   set "LIB=%DAAL%\lib\%DAAL_IA%;%LIB%"
   set "CLASSPATH=%DAAL%\lib\onedal.jar;%CLASSPATH%"
   if exist "%DAAL_UP_OLD%\redist" (

--- a/deploy/local/vars_win.bat
+++ b/deploy/local/vars_win.bat
@@ -35,7 +35,7 @@ if "%SCRIPT_PATH%"=="%DAAL%\env\" (
 ) else (
   set "DALROOT=%ONEAPI_ROOT%"
   set "INCLUDE=%ONEAPI_ROOT%\include\dal;%INCLUDE%"
-  set "CPATH=%ONEAPI_ROOT%\include\dal;%CPATH%"
+  set "CPATH=%ONEAPI_ROOT%\include;%ONEAPI_ROOT%\include\dal;%CPATH%"
   goto :GoodArgs2024
 )
 
@@ -53,15 +53,14 @@ exit /b 0
 
 :GoodArgs
 set "DALROOT=%DAAL%"
+set "CPATH=%DAAL%\include;%DAAL%\include\dal;%CPATH%"
 if exist "%DAAL%\include\dal" (
   set "INCLUDE=%DAAL%\include\dal;%INCLUDE%"
-  set "CPATH=%DAAL%\include\dal;%CPATH%"
   set "LIB=%DAAL%\lib;%LIB%"
   set "CLASSPATH=%DAAL%\share\java\onedal.jar;%CLASSPATH%"
   set "PATH=%DAAL%\bin;%PATH%"
 ) else (
   set "INCLUDE=%DAAL%\include;%INCLUDE%"
-  set "CPATH=%DAAL%\include;%CPATH%"
   set "LIB=%DAAL%\lib\%DAAL_IA%;%LIB%"
   set "CLASSPATH=%DAAL%\lib\onedal.jar;%CLASSPATH%"
   if exist "%DAAL_UP_OLD%\redist" (


### PR DESCRIPTION
## Description

Revert of https://github.com/oneapi-src/oneDAL/pull/2777

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance has changed or why changes are not expected.
- [x] I have provided justification why quality metrics have changed or why changes are not expected.
- [x] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
