### PR TITLE
Fix architecture typos

### DIFF
--- a/dev/make/identify_os.sh
+++ b/dev/make/identify_os.sh
@@ -23,7 +23,7 @@ if [ "${os}" = "Linux" ]; then
   elif [ "${ARCH}" = "aarch64" ]; then
     echo lnxarm
   else
-    echo "Unkown architecture: ${ARCH}"
+    echo "Unknown architecture: ${ARCH}"
     exit 1
   fi
 elif [ "${os}" = "Darwin" ]; then

--- a/examples/cmake/setup_examples.cmake
+++ b/examples/cmake/setup_examples.cmake
@@ -111,7 +111,7 @@ function (add_examples examples_paths)
         elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "riscv64")
             set(CPU_ARCHITECTURE "riscv64_riscv64")
         else()
-            message(FATAL_ERROR "Unkown architecture ${CMAKE_SYSTEM_PROCESSOR}")
+            message(FATAL_ERROR "Unknown architecture ${CMAKE_SYSTEM_PROCESSOR}")
         endif()
 
         add_executable(${example} ${example_file_path})

--- a/samples/cmake/setup_samples.cmake
+++ b/samples/cmake/setup_samples.cmake
@@ -90,7 +90,7 @@ function(add_samples samples_paths)
         elseif(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "aarch64")
             set(CPU_ARCHITECTURE "arm_aarch64")
         else()
-            message(FATAL_ERROR "Unkown architecture ${CMAKE_HOST_SYSTEM_PROCESSOR}")
+            message(FATAL_ERROR "Unknown architecture ${CMAKE_HOST_SYSTEM_PROCESSOR}")
         endif()
 
         add_executable(${sample} ${sample_file_path})


### PR DESCRIPTION
## Description

Summary
fix typos in "Unknown architecture" messages across build scripts
Testing
bash dev/make/identify_os.sh

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance has changed or why changes are not expected.
- [x] I have provided justification why quality metrics have changed or why changes are not expected.
- [x] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
