### PR TITLE
MAINT: Delete unused operators for algorithm metrics set class

### DIFF
--- a/cpp/daal/include/algorithms/algorithm_quality_metric_set_types.h
+++ b/cpp/daal/include/algorithms/algorithm_quality_metric_set_types.h
@@ -57,6 +57,10 @@ public:
 
     virtual ~InputAlgorithmsCollection();
 
+    InputAlgorithmsCollection(InputAlgorithmsCollection & other) = delete;
+
+    InputAlgorithmsCollection & operator=(InputAlgorithmsCollection & other) = delete;
+
     /**
      * Returns a reference to SharedPtr for a stored object with a given key if an object with such key is registered
      * \param[in] k     Key value


### PR DESCRIPTION
## Description

ref https://github.com/oneapi-src/oneDAL/pull/2991#issuecomment-2507325172

This PR deletes the copy and copy-assignment operators for the algorithm metrics set class, in order to clear warnings from static code analyzers.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/intel/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [ ] All CI jobs are green or I have provided justification why they aren't.

**Performance**

Not applicable.
