### PR TITLE
Align pragma conditionals in onedal and daal

### DIFF
--- a/cpp/oneapi/dal/backend/common.hpp
+++ b/cpp/oneapi/dal/backend/common.hpp
@@ -30,12 +30,19 @@
 #define PRAGMA_TO_STR_(ARGS) PRAGMA_TO_STR(ARGS)
 
 #if defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)
-#define PRAGMA_IVDEP               _Pragma("ivdep")
-#define PRAGMA_NOVECTOR            _Pragma("novector")
-#define PRAGMA_VECTOR_UNALIGNED    _Pragma("vector unaligned")
+#define PRAGMA_IVDEP            _Pragma("ivdep")
+#define PRAGMA_NOVECTOR         _Pragma("novector")
+#define PRAGMA_VECTOR_UNALIGNED _Pragma("vector unaligned")
+// TODO: Temporary workaround. icx fails to vectorize some loops in debug build on Windows or with gcov.
+#if (defined(_MSC_VER) && defined(_DEBUG)) || defined(GCOV_BUILD)
+#define PRAGMA_VECTOR_ALWAYS
+#define PRAGMA_OMP_SIMD
+#define PRAGMA_OMP_SIMD_ARGS(ARGS)
+#else
 #define PRAGMA_VECTOR_ALWAYS       _Pragma("vector always")
 #define PRAGMA_OMP_SIMD            PRAGMA_TO_STR(omp simd)
 #define PRAGMA_OMP_SIMD_ARGS(ARGS) PRAGMA_TO_STR_(omp simd ARGS)
+#endif
 #elif defined(__GNUC__) || defined(__clang__)
 #define PRAGMA_IVDEP _Pragma("ivdep")
 #define PRAGMA_NOVECTOR


### PR DESCRIPTION
## Description

Follow up to https://github.com/uxlfoundation/oneDAL/pull/3430, keeps conditionals aligned. Resolves new fail in CEV windows oneDAL build.


Before: http://intel-ci.intel.com/f0babcaf-6253-f143-879a-a4bf010d0e2d
After: http://intel-ci.intel.com/f0bb737e-9851-f13b-a4e2-a4bf010d0e2d

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

</details>
