### PR TITLE
ENH: Add more vectorization pragmas in covariance

### DIFF
--- a/cpp/daal/src/algorithms/covariance/covariance_impl.i
+++ b/cpp/daal/src/algorithms/covariance/covariance_impl.i
@@ -674,6 +674,7 @@ services::Status finalizeCovariance(size_t nFeatures, algorithmFPType nObservati
     }
 
     /* Calculate resulting mean vector */
+    PRAGMA_OMP_SIMD
     for (size_t i = 0; i < nFeatures; i++)
     {
         mean[i] = sums[i] * invNObservations;
@@ -690,6 +691,7 @@ services::Status finalizeCovariance(size_t nFeatures, algorithmFPType nObservati
 
         for (size_t i = 0; i < nFeatures; i++)
         {
+            PRAGMA_OMP_SIMD
             for (size_t j = 0; j < i; j++)
             {
                 cov[i * nFeatures + j] = crossProduct[i * nFeatures + j] * diagInvSqrts[i] * diagInvSqrts[j];
@@ -702,6 +704,7 @@ services::Status finalizeCovariance(size_t nFeatures, algorithmFPType nObservati
         /* Calculate resulting covariance matrix */
         for (size_t i = 0; i < nFeatures; i++)
         {
+            PRAGMA_OMP_SIMD
             for (size_t j = 0; j <= i; j++)
             {
                 cov[i * nFeatures + j] = crossProduct[i * nFeatures + j] * multiplier;
@@ -712,6 +715,7 @@ services::Status finalizeCovariance(size_t nFeatures, algorithmFPType nObservati
     /* Copy results into symmetric upper triangle */
     for (size_t i = 0; i < nFeatures; i++)
     {
+        PRAGMA_OMP_SIMD
         for (size_t j = 0; j < i; j++)
         {
             cov[j * nFeatures + i] = cov[i * nFeatures + j];


### PR DESCRIPTION
## Description

PR adds pragmas to some sections in covariance that were left out when making the switch to new compiler pragmas:
https://github.com/uxlfoundation/oneDAL/pull/3246

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least a summary table with measured data, if performance change is expected.

</details>
