### PR TITLE
MAINT: Fix typo in variable used for KMeans

### DIFF
--- a/cpp/daal/src/algorithms/kmeans/kmeans_plusplus_init_impl.i
+++ b/cpp/daal/src/algorithms/kmeans/kmeans_plusplus_init_impl.i
@@ -679,7 +679,7 @@ void TaskPlusPlusBatch<algorithmFPType, cpu, DataHelper>::calcCenter(size_t iClu
 
     // search best candidate from nTrials
     algorithmFPType bestMinInertia = daal::services::internal::MaxVal<algorithmFPType>::get();
-    size_t iTialBest               = 0u;
+    size_t iTrialBest              = 0u;
 
     for (size_t iTrials = 0u; iTrials < this->_nTrials; iTrials++)
     {
@@ -688,11 +688,11 @@ void TaskPlusPlusBatch<algorithmFPType, cpu, DataHelper>::calcCenter(size_t iClu
         if (newInertia < bestMinInertia)
         {
             bestMinInertia = newInertia;
-            iTialBest      = iTrials;
+            iTrialBest     = iTrials;
         }
     }
 
-    this->_trialBest = iTialBest;
+    this->_trialBest = iTrialBest;
 }
 
 template <typename algorithmFPType, CpuType cpu>


### PR DESCRIPTION
## Description

Fixes a small typo in the implementation of KMeans initialization.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [x] I have reviewed my changes thoroughly before submitting this pull request.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have added a respective label(s) to PR if I have a permission for that.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.