### PR TITLE
extend timeout for windows in nightly-build.yml

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -51,7 +51,7 @@ jobs:
     name: oneDAL Linux nightly build
     if: github.repository == 'uxlfoundation/oneDAL'
     runs-on: ubuntu-24.04
-    timeout-minutes: 180
+    timeout-minutes: 120
 
     steps:
       - name: Checkout oneDAL
@@ -87,7 +87,7 @@ jobs:
     name: oneDAL Windows nightly build
     if: github.repository == 'uxlfoundation/oneDAL'
     runs-on: windows-2025
-    timeout-minutes: 150
+    timeout-minutes: 180
 
     steps:
       - name: Checkout oneDAL


### PR DESCRIPTION
## Description

Compliation on windows has increased since opt flags were added, this is needed to have it run through consistently.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

*