### PR TITLE
MAINT: Backport fix for DLL loading error (v2)

### DIFF
--- a/cpp/daal/src/algorithms/covariance/covariance_impl.i
+++ b/cpp/daal/src/algorithms/covariance/covariance_impl.i
@@ -35,7 +35,7 @@
 #include "src/data_management/service_numeric_table.h"
 #include "src/algorithms/service_error_handling.h"
 #include "src/threading/threading.h"
-#include "services/internal/service_profiler.h"
+#include "src/services/service_profiler.h"
 
 using namespace daal::internal;
 using namespace daal::services::internal;

--- a/cpp/daal/src/algorithms/kernel_function/kernel_function_rbf_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/kernel_function/kernel_function_rbf_dense_default_impl.i
@@ -28,7 +28,7 @@
 #include "src/data_management/service_numeric_table.h"
 #include "src/externals/service_math.h"
 #include "src/externals/service_blas.h"
-#include "services/internal/service_profiler.h"
+#include "src/services/service_profiler.h"
 #include "src/threading/threading.h"
 #include "src/algorithms/kernel_function/kernel_function_rbf_helper.h"
 

--- a/cpp/daal/src/algorithms/kmeans/kmeans_lloyd_batch_impl.i
+++ b/cpp/daal/src/algorithms/kmeans/kmeans_lloyd_batch_impl.i
@@ -32,7 +32,7 @@
 #include "src/algorithms/kmeans/kmeans_lloyd_impl.i"
 #include "src/algorithms/kmeans/kmeans_lloyd_postprocessing.h"
 
-#include "services/internal/service_profiler.h"
+#include "src/services/service_profiler.h"
 
 using namespace daal::internal;
 using namespace daal::services::internal;

--- a/cpp/daal/src/algorithms/linear_model/linear_model_train_normeq_finalize_impl.i
+++ b/cpp/daal/src/algorithms/linear_model/linear_model_train_normeq_finalize_impl.i
@@ -26,7 +26,7 @@
 
 #include "src/algorithms/service_kernel_math.h"
 #include "src/externals/service_lapack.h"
-#include "services/internal/service_profiler.h"
+#include "src/services/service_profiler.h"
 
 namespace daal
 {

--- a/cpp/daal/src/algorithms/linear_model/linear_model_train_normeq_update_impl.i
+++ b/cpp/daal/src/algorithms/linear_model/linear_model_train_normeq_update_impl.i
@@ -27,7 +27,7 @@
 #include "src/externals/service_blas.h"
 #include "src/algorithms/service_error_handling.h"
 #include "src/threading/threading.h"
-#include "services/internal/service_profiler.h"
+#include "src/services/service_profiler.h"
 
 namespace daal
 {

--- a/cpp/daal/src/algorithms/logistic_regression/logistic_regression_train_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/logistic_regression/logistic_regression_train_dense_default_impl.i
@@ -33,7 +33,7 @@
 #include "algorithms/optimization_solver/objective_function/cross_entropy_loss_batch.h"
 #include "src/data_management/service_numeric_table.h"
 #include "src/externals/service_math.h"
-#include "services/internal/service_profiler.h"
+#include "src/services/service_profiler.h"
 
 using namespace daal::algorithms::logistic_regression::training::internal;
 using namespace daal::algorithms::optimization_solver;

--- a/cpp/daal/src/algorithms/low_order_moments/low_order_moments_csr_fast_batch_fpt_cpu.cpp
+++ b/cpp/daal/src/algorithms/low_order_moments/low_order_moments_csr_fast_batch_fpt_cpu.cpp
@@ -21,7 +21,7 @@
 //--
 */
 
-#include "services/internal/service_profiler.h"
+#include "src/services/service_profiler.h"
 
 #include "src/algorithms/low_order_moments/low_order_moments_container.h"
 #include "src/algorithms/low_order_moments/low_order_moments_batch_impl.i"

--- a/cpp/daal/src/algorithms/low_order_moments/low_order_moments_csr_fast_distr_step2_fpt_cpu.cpp
+++ b/cpp/daal/src/algorithms/low_order_moments/low_order_moments_csr_fast_distr_step2_fpt_cpu.cpp
@@ -20,7 +20,7 @@
 //  Implementation of low order moments kernel.
 //--
 */
-#include "services/internal/service_profiler.h"
+#include "src/services/service_profiler.h"
 
 #include "src/algorithms/low_order_moments/low_order_moments_container.h"
 #include "src/algorithms/low_order_moments/low_order_moments_distributed_impl.i"

--- a/cpp/daal/src/algorithms/low_order_moments/low_order_moments_csr_fast_online_fpt_cpu.cpp
+++ b/cpp/daal/src/algorithms/low_order_moments/low_order_moments_csr_fast_online_fpt_cpu.cpp
@@ -21,7 +21,7 @@
 //--
 */
 
-#include "services/internal/service_profiler.h"
+#include "src/services/service_profiler.h"
 
 #include "src/algorithms/low_order_moments/low_order_moments_container.h"
 #include "src/algorithms/low_order_moments/low_order_moments_online_impl.i"

--- a/cpp/daal/src/algorithms/low_order_moments/low_order_moments_csr_singlepass_batch_fpt_cpu.cpp
+++ b/cpp/daal/src/algorithms/low_order_moments/low_order_moments_csr_singlepass_batch_fpt_cpu.cpp
@@ -21,7 +21,7 @@
 //--
 */
 
-#include "services/internal/service_profiler.h"
+#include "src/services/service_profiler.h"
 
 #include "src/algorithms/low_order_moments/low_order_moments_container.h"
 #include "src/algorithms/low_order_moments/low_order_moments_batch_impl.i"

--- a/cpp/daal/src/algorithms/low_order_moments/low_order_moments_csr_singlepass_distr_step2_fpt_cpu.cpp
+++ b/cpp/daal/src/algorithms/low_order_moments/low_order_moments_csr_singlepass_distr_step2_fpt_cpu.cpp
@@ -21,7 +21,7 @@
 //--
 */
 
-#include "services/internal/service_profiler.h"
+#include "src/services/service_profiler.h"
 
 #include "src/algorithms/low_order_moments/low_order_moments_container.h"
 #include "src/algorithms/low_order_moments/low_order_moments_distributed_impl.i"

--- a/cpp/daal/src/algorithms/low_order_moments/low_order_moments_csr_singlepass_online_fpt_cpu.cpp
+++ b/cpp/daal/src/algorithms/low_order_moments/low_order_moments_csr_singlepass_online_fpt_cpu.cpp
@@ -21,7 +21,7 @@
 //--
 */
 
-#include "services/internal/service_profiler.h"
+#include "src/services/service_profiler.h"
 
 #include "src/algorithms/low_order_moments/low_order_moments_container.h"
 #include "src/algorithms/low_order_moments/low_order_moments_online_impl.i"

--- a/cpp/daal/src/algorithms/low_order_moments/low_order_moments_csr_sum_batch_fpt_cpu.cpp
+++ b/cpp/daal/src/algorithms/low_order_moments/low_order_moments_csr_sum_batch_fpt_cpu.cpp
@@ -21,7 +21,7 @@
 //--
 */
 
-#include "services/internal/service_profiler.h"
+#include "src/services/service_profiler.h"
 
 #include "src/algorithms/low_order_moments/low_order_moments_container.h"
 #include "src/algorithms/low_order_moments/low_order_moments_batch_impl.i"

--- a/cpp/daal/src/algorithms/low_order_moments/low_order_moments_csr_sum_distr_step2_fpt_cpu.cpp
+++ b/cpp/daal/src/algorithms/low_order_moments/low_order_moments_csr_sum_distr_step2_fpt_cpu.cpp
@@ -21,7 +21,7 @@
 //--
 */
 
-#include "services/internal/service_profiler.h"
+#include "src/services/service_profiler.h"
 
 #include "src/algorithms/low_order_moments/low_order_moments_container.h"
 #include "src/algorithms/low_order_moments/low_order_moments_distributed_impl.i"

--- a/cpp/daal/src/algorithms/low_order_moments/low_order_moments_csr_sum_online_fpt_cpu.cpp
+++ b/cpp/daal/src/algorithms/low_order_moments/low_order_moments_csr_sum_online_fpt_cpu.cpp
@@ -21,7 +21,7 @@
 //--
 */
 
-#include "services/internal/service_profiler.h"
+#include "src/services/service_profiler.h"
 
 #include "src/algorithms/low_order_moments/low_order_moments_container.h"
 #include "src/algorithms/low_order_moments/low_order_moments_online_impl.i"

--- a/cpp/daal/src/algorithms/low_order_moments/low_order_moments_dense_default_batch_fpt_cpu.cpp
+++ b/cpp/daal/src/algorithms/low_order_moments/low_order_moments_dense_default_batch_fpt_cpu.cpp
@@ -21,7 +21,7 @@
 //--
 */
 
-#include "services/internal/service_profiler.h"
+#include "src/services/service_profiler.h"
 
 #include "src/algorithms/low_order_moments/low_order_moments_container.h"
 #include "src/algorithms/low_order_moments/low_order_moments_batch_impl.i"

--- a/cpp/daal/src/algorithms/low_order_moments/low_order_moments_dense_default_distr_step2_fpt_cpu.cpp
+++ b/cpp/daal/src/algorithms/low_order_moments/low_order_moments_dense_default_distr_step2_fpt_cpu.cpp
@@ -21,7 +21,7 @@
 //--
 */
 
-#include "services/internal/service_profiler.h"
+#include "src/services/service_profiler.h"
 
 #include "src/algorithms/low_order_moments/low_order_moments_container.h"
 #include "src/algorithms/low_order_moments/low_order_moments_distributed_impl.i"

--- a/cpp/daal/src/algorithms/low_order_moments/low_order_moments_dense_default_online_fpt_cpu.cpp
+++ b/cpp/daal/src/algorithms/low_order_moments/low_order_moments_dense_default_online_fpt_cpu.cpp
@@ -21,7 +21,7 @@
 //--
 */
 
-#include "services/internal/service_profiler.h"
+#include "src/services/service_profiler.h"
 
 #include "src/algorithms/low_order_moments/low_order_moments_container.h"
 #include "src/algorithms/low_order_moments/low_order_moments_online_impl.i"

--- a/cpp/daal/src/algorithms/low_order_moments/low_order_moments_dense_singlepass_batch_fpt_cpu.cpp
+++ b/cpp/daal/src/algorithms/low_order_moments/low_order_moments_dense_singlepass_batch_fpt_cpu.cpp
@@ -21,7 +21,7 @@
 //--
 */
 
-#include "services/internal/service_profiler.h"
+#include "src/services/service_profiler.h"
 
 #include "src/algorithms/low_order_moments/low_order_moments_container.h"
 #include "src/algorithms/low_order_moments/low_order_moments_batch_impl.i"

--- a/cpp/daal/src/algorithms/low_order_moments/low_order_moments_dense_singlepass_distr_step2_fpt_cpu.cpp
+++ b/cpp/daal/src/algorithms/low_order_moments/low_order_moments_dense_singlepass_distr_step2_fpt_cpu.cpp
@@ -21,7 +21,7 @@
 //--
 */
 
-#include "services/internal/service_profiler.h"
+#include "src/services/service_profiler.h"
 
 #include "src/algorithms/low_order_moments/low_order_moments_container.h"
 #include "src/algorithms/low_order_moments/low_order_moments_distributed_impl.i"

--- a/cpp/daal/src/algorithms/low_order_moments/low_order_moments_dense_singlepass_online_fpt_cpu.cpp
+++ b/cpp/daal/src/algorithms/low_order_moments/low_order_moments_dense_singlepass_online_fpt_cpu.cpp
@@ -21,7 +21,7 @@
 //--
 */
 
-#include "services/internal/service_profiler.h"
+#include "src/services/service_profiler.h"
 
 #include "src/algorithms/low_order_moments/low_order_moments_container.h"
 #include "src/algorithms/low_order_moments/low_order_moments_online_impl.i"

--- a/cpp/daal/src/algorithms/low_order_moments/low_order_moments_dense_sum_batch_fpt_cpu.cpp
+++ b/cpp/daal/src/algorithms/low_order_moments/low_order_moments_dense_sum_batch_fpt_cpu.cpp
@@ -21,7 +21,7 @@
 //--
 */
 
-#include "services/internal/service_profiler.h"
+#include "src/services/service_profiler.h"
 
 #include "src/algorithms/low_order_moments/low_order_moments_container.h"
 #include "src/algorithms/low_order_moments/low_order_moments_batch_impl.i"

--- a/cpp/daal/src/algorithms/low_order_moments/low_order_moments_dense_sum_distr_step2_fpt_cpu.cpp
+++ b/cpp/daal/src/algorithms/low_order_moments/low_order_moments_dense_sum_distr_step2_fpt_cpu.cpp
@@ -21,7 +21,7 @@
 //--
 */
 
-#include "services/internal/service_profiler.h"
+#include "src/services/service_profiler.h"
 
 #include "src/algorithms/low_order_moments/low_order_moments_container.h"
 #include "src/algorithms/low_order_moments/low_order_moments_distributed_impl.i"

--- a/cpp/daal/src/algorithms/low_order_moments/low_order_moments_dense_sum_online_fpt_cpu.cpp
+++ b/cpp/daal/src/algorithms/low_order_moments/low_order_moments_dense_sum_online_fpt_cpu.cpp
@@ -21,7 +21,7 @@
 //--
 */
 
-#include "services/internal/service_profiler.h"
+#include "src/services/service_profiler.h"
 
 #include "src/algorithms/low_order_moments/low_order_moments_container.h"
 #include "src/algorithms/low_order_moments/low_order_moments_online_impl.i"

--- a/cpp/daal/src/algorithms/low_order_moments/low_order_moments_kernel.h
+++ b/cpp/daal/src/algorithms/low_order_moments/low_order_moments_kernel.h
@@ -28,7 +28,7 @@
 #include "data_management/data/numeric_table.h"
 #include "algorithms/algorithm_base_common.h"
 #include "algorithms/moments/low_order_moments_types.h"
-#include "services/internal/service_profiler.h"
+#include "src/services/service_profiler.h"
 
 using namespace daal::services;
 using namespace daal::data_management;

--- a/cpp/daal/src/algorithms/objective_function/cross_entropy_loss/cross_entropy_loss_dense_default_batch_impl.i
+++ b/cpp/daal/src/algorithms/objective_function/cross_entropy_loss/cross_entropy_loss_dense_default_batch_impl.i
@@ -24,7 +24,7 @@
 #include "src/externals/service_math.h"
 #include "src/services/service_utils.h"
 #include "src/services/service_environment.h"
-#include "services/internal/service_profiler.h"
+#include "src/services/service_profiler.h"
 
 #include "src/algorithms/objective_function/common/objective_function_utils.i"
 

--- a/cpp/daal/src/algorithms/objective_function/logistic_loss/logistic_loss_dense_default_batch_impl.i
+++ b/cpp/daal/src/algorithms/objective_function/logistic_loss/logistic_loss_dense_default_batch_impl.i
@@ -23,7 +23,7 @@
 #include "src/services/service_data_utils.h"
 #include "src/externals/service_math.h"
 #include "src/services/service_utils.h"
-#include "services/internal/service_profiler.h"
+#include "src/services/service_profiler.h"
 
 #include "src/algorithms/objective_function/common/objective_function_utils.i"
 

--- a/cpp/daal/src/algorithms/optimization_solver/sgd/sgd_dense_minibatch_impl.i
+++ b/cpp/daal/src/algorithms/optimization_solver/sgd/sgd_dense_minibatch_impl.i
@@ -30,7 +30,7 @@
 #include "src/externals/service_math.h"
 #include "src/services/service_utils.h"
 #include "src/services/service_data_utils.h"
-#include "services/internal/service_profiler.h"
+#include "src/services/service_profiler.h"
 
 using namespace daal::internal;
 using namespace daal::services;

--- a/cpp/daal/src/algorithms/pca/pca_dense_correlation_batch_impl.i
+++ b/cpp/daal/src/algorithms/pca/pca_dense_correlation_batch_impl.i
@@ -30,7 +30,7 @@
 #include "src/algorithms/service_error_handling.h"
 #include "src/threading/threading.h"
 
-#include "services/internal/service_profiler.h"
+#include "src/services/service_profiler.h"
 
 namespace daal
 {

--- a/cpp/daal/src/algorithms/service_kernel_math.h
+++ b/cpp/daal/src/algorithms/service_kernel_math.h
@@ -44,7 +44,7 @@
 #include "src/externals/service_lapack.h"
 #include "src/externals/service_memory.h"
 #include "src/externals/service_math.h"
-#include "services/internal/service_profiler.h"
+#include "src/services/service_profiler.h"
 
 #if defined(DAAL_INTEL_CPP_COMPILER)
     #include "immintrin.h"

--- a/cpp/daal/src/algorithms/svm/svm_train_boser_cache.i
+++ b/cpp/daal/src/algorithms/svm/svm_train_boser_cache.i
@@ -28,7 +28,7 @@
 #include "src/externals/service_memory.h"
 #include "src/data_management/service_micro_table.h"
 #include "src/data_management/service_numeric_table.h"
-#include "services/internal/service_profiler.h"
+#include "src/services/service_profiler.h"
 #include "src/algorithms/svm/svm_train_cache.h"
 
 namespace daal

--- a/cpp/daal/src/algorithms/svm/svm_train_boser_impl.i
+++ b/cpp/daal/src/algorithms/svm/svm_train_boser_impl.i
@@ -45,7 +45,7 @@
 #include "src/data_management/service_numeric_table.h"
 #include "src/services/service_utils.h"
 #include "src/services/service_data_utils.h"
-#include "services/internal/service_profiler.h"
+#include "src/services/service_profiler.h"
 #include "src/algorithms/svm/svm_train_result.h"
 #include "src/algorithms/svm/svm_train_common_impl.i"
 

--- a/cpp/daal/src/algorithms/svm/svm_train_common.h
+++ b/cpp/daal/src/algorithms/svm/svm_train_common.h
@@ -19,7 +19,7 @@
 #define __SVM_TRAIN_COMMON_H__
 
 #include "src/data_management/service_numeric_table.h"
-#include "services/internal/service_profiler.h"
+#include "src/services/service_profiler.h"
 #include "src/services/service_utils.h"
 #include "src/algorithms/service_hash_table.h"
 

--- a/cpp/daal/src/algorithms/svm/svm_train_common_impl.i
+++ b/cpp/daal/src/algorithms/svm/svm_train_common_impl.i
@@ -29,7 +29,7 @@
 #include "src/data_management/service_numeric_table.h"
 #include "src/services/service_utils.h"
 #include "src/services/service_data_utils.h"
-#include "services/internal/service_profiler.h"
+#include "src/services/service_profiler.h"
 #include "src/algorithms/svm/svm_train_result.h"
 #include "src/algorithms/svm/svm_train_common.h"
 

--- a/cpp/daal/src/algorithms/svm/svm_train_result.h
+++ b/cpp/daal/src/algorithms/svm/svm_train_result.h
@@ -33,7 +33,7 @@
 #include "src/services/service_data_utils.h"
 #include "src/algorithms/svm/svm_train_cache.h"
 #include "src/algorithms/svm/svm_train_common.h"
-#include "services/internal/service_profiler.h"
+#include "src/services/service_profiler.h"
 #include "src/externals/service_math.h"
 #include "src/algorithms/svm/svm_train_kernel.h"
 

--- a/cpp/daal/src/algorithms/svm/svm_train_thunder_impl.i
+++ b/cpp/daal/src/algorithms/svm/svm_train_thunder_impl.i
@@ -48,7 +48,7 @@
 #include "src/data_management/service_numeric_table.h"
 #include "src/services/service_utils.h"
 #include "src/services/service_data_utils.h"
-#include "services/internal/service_profiler.h"
+#include "src/services/service_profiler.h"
 #include "src/externals/service_blas.h"
 #include "src/externals/service_math.h"
 

--- a/cpp/daal/src/externals/service_memory.cpp
+++ b/cpp/daal/src/externals/service_memory.cpp
@@ -23,7 +23,7 @@
 
 #include "src/externals/service_memory.h"
 #include "src/externals/service_service.h"
-#include "services/internal/service_profiler.h"
+#include "src/services/service_profiler.h"
 
 void * daal::services::daal_malloc(size_t size, size_t alignment)
 {

--- a/cpp/daal/src/externals/service_memory.h
+++ b/cpp/daal/src/externals/service_memory.h
@@ -28,7 +28,7 @@
 #include "services/daal_memory.h"
 #include "src/services/service_defines.h"
 #include "src/threading/threading.h"
-#include "services/internal/service_profiler.h"
+#include "src/services/service_profiler.h"
 
 #include <climits>     // UINT_MAX
 #include <type_traits> // is_trivially_default_constructible

--- a/cpp/daal/src/services/library_version_info.cpp
+++ b/cpp/daal/src/services/library_version_info.cpp
@@ -26,7 +26,7 @@
 #include "src/services/service_defines.h"
 #include "services/env_detect.h"
 
-#include "services/internal/service_profiler.h"
+#include "src/services/service_profiler.h"
 
 // Initialize for DAAL INFO output in KERNEL_PROFILER
 static bool print_profiler_header = (daal::internal::print_header(), false);

--- a/cpp/daal/src/services/service_profiler.h
+++ b/cpp/daal/src/services/service_profiler.h
@@ -137,8 +137,6 @@ namespace internal
 
 inline static void set_verbose_from_env()
 {
-    static std::mutex mutex;
-    std::lock_guard<std::mutex> lock(mutex);
     const char * verbose_str = std::getenv("ONEDAL_VERBOSE");
     int newval               = PROFILER_MODE_OFF;
     if (verbose_str)

--- a/cpp/oneapi/dal/detail/profiler.hpp
+++ b/cpp/oneapi/dal/detail/profiler.hpp
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include "services/internal/service_profiler.h"
+#include "src/services/service_profiler.h"
 
 // UTILS
 #define ONEDAL_PROFILER_MACRO_1(name)                       ONEDAL_PROFILER_START_TASK(name)


### PR DESCRIPTION
This PR backports the fix for the DLL loading issue that was seen in some CI jobs on windows:
https://github.com/uxlfoundation/oneDAL/pull/3222

It's not clear whether the issue has any chance of affecting production releases or whether internal testing would be able to catch this kind of issues, but better backport it to be safe.

Note: this is a duplicate of a previous PR which somehow got auto-closed after a rebase:
https://github.com/uxlfoundation/oneDAL/pull/3242