### PR TITLE
RFC: oneDAL 2026.0 data sources deprecations

### DIFF
--- a/rfcs/20251016-DAAL-data-sources-deprecation/README.md
+++ b/rfcs/20251016-DAAL-data-sources-deprecation/README.md
@@ -14,7 +14,7 @@ However, the data ingestion landscape has evolved with the development
 of scikit-learn-intelex, which has established Python as the primary interface
 for DAAL algorithms.
 
-Python's ecosystem of data manipulation libraries, including pandas, parquet,
+Python's ecosystem of data manipulation libraries, including pandas, Parquet,
 and specialized database connectors, now provides improved flexibility
 and functionality for data import tasks.
 This evolution has reduced the value of DAAL's native data source


### PR DESCRIPTION
## Description

This RFC proposes to deprecate select data sources available in the DAAL because Python's ecosystem now provides much better data handling functionality through scikit-learn-intelex, making most of DAAL's built-in data sources redundant.

Rendered version of the text: https://github.com/Vika-F/daal/blob/dev/ds_removal/rfcs/20251016-DAAL-data-sources-deprecation/README.md

---

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [ ] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

not applicable

**Performance**

not applicable

</details>
