### PR TITLE
FIX: Fix histogram reduction when number of tasks is larger than input data

### DIFF
--- a/cpp/oneapi/dal/algo/decision_forest/backend/gpu/train_helpers.hpp
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/gpu/train_helpers.hpp
@@ -39,6 +39,12 @@ inline void merge_stat(Float& dst_count,
                        Float src_s2c) {
     if (Float(0) == src_count)
         return;
+    if (!dst_count) {
+        dst_count = src_count;
+        dst_mean = src_mean;
+        dst_s2c = src_s2c;
+        return;
+    }
 
     Float sum_n1n2 = dst_count + src_count;
     Float mul_n1n2 = dst_count * src_count;


### PR DESCRIPTION
## Description

This PR fixes an issue in the GPU implementations of decision trees in which inputs that are smaller than the task size of the device queue fail their histogram calculations due to divisions by zeros, as the number of spawned tasks is always the same and in such cases some tasks get empty inputs.

Note: while this PR is not adding any tests in oneDAL, there are currently some deselected tests in scikit-learn-intelex which should be able to test these cases after merging it.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

**Performance**

Not applicable.
