### PR TITLE
Add ability of vtune profiling

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -78,7 +78,7 @@ is available as an alternative to the manual setup.
 4. Set up MKL:
 
     _Note: if you used the general oneAPI setvars script from a Base Toolkit installation, this step will not be necessary as oneMKL will already have been set up._
-    
+
     Download and install [Intel(R) oneMKL](https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html).
     Set the environment variables for for Intel(R) oneMKL. For example:
 
@@ -149,7 +149,15 @@ It is possible to build oneDAL libraries with selected set of algorithms and/or 
 
             make -f makefile daal PLAT=win32e CORE.ALGORITHMS.CUSTOM=low_order_moments REQCPU=avx2 -j16
 
+On **Linux\*** it is possible to build debug version of oneDAL or the version that allows to do kernel profiling using <ittnotify.h>.
 
+- To build debug version of oneDAL, run:
+
+            make -f makefile daal oneapi_c PLAT=lnx32e REQDBG=yes
+
+- To build oneDAL with kernel profiling information, run:
+
+            make -f makefile daal oneapi_c PLAT=lnx32e REQPROFILE=yes
 
 ---
 **NOTE:** Built libraries are located in the `__release_{os_name}[_{compiler_name}]/daal` directory.

--- a/cpp/daal/src/externals/service_profiler.cpp
+++ b/cpp/daal/src/externals/service_profiler.cpp
@@ -21,6 +21,29 @@ namespace daal
 {
 namespace internal
 {
+#ifdef ONEDAL_KERNEL_PROFILER
+
+ProfilerTask::ProfilerTask(const char * taskName) : _taskName(taskName)
+{
+    _handle = __itt_string_handle_create(taskName);
+
+    __itt_task_begin(Profiler::getDomain(), __itt_null, __itt_null, _handle);
+}
+
+ProfilerTask::~ProfilerTask() {
+    Profiler::endTask(_taskName);
+}
+
+ProfilerTask Profiler::startTask(const char * taskName)
+{
+    return ProfilerTask(taskName);
+}
+
+void Profiler::endTask(const char * taskName) {
+    __itt_task_end(Profiler::getDomain());
+}
+
+#else
 ProfilerTask Profiler::startTask(const char * taskName)
 {
     return ProfilerTask(taskName);
@@ -34,6 +57,7 @@ ProfilerTask::~ProfilerTask()
 {
     Profiler::endTask(_taskName);
 }
+#endif
 
 } // namespace internal
 } // namespace daal

--- a/cpp/daal/src/externals/service_profiler.cpp
+++ b/cpp/daal/src/externals/service_profiler.cpp
@@ -30,7 +30,8 @@ ProfilerTask::ProfilerTask(const char * taskName) : _taskName(taskName)
     __itt_task_begin(Profiler::getDomain(), __itt_null, __itt_null, _handle);
 }
 
-ProfilerTask::~ProfilerTask() {
+ProfilerTask::~ProfilerTask()
+{
     Profiler::endTask(_taskName);
 }
 
@@ -39,7 +40,8 @@ ProfilerTask Profiler::startTask(const char * taskName)
     return ProfilerTask(taskName);
 }
 
-void Profiler::endTask(const char * taskName) {
+void Profiler::endTask(const char * taskName)
+{
     __itt_task_end(Profiler::getDomain());
 }
 

--- a/cpp/daal/src/externals/service_profiler.h
+++ b/cpp/daal/src/externals/service_profiler.h
@@ -101,13 +101,19 @@ public:
      * Get pointer to the ITT domain associated with the profiler.
      * \return Pointer to the ITT domain.
      */
-    static __itt_domain * getDomain() { return (getInstance())->_domain; }
+    static __itt_domain * getDomain()
+    {
+        return (getInstance())->_domain;
+    }
 
 private:
     /**
      * Construct the profiler.
      */
-    Profiler() { _domain = __itt_domain_create("oneDAL"); }
+    Profiler()
+    {
+        _domain = __itt_domain_create("oneDAL");
+    }
     ~Profiler() {}
     __itt_domain * _domain; /* Pointer to the ITT domain */
 #endif

--- a/cpp/daal/src/externals/service_profiler.h
+++ b/cpp/daal/src/externals/service_profiler.h
@@ -24,6 +24,12 @@
 #ifndef __SERVICE_PROFILER_H__
 #define __SERVICE_PROFILER_H__
 
+// #define ONEDAL_KERNEL_PROFILER
+
+#ifdef ONEDAL_KERNEL_PROFILER
+#include <ittnotify.h>
+#endif
+
 #define DAAL_ITTNOTIFY_CONCAT2(x, y) x##y
 #define DAAL_ITTNOTIFY_CONCAT(x, y)  DAAL_ITTNOTIFY_CONCAT2(x, y)
 
@@ -44,6 +50,10 @@ public:
 
 private:
     const char * _taskName;
+#ifdef ONEDAL_KERNEL_PROFILER
+    __itt_string_handle* _handle;
+    __itt_domain* _domain;
+#endif
 };
 
 // This class is a stub in the library. Its redefinition will be in Bechmarks
@@ -52,6 +62,22 @@ class Profiler
 public:
     static ProfilerTask startTask(const char * taskName);
     static void endTask(const char * taskName);
+#ifdef ONEDAL_KERNEL_PROFILER
+    static Profiler* getInstance() {
+        static Profiler  instance;
+        return &instance;
+    }
+
+    static __itt_domain* getDomain() {
+        return (getInstance())->_domain;
+    }
+private:
+    Profiler() {
+        _domain = __itt_domain_create("oneDAL");
+    }
+    ~Profiler() {}
+    __itt_domain* _domain;
+#endif
 };
 
 } // namespace internal

--- a/cpp/daal/src/externals/service_profiler.h
+++ b/cpp/daal/src/externals/service_profiler.h
@@ -24,9 +24,8 @@
 #ifndef __SERVICE_PROFILER_H__
 #define __SERVICE_PROFILER_H__
 
-// #define ONEDAL_KERNEL_PROFILER
-
 #ifdef ONEDAL_KERNEL_PROFILER
+/* Here if oneDAL kernel profiling is enabled in the build */
 #include <ittnotify.h>
 #endif
 
@@ -36,47 +35,83 @@
 #define DAAL_ITTNOTIFY_UNIQUE_ID __LINE__
 
 #define DAAL_ITTNOTIFY_SCOPED_TASK(name) \
