### PR TITLE
Minor updates to 2026.0 deprecation RFCs

### DIFF
--- a/rfcs/20251015-DAAL-algorithms-deprecation/README.md
+++ b/rfcs/20251015-DAAL-algorithms-deprecation/README.md
@@ -1,4 +1,4 @@
-# Deprecation of certain DAAL algorithms in oneDAL 2025.1X
+# Deprecation of certain DAAL algorithms in oneDAL 2025.10
 
 ## Introduction
 
@@ -41,7 +41,7 @@ based on their current relevance:
   cannot be utilized with scikit-learn-intelex.
 
 The following **Tier 1** algorithms will be marked as deprecated
-in oneDAL 2025.1X with complete removal planned for the next major release,
+in oneDAL 2025.10 with complete removal planned for the next major release,
 oneDAL 2026.0:
 
 ### Analysis algorithms to be deprecated:
@@ -53,6 +53,7 @@ oneDAL 2026.0:
 - [SGD Optimization Solver](https://uxlfoundation.github.io/oneDAL/daal/algorithms/optimization-solvers/solvers/stochastic-gradient-descent-algorithm.html)
 - [Adaptive Subgradient Method (AdaGrad)](https://uxlfoundation.github.io/oneDAL/daal/algorithms/optimization-solvers/solvers/adaptive-subgradient-method.html)
 - [Sorting](https://uxlfoundation.github.io/oneDAL/daal/algorithms/sorting/index.html)
+- [Quality Metrics](https://uxlfoundation.github.io/oneDAL/daal/algorithms/quality_metrics/index.html)
 - [Quantile](https://uxlfoundation.github.io/oneDAL/daal/algorithms/quantiles/index.html)
 
 ### Training and prediction algorithms to be deprecated:
@@ -60,7 +61,11 @@ oneDAL 2026.0:
 - [AdaBoost Multiclass Classifier](https://uxlfoundation.github.io/oneDAL/daal/algorithms/boosting/adaboost-multiclass.html)
 - [BrownBoost Classifier](https://uxlfoundation.github.io/oneDAL/daal/algorithms/boosting/brownboost.html)
 - [LogitBoost Classifier](https://uxlfoundation.github.io/oneDAL/daal/algorithms/boosting/logitboost.html)
+- [Classification Decision Tree](https://uxlfoundation.github.io/oneDAL/daal/algorithms/decision_tree/decision-tree-classification.html)
+- [Regression Decision Tree](https://uxlfoundation.github.io/oneDAL/daal/algorithms/decision_tree/decision-tree-regression.html)
 - [Naive Bayes Classifier](https://uxlfoundation.github.io/oneDAL/daal/algorithms/naive_bayes/naive-bayes-classifier.html)
+- [Classificaton Stump](https://uxlfoundation.github.io/oneDAL/daal/algorithms/stump/classification.html)
+- [Regression Stump](https://uxlfoundation.github.io/oneDAL/daal/algorithms/stump/regression.html)
 
 **Tier 2** algorithms under consideration for future deprecation:
 

--- a/rfcs/20251016-DAAL-data-sources-deprecation/README.md
+++ b/rfcs/20251016-DAAL-data-sources-deprecation/README.md
@@ -1,4 +1,4 @@
-# Deprecation of certain DAAL data sources in oneDAL 2025.1X
+# Deprecation of certain DAAL data sources in oneDAL 2025.10
 
 ## Introduction
 
@@ -26,7 +26,7 @@ algorithms, creating a more streamlined workflow.
 
 ## Proposal
 
-The following data sources will be marked as deprecated in oneDAL 2025.1X
+The following data sources will be marked as deprecated in oneDAL 2025.10
 with complete removal planned for the next major release, oneDAL 2026.0:
 
 - [ODBC Data Source](https://github.com/uxlfoundation/oneDAL/blob/main/cpp/daal/include/data_management/data_source/odbc_data_source.h#L97)

--- a/rfcs/20251023-DAAL-matrices-deprecation/README.md
+++ b/rfcs/20251023-DAAL-matrices-deprecation/README.md
@@ -1,4 +1,4 @@
-# Deprecation of certain DAAL numeric tables in oneDAL 2025.1X
+# Deprecation of certain DAAL numeric tables in oneDAL 2025.10
 
 ## Introduction
 
@@ -17,7 +17,7 @@ overhead.
 ## Proposal
 
 The following types of [homogeneous numeric tables](https://uxlfoundation.github.io/oneDAL/daal/data-management/numeric-tables-types.html#homogeneous-numeric-tables)
-will be marked as deprecated in oneDAL 2025.1X with complete removal planned
+will be marked as deprecated in oneDAL 2025.10 with complete removal planned
 for the next major release, oneDAL 2026.0:
 
 - [Matrix](https://github.com/uxlfoundation/oneDAL/blob/main/cpp/daal/include/data_management/data/matrix.h#L49)


### PR DESCRIPTION
## Description

- Decision Tree, Stump and Quality Metrics were added to the list of the **Tier 1** deprecated algorithms.
- oneDAL version '2025.1x' was replaced with exact '2025.10'.
- A typo in a folder name was fixed

---

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

not applicable

**Performance**

not applicable

</details>
