### PR TITLE
Fix rule of three violations in AlgorithmContainer classes

### DIFF
--- a/cpp/daal/include/algorithms/algorithm_container_base.h
+++ b/cpp/daal/include/algorithms/algorithm_container_base.h
@@ -158,7 +158,6 @@ template <ComputeMode mode>
 class AlgorithmContainerImpl : public AlgorithmContainer<mode>
 {
 public:
-    AlgorithmContainerImpl()                               = default;
     AlgorithmContainerImpl(const AlgorithmContainerImpl &) = delete;
 
     /**

--- a/cpp/daal/include/algorithms/algorithm_container_base.h
+++ b/cpp/daal/include/algorithms/algorithm_container_base.h
@@ -65,8 +65,9 @@ public:
 class AlgorithmContainerIfaceImpl : public AlgorithmContainerIface
 {
 public:
-    AlgorithmContainerIfaceImpl()                                    = default;
-    AlgorithmContainerIfaceImpl(const AlgorithmContainerIfaceImpl &) = delete;
+    AlgorithmContainerIfaceImpl()                                                      = default;
+    AlgorithmContainerIfaceImpl(const AlgorithmContainerIfaceImpl &)                   = delete;
+    AlgorithmContainerIfaceImpl & operator=(const AlgorithmContainerIfaceImpl & other) = delete;
 
     /**
      * Default constructor
@@ -100,8 +101,9 @@ template <ComputeMode mode>
 class AlgorithmContainer : public AlgorithmContainerIfaceImpl
 {
 public:
-    AlgorithmContainer()                           = default;
-    AlgorithmContainer(const AlgorithmContainer &) = delete;
+    AlgorithmContainer()                                                         = default;
+    AlgorithmContainer(const AlgorithmContainer &)                               = delete;
+    AlgorithmContainer<mode> & operator=(const AlgorithmContainer<mode> & other) = delete;
 
     /**
      * Default constructor
@@ -158,7 +160,8 @@ template <ComputeMode mode>
 class AlgorithmContainerImpl : public AlgorithmContainer<mode>
 {
 public:
-    AlgorithmContainerImpl(const AlgorithmContainerImpl &) = delete;
+    AlgorithmContainerImpl(const AlgorithmContainerImpl &)                       = delete;
+    AlgorithmContainer<mode> & operator=(const AlgorithmContainer<mode> & other) = delete;
 
     /**
      * Default constructor

--- a/cpp/daal/include/algorithms/algorithm_container_base.h
+++ b/cpp/daal/include/algorithms/algorithm_container_base.h
@@ -97,6 +97,9 @@ template <ComputeMode mode>
 class AlgorithmContainer : public AlgorithmContainerIfaceImpl
 {
 public:
+    AlgorithmContainer()                           = delete;
+    AlgorithmContainer(const AlgorithmContainer &) = delete;
+
     /**
      * Default constructor
      * \param[in] daalEnv   Pointer to the structure that contains information about the environment
@@ -152,6 +155,9 @@ template <ComputeMode mode>
 class AlgorithmContainerImpl : public AlgorithmContainer<mode>
 {
 public:
+    AlgorithmContainerImpl()                               = delete;
+    AlgorithmContainerImpl(const AlgorithmContainerImpl &) = delete;
+
     /**
      * Default constructor
      * \param[in] daalEnv   Pointer to the structure that contains information about the environment

--- a/cpp/daal/include/algorithms/algorithm_container_base.h
+++ b/cpp/daal/include/algorithms/algorithm_container_base.h
@@ -65,6 +65,9 @@ public:
 class AlgorithmContainerIfaceImpl : public AlgorithmContainerIface
 {
 public:
+    AlgorithmContainerIfaceImpl()                                    = default;
+    AlgorithmContainerIfaceImpl(const AlgorithmContainerIfaceImpl &) = delete;
+
     /**
      * Default constructor
      * \param[in] daalEnv   Pointer to the structure that contains information about the environment
@@ -97,7 +100,7 @@ template <ComputeMode mode>
 class AlgorithmContainer : public AlgorithmContainerIfaceImpl
 {
 public:
-    AlgorithmContainer()                           = delete;
+    AlgorithmContainer()                           = default;
     AlgorithmContainer(const AlgorithmContainer &) = delete;
 
     /**
@@ -155,7 +158,7 @@ template <ComputeMode mode>
 class AlgorithmContainerImpl : public AlgorithmContainer<mode>
 {
 public:
-    AlgorithmContainerImpl()                               = delete;
+    AlgorithmContainerImpl()                               = default;
     AlgorithmContainerImpl(const AlgorithmContainerImpl &) = delete;
 
     /**

--- a/cpp/daal/include/algorithms/algorithm_container_base_batch.h
+++ b/cpp/daal/include/algorithms/algorithm_container_base_batch.h
@@ -94,7 +94,6 @@ class AlgorithmContainerImpl<batch> : public AlgorithmContainer<batch>
 public:
     DAAL_NEW_DELETE();
 
-    AlgorithmContainerImpl()                               = default;
     AlgorithmContainerImpl(const AlgorithmContainerImpl &) = delete;
 
     /**

--- a/cpp/daal/include/algorithms/algorithm_container_base_batch.h
+++ b/cpp/daal/include/algorithms/algorithm_container_base_batch.h
@@ -53,6 +53,9 @@ template <>
 class AlgorithmContainer<batch> : public AlgorithmContainerIfaceImpl
 {
 public:
+    AlgorithmContainer()                           = delete;
+    AlgorithmContainer(const AlgorithmContainer &) = delete;
+
     /**
      * Default constructor
      * \param[in] daalEnv   Pointer to the structure that contains information about the environment
@@ -90,6 +93,9 @@ class AlgorithmContainerImpl<batch> : public AlgorithmContainer<batch>
 {
 public:
     DAAL_NEW_DELETE();
+
+    AlgorithmContainerImpl()                               = delete;
+    AlgorithmContainerImpl(const AlgorithmContainerImpl &) = delete;
 
     /**
      * Default constructor

--- a/cpp/daal/include/algorithms/algorithm_container_base_batch.h
+++ b/cpp/daal/include/algorithms/algorithm_container_base_batch.h
@@ -53,7 +53,7 @@ template <>
 class AlgorithmContainer<batch> : public AlgorithmContainerIfaceImpl
 {
 public:
-    AlgorithmContainer()                           = delete;
+    AlgorithmContainer()                           = default;
     AlgorithmContainer(const AlgorithmContainer &) = delete;
 
     /**
@@ -94,7 +94,7 @@ class AlgorithmContainerImpl<batch> : public AlgorithmContainer<batch>
 public:
     DAAL_NEW_DELETE();
 
-    AlgorithmContainerImpl()                               = delete;
+    AlgorithmContainerImpl()                               = default;
     AlgorithmContainerImpl(const AlgorithmContainerImpl &) = delete;
 
     /**

--- a/cpp/daal/include/algorithms/algorithm_container_base_batch.h
+++ b/cpp/daal/include/algorithms/algorithm_container_base_batch.h
@@ -53,8 +53,9 @@ template <>
 class AlgorithmContainer<batch> : public AlgorithmContainerIfaceImpl
 {
 public:
-    AlgorithmContainer()                           = default;
-    AlgorithmContainer(const AlgorithmContainer &) = delete;
+    AlgorithmContainer()                                                           = default;
+    AlgorithmContainer(const AlgorithmContainer &)                                 = delete;
+    AlgorithmContainer<batch> & operator=(const AlgorithmContainer<batch> & other) = delete;
 
     /**
      * Default constructor
@@ -94,7 +95,8 @@ class AlgorithmContainerImpl<batch> : public AlgorithmContainer<batch>
 public:
     DAAL_NEW_DELETE();
 
-    AlgorithmContainerImpl(const AlgorithmContainerImpl &) = delete;
+    AlgorithmContainerImpl(const AlgorithmContainerImpl &)                                 = delete;
+    AlgorithmContainerImpl<batch> & operator=(const AlgorithmContainerImpl<batch> & other) = delete;
 
     /**
      * Default constructor


### PR DESCRIPTION
Default constructors are set to 'default' implementations;
Copy constructors and copy assignment operators are deleted in base algorithm container classes.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

