### PR TITLE
RFC: oneDAL 2026.0: DAAL API layers of certain algorithms deprecations 

### DIFF
--- a/rfcs/20251022-DAAL-interfaces-deprecation/README.md
+++ b/rfcs/20251022-DAAL-interfaces-deprecation/README.md
@@ -68,7 +68,7 @@ with complete API removal scheduled for the next major release, oneDAL 2026.0:
 - [kernel_function::rbf::Batch](https://github.com/uxlfoundation/oneDAL/blob/main/cpp/daal/include/algorithms/kernel_function/kernel_function_rbf.h#L91)
 - [kernel_function::rbf::Input](https://github.com/uxlfoundation/oneDAL/blob/main/cpp/daal/include/algorithms/kernel_function/kernel_function_types_rbf.h#L82)
 
-#### CPU Features Dispatching(https://uxlfoundation.github.io/oneDAL/contribution/cpu_features.html#cpu-features-dispatching)
+#### [CPU Features Dispatching](https://uxlfoundation.github.io/oneDAL/contribution/cpu_features.html#cpu-features-dispatching)
 
 - [CpuType](https://github.com/uxlfoundation/oneDAL/blob/main/cpp/daal/include/services/cpu_type.h#L27)
 - [CpuFeature](https://github.com/uxlfoundation/oneDAL/blob/main/cpp/daal/include/services/cpu_type.h#L52)


### PR DESCRIPTION
## Description

This RFC proposes to deprecate API layers of the select algorithms available in the DAAL as part of the ongoing transition to the modern oneDAL API.

In contrast to PR #3400, this RFC proposes removing only the API layers while preserving all underlying
algorithmic computational kernels.

A rendered variant of this RFC: https://github.com/Vika-F/daal/blob/dev/interfaces_removal/rfcs/20251022-DAAL-interfaces-deprecation/README.md

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

not applicable

**Performance**

not applicable

</details>
