### PR TITLE
RFC: oneDAL 2026.0 algorithms deprecations

### DIFF
--- a/rfcs/20251015-DAAL-algorithms-deprecation/README.md
+++ b/rfcs/20251015-DAAL-algorithms-deprecation/README.md
@@ -2,24 +2,6 @@
 
 ## Introduction
 
-DAAL as a project was started about 10 years ago and was initially developed
-to cover broad variety of data analysis tasks.
-
-Since then the importance of some algorithms lowered.
-Having those algorithm in oneDAL doesn't add value to the product, but creates
-additional maintenance costs.
-
-The long-term goal is to cover all the functionality with oneDAL API.
-
-Removing certain DAAL algorithms will have following positive effects
-for the users of oneDAL:
-
-- The size of the oneDAL binaries will be reduced.
-- The library will be more concise and it would be easier to understand its
-  possibilities.
-- The build and testing time will be reduced, which can be important
-  for the open source community members.
-
 The DAAL library was launched approximately 10 years ago with the goal
 of providing comprehensive coverage for a wide variety of data analysis tasks.
 


### PR DESCRIPTION
## Description

This RFC proposes to deprecate select algorithms available in the DAAL as part of the ongoing transition to the modern oneDAL API.

A rendered variant of this RFC: https://github.com/Vika-F/daal/blob/dev/rfcs/algo_removal/rfcs/20251015-DAAL-algorithms-deprecation/README.md

