### PR TITLE
ENH: Add ivdep pragma for more compilers

### DIFF
--- a/cpp/daal/src/services/service_defines.h
+++ b/cpp/daal/src/services/service_defines.h
@@ -57,7 +57,7 @@ DAAL_EXPORT bool daal_check_is_intel_cpu();
     #define PRAGMA_OMP_SIMD            PRAGMA_TO_STR(omp simd)
     #define PRAGMA_OMP_SIMD_ARGS(ARGS) PRAGMA_TO_STR_(omp simd ARGS)
 #elif defined(__GNUC__) || defined(__clang__)
-    #define PRAGMA_IVDEP               _Pragma("ivdep")
+    #define PRAGMA_IVDEP _Pragma("ivdep")
     #define PRAGMA_NOVECTOR
     #define PRAGMA_VECTOR_UNALIGNED
     #define PRAGMA_VECTOR_ALWAYS

--- a/cpp/oneapi/dal/backend/common.hpp
+++ b/cpp/oneapi/dal/backend/common.hpp
@@ -37,7 +37,7 @@
 #define PRAGMA_OMP_SIMD            PRAGMA_TO_STR(omp simd)
 #define PRAGMA_OMP_SIMD_ARGS(ARGS) PRAGMA_TO_STR_(omp simd ARGS)
 #elif defined(__GNUC__) || defined(__clang__)
-#define PRAGMA_IVDEP               _Pragma("ivdep")
+#define PRAGMA_IVDEP _Pragma("ivdep")
 #define PRAGMA_NOVECTOR
 #define PRAGMA_VECTOR_UNALIGNED
 #define PRAGMA_VECTOR_ALWAYS


### PR DESCRIPTION
## Description

PR adds a missing pragma from https://github.com/uxlfoundation/oneDAL/pull/3246 in compilers that support it. This is quite useful when testing and debugging things internally through e.g. compiler-specific sanitizers, as placing this pragma incorrectly can lead to incorrect results which are hard to figure out.

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

</details>
