### PR TITLE
FIX: Fix mismatched types in forest prediction aggregations

### DIFF
--- a/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_predict_dense_default_batch_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_predict_dense_default_batch_impl.i
@@ -405,7 +405,7 @@ Status PredictClassificationTask<algorithmFPType, cpu>::predictByTreesWithoutCon
 
             if (iTree + 1 == nTreesTotal)
             {
-                algorithmFPType sum(0);
+                double sum = 0;
 
                 PRAGMA_OMP_SIMD_ARGS(reduction(+ : sum))
                 for (size_t i = 0; i < _nClasses; ++i)


### PR DESCRIPTION
## Description

ref https://github.com/uxlfoundation/oneDAL/pull/3423 https://github.com/uxlfoundation/oneDAL/pull/3246

Fixes an issue with mismatched types that might be triggering a failed vectorization warning.

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] All CI jobs are green or I have provided justification why they aren't.

</details>