-    daal::internal::ProfilerTask DAAL_ITTNOTIFY_CONCAT(__profiler_taks__, DAAL_ITTNOTIFY_UNIQUE_ID) = daal::internal::Profiler::startTask(#name);
+    daal::internal::ProfilerTask DAAL_ITTNOTIFY_CONCAT(__profiler_task__, DAAL_ITTNOTIFY_UNIQUE_ID) = daal::internal::Profiler::startTask(#name);
 
 namespace daal
 {
 namespace internal
 {
+/**
+ * Defines a logical unit of work to be tracked by performance profilier.
+ */
 class ProfilerTask
 {
 public:
+    /**
+     * Constructs a task with a given name.
+     * \param[in] taskName   Name of the task.
+     */
     ProfilerTask(const char * taskName);
     ~ProfilerTask();
 
 private:
     const char * _taskName;
 #ifdef ONEDAL_KERNEL_PROFILER
-    __itt_string_handle* _handle;
-    __itt_domain* _domain;
+    /* Here if oneDAL kernel profiling is enabled */
+    __itt_string_handle * _handle;  /* The task string handle */
+    __itt_domain * _domain;         /* Pointer to the domain of the task */
 #endif
 };
 
-// This class is a stub in the library. Its redefinition will be in Bechmarks
+/**
+ * Global performance profiler.
+ *
+ * By default this class is a stub in the library and its redefinition will be in C++ Bechmarks.
+ * If oneDAL kernel profiling is enabled, the profiler uses Task API from <ittnotify.h>
+ */
 class Profiler
 {
 public:
+    /**
+     * Start the task to be profiled.
+     * \param[in] taskName   Name of the task.
+     */
     static ProfilerTask startTask(const char * taskName);
+
+    /**
+     * Start the task to profile.
+     * \param[in] taskName   Name of the task.
+     */
     static void endTask(const char * taskName);
+
 #ifdef ONEDAL_KERNEL_PROFILER
+    /* Here if oneDAL kernel profiling is enabled */
+
+    /**
+     * Get pointer to a global profiler state.
+     * \return Pointer to a global profiler state.
+     */
     static Profiler* getInstance() {
         static Profiler  instance;
         return &instance;
     }
 
-    static __itt_domain* getDomain() {
+    /**
+     * Get pointer to the ITT domain associated with the profiler.
+     * \return Pointer to the ITT domain.
+     */
+    static __itt_domain * getDomain() {
         return (getInstance())->_domain;
     }
 private:
+    /**
+     * Construct the profiler.
+     */
     Profiler() {
         _domain = __itt_domain_create("oneDAL");
     }
     ~Profiler() {}
-    __itt_domain* _domain;
+    __itt_domain * _domain;     /* Pointer to the ITT domain */
 #endif
 };
 

--- a/cpp/daal/src/externals/service_profiler.h
+++ b/cpp/daal/src/externals/service_profiler.h
@@ -25,8 +25,8 @@
 #define __SERVICE_PROFILER_H__
 
 #ifdef ONEDAL_KERNEL_PROFILER
-/* Here if oneDAL kernel profiling is enabled in the build */
-#include <ittnotify.h>
+    /* Here if oneDAL kernel profiling is enabled in the build */
+    #include <ittnotify.h>
 #endif
 
 #define DAAL_ITTNOTIFY_CONCAT2(x, y) x##y
@@ -58,8 +58,8 @@ private:
     const char * _taskName;
 #ifdef ONEDAL_KERNEL_PROFILER
     /* Here if oneDAL kernel profiling is enabled */
-    __itt_string_handle * _handle;  /* The task string handle */
-    __itt_domain * _domain;         /* Pointer to the domain of the task */
+    __itt_string_handle * _handle; /* The task string handle */
+    __itt_domain * _domain;        /* Pointer to the domain of the task */
 #endif
 };
 
@@ -91,8 +91,9 @@ public:
      * Get pointer to a global profiler state.
      * \return Pointer to a global profiler state.
      */
-    static Profiler* getInstance() {
-        static Profiler  instance;
+    static Profiler * getInstance()
+    {
+        static Profiler instance;
         return &instance;
     }
 
@@ -100,18 +101,15 @@ public:
      * Get pointer to the ITT domain associated with the profiler.
      * \return Pointer to the ITT domain.
      */
-    static __itt_domain * getDomain() {
-        return (getInstance())->_domain;
-    }
+    static __itt_domain * getDomain() { return (getInstance())->_domain; }
+
 private:
     /**
      * Construct the profiler.
      */
-    Profiler() {
-        _domain = __itt_domain_create("oneDAL");
-    }
+    Profiler() { _domain = __itt_domain_create("oneDAL"); }
     ~Profiler() {}
-    __itt_domain * _domain;     /* Pointer to the ITT domain */
+    __itt_domain * _domain; /* Pointer to the ITT domain */
 #endif
 };
 

--- a/makefile
+++ b/makefile
@@ -306,14 +306,11 @@ include dev/make/deps.$(BACKEND_CONFIG).mk
 #=============================== VTune SDK folders ======================================
 
 ifeq ($(REQPROFILE), yes)
+    -DPROFILER := -DONEDAL_KERNEL_PROFILER
     VTUNESDK.include := $(VTUNE_PROFILER_DIR)/sdk/include
-
     VTUNESDK.libia := $(if $(OS_is_lnx), $(VTUNE_PROFILER_DIR)/sdk/lib64,)
-
     VTUNESDK.LIBS_A := $(if $(OS_is_lnx), $(VTUNESDK.libia)/libittnotify.a,)
 endif
-
-$(info VTUNESDK: $(VTUNESDK.include))
 
 #===============================================================================
 # Release library names
@@ -506,7 +503,7 @@ $(WORKDIR.lib)/$(core_y):                   $(daaldep.math_backend.ext) $(VTUNES
                                             $(CORE.tmpdir_y)/$(core_y:%.$y=%_link.txt) ; $(LINK.DYNAMIC) ; $(LINK.DYNAMIC.POST)
 
 $(CORE.objs_a): $(CORE.tmpdir_a)/inc_a_folders.txt
-$(CORE.objs_a): COPT += $(-fPIC) $(-cxx17) $(-Zl) $(-DEBC) $(-DMKL_ILP64)
+$(CORE.objs_a): COPT += $(-fPIC) $(-cxx17) $(-Zl) $(-DEBC) $(-DMKL_ILP64) $(-DPROFILER)
 $(CORE.objs_a): COPT += -D__TBB_NO_IMPLICIT_LINKAGE -DDAAL_NOTHROW_EXCEPTIONS \
                         -DDAAL_HIDE_DEPRECATED -DTBB_USE_ASSERT=0 -D_ENABLE_ATOMIC_ALIGNMENT_FIX \
                         $(if $(CHECK_DLL_SIG),-DDAAL_CHECK_DLL_SIG)
@@ -515,7 +512,7 @@ $(CORE.objs_a): COPT += @$(CORE.tmpdir_a)/inc_a_folders.txt
 $(eval $(call append_uarch_copt,$(CORE.objs_a)))
 
 $(CORE.objs_y): $(CORE.tmpdir_y)/inc_y_folders.txt
-$(CORE.objs_y): COPT += $(-fPIC) $(-cxx17) $(-Zl) $(-DEBC) $(-DMKL_ILP64)
+$(CORE.objs_y): COPT += $(-fPIC) $(-cxx17) $(-Zl) $(-DEBC) $(-DMKL_ILP64) $(-DPROFILER)
 $(CORE.objs_y): COPT += -D__DAAL_IMPLEMENTATION \
                         -D__TBB_NO_IMPLICIT_LINKAGE -DDAAL_NOTHROW_EXCEPTIONS \
                         -DDAAL_HIDE_DEPRECATED -DTBB_USE_ASSERT=0 -D_ENABLE_ATOMIC_ALIGNMENT_FIX \
@@ -1117,7 +1114,8 @@ Flags:
       possible values: $(CORE.ALGORITHMS.CUSTOM.AVAILABLE)
   REQCPU - list of CPU optimizations to be included into library
       possible values: $(CPUs)
-  REQDBG - Flag that enables build in debug mode
+  REQDBG - flag that enables build in debug mode
+  REQPROFILE - flag that enables kernel profiling using <ittnotify.h>
 endef
 
 daal_dbg:


### PR DESCRIPTION
Add ability of oneDAL kernels profiling on CPU using <ittnotify.h>.

To enable the kernel profiling in oneDAL build use `REQPROFILE=yes` option of the makefile.
After that run VTune profiling as usual to get performance profiling data.

Example of the hotspot analysis run on Linear Regression example binary:

![image](https://github.com/user-attachments/assets/5917d9e4-f843-4d06-9e27-638a788de843)

---

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

