### PR TITLE
[bugfix] Correct pkg-config opts for Windows

### DIFF
--- a/deploy/pkg-config/pkg-config.cpp
+++ b/deploy/pkg-config/pkg-config.cpp
@@ -70,7 +70,7 @@
         #define PATH(inp) ${libdir}/inp##_dll.lib
     #endif
 
-    #define OPTS /std:c++17 /MD /wd4996
+    #define OPTS /std:c++17 /MD /wd4996 /EHsc
 
 #else
     #error Not a supported OS


### PR DESCRIPTION
## Description

I made a mistake in #3395 where changes introduced in #3368 to main the day before were not propagated into that PR, and was not possible to discover as a merge conflict.

This PR brings CI back in line, as the previous cause being sporadic was a true failure I did not catch (and could not easily see due to some sort of private CI logging issue). Private CI failures are unrelated (as it only changes things for Windows, which passes green).

This fixes the issue.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

</details>
