### PR TITLE
fix: rf out of int issue in best_split

### DIFF
--- a/cpp/oneapi/dal/algo/decision_forest/backend/gpu/train_splitter_impl_dpc.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/gpu/train_splitter_impl_dpc.cpp
@@ -373,9 +373,9 @@ inline void compute_histogram(const local_accessor_rw_t<hist_type_t>& hist,
     if constexpr (std::is_same_v<Task, task::classification>) {
         // Classification case
         for (Index row_idx = id; row_idx < row_count; row_idx += local_size) {
-            const Index id = data.order_[row_ofs + row_idx];
-            const Index bin = data.data_[id * column_count + ts_ftr_id];
-            const Index response_int = static_cast<Index>(data.response_[id]);
+            const Index row_id = data.order_[row_ofs + row_idx];
+            const Index bin = data.data_[row_id * column_count + ts_ftr_id];
+            const Index response_int = static_cast<Index>(data.response_[row_id]);
             const Index start = sycl::max(0, bin - bin_ofs);
             for (Index bin_id = start; bin_id < act_bin_block; ++bin_id) {
                 const Index loc_bin_pos = bin_id * hist_prop_count;
@@ -391,7 +391,7 @@ inline void compute_histogram(const local_accessor_rw_t<hist_type_t>& hist,
                                      sycl::memory_scope_work_group,
                                      sycl::access::address_space::local_space>
                         hist_weight(local_weight[bin_id]);
-                    hist_weight += data.weight_[id];
+                    hist_weight += data.weight_[row_id];
                 }
             }
         }


### PR DESCRIPTION
## Description

## Fix: prevent int32 overflow in RF best_split kernel

Refactored the histogram and best split SYCL kernels to eliminate out-of-int overflow issues caused by excessive total work-item counts.

### Changes
- Switched kernel execution from 3D `nd_range` to 2D `nd_range`
- Introduced node batching to keep total work-items within `INT32_MAX`
- Added dynamic batch size calculation based on feature count and local workgroup size

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least a summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance and/or quality metrics have changed or why changes are not expected.
- [x] I have extended the benchmarking suite and provided a corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.

</details>
