### PR TITLE
RFC: Discontinuing static-link library

### DIFF
--- a/rfcs/20250709-discontinuing-static-lib/README.md
+++ b/rfcs/20250709-discontinuing-static-lib/README.md
@@ -13,7 +13,7 @@ Some of those distributions include only the shared library - for example, there
 are no static-link oneDAL libraries distributed in PyPI and NuGet due to file
 size constraints, nor in Spack.
 
-Most usage of oneDAL happens through the Python bindings with the extension for
+Most usage of oneDAL happens through the Python bindings with the Extension for
 Scikit-Learn, which only uses the shared library of oneDAL. Other known public
 consumers of oneDAL, such as
 [OAP MLlib](https://github.com/oap-project/oap-mllib) and


### PR DESCRIPTION
## Description

RFC about discontinuing the static-link version of oneDAL.

This is mutually exclusive (and broader) than previous RFC here: https://github.com/uxlfoundation/oneDAL/pull/3253

Hoping to get comments from other UXL members (@rakshithgb-fujitsu @keeranroth )