### PR TITLE
MAINT: Disable warning on non-vectorized loops for clang

### DIFF
--- a/dev/make/compiler_definitions/clang.32e.mk
+++ b/dev/make/compiler_definitions/clang.32e.mk
@@ -53,7 +53,7 @@ endif
 COMPILER.mac.clang = clang++ -m64 -fgnu-runtime -stdlib=libc++ -mmacosx-version-min=10.15 -fwrapv \
                      -Werror -Wreturn-type ${CXXFLAGS}
 COMPILER.lnx.clang = clang++ -m64 \
-                     -Werror -Wreturn-type -fopenmp-simd ${CXXFLAGS}
+                     -Werror -Wreturn-type -fopenmp-simd -Wno-pass-failed ${CXXFLAGS}
 
 linker.ld.flag := $(if $(LINKER),-fuse-ld=$(LINKER),)
 link.dynamic.mac.clang = clang++ $(linker.ld.flag) -m64


### PR DESCRIPTION
## Description

ref https://github.com/uxlfoundation/oneDAL/pull/3246

This PR disables warnings about loops that failed to vectorize when building with clang, so that they do not turn into compilation errors due to `-Werror`.

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] All CI jobs are green or I have provided justification why they aren't.

</details>
