### PR TITLE
Fix error in modelbuilders examples

### DIFF
--- a/examples/daal/cpp/BUILD
+++ b/examples/daal/cpp/BUILD
@@ -158,13 +158,10 @@ dal_example_suite(
     extra_deps = _TEST_DEPS
 )
 
-# TODO: investigate the issue with excluded example
 dal_example_suite(
     name = "gradient_boosted_trees",
     compile_as = [ "c++" ],
-    srcs = glob(["source/gradient_boosted_trees/*.cpp"],
-    exclude = ["source/gradient_boosted_trees/gbt_cls_traversed_model_builder.cpp",
-    "source/gradient_boosted_trees/gbt_reg_traversed_model_builder.cpp"],),
+    srcs = glob(["source/gradient_boosted_trees/*.cpp"]),
     dal_deps = [
         "@onedal//cpp/daal/src/algorithms/dtrees/gbt/regression:kernel",
         "@onedal//cpp/daal/src/algorithms/dtrees/gbt/classification:kernel",

--- a/examples/daal/cpp/source/gradient_boosted_trees/gbt_cls_traversed_model_builder.cpp
+++ b/examples/daal/cpp/source/gradient_boosted_trees/gbt_cls_traversed_model_builder.cpp
@@ -174,7 +174,7 @@ bool buildTree(size_t treeId,
                const ParentPlace &parentPlace);
 
 int main(int argc, char *argv[]) {
-    checkArguments(argc, argv, 1, &trainDatasetFileName);
+    checkArguments(argc, argv, 2, &trainDatasetFileName, &testDatasetFileName);
 
     /* train DAAL DF Classification model */
     training::ResultPtr trainingResult = trainModel();

--- a/examples/daal/cpp/source/gradient_boosted_trees/gbt_reg_traversed_model_builder.cpp
+++ b/examples/daal/cpp/source/gradient_boosted_trees/gbt_reg_traversed_model_builder.cpp
@@ -174,7 +174,7 @@ bool buildTree(size_t treeId,
                const ParentPlace &parentPlace);
 
 int main(int argc, char *argv[]) {
-    checkArguments(argc, argv, 1, &trainDatasetFileName);
+    checkArguments(argc, argv, 2, &trainDatasetFileName, &testDatasetFileName);
 
     /* Train DAAL Gradient Boosted Trees Regression model */
     training::ResultPtr trainingResult = trainModel();


### PR DESCRIPTION
## Description

Fix error in modelbuilders example, test filename was incorrect. Remove examples from excluded list

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

Not applicable
