### PR TITLE
Revert SPMD K-means instantiation to fix #2959

### DIFF
--- a/cpp/oneapi/dal/algo/kmeans/detail/infer_ops_dpc.cpp
+++ b/cpp/oneapi/dal/algo/kmeans/detail/infer_ops_dpc.cpp
@@ -42,13 +42,10 @@ struct infer_ops_dispatcher<Policy, Float, Method, Task> {
     template struct ONEDAL_EXPORT                                         \
         infer_ops_dispatcher<dal::detail::spmd_data_parallel_policy, F, M, T>;
 
-#define INSTANTIATE_NON_DISTRIBUTED(F, M, T) \
-    template struct ONEDAL_EXPORT infer_ops_dispatcher<dal::detail::data_parallel_policy, F, M, T>;
-
 INSTANTIATE(float, method::lloyd_dense, task::clustering)
 INSTANTIATE(double, method::lloyd_dense, task::clustering)
-INSTANTIATE_NON_DISTRIBUTED(float, method::lloyd_csr, task::clustering)
-INSTANTIATE_NON_DISTRIBUTED(double, method::lloyd_csr, task::clustering)
+INSTANTIATE(float, method::lloyd_csr, task::clustering)
+INSTANTIATE(double, method::lloyd_csr, task::clustering)
 
 } // namespace v1
 } // namespace oneapi::dal::kmeans::detail

--- a/cpp/oneapi/dal/algo/kmeans/detail/train_ops_dpc.cpp
+++ b/cpp/oneapi/dal/algo/kmeans/detail/train_ops_dpc.cpp
@@ -43,13 +43,10 @@ struct train_ops_dispatcher<Policy, Float, Method, Task> {
     template struct ONEDAL_EXPORT                                         \
         train_ops_dispatcher<dal::detail::spmd_data_parallel_policy, F, M, T>;
 
-#define INSTANTIATE_NON_DISTRIBUTED(F, M, T) \
-    template struct ONEDAL_EXPORT train_ops_dispatcher<dal::detail::data_parallel_policy, F, M, T>;
-
 INSTANTIATE(float, method::lloyd_dense, task::clustering)
 INSTANTIATE(double, method::lloyd_dense, task::clustering)
-INSTANTIATE_NON_DISTRIBUTED(float, method::lloyd_csr, task::clustering)
-INSTANTIATE_NON_DISTRIBUTED(double, method::lloyd_csr, task::clustering)
+INSTANTIATE(float, method::lloyd_csr, task::clustering)
+INSTANTIATE(double, method::lloyd_csr, task::clustering)
 
 } // namespace v1
 } // namespace oneapi::dal::kmeans::detail


### PR DESCRIPTION
The changes in SPMD K-means instantiation were reverted to fix the bug in #2959.

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.
- [ ] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [ ] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [ ] I have provided justification why performance has changed or why changes are not expected.
- [ ] I have provided justification why quality metrics have changed or why changes are not expected.
- [ ] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
