### PR TITLE
FIX: Fix undefined behavior warning with GCC

### DIFF
--- a/cpp/daal/src/algorithms/dtrees/forest/regression/df_regression_train_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/regression/df_regression_train_dense_default_impl.i
@@ -219,6 +219,12 @@ void OrderedRespHelperBest<algorithmFPType, cpu>::calcImpurity(const IndexType *
             {
                 const size_t iStart = iMain * simdBatchSize;
 #if defined(__GNUC__) && !defined(__clang__)
+                // Note: GCC is unable to determine that the pointer offset plus the
+                // vectorized section will be within the limits of pointer ranges
+                // from the start of the array, and without this hint, ends up issuing
+                // a warning about undefined behavior when loops exceed 2^63. This
+                // attribute leads to a compilation error with LLVM-based compilers,
+                // so it's defined conditionally regardless of compiler support.
                 __attribute__((__assume__(iStart < std::numeric_limits<std::ptrdiff_t>::max())));
 #endif
                 const auto aIdxStart        = aIdx + iStart;


### PR DESCRIPTION
## Description

Fixes a warning from GCC about potential undefined behavior, which cannot be encountered either way but lacks hints for it.

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

</details>
