### PR TITLE
Fix typo: rename dispath_by_policy to dispatch_by_policy

### DIFF
--- a/cpp/oneapi/dal/detail/array_utils.hpp
+++ b/cpp/oneapi/dal/detail/array_utils.hpp
@@ -43,7 +43,7 @@ public:
 };
 
 template <typename T, typename Body>
-inline auto dispath_by_policy(const dal::array<T>& data, Body&& body) {
+inline auto dispatch_by_policy(const dal::array<T>& data, Body&& body) {
 #ifdef ONEDAL_DATA_PARALLEL
     const auto optional_queue = data.get_queue();
     if (optional_queue) {
@@ -80,7 +80,7 @@ inline dal::array<T> discard_mutable_data(const dal::array<T>& ary) {
 
 } // namespace v1
 using v1::array_via_policy;
-using v1::dispath_by_policy;
+using v1::dispatch_by_policy;
 using v1::reinterpret_array_cast;
 using v1::discard_mutable_data;
 

--- a/cpp/oneapi/dal/table/homogen.hpp
+++ b/cpp/oneapi/dal/table/homogen.hpp
@@ -255,7 +255,7 @@ private:
             throw invalid_argument{ msg::rc_and_cc_do_not_match_element_count_in_array() };
         }
 
-        detail::dispath_by_policy(data, [&](auto policy) {
+        detail::dispatch_by_policy(data, [&](auto policy) {
             init_impl(policy,
                       row_count,
                       column_count,


### PR DESCRIPTION
## Summary
Fixes a typo in function name `dispath_by_policy` which should be `dispatch_by_policy` (missing 'i' in "dispatch").

## Changes Made
- **File**: `cpp/oneapi/dal/detail/array_utils.hpp:46` - Fixed function definition
- **File**: `cpp/oneapi/dal/detail/array_utils.hpp:83` - Fixed using declaration  
- **File**: `cpp/oneapi/dal/table/homogen.hpp:258` - Fixed function call

## Impact
- **Severity**: LOW (cosmetic improvement)
- **Scope**: Code readability and professionalism
- **Files affected**: 3 locations total

## Testing
- ✅ Verified all instances of misspelled name have been corrected
- ✅ Verified correct spelling is now used in all 3 locations
- ✅ No linting errors introduced
- ✅ Functionality unchanged (only spelling correction)

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] Code follows oneDAL coding standards
- [x] No linting errors introduced
- [x] Functionality verified unchanged
- [x] All instances of typo corrected