### PR TITLE
DOC: Do not require intel conda channel now that dependencies are in conda-forge

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -302,7 +302,7 @@ conda create -y -n onedal_env
 conda activate onedal_env
 ```
 
-Then, install the necessary dependencies with `conda` - note that these are not available in the Anaconda main channel, but can be installed from either `conda-forge` or from Inte;'s conda channel (https://software.repos.intel.com/python/conda/):
+Then, install the necessary dependencies with `conda` - note that these are not available in the Anaconda main channel, but can be installed from either `conda-forge` or from Intel's conda channel (https://software.repos.intel.com/python/conda/):
 
 ```shell
 conda install -c conda-forge \


### PR DESCRIPTION
## Description

The docs for conda installation mention to use the intel channel for the necessary dependencies, but by now, all of those dependencies are available in conda-forge, so this PR updates the instructions.

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

</details>
