### PR TITLE
fix: memory usage optimizations in public LinuxBazel step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,9 +100,9 @@ jobs:
         run: |
           # generate new onedal portion for use in examples testing (due to issues with dpc debug build)
           source /opt/intel/oneapi/setvars.sh
-          rm -rf __work_daal __work
-          .ci/scripts/build.sh --compiler icx  --optimizations ${{ matrix.ISA }} --target onedal --jobs 20
           rm -rf __work
+          mv __work_daal __work
+          .ci/scripts/build.sh --compiler icx  --optimizations ${{ matrix.ISA }} --target onedal --jobs 20
       - name: daal/cpp examples
         run: |
             source /opt/intel/oneapi/setvars.sh


### PR DESCRIPTION
### PR Description

**Feature:** Prepare a standalone release directory for Bazel build outputs.

**Details:**  
This change adds a script to move the Bazel release output to a separate `standalone_release` directory. Previously, the build artifacts were stored inside the Bazel output tree, which meant that running `bazel clean --expunge` would delete the build outputs along with the cache.  

By moving the release to a standalone folder:

- Disk space is saved during cleaning operations.
- Test cache can be cleared without affecting the build artifacts.
- The `DALROOT` environment variable is set to point to the latest standalone build for use in subsequent tasks.

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least a summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance and/or quality metrics have changed or why changes are not expected.
- [x] I have extended the benchmarking suite and provided a corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.

</details>
