### PR TITLE
Suppress vectorization pragmas warnings (REQDBG=yes)

### DIFF
--- a/dev/make/compiler_definitions/clang.mk
+++ b/dev/make/compiler_definitions/clang.mk
@@ -43,7 +43,7 @@ endif
 
 -Zl.clang =
 
--DEBC.clang = -g
+-DEBC.clang = -g -Wno-pass-failed
 
 -asanstatic.clang = -static-libasan
 -asanshared.clang = -shared-libasan

--- a/dev/make/compiler_definitions/icx.mkl.32e.mk
+++ b/dev/make/compiler_definitions/icx.mkl.32e.mk
@@ -60,7 +60,7 @@ else
 endif
 
 -Zl.icx = $(if $(OS_is_win),-Zl,) $(-Q)no-intel-lib
--DEBC.icx = $(if $(OS_is_win),-debug:all -Z7,-g) -fno-system-debug
+-DEBC.icx = $(if $(OS_is_win),-debug:all -Z7,-g) -fno-system-debug -Wno-pass-failed
 
 -asanstatic.icx = -static-libasan
 -asanshared.icx = -shared-libasan


### PR DESCRIPTION
## Description

Add `-Wno-pass-failed` compiler option to ICX and Clang debug builds to suppress the warnings that cause build failures.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.

**Performance**

not applicable

</details>
