### PR TITLE
2025.11: Fix incorrect CPU topology initialization (#3304)

### DIFF
--- a/cpp/daal/include/algorithms/algorithm_base_common.h
+++ b/cpp/daal/include/algorithms/algorithm_base_common.h
@@ -116,7 +116,9 @@ private:
 protected:
     services::Status getEnvironment()
     {
-        int cpuid = (int)daal::services::Environment::getInstance()->getCpuId();
+        daal::services::Environment * env = daal::services::Environment::getInstance();
+        if (!env) return services::Status(services::ErrorCpuNotSupported);
+        int cpuid = (int)env->getCpuId();
         if (cpuid < 0) return services::Status(services::ErrorCpuNotSupported);
         _env.cpuid           = cpuid;
         _env.cpuid_init_flag = true;

--- a/cpp/daal/include/services/daal_defines.h
+++ b/cpp/daal/include/services/daal_defines.h
@@ -41,6 +41,12 @@
     #define TARGET_RISCV64
 #endif
 
+#if !defined(TARGET_X86_64)
+    #ifndef DAAL_CPU_TOPO_DISABLED
+        #define DAAL_CPU_TOPO_DISABLED
+    #endif
+#endif
+
 #if (defined(__INTEL_COMPILER) || defined(__INTEL_LLVM_COMPILER)) && !defined(SYCL_LANGUAGE_VERSION)
     #define DAAL_INTEL_CPP_COMPILER
 #endif

--- a/cpp/daal/include/services/env_detect.h
+++ b/cpp/daal/include/services/env_detect.h
@@ -66,6 +66,12 @@ public:
     static Environment * getInstance();
 
     /**
+     *  Returns the status of the environment instance initialization
+     *  \return Status of the environment instance initialization
+     */
+    static int getStatus();
+
+    /**
      *  Decreases the instance counter
      *  \return The return code
      *  \DAAL_DEPRECATED

--- a/cpp/daal/src/data_management/data_conversion.cpp
+++ b/cpp/daal/src/data_management/data_conversion.cpp
@@ -42,7 +42,9 @@ static bool tryToCopyFuncAVX512(const size_t nrows, const size_t ncols, void * d
 
     if (!ptr)
     {
-        int cpuid = (int)daal::services::Environment::getInstance()->getCpuId();
+        daal::services::Environment * env = daal::services::Environment::getInstance();
+        if (!env) return false; // Environment not initialized
+        int cpuid = (int)env->getCpuId();
 
         switch (cpuid)
         {

--- a/cpp/daal/src/services/library_version_info.cpp
+++ b/cpp/daal/src/services/library_version_info.cpp
@@ -53,12 +53,25 @@ DAAL_EXPORT daal::services::LibraryVersionInfo::LibraryVersionInfo()
       productStatus(PRODUCTSTATUS),
       build(BUILD),
       build_rev(BUILD_REV),
-      name(PRODUCT_NAME_STR),
+      name(PRODUCT_NAME_STR)
+{
 #ifndef DAAL_REF
-      processor(cpu_long_names[daal::services::Environment::getInstance()->getCpuId()])
+    daal::services::Environment * env = daal::services::Environment::getInstance();
+    if (env)
+    {
+        processor = cpu_long_names[env->getCpuId()];
+    }
+    else
+    {
+    #if (!defined(DAAL_NOTHROW_EXCEPTIONS))
+        int error = daal::services::Environment::getStatus();
+        throw std::runtime_error("Environment not initialized, cannot get processor info, error code: " + std::to_string(error));
+    #else
+        processor = cpu_long_names[0];
+    #endif
+    }
 #else
-      processor(cpu_long_names[0])
+    processor = cpu_long_names[0];
 #endif
-{}
-
+}
 DAAL_EXPORT daal::services::LibraryVersionInfo::~LibraryVersionInfo() {}

--- a/cpp/daal/src/services/service_topo.cpp
+++ b/cpp/daal/src/services/service_topo.cpp
@@ -1,6 +1,7 @@
 /* file: service_topo.cpp */
 /*******************************************************************************
 * Copyright 2014 Intel Corporation
+* Copyright contributors to the oneDAL project
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -22,7 +23,130 @@
 */
 #include "services/daal_defines.h"
 
-#if !(defined DAAL_CPU_TOPO_DISABLED)
+#define MAX_CACHE_LEVELS      4
+#define DEFAULT_L1_CACHE_SIZE 32 * 1024
+#define DEFAULT_L2_CACHE_SIZE 256 * 1024
+#define DEFAULT_LL_CACHE_SIZE 4 * 1024 * 1024
+
+#if !defined(DAAL_CPU_TOPO_DISABLED)
+
+    #include <limits>
+
+    #if defined(__linux__) || defined(__FreeBSD__)
+
+        #include <cstdio>
+        #include <cstdlib>
+        #include <cstring>
+        #include <unistd.h>
+        #include <sched.h>
+
+        #ifdef __FreeBSD__
+            #include <sys/param.h>
+            #include <sys/cpuset.h>
+typedef cpuset_t cpu_set_t;
+        #endif
+
+        #ifdef __linux__
+            #include <alloca.h>
+        #endif
+
+        #include <cstdarg>
+
+        #ifdef __CPU_ISSET
+            #define MY_CPU_SET   __CPU_SET
+            #define MY_CPU_ZERO  __CPU_ZERO
+            #define MY_CPU_ISSET __CPU_ISSET
+        #else
+            #define MY_CPU_SET   CPU_SET
+            #define MY_CPU_ZERO  CPU_ZERO
+            #define MY_CPU_ISSET CPU_ISSET
+        #endif
+
+        #if defined(TARGET_X86_64)
+            #define LNX_PTR2INT unsigned long long
+            #define LNX_MY1CON  1LL
+        #elif defined(TARGET_ARM)
+            #define LNX_PTR2INT unsigned long long
+            #define LNX_MY1CON  1LL
+        #elif defined(TARGET_RISCV64)
+            #define LNX_PTR2INT uintptr_t
+            #define LNX_MY1CON  1LL
+        #else
+            #define LNX_PTR2INT unsigned int
+            #define LNX_MY1CON  1
+        #endif
+
+        #ifndef __int64
+            #define __int64 long long
+        #endif
+
+        #ifndef __int32
+            #define __int32 int
+        #endif
+
+        #ifndef DWORD
+            #define DWORD unsigned long
+        #endif
+
+        #ifndef DWORD_PTR
+            #define DWORD_PTR unsigned long *
+        #endif
+
+        #ifndef BYTE
+            #define BYTE unsigned char
+        #endif
+
+        #define AFFINITY_MASK unsigned __int64
+
+    #else /* WINDOWS */
+        #define NOMINMAX
+        #include <windows.h>
+        #include <tlhelp32.h> // CreateToolhelp32Snapshot, THREADENTRY32, Thread32First, Thread32Next
+
+        #ifdef _M_IA64
+            #define LNX_PTR2INT unsigned long long
+            #define LNX_MY1CON  1LL
+        #else
+            #ifdef _M_X64
+                #define LNX_PTR2INT __int64
+                #define LNX_MY1CON  1LL
+            #else
+                #define LNX_PTR2INT unsigned int
+                #define LNX_MY1CON  1
+            #endif
+        #endif
+
+        #if defined(_MSC_VER)
+            #if (_MSC_FULL_VER >= 160040219)
+                #include <intrin.h>
+            #else
+                #error "min VS2010 SP1 compiler is required"
+            #endif
+        #endif
+
+        #if _MSC_VER < 1300
+            #ifndef DWORD_PTR
+                #define DWORD_PTR unsigned long *
+            #endif
+        #endif
+
+        #ifdef _M_IA64
+typedef unsigned __int64 AFFINITY_MASK;
+        #else
+typedef unsigned __int32 AFFINITY_MASK;
+        #endif
+
+    #endif /* WINDOWS */
+
+    #define MAX_LOG_CPU                      (8 * sizeof(DWORD_PTR) * 8)
+    #define MAX_WIN7_LOG_CPU                 (4 * sizeof(DWORD_PTR) * 8)
+    #define MAX_CORES                        MAX_LOG_CPU
+    #define MAX_THREAD_GROUPS_WIN7           4
+    #define MAX_LOGICAL_PROCESSORS_PER_GROUP 64
+
+    #define MAX_CACHE_SUBLEAFS 16 // max allocation limit of data structure per sub leaf of cpuid leaf 4 enumerated results
+
+    #define ENUM_ALL (0xffffffff)
 
     #include "src/externals/service_memory.h"
     #include "src/services/service_topo.h"
@@ -43,375 +167,59 @@ FILE * stdout = __stdoutp;
 FILE * stderr = __stderrp;
     #endif
 
-    #define _INTERNAL_DAAL_MALLOC(x)              daal_malloc((x), 64)
+    #define _INTERNAL_DAAL_MALLOC(x)              daal_malloc((x), DAAL_MALLOC_DEFAULT_ALIGNMENT)
     #define _INTERNAL_DAAL_FREE(x)                daal_free((x))
     #define _INTERNAL_DAAL_MEMSET(a1, a2, a3)     __internal_daal_memset((a1), (a2), (a3))
     #define _INTERNAL_DAAL_MEMCPY(a1, a2, a3, a4) daal::services::internal::daal_memcpy_s((a1), (a2), (a3), (a4))
 
+    #define _INTERNAL_DAAL_OVERFLOW_CHECK_BY_ADDING(type, op1, op2) \
+        {                                                           \
+            volatile type r = (op1) + (op2);                        \
+            r -= (op1);                                             \
+            if (!(r == (op2))) error |= _MSGTYP_INT_OVERFLOW;       \
+        }
 namespace daal
 {
 namespace services
 {
 namespace internal
 {
-static glktsn glbl_obj;
-
-static char scratch[BLOCKSIZE_4K]; // scratch space large enough for OS to write SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX
-
-static void * __internal_daal_memset(void * s, int c, size_t n)
+struct leaf2_cache_struct
 {
-    unsigned char * p = (unsigned char *)s;
-    while (n--) *p++ = (unsigned char)c;
-    return s;
-}
+    int L1;       // L1Data size
+    int L1i;      // L1 instruction size
+    int L1i_type; // L1 instruction type (0 == size in bytes, 1= size in trace cache uops)
+    int L2;       // L2 size
+    int L3;       // L3 size
+    int cl;       // cache line size
+    int sectored; // cache lines sectored
+};
 
-/*
- * __internal_daal_bindContext
- * A wrapper function that can compile under two OS environments
- * The size of the bitmap that underlies cpu_set_t is configurable
- * at Linux Kernel Compile time. Each distro may set limit on its own.
- * Some newer Linux distro may support 256 logical processors,
- * For simplicity we don't show the check for range on the ordinal index
- * of the target cpu in Linux, interested reader can check Linux kernel documentation.
- * Prior to Windows OS with version signature 0601H, it has size limit of 64 cpu
- * in 64-bit mode, 32 in 32-bit mode, the size limit is checked.
- * Starting with Windows OS version 0601H (e.g. Windows 7), it supports up to 4 sets of
- * affinity masks, referred to as "GROUP_AFFINITY".
- * Constext switch within the same group is done by the same API as was done in previous
- * generations of windows (such as Vista). In order to bind the current executing
- * process context to a logical processor in a different group, it must be be binded
- * using a new API to the target processor group, followed by a similar
- * SetThreadAffinityMask API
- * New API related to GROUP_AFFINITY are present only in kernel32.dll of the OS with the
- * relevant version signatures. So we dynamically examine the presence of thse API
- * and fall back of legacy AffinityMask API if the new APIs are not available.
- * Limitation, New Windows APIs that support GROUP_AFFINITY requires
- *  Windows platform SDK 7.0a. The executable
- *  using this SDK and recent MS compiler should be able to perform topology enumeration on
- *  Windows 7 and prior versions
- *  If the executable is compiled with prior versions of platform SDK,
- *  the topology enumeration will not use API and data structures defined in SDK 7.0a,
- *  So enumeration will be limited to the active processor group.
- * Arguments:
- *      cpu :   the ordinal index to reference a logical processor in the system
- * Return:        0 is no error
- */
-static int __internal_daal_bindContext(unsigned int cpu, void * prevAffinity)
+struct CPUIDinfo
 {
-    int ret = -1;
-    #if defined(__linux__) || defined(__FreeBSD__)
-    cpu_set_t currentCPU;
-    // add check for size of cpumask_t.
-    MY_CPU_ZERO(&currentCPU);
-    // turn on the equivalent bit inside the bitmap corresponding to affinitymask
-    MY_CPU_SET(cpu, &currentCPU);
-    sched_getaffinity(0, sizeof(*((cpu_set_t *)prevAffinity)), (cpu_set_t *)prevAffinity);
-    if (!sched_setaffinity(0, sizeof(currentCPU), &currentCPU)) ret = 0;
-    #else
-        // compile with SDK 7.0a will allow EXE to run on Windows versions
-        // with and without GROUP_AFFINITY support
-        #if (_WIN32_WINNT >= 0x0601)
-    //we resolve API dynamically at runtime, data structures required by new API is determined at compile time
+    unsigned __int32 EAX = 0, EBX = 0, ECX = 0, EDX = 0;
 
-    unsigned int cpu_beg = 0, cpu_cnt, j;
-    DWORD cnt;
-    SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX * pSystem_rel_info = NULL;
-    GROUP_AFFINITY grp_affinity;
-    if (cpu >= MAX_WIN7_LOG_CPU) return ret;
+    /*
+     * Stores the raw data reported in 4 registers by CPUID into the structure,
+     * supports sub-leaf reporting.
+     * Note: The CPUID instrinsic in MSVC does not support sub-leaf reporting.
+     *
+     * \param func       CPUID leaf number
+     * \param subfunc    CPUID subleaf number
+     */
+    void get(unsigned int func, unsigned int subfunc = 0) { get_info(func, subfunc); }
 
-    cnt = BLOCKSIZE_4K;
-    _INTERNAL_DAAL_MEMSET(&scratch[0], 0, cnt);
-    pSystem_rel_info = (SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX *)&scratch[0];
-
-    if (!GetLogicalProcessorInformationEx(RelationGroup, pSystem_rel_info, &cnt)) return ret;
-
-    if (pSystem_rel_info->Relationship != RelationGroup) return ret;
-    // to determine the input ordinal 'cpu' number belong to which processor group,
-    // we consider each processor group to have its logical processors assigned with
-    // numerical index consecutively in increasing order
-    for (j = 0; j < pSystem_rel_info->Group.ActiveGroupCount; j++)
+private:
+    void get_info(unsigned int eax, unsigned int ecx)
     {
-        cpu_cnt = pSystem_rel_info->Group.GroupInfo[j].ActiveProcessorCount;
-        // if the 'cpu' value is within the lower and upper bounds of a
-        // processor group, we can use the new API to bind current thread to
-        // the target thread affinity bit in the target processor group
-        if (cpu >= cpu_beg && cpu < (cpu_beg + cpu_cnt))
-        {
-            _INTERNAL_DAAL_MEMSET(&grp_affinity, 0, sizeof(GROUP_AFFINITY));
-            grp_affinity.Group = j;
-            grp_affinity.Mask = (KAFFINITY)((DWORD_PTR)(LNX_MY1CON << (cpu - cpu_beg)));
-            if (!SetThreadGroupAffinity(GetCurrentThread(), &grp_affinity, (GROUP_AFFINITY *)prevAffinity))
-            {
-                GetLastError();
-                return ret;
-            }
-
-            return 0;
-        }
-        // if the value of 'cpu' is not this processor group, we move to the next group
-        cpu_beg += cpu_cnt;
+        uint32_t abcd[4];
+        run_cpuid(eax, ecx, abcd);
+        EAX = abcd[0];
+        EBX = abcd[1];
+        ECX = abcd[2];
+        EDX = abcd[3];
     }
-        #else // If SDK version does not support GROUP_AFFINITY,
-    DWORD_PTR affinity;
-
-    // only the active processor group and be succesfully queried and analyzed for topology information
-    if (cpu >= MAX_PREWIN7_LOG_CPU) return ret;
-    // flip on the bit in the affinity mask corresponding to the input ordinal index
-
-    affinity                     = (DWORD_PTR)(LNX_MY1CON << cpu);
-    *((DWORD_PTR *)prevAffinity) = SetThreadAffinityMask(GetCurrentThread(), affinity) if ((DWORD_PTR)(*prevAffinity)) ret = 0;
-        #endif
-    #endif
-    return ret;
-}
-
-static void __internal_daal_restoreContext(void * prevAffinity)
-{
-    #if defined(__linux__) || defined(__FreeBSD__)
-    sched_setaffinity(0, sizeof(*((cpu_set_t *)prevAffinity)), (cpu_set_t *)prevAffinity);
-    #else
-        #if (_WIN32_WINNT >= 0x0601)
-    SetThreadGroupAffinity(GetCurrentThread(), (GROUP_AFFINITY *)prevAffinity, NULL);
-        #else // If SDK version does not support GROUP_AFFINITY,
-    SetThreadAffinityMask(GetCurrentThread(), *((DWORD_PTR *)prevAffinity));
-        #endif
-    #endif
-}
-
-/*
- * _internal_daal_GetMaxCPUSupportedByOS
- * A wrapper function that calls OS specific system API to find out
- * how many logical processor the OS supports
- * Return:        a non-zero value
- */
-unsigned int _internal_daal_GetMaxCPUSupportedByOS()
-{
-    unsigned int lcl_OSProcessorCount = 0;
-    #if defined(__linux__) || defined(__FreeBSD__)
-
-    lcl_OSProcessorCount = sysconf(_SC_NPROCESSORS_CONF); //This will tell us how many CPUs are currently enabled.
-
-    #else
-        #if (_WIN32_WINNT >= 0x0601)
-    unsigned short grpCnt;
-    DWORD cnt;
-    SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX * pSystem_rel_info = NULL;
-
-    // runtime check if os version is greater than 0601h
-
-    lcl_OSProcessorCount = 0;
-    // if Windows version support processor groups
-    // tally actually populated logical processors in each group
-    grpCnt = (WORD)GetActiveProcessorGroupCount();
-    cnt = BLOCKSIZE_4K;
-    _INTERNAL_DAAL_MEMSET(&scratch[0], 0, cnt);
-    pSystem_rel_info = (SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX *)&scratch[0];
-
-    if (!GetLogicalProcessorInformationEx(RelationGroup, pSystem_rel_info, &cnt))
-    {
-        glbl_obj.error |= _MSGTYP_UNKNOWNERR_OS;
-        return 0;
-    }
-    if (pSystem_rel_info->Relationship != RelationGroup)
-    {
-        glbl_obj.error |= _MSGTYP_UNKNOWNERR_OS;
-        return 0;
-    }
-    for (unsigned int i = 0; i < grpCnt; i++) lcl_OSProcessorCount += pSystem_rel_info->Group.GroupInfo[i].ActiveProcessorCount;
-        #else
-    SYSTEM_INFO si;
-    GetSystemInfo(&si);
-    lcl_OSProcessorCount = si.dwNumberOfProcessors;
-        #endif
-    #endif
-    return lcl_OSProcessorCount;
-}
-
-/*
- * __internal_daal_setChkProcessAffinityConsistency
- *
- * A wrapper function that calls OS specific system API to find out
- * the number of logical processor support by OS matches
- * the same set of logical processors this process is allowed to run on
- * if the two set matches, set the corresponding bits in our
- * generic affinity mask construct.
- * if inconsistency is found, app-specific error code is set
- *
- * Return: none
- */
-static void __internal_daal_setChkProcessAffinityConsistency(unsigned int lcl_OSProcessorCount)
-{
-    unsigned int i, sum = 0;
-    #if defined(__linux__) || defined(__FreeBSD__)
-    cpu_set_t allowedCPUs;
-
-    sched_getaffinity(0, sizeof(allowedCPUs), &allowedCPUs);
-    for (i = 0; i < lcl_OSProcessorCount; i++)
-    {
-        if (MY_CPU_ISSET(i, &allowedCPUs) == 0)
-        {
-            glbl_obj.error |= _MSGTYP_USERAFFINITYERR;
-        }
-        else
-        {
-            __internal_daal_setGenericAffinityBit(&glbl_obj.cpu_generic_processAffinity, i);
-            __internal_daal_setGenericAffinityBit(&glbl_obj.cpu_generic_systemAffinity, i);
-        }
-    }
-
-    #else
-    DWORD_PTR processAffinity;
-    DWORD_PTR systemAffinity;
-
-        #if (_WIN32_WINNT >= 0x0601)
-
-    GROUP_AFFINITY grp_affinity, prev_grp_affinity;
-    unsigned int cpu_cnt;
-    DWORD cnt;
-    SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX * pSystem_rel_info = NULL;
-
-    {
-        cnt = BLOCKSIZE_4K;
-        _INTERNAL_DAAL_MEMSET(&scratch[0], 0, cnt);
-        pSystem_rel_info = (SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX *)&scratch[0];
-
-        if (!GetLogicalProcessorInformationEx(RelationGroup, pSystem_rel_info, &cnt))
-        {
-            glbl_obj.error |= _MSGTYP_UNKNOWNERR_OS;
-            return;
-        }
-        if (pSystem_rel_info->Relationship != RelationGroup)
-        {
-            glbl_obj.error |= _MSGTYP_UNKNOWNERR_OS;
-            return;
-        }
-        if (lcl_OSProcessorCount > MAX_WIN7_LOG_CPU)
-        {
-            glbl_obj.error |= _MSGTYP_OSAFFCAP_ERROR; // If the os supports more processors than allowed, make change as required.
-        }
-        const unsigned short grpCnt = GetActiveProcessorGroupCount();
-        for (i = 0; i < grpCnt; i++)
-        {
-            unsigned short grpAffinity[MAX_THREAD_GROUPS_WIN7];
-            unsigned short grpCntArg = grpCnt;
-            if (!GetProcessGroupAffinity(GetCurrentProcess(), &grpCntArg, &grpAffinity[0]))
-            {
-                //throw some exception here, no full affinity for the process
-                glbl_obj.error |= _MSGTYP_UNKNOWNERR_OS;
-                break;
-            }
-            else
-            {
-                cpu_cnt = pSystem_rel_info->Group.GroupInfo[i].ActiveProcessorCount;
-                _INTERNAL_DAAL_MEMSET(&grp_affinity, 0, sizeof(GROUP_AFFINITY));
-                grp_affinity.Group = (WORD)i;
-                if (cpu_cnt == (sizeof(DWORD_PTR) * 8))
-                    grp_affinity.Mask = (DWORD_PTR)(-LNX_MY1CON);
-                else
-                    grp_affinity.Mask = (DWORD_PTR)(((DWORD_PTR)LNX_MY1CON << cpu_cnt) - 1);
-                if (!SetThreadGroupAffinity(GetCurrentThread(), &grp_affinity, &prev_grp_affinity))
-                {
-                    glbl_obj.error |= _MSGTYP_UNKNOWNERR_OS;
-                    return;
-                }
-
-                GetThreadGroupAffinity(GetCurrentProcess(), &grp_affinity);
-                sum += __internal_daal_countBits(grp_affinity.Mask); // count bits on each target affinity group
-
-                if (sum > lcl_OSProcessorCount)
-                {
-                    //throw some exception here, no full affinity for the process
-                    glbl_obj.error |= _MSGTYP_USERAFFINITYERR;
-                    break;
-                }
-            }
-        }
-        if (sum != lcl_OSProcessorCount) // check cumulative bit counts matches processor count
-        {
-            // if this process is restricted and not able to run on all logical processors managed by OS
-            // the LS bytes can be extracted to indicate the affinity restrictions
-            glbl_obj.error |= _MSGTYP_USERAFFINITYERR + sum;
-            return;
-        }
-
-        for (i = 0; i < lcl_OSProcessorCount; i++)
-        {
-            __internal_daal_setGenericAffinityBit(&glbl_obj.cpu_generic_processAffinity, i);
-        }
-
-        return;
-    }
-        #else
-    {
-        if (lcl_OSProcessorCount > MAX_PREWIN7_LOG_CPU)
-        {
-            glbl_obj.error |= _MSGTYP_OSAFFCAP_ERROR; // If the os supports more processors than existing win32 or win64 API,
-                                                      // we need to know the new API interface in that OS
-        }
-        GetProcessAffinityMask(GetCurrentProcess(), &processAffinity, &systemAffinity);
-        sum = __internal_daal_countBits(processAffinity);
-        if (lcl_OSProcessorCount != (unsigned long)sum)
-        {
-            //throw some exception here, no full affinity for the process
-            glbl_obj.error |= _MSGTYP_USERAFFINITYERR + sum;
-        }
-
-        if (lcl_OSProcessorCount != (unsigned long)__internal_daal_countBits(systemAffinity))
-        {
-            //throw some exception here, no full system affinity
-            glbl_obj.error |= _MSGTYP_UNKNOWNERR_OS;
-        }
-    }
-        #endif
-    for (i = 0; i < lcl_OSProcessorCount; i++)
-    {
-        // This logic assumes that looping over OSProcCount will let us inspect all the affinity bits
-        // That is, we can't need more than OSProcessorCount bits in the affinityMask
-        if (((unsigned long)systemAffinity & (LNX_MY1CON << i)) == 0)
-            glbl_obj.error |= _MSGTYP_USERAFFINITYERR;
-        else
-            __internal_daal_setGenericAffinityBit(&glbl_obj.cpu_generic_systemAffinity, i);
-
-        if (((unsigned long)processAffinity & (LNX_MY1CON << i)) == 0)
-            glbl_obj.error |= _MSGTYP_USERAFFINITYERR;
-        else
-            __internal_daal_setGenericAffinityBit(&glbl_obj.cpu_generic_processAffinity, i);
-    }
-    #endif
-}
-
-static void __internal_daal_getCpuidInfo(CPUIDinfo * info, unsigned int eax, unsigned int ecx)
-{
-    uint32_t abcd[4];
-    run_cpuid(eax, ecx, abcd);
-    info->EAX = abcd[0];
-    info->EBX = abcd[1];
-    info->ECX = abcd[2];
-    info->EDX = abcd[3];
-}
-
-/*
- * __internal_daal_cpuid_
- *
- * Returns the raw data reported in 4 registers by _internal_daal_CPUID, support sub-leaf reporting
- *          The _internal_daal_CPUID instrinsic in MSC does not support sub-leaf reporting
- *
- * Arguments:
- *     info       Point to strucrture to get output from CPIUD instruction
- *     func       _internal_daal_CPUID Leaf number
- *     subfunc    _internal_daal_CPUID Subleaf number
- * Return:        None
- */
-static void __cdecl __internal_daal_cpuid_(CPUIDinfo * info, const unsigned int func, const unsigned int subfunc)
-{
-    __internal_daal_getCpuidInfo(info, func, subfunc);
-}
-
-// Simpler version for __internal_daal_cpuid leaf that do not require sub-leaf reporting
-static void __internal_daal_cpuid(CPUIDinfo * info, const unsigned int func)
-{
-    __internal_daal_cpuid_(info, func, 0);
-}
+};
 
 /*
  * __internal_daal_getBitsFromDWORD
@@ -431,6 +239,33 @@ static unsigned long __internal_daal_getBitsFromDWORD(const unsigned int val, co
     unsigned long mask = (1 << (to + 1)) - 1;
 
     return (val & mask) >> from;
+}
+
+/*
+ * __internal_daal_myBitScanReverse
+ *
+ * Returns of bits [to:from] of DWORD
+ * This c-emulation of the BSR instruction is shown here for tool portability
+ *
+ * \param index      Bit offset of the most significant bit that's not 0 found in mask
+ * \param mask       Input data to search the most significant bit
+ *
+ * \return        1 if a non-zero bit is found, otherwise 0
+ */
+static unsigned char __internal_daal_myBitScanReverse(unsigned * index, unsigned long mask)
+{
+    unsigned long i;
+
+    for (i = (8 * sizeof(unsigned long)); i > 0; i--)
+    {
+        if ((mask & (LNX_MY1CON << (i - 1))) != 0)
+        {
+            *index = (unsigned long)(i - 1);
+            break;
+        }
+    }
+
+    return (unsigned char)(mask != 0);
 }
 
 /*
@@ -457,33 +292,6 @@ static int __internal_daal_countBits(DWORD_PTR x)
     }
 
     return res;
-}
-
-/*
- * __internal_daal_myBitScanReverse
- *
- * Returns of bits [to:from] of DWORD
- * This c-emulation of the BSR instruction is shown here for tool portability
- *
- * Arguments:
- *     index      bit offset of the most significant bit that's not 0 found in mask
- *     mask       input data to search the most significant bit
-  * Return:        1 if a non-zero bit is found, otherwise 0
- */
-static unsigned char __internal_daal_myBitScanReverse(unsigned * index, unsigned long mask)
-{
-    unsigned long i;
-
-    for (i = (8 * sizeof(unsigned long)); i > 0; i--)
-    {
-        if ((mask & (LNX_MY1CON << (i - 1))) != 0)
-        {
-            *index = (unsigned long)(i - 1);
-            break;
-        }
-    }
-
-    return (unsigned char)(mask != 0);
 }
 
 /* __internal_daal_createMask
@@ -522,251 +330,693 @@ static unsigned __internal_daal_createMask(unsigned numEntries, unsigned * maskW
     return (1 << i) - 1;
 }
 
-/* __internal_daal_allocateGenericAffinityMask
- *
- * Allocate the memory needed for the bitmap of a generic affinity mask
- *  The memory buffer needed must be large enough to cover the specified maxcpu number
- *  Each cpu is represented by one bit in the bitmap
- *
- * Arguments:
- *     GenericAffintyMask - ptr to be filled in.
- *     maxcpu - max number of logical processors the bitmap of this generic affinity mask needs to  handle
- * Return: 0 if no errors, -1 otherwise
- */
-static int __internal_daal_allocateGenericAffinityMask(GenericAffinityMask * pAffinityMap, unsigned maxcpu)
+// The width of affinity mask in legacy Windows API is 32 or 64, depending on
+// 32-bit or 64-bit OS.
+// Linux abstract its equivalent bitmap cpumask_t from direct programmer access,
+// cpumask_t can support more than 64 cpu, but is configured at kernel
+// compile time by configuration parameter.
+// To abstract the size difference of the bitmap used by different OSes
+// for topology analysis, we use an unsigned char buffer that can
+// map to different OS implementation's affinity mask data structure
+struct GenericAffinityMask
 {
-    int bytes;
-    // Allocate an unsigned char string long enough (cpus/8 + 1) bytes to have 1 bit per cpu.
-    // cpu 0 is the lsb of byte0, cpu1 is byte[0]:1, cpu2 is byte[0]:2 etc
-
-    bytes                      = (maxcpu >> 3) + 1;
-    pAffinityMap->AffinityMask = (unsigned char *)_INTERNAL_DAAL_MALLOC(bytes * sizeof(unsigned char));
-    if (pAffinityMap->AffinityMask == NULL) return -1;
-
-    pAffinityMap->maxByteLength = bytes;
-    _INTERNAL_DAAL_MEMSET(pAffinityMap->AffinityMask, 0, bytes * sizeof(unsigned char));
-
-    return 0;
-}
-
-/*
- * __internal_daal_freeGenericAffinityMask
- *
- * free up the memory allocated to the bitmap of a generic affinity mask
- *
- * Arguments:
- *     pAffinityMap - pointer to a generic affinity mask
- * Return: none
- */
-static void __internal_daal_freeGenericAffinityMask(GenericAffinityMask * pAffinityMap)
-{
-    _INTERNAL_DAAL_FREE(pAffinityMap->AffinityMask);
-    pAffinityMap->maxByteLength = 0;
-}
-
-/*
- * __internal_daal_clearGenericAffinityMask
- *
- * Clear all the affinity bits in the bitmap of a generic affinity mask
- *
- * Arguments:
- *     pAffinityMap - pointer to a generic affinity mask
- * Return: none
- */
-static void __internal_daal_clearGenericAffinityMask(GenericAffinityMask * pAffinityMap)
-{
-    _INTERNAL_DAAL_MEMSET(pAffinityMap->AffinityMask, 0, pAffinityMap->maxByteLength);
-}
-
-/*
- * __internal_daal_setGenericAffinityBit
- *
- * Set the affinity bit corresponding to a specified logical processor .
- * The bitmap in a generic affinity mask is
- *
- * Arguments:
- *     pAffinityMap - pointer to a generic affinity mask
- *     cpu - an ordinal number that reference a logical processor visible to the OS
- * Return: none, abort if error occured
- */
-static void __internal_daal_setGenericAffinityBit(GenericAffinityMask * pAffinityMap, unsigned cpu)
-{
-    if (cpu < (pAffinityMap->maxByteLength << 3)) pAffinityMap->AffinityMask[cpu >> 3] |= 1 << (cpu % 8);
-}
-
-/*
- * __internal_daal_compareEqualGenericAffinity
- *
- * compare two generic affinity masks if the identical set of
- * logical processors are set in two generic affinity mask bitmaps.
- * Since each generic affinity mask is allocated by user and can be of different length,
- * if the length of one mask is shorter then check the shorter part first.
- * If the second mask is longer than the first mask, check that the longer part is all zero.
- *
- * Arguments:
- *     pAffinityMap1 - pointer to a generic affinity mask
- *     pAffinityMap2 - pointer to another generic affinity mask
- * Return: 0 if equal, 1 otherwise
- */
-static int __internal_daal_compareEqualGenericAffinity(GenericAffinityMask * pAffinityMap1, GenericAffinityMask * pAffinityMap2)
-{
-    int rc;
-    unsigned i, smaller;
-
-    smaller = pAffinityMap1->maxByteLength;
-    if (smaller > pAffinityMap2->maxByteLength) smaller = pAffinityMap2->maxByteLength;
-    if (!smaller) return 1;
-
-    rc = memcmp(pAffinityMap1->AffinityMask, pAffinityMap2->AffinityMask, smaller);
-    if (rc != 0)
+    GenericAffinityMask() = default;
+    GenericAffinityMask(const unsigned numCpus);
+    GenericAffinityMask(const GenericAffinityMask & other);
+    GenericAffinityMask & operator=(GenericAffinityMask other)
     {
-        return 1;
+        swap(*this, other);
+        return *this;
     }
-    else
-    {
-        if (pAffinityMap1->maxByteLength == pAffinityMap2->maxByteLength)
-        {
-            return 0;
-        }
-        else if (pAffinityMap1->maxByteLength > pAffinityMap2->maxByteLength)
-        {
-            for (i = smaller; i < pAffinityMap1->maxByteLength; i++)
-            {
-                if (pAffinityMap1->AffinityMask[i] != 0) return 1;
-            }
+    ~GenericAffinityMask();
 
-            return 0;
+    friend void swap(GenericAffinityMask & first, GenericAffinityMask & second) // nothrow
+    {
+        unsigned tmp    = first.cpuCount;
+        first.cpuCount  = second.cpuCount;
+        second.cpuCount = tmp;
+
+        tmp                  = first.maxByteLength;
+        first.maxByteLength  = second.maxByteLength;
+        second.maxByteLength = tmp;
+
+        unsigned char * tmpMask = first.AffinityMask;
+        first.AffinityMask      = second.AffinityMask;
+        second.AffinityMask     = tmpMask;
+    }
+
+    static constexpr unsigned char N_BITS_IN_BYTE      = 8;
+    static constexpr unsigned char LOG2_N_BITS_IN_BYTE = 3; // log2(8) = 3
+
+    static constexpr unsigned char OUT_OF_BOUND_ERROR = 0xff;
+
+    unsigned char test(unsigned cpu) const
+    {
+        if (cpu < (maxByteLength << LOG2_N_BITS_IN_BYTE))
+        {
+            if ((AffinityMask[cpu >> LOG2_N_BITS_IN_BYTE] & (1 << (cpu % N_BITS_IN_BYTE))))
+                return 1;
+            else
+                return 0;
         }
         else
         {
-            for (i = smaller; i < pAffinityMap2->maxByteLength; i++)
-            {
-                if (pAffinityMap2->AffinityMask[i] != 0) return 1;
-            }
-            return 0;
+            // If cpu is out of range, return 0xff to indicate an error
+            return OUT_OF_BOUND_ERROR;
         }
     }
+
+    unsigned char set(unsigned cpu)
+    {
+        if (cpu < (maxByteLength << LOG2_N_BITS_IN_BYTE))
+            AffinityMask[cpu >> LOG2_N_BITS_IN_BYTE] |= 1 << (cpu % N_BITS_IN_BYTE);
+        else
+        {
+            // If cpu is out of range, return 0xff to indicate an error
+            return OUT_OF_BOUND_ERROR;
+        }
+        return 0;
+    }
+
+    unsigned maxByteLength       = 0;
+    unsigned cpuCount            = 0;
+    unsigned char * AffinityMask = nullptr;
+};
+
+struct Dyn2Arr_str
+{
+    Dyn2Arr_str() : dim0(0), dim1(0), data(nullptr) {}
+    explicit Dyn2Arr_str(const unsigned xdim, const unsigned ydim, const unsigned value = 0);
+
+    ~Dyn2Arr_str();
+
+    Dyn2Arr_str(const Dyn2Arr_str & other);
+    Dyn2Arr_str & operator=(Dyn2Arr_str other)
+    {
+        swap(*this, other);
+        return *this;
+    }
+
+    unsigned & operator[](unsigned idx)
+    {
+        DAAL_ASSERT(idx < size());
+        return data[idx];
+    }
+
+    const unsigned & operator[](unsigned idx) const
+    {
+        DAAL_ASSERT(idx < size());
+        return data[idx];
+    }
+
+    bool isEmpty() const { return (data == nullptr); }
+
+    unsigned size() const { return dim0 * dim1; }
+
+    void fill(const unsigned value);
+
+    friend void swap(Dyn2Arr_str & first, Dyn2Arr_str & second) // nothrow
+    {
+        unsigned tmp = first.dim0;
+        first.dim0   = second.dim0;
+        second.dim0  = tmp;
+
+        tmp         = first.dim1;
+        first.dim1  = second.dim1;
+        second.dim1 = tmp;
+
+        unsigned * tmpData = first.data;
+        first.data         = second.data;
+        second.data        = tmpData;
+    }
+
+private:
+    unsigned dim0;
+    unsigned dim1;
+    unsigned * data; // data array to be malloc'd
+};
+
+struct Dyn1Arr_str
+{
+    Dyn1Arr_str() = default;
+    explicit Dyn1Arr_str(const unsigned xdim, const unsigned value = 0);
+    ~Dyn1Arr_str();
+
+    Dyn1Arr_str(const Dyn1Arr_str & other);
+    Dyn1Arr_str & operator=(Dyn1Arr_str other)
+    {
+        swap(*this, other);
+        return *this;
+    }
+
+    unsigned & operator[](unsigned idx)
+    {
+        DAAL_ASSERT(idx < dim0);
+        return data[idx];
+    }
+
+    const unsigned & operator[](unsigned idx) const
+    {
+        DAAL_ASSERT(idx < dim0);
+        return data[idx];
+    }
+
+    bool isEmpty() const { return (data == nullptr); }
+
+    void fill(const unsigned value);
+
+    void reset(const unsigned xdim)
+    {
+        if (xdim > dim0)
+        {
+            _INTERNAL_DAAL_FREE(data);
+            data = (unsigned *)_INTERNAL_DAAL_MALLOC(xdim * sizeof(unsigned));
+        }
+        dim0 = xdim;
+    }
+
+    friend void swap(Dyn1Arr_str & first, Dyn1Arr_str & second) // nothrow
+    {
+        unsigned tmp = first.dim0;
+        first.dim0   = second.dim0;
+        second.dim0  = tmp;
+
+        unsigned * tmpData = first.data;
+        first.data         = second.data;
+        second.data        = tmpData;
+    }
+
+private:
+    unsigned dim0;   // xdim
+    unsigned * data; // data array to be malloc'd
+};
+
+struct idAffMskOrdMapping_t
+{
+    idAffMskOrdMapping_t() = default;
+    explicit idAffMskOrdMapping_t(unsigned int cpu, bool hasLeafB, unsigned PkgSelectMask, unsigned PkgSelectMaskShift, unsigned CoreSelectMask,
+                                  unsigned SMTSelectMask, unsigned SMTMaskWidth);
+    unsigned __int32 APICID;        // the full x2APIC ID or initial APIC ID of a logical
+                                    //  processor assigned by HW
+    unsigned __int32 OrdIndexOAMsk; // An ordinal index (zero-based) for each logical
+                                    //  processor in the system
+    // Next three members are the sub IDs for processor topology enumeration
+    unsigned __int32 pkg_IDAPIC;  // Pkg_ID field, subset of APICID bits
+                                  //  to distinguish different packages
+    unsigned __int32 Core_IDAPIC; // Core_ID field, subset of APICID bits to
+                                  //  distinguish different cores in a package
+    unsigned __int32 SMT_IDAPIC;  // SMT_ID field, subset of APICID bits to
+                                  //  distinguish different logical processors in a core
+private:
+    void initApicID(bool hasLeafB);
+};
+
+// we are going to put an assortment of global variable, 1D and 2D arrays into
+// a data structure. This is the declaration
+struct glktsn
+{
+    // for each logical processor we need spaces to store APIC ID,
+    // sub IDs, affinity mappings, etc.
+    // Array of size EnumeratedThreadCount
+    idAffMskOrdMapping_t * pApicAffOrdMapping = nullptr;
+
+    // workspace for storing hierarchical counts of each level
+    Dyn1Arr_str perPkg_detectedCoresCount;
+    Dyn2Arr_str perCore_detectedThreadsCount;
+
+    // we use an error code to indicate any abnoral situation
+    unsigned error;
+
+    unsigned OSProcessorCount = 0; // how many logical processor the OS sees
+    bool hasLeafB;                 // flag to keep track of whether CPUID leaf 0BH is supported
+
+    // the following global variables are the total counts in the system resulting from software enumeration
+    unsigned EnumeratedCoreCount;
+    unsigned EnumeratedThreadCount;
+
+    unsigned maxCPUIDLeaf; // highest CPUID leaf index in a processor
+
+    bool isInit = false;
+
+    glktsn();
+
+    ~glktsn() { freeArrays(); }
+
+private:
+    int allocArrays(const unsigned cpus);
+    void freeArrays();
+    unsigned getMaxCPUSupportedByOS();
+
+    int parseAPICIDs(const GenericAffinityMask & processAffinity, unsigned & maxPkgSelectMaskShift);
+    int analyzeCPUHierarchy(unsigned PkgSelectMaskShift);
+    void buildSystemTopologyTables(const GenericAffinityMask & processAffinity);
+};
+
+// Global CPU topology object
+static glktsn globalCPUTopology;
+
+static void * __internal_daal_memset(void * s, int c, size_t nbytes)
+{
+    const unsigned char value = static_cast<unsigned char>(c);
+    unsigned char * p         = static_cast<unsigned char *>(s);
+    for (size_t i = 0; i < nbytes; ++i)
+    {
+        p[i] = value;
+    }
+    return s;
 }
 
 /*
- * __internal_daal_clearGenericAffinityBit
- *
- * Clear (set to 0) the cpu'th bit in the generic affinity mask.
- *
- * Arguments:
- *     generic affinty mask ptr
- * Return: 0 if no error, -1 otherise
+ * Binds the execution context of the process to a specific logical processor on construction.
+ * Restores the previous affinity mask on destruction.
  */
-static int __internal_daal_clearGenericAffinityBit(GenericAffinityMask * pAffinityMap, unsigned cpu)
+struct ScopedThreadContext
 {
-    if (cpu < (pAffinityMap->maxByteLength << 3))
+    // Constructor that binds the execution context to the specified logical processor
+    //
+    // \param cpu The ordinal index to reference a logical processor in the system
+    explicit ScopedThreadContext(unsigned int cpu)
     {
-        pAffinityMap->AffinityMask[cpu >> 3] ^= 1 << (cpu % 8);
+        error = 0;
+        error |= bindContext(cpu);
+    }
+
+    ~ScopedThreadContext() {}
+
+    void restoreContext()
+    {
+    #if defined(__linux__) || defined(__FreeBSD__)
+        if (sched_setaffinity(0, sizeof(prevAffinity), &prevAffinity))
+        {
+            error |= _MSGTYP_RESTORE_THREAD_AFFINITY_FAILED;
+        }
+    #else
+        if (!SetThreadGroupAffinity(GetCurrentThread(), &prevAffinity, NULL))
+        {
+            error |= _MSGTYP_RESTORE_THREAD_AFFINITY_FAILED;
+        }
+    #endif
+    }
+
+    int error;
+
+private:
+    /*
+    * A wrapper function that can compile under two OS environments
+    * Linux and Windows, to bind the current executing process context.
+    *
+    * The size of the bitmap that underlies cpu_set_t is configurable
+    * at Linux Kernel Compile time. Each distro may set limit on its own.
+    * Some newer Linux distro may support 256 logical processors,
+    * For simplicity we don't show the check for range on the ordinal index
+    * of the target cpu in Linux, interested reader can check Linux kernel documentation.
+    *
+    * Starting with Windows OS version 0601H (e.g. Windows 7), it supports up to 4 sets of
+    * affinity masks, referred to as "GROUP_AFFINITY".
+    * Constext switch within the same group is done by the same API as was done in previous
+    * generations of windows (such as Vista). In order to bind the current executing
+    * process context to a logical processor in a different group, it must be be binded
+    * using a new API to the target processor group.
+    * Limitation, New Windows APIs that support GROUP_AFFINITY requires
+    * Windows platform SDK 7.0a.
+    *
+    * \param cpu    The ordinal index to reference a logical processor in the system
+    *
+    * \return       0 is no error
+    */
+    int bindContext(unsigned int cpu)
+    {
+    #if defined(__linux__) || defined(__FreeBSD__)
+        cpu_set_t currentCPU;
+        // add check for size of cpumask_t.
+        MY_CPU_ZERO(&currentCPU);
+        // turn on the equivalent bit inside the bitmap corresponding to affinitymask
+        MY_CPU_SET(cpu, &currentCPU);
+        if (sched_getaffinity(0, sizeof(prevAffinity), &prevAffinity))
+        {
+            return _MSGTYP_GET_THREAD_AFFINITY_FAILED;
+        }
+        if (sched_setaffinity(0, sizeof(currentCPU), &currentCPU))
+        {
+            return _MSGTYP_SET_THREAD_AFFINITY_FAILED;
+        }
+    #else // Windows
+        if (cpu >= MAX_WIN7_LOG_CPU) return _MSGTYP_OS_PROC_COUNT_EXCEEDED;
+
+        // determine the group number and the cpu number within the group
+        unsigned int groupId      = cpu / MAX_LOGICAL_PROCESSORS_PER_GROUP;
+        unsigned int cpuIdInGroup = cpu - groupId * MAX_LOGICAL_PROCESSORS_PER_GROUP;
+
+        GROUP_AFFINITY grp_affinity;
+        _INTERNAL_DAAL_MEMSET(&grp_affinity, 0, sizeof(GROUP_AFFINITY));
+        grp_affinity.Group = groupId;
+        grp_affinity.Mask  = (KAFFINITY)((DWORD_PTR)(LNX_MY1CON << cpuIdInGroup));
+        if (!SetThreadGroupAffinity(GetCurrentThread(), &grp_affinity, &prevAffinity))
+        {
+            return _MSGTYP_SET_THREAD_AFFINITY_FAILED;
+        }
+    #endif
         return 0;
     }
-    else
+
+    #if defined(__linux__) || defined(__FreeBSD__)
+    cpu_set_t prevAffinity;
+    #else
+    GROUP_AFFINITY prevAffinity;
+    #endif
+};
+
+/*
+ * A wrapper function that calls OS specific system API to find out
+ * which logical processors this process is allowed to run on.
+ * And set the corresponding bits in our generic affinity mask construct.
+ *
+ * \param[in,out] processAffinity  Generic affinity mask to store the process affinity bits.
+ *                                 On input, cpuCount member must be set to the number
+ *                                 of logical processors available on the OS.
+ *
+ * \return 0 if no error, otherwise error code.
+ */
+int setChkProcessAffinityConsistency(GenericAffinityMask & processAffinity)
+{
+    int error = 0;
+
+    const unsigned OSProcessorCount = processAffinity.cpuCount;
+
+    #if defined(__linux__) || defined(__FreeBSD__)
+    cpu_set_t allowedCPUs;
+
+    sched_getaffinity(0, sizeof(allowedCPUs), &allowedCPUs);
+    for (unsigned int i = 0; i < OSProcessorCount; i++)
+    {
+        // check that i-th core belongs to the process affinity mask
+        if (MY_CPU_ISSET(i, &allowedCPUs))
+        {
+            if (processAffinity.set(i))
+            {
+                error |= _MSGTYP_CANNOT_SET_AFFINITY_BIT;
+                break;
+            }
+        }
+    }
+
+    #else
+
+    if (OSProcessorCount > MAX_WIN7_LOG_CPU)
+    {
+        error |= _MSGTYP_OS_PROC_COUNT_EXCEEDED; // If the os supports more processors than allowed, make change as required.
+        return error;
+    }
+
+    const unsigned short grpCnt = GetActiveProcessorGroupCount();
+
+    if (grpCnt > MAX_THREAD_GROUPS_WIN7)
+    {
+        error |= _MSGTYP_OS_GROUP_COUNT_EXCEEDED; // If the os supports more processor groups than allowed, make change as required.
+        return error;
+    }
+
+    // Take snapshot of all threads in the process
+    DWORD processId       = GetCurrentProcessId();
+    HANDLE snapshotHandle = CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, processId);
+    if (snapshotHandle == INVALID_HANDLE_VALUE)
+    {
+        error |= _MSGTYP_INVALID_SNAPSHOT_HANDLE;
+        return error;
+    }
+
+    // Index of the array is the group number, value is the affinity mask
+    KAFFINITY groupAffinityMap[MAX_THREAD_GROUPS_WIN7] = { 0, 0, 0, 0 };
+    bool groupAffinityInitialized                      = false;
+
+    // Iterate through all threads, get their group affinities and store them in the map
+    THREADENTRY32 threadEntry;
+    threadEntry.dwSize = sizeof(THREADENTRY32);
+
+    if (Thread32First(snapshotHandle, &threadEntry))
+    {
+        do
+        {
+            if (threadEntry.th32OwnerProcessID == processId)
+            {
+                HANDLE threadHandle = OpenThread(THREAD_QUERY_INFORMATION, FALSE, threadEntry.th32ThreadID);
+                if (threadHandle)
+                {
+                    GROUP_AFFINITY threadAffinity;
+                    if (GetThreadGroupAffinity(threadHandle, &threadAffinity))
+                    {
+                        // Store the affinity mask for this group
+                        groupAffinityMap[threadAffinity.Group] |= threadAffinity.Mask;
+                        groupAffinityInitialized = true;
+                    }
+                    CloseHandle(threadHandle);
+                }
+            }
+        } while (Thread32Next(snapshotHandle, &threadEntry));
+    }
+
+    CloseHandle(snapshotHandle);
+
+    if (!groupAffinityInitialized)
+    {
+        error |= _MSGTYP_FAILED_TO_INIT_PROC_AFFINITY;
+        return error;
+    }
+
+    unsigned int sum = 0;
+    for (unsigned int group = 0; group < grpCnt; group++)
+    {
+        KAFFINITY groupAffinityMask = groupAffinityMap[group];
+        if (groupAffinityMask)
+        {
+            unsigned int cpu_cnt = __internal_daal_countBits(groupAffinityMask); // count bits on each target affinity group
+            sum += cpu_cnt;
+            if (sum > OSProcessorCount)
+            {
+                // should never happen, number of bits set in all groups exceeds number of processors available to the OS
+                error |= _MSGTYP_USER_AFFINITY_ERROR;
+                break;
+            }
+
+            for (unsigned int j = 0; (j < MAX_LOGICAL_PROCESSORS_PER_GROUP) && (group * MAX_LOGICAL_PROCESSORS_PER_GROUP + j < OSProcessorCount); j++)
+            {
+                // check that j-th core belongs to the process affinity mask
+                if (groupAffinityMask & (KAFFINITY)((DWORD_PTR)(LNX_MY1CON << j)))
+                {
+                    if (processAffinity.set(j + group * MAX_LOGICAL_PROCESSORS_PER_GROUP))
+                    {
+                        error |= _MSGTYP_CANNOT_SET_AFFINITY_BIT;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    #endif
+
+    return error;
+}
+
+/*
+ * Use OS specific service to find out how many logical processors can be accessed
+ * by this application.
+ *
+ * \param[in,out] processAffinity  Generic affinity mask to store the process affinity bits.
+ *                                 On input, cpuCount member must be set to the size
+ *                                 of the full affinity mask of the OS.
+ *                                 On output, the affinity bits will be set according to
+ *                                 the process affinity mask retrieved from OS.
+ *
+ * \return Number of logical processors enabled by the OS for this process,
+ *         or -1 in case of error.
+ */
+int initEnumeratedThreadCount(GenericAffinityMask & processAffinity)
+{
+    unsigned cpuCount              = processAffinity.cpuCount;
+    unsigned enumeratedThreadCount = 0;
+
+    // Set the affinity bits of our generic affinity bitmap according to
+    // the system affinity mask and process affinity mask
+    int error = setChkProcessAffinityConsistency(processAffinity);
+    if (error)
     {
         return -1;
     }
+
+    for (unsigned i = 0; i < cpuCount; i++)
+    {
+        // can't asume OS affinity bit mask is contiguous,
+        // but we are using our generic bitmap representation for affinity
+        unsigned char processAffinityBit = processAffinity.test(i);
+        if (processAffinityBit == 1)
+        {
+            enumeratedThreadCount++;
+        }
+        else if (processAffinityBit == 0xff)
+        {
+            // should never happen
+            // i-th bit is out of bounds of the process affinity mask
+            error |= _MSGTYP_CANNOT_TEST_AFFINITY_BIT;
+            break;
+        }
+    }
+
+    if (error) return -1;
+
+    return enumeratedThreadCount;
 }
 
-/*
- * __internal_daal_testGenericAffinityBit
- *
- * check the cpu'th bit of the affinity mask and return 1 if the bit is set and 0 if the bit is 0.
- *
- * Arguments:
- *     generic affinty mask ptr
- *     cpu - cpu number. Signifies bit in the unsigned char affinity mask to be checked
- * Return: 0 if the cpu's bit is clear, returns 1 if the bit is set, -1 if an error
- *   The error condition makes it where you can't just check for '0' or 'not 0'
- *
- */
-static unsigned char __internal_daal_testGenericAffinityBit(GenericAffinityMask * pAffinityMap, unsigned cpu)
+glktsn::glktsn()
 {
-    if (cpu < (pAffinityMap->maxByteLength << 3))
+    isInit                = false;
+    error                 = 0;
+    hasLeafB              = false;
+    EnumeratedCoreCount   = 0;
+    EnumeratedThreadCount = 0;
+
+    // call CPUID with leaf 0 to get the maximum supported CPUID leaf index
+    CPUIDinfo info;
+    info.get(0);
+    maxCPUIDLeaf = info.EAX;
+
+    // call OS-specific service to find out how many logical processors
+    // are supported by the OS
+    OSProcessorCount = getMaxCPUSupportedByOS();
+
+    #ifdef __linux__
+    GenericAffinityMask processAffinity(OSProcessorCount);
+    #else
+    // For Windows, we need to consider processor groups.
+    // Each group can contain up to 64 logical processors.
+    const unsigned short grpCnt = GetActiveProcessorGroupCount();
+    GenericAffinityMask processAffinity(grpCnt * MAX_LOGICAL_PROCESSORS_PER_GROUP);
+    #endif
+    if (processAffinity.AffinityMask == NULL)
     {
-        if ((pAffinityMap->AffinityMask[cpu >> 3] & (1 << (cpu % 8))))
-            return 1;
-        else
-            return 0;
+        error |= _MSGTYP_MEMORY_ALLOCATION_FAILED;
+        return;
     }
-    else
+
+    int threadCount = initEnumeratedThreadCount(processAffinity);
+    if (threadCount < 0)
     {
-        return 0xff;
+        return;
     }
+    EnumeratedThreadCount = (unsigned)threadCount;
+    if (EnumeratedThreadCount == 0 || EnumeratedThreadCount > OSProcessorCount)
+    {
+        error |= _MSGTYP_USER_AFFINITY_ERROR;
+        return;
+    }
+    // Allocate memory to store the APIC ID, sub IDs, affinity mappings, etc.
+    allocArrays(EnumeratedThreadCount);
+    if (error) return;
+
+    // Initialize the global CPU topology object
+    buildSystemTopologyTables(processAffinity);
 }
 
 /*
- * __internal_daal_getApicID
+ * A wrapper function that calls OS specific system API to find out
+ * how many logical processor the OS supports
  *
- * Returns APIC ID from leaf B if it else from leaf 1
- *
- * Arguments: None
- * Return: APIC ID
+ * \return Number of logical processors enabled by the OS for this process
  */
-static unsigned __internal_daal_getApicID()
+unsigned int glktsn::getMaxCPUSupportedByOS()
+{
+    #if defined(__linux__) || defined(__FreeBSD__)
+
+    OSProcessorCount = sysconf(_SC_NPROCESSORS_ONLN); //This will tell us how many CPUs are currently enabled.
+
+    #else
+
+    OSProcessorCount = GetActiveProcessorCount(ALL_PROCESSOR_GROUPS);
+
+    #endif
+    return OSProcessorCount;
+}
+
+GenericAffinityMask::GenericAffinityMask(const unsigned numCpus) : cpuCount(numCpus)
+{
+    maxByteLength = (numCpus >> 3) + 1;
+    AffinityMask  = (unsigned char *)_INTERNAL_DAAL_MALLOC(maxByteLength * sizeof(unsigned char));
+    if (!AffinityMask) return;
+
+    _INTERNAL_DAAL_MEMSET(AffinityMask, 0, maxByteLength * sizeof(unsigned char));
+}
+
+GenericAffinityMask::GenericAffinityMask(const GenericAffinityMask & other)
+{
+    maxByteLength      = other.maxByteLength;
+    const int maskSize = maxByteLength * sizeof(unsigned char);
+    AffinityMask       = (unsigned char *)_INTERNAL_DAAL_MALLOC(maskSize);
+    if (!AffinityMask) return;
+
+    _INTERNAL_DAAL_MEMCPY(AffinityMask, maskSize, other.AffinityMask, maskSize);
+}
+
+GenericAffinityMask::~GenericAffinityMask()
+{
+    if (AffinityMask)
+    {
+        _INTERNAL_DAAL_FREE(AffinityMask);
+        AffinityMask = NULL;
+    }
+    maxByteLength = 0;
+}
+
+/*
+ * Initialize APIC ID from leaf B if it is available on the CPU, else from leaf 1
+ *
+ * \param hasLeafB  Flag to indicate whether CPUID leaf 0BH is supported
+ */
+void idAffMskOrdMapping_t::initApicID(bool hasLeafB)
 {
     CPUIDinfo info;
 
-    if (glbl_obj.hasLeafB)
+    if (hasLeafB)
     {
-        __internal_daal_cpuid(&info, 0xB); // query subleaf 0 of leaf B
-        return info.EDX;                   //  x2APIC ID
+        info.get(0xB);     // query subleaf 0 of leaf B
+        APICID = info.EDX; //  x2APIC ID
     }
-
-    __internal_daal_cpuid(&info, 1);
-
-    return (BYTE)(__internal_daal_getBitsFromDWORD(info.EBX, 24, 31)); // zero extend 8-bit initial APIC ID
-}
-
-// select the system-wide ordinal number of the first logical processor the is located
-// within the entity specified from the hierarchical ordinal number scheme
-// package: ordinal number of a package; ENUM_ALL means any package
-// core   : ordinal number of a core in the specified package; ENUM_ALL means any core
-// logical: ordinal number of a logical processor within the specifed core; ; ENUM_ALL means any thread
-// returns: the system wide ordinal number of the first logical processor that matches the
-//    specified (package, core, logical) triplet specification.
-static unsigned __internal_daal_slectOrdfromPkg(unsigned package, unsigned core, unsigned logical)
-{
-    unsigned i;
-
-    if (package != ENUM_ALL && package >= _internal_daal_GetSysProcessorPackageCount()) return 0;
-
-    for (i = 0; i < _internal_daal_GetOSLogicalProcessorCount(); i++)
+    else
     {
-        ////
-        if (!(package == ENUM_ALL || glbl_obj.pApicAffOrdMapping[i].packageORD == package)) continue;
-
-        if (!(core == ENUM_ALL || core == glbl_obj.pApicAffOrdMapping[i].coreORD)) continue;
-
-        if (!(logical == ENUM_ALL || logical == glbl_obj.pApicAffOrdMapping[i].threadORD)) continue;
-
-        return i;
+        info.get(1);
+        APICID = (BYTE)(__internal_daal_getBitsFromDWORD(info.EBX, 24, 31)); // zero extend 8-bit initial APIC ID
     }
-
-    return 0;
 }
 
 // Derive bitmask extraction parameters used to extract/decompose x2APIC ID.
-// The algorithm assumes __internal_daal_cpuid feature symmetry across all physical packages.
-// Since __internal_daal_cpuid reporting by each logical processor in a physical package are identical, we only execute __internal_daal_cpuid
-// on one logical processor to derive these system-wide parameters
-static int __internal_daal_cpuTopologyLeafBConstants()
+//
+// \param[out] PkgSelectMask        Mask to extract Pkg_ID field from APIC ID.
+//                                  Pkg_ID is an index of the physical package in the system,
+//                                  i.e. NUMA node index
+// \param[out] PkgSelectMaskShift   Shift count to right shift APIC ID before applying PkgSelectMask
+// \param[out] CoreSelectMask       Mask to extract Core_ID field from APIC ID.
+//                                  Core_ID is an index of the core in a physical package
+// \param[out] SMTSelectMask        Mask to extract SMT_ID (simultaneous multithreading)
+//                                  field from APIC ID.
+//                                  SMT_ID is an index of the logical processor in a core
+// \param[out] SMTMaskWidth         Width of the SMT_ID field in bits
+//
+// \return 0 if successful, non-zero if error occurred
+int cpuTopologyLeafBConstants(unsigned & PkgSelectMask, unsigned & PkgSelectMaskShift, unsigned & CoreSelectMask, unsigned & SMTSelectMask,
+                              unsigned & SMTMaskWidth)
 {
+    int error = 0;
     CPUIDinfo infoB;
-    int wasCoreReported            = 0;
-    int wasThreadReported          = 0;
+    bool wasCoreReported           = false;
+    bool wasThreadReported         = false;
     int subLeaf                    = 0, levelType, levelShift;
     unsigned long coreplusSMT_Mask = 0;
 
     do
     {
-        // we already tested __internal_daal_cpuid leaf 0BH contain valid sub-leaves
-        __internal_daal_cpuid_(&infoB, 0xB, subLeaf);
+        // we already tested CPUID leaf 0BH contain valid sub-leaves
+        infoB.get(0xB, subLeaf);
         if (infoB.EBX == 0)
         {
-            // if EBX ==0 then this subleaf is not valid, we can exit the loop
+            // if EBX == 0 then this subleaf is not valid, we can exit the loop
             break;
         }
 
@@ -777,16 +1027,16 @@ static int __internal_daal_cpuTopologyLeafBConstants()
         {
         case 1:
             // level type is SMT, so levelShift is the SMT_Mask_Width
-            glbl_obj.SMTSelectMask = ~((-1) << levelShift);
-            glbl_obj.SMTMaskWidth  = levelShift;
-            wasThreadReported      = 1;
+            SMTSelectMask     = ~((std::numeric_limits<unsigned>::max()) << levelShift);
+            SMTMaskWidth      = levelShift;
+            wasThreadReported = true;
             break;
         case 2:
             // level type is Core, so levelShift is the CorePlsuSMT_Mask_Width
-            coreplusSMT_Mask            = ~((-1) << levelShift);
-            glbl_obj.PkgSelectMaskShift = levelShift;
-            glbl_obj.PkgSelectMask      = (-1) ^ coreplusSMT_Mask;
-            wasCoreReported             = 1;
+            coreplusSMT_Mask   = ~((std::numeric_limits<unsigned long>::max()) << levelShift);
+            PkgSelectMaskShift = levelShift;
+            PkgSelectMask      = (-1) ^ coreplusSMT_Mask;
+            wasCoreReported    = true;
             break;
         default:
             // handle in the future
@@ -798,73 +1048,67 @@ static int __internal_daal_cpuTopologyLeafBConstants()
 
     if (wasThreadReported && wasCoreReported)
     {
-        glbl_obj.CoreSelectMask = coreplusSMT_Mask ^ glbl_obj.SMTSelectMask;
+        CoreSelectMask = coreplusSMT_Mask ^ SMTSelectMask;
     }
     else if (!wasCoreReported && wasThreadReported)
     {
-        glbl_obj.CoreSelectMask     = 0;
-        glbl_obj.PkgSelectMaskShift = glbl_obj.SMTMaskWidth;
-        glbl_obj.PkgSelectMask      = (-1) ^ glbl_obj.SMTSelectMask;
+        CoreSelectMask     = 0;
+        PkgSelectMaskShift = SMTMaskWidth;
+        PkgSelectMask      = (-1) ^ SMTSelectMask;
     }
-    else //(case where !wasThreadReported)
+    else // (case where !wasThreadReported)
     {
         // throw an error, this should not happen if hardware function normally
-        glbl_obj.error |= _MSGTYP_GENERAL_ERROR;
+        error |= _MSGTYP_THREAD_REPORTING_FAILED;
     }
 
-    if (glbl_obj.error) return -1;
+    if (error) return error;
 
     return 0;
 }
 
-// Calculate parameters used to extract/decompose Initial APIC ID.
-// The algorithm assumes __internal_daal_cpuid feature symmetry across all physical packages.
-// Since __internal_daal_cpuid reporting by each logical processor in a physical package are identical, we only execute __internal_daal_cpuid
-// on one logical processor to derive these system-wide parameters
-/*
- * __internal_daal_cpuTopologyLegacyConstants
- *
- * Derive bitmask extraction parameter using __internal_daal_cpuid leaf 1 and leaf 4
- *
- * Arguments:
- *     info - Point to strucrture containing CPIUD instruction leaf 1 data
- *     maxCPUID - Maximum __internal_daal_cpuid Leaf number supported by the processor
- * Return: 0 is no error
- */
-static int __internal_daal_cpuTopologyLegacyConstants(CPUIDinfo * pinfo, DWORD maxCPUID)
+// Derive bitmask extraction parameter using CPUID leaf 1 and leaf 4
+//
+// \param[in] maxCPUIDLeaf          Maximum supported CPUID leaf index
+// \param[in] info                  CPUID leaf 1 data structure
+// \param[out] PkgSelectMask        Mask to extract Pkg_ID field from APIC ID.
+//                                  Pkg_ID is an index of the physical package in the system,
+//                                  i.e. NUMA node index
+// \param[out] PkgSelectMaskShift   Shift count to right shift APIC ID before applying PkgSelectMask
+// \param[out] CoreSelectMask       Mask to extract Core_ID field from APIC ID.
+//                                  Core_ID is an index of the core in a physical package
+// \param[out] SMTSelectMask        Mask to extract SMT_ID (simultaneous multithreading)
+//                                  field from APIC ID.
+//                                  SMT_ID is an index of the logical processor in a core
+// \param[out] SMTMaskWidth         Width of the SMT_ID field in bits
+//
+// \return 0 if successful, non-zero if error occurred
+int cpuTopologyLegacyConstants(unsigned maxCPUIDLeaf, const CPUIDinfo & info, unsigned & PkgSelectMask, unsigned & PkgSelectMaskShift,
+                               unsigned & CoreSelectMask, unsigned & SMTSelectMask, unsigned & SMTMaskWidth)
 {
     unsigned corePlusSMTIDMaxCnt;
     unsigned coreIDMaxCnt       = 1;
     unsigned SMTIDPerCoreMaxCnt = 1;
 
-    corePlusSMTIDMaxCnt = __internal_daal_getBitsFromDWORD(pinfo->EBX, 16, 23);
-    if (maxCPUID >= 4)
+    corePlusSMTIDMaxCnt = __internal_daal_getBitsFromDWORD(info.EBX, 16, 23);
+    if (maxCPUIDLeaf >= 4)
     {
         CPUIDinfo info4;
-        __internal_daal_cpuid_(&info4, 4, 0);
+        info4.get(4, 0);
         coreIDMaxCnt       = __internal_daal_getBitsFromDWORD(info4.EAX, 26, 31) + 1; // related to coreMaskWidth
         SMTIDPerCoreMaxCnt = corePlusSMTIDMaxCnt / coreIDMaxCnt;
     }
     else
     {
-        // no support for __internal_daal_cpuid leaf 4 but caller has verified  HT support
-        if (!glbl_obj.Alert_BiosCPUIDmaxLimitSetting)
-        {
-            coreIDMaxCnt       = 1;
-            SMTIDPerCoreMaxCnt = corePlusSMTIDMaxCnt / coreIDMaxCnt;
-        }
-        else
-        {
-            // we got here most likely because IA32_MISC_ENABLES[22] was set to 1 by BIOS
-            glbl_obj.error |= _MSGTYP_CHECKBIOS_CPUIDMAXSETTING; // IA32_MISC_ENABLES[22] may have been set to 1, will cause inaccurate reporting
-        }
+        coreIDMaxCnt       = 1;
+        SMTIDPerCoreMaxCnt = corePlusSMTIDMaxCnt / coreIDMaxCnt;
     }
 
-    glbl_obj.SMTSelectMask  = __internal_daal_createMask(SMTIDPerCoreMaxCnt, &glbl_obj.SMTMaskWidth);
-    glbl_obj.CoreSelectMask = __internal_daal_createMask(coreIDMaxCnt, &glbl_obj.PkgSelectMaskShift);
-    glbl_obj.PkgSelectMaskShift += glbl_obj.SMTMaskWidth;
-    glbl_obj.CoreSelectMask <<= glbl_obj.SMTMaskWidth;
-    glbl_obj.PkgSelectMask = (-1) ^ (glbl_obj.CoreSelectMask | glbl_obj.SMTSelectMask);
+    SMTSelectMask  = __internal_daal_createMask(SMTIDPerCoreMaxCnt, &SMTMaskWidth);
+    CoreSelectMask = __internal_daal_createMask(coreIDMaxCnt, &PkgSelectMaskShift);
+    PkgSelectMaskShift += SMTMaskWidth;
+    CoreSelectMask <<= SMTMaskWidth;
+    PkgSelectMask = (-1) ^ (CoreSelectMask | SMTSelectMask);
 
     return 0;
 }
@@ -872,15 +1116,14 @@ static int __internal_daal_cpuTopologyLegacyConstants(CPUIDinfo * pinfo, DWORD m
 /*
  * __internal_daal_getCacheTotalLize
  *
- * Caluculates the total capacity (bytes) from the cache parameters reported by __internal_daal_cpuid leaf 4
+ * Caluculates the total capacity (bytes) from the cache parameters reported by CPUID leaf 4
  *          the caller provides the raw data reported by the target sub leaf of cpuid leaf 4
  *
  * Arguments:
- *     maxCPUID - Maximum __internal_daal_cpuid Leaf number supported by the processor, provided by parent
  *     cache_type - the cache type encoding recognized by CPIUD instruction leaf 4 for the target cache level
  * Return: the sub-leaf index corresponding to the largest cache of specified cache type
  */
-static unsigned long __internal_daal_getCacheTotalLize(CPUIDinfo info)
+static unsigned long __internal_daal_getCacheTotalLize(const CPUIDinfo & info)
 {
     unsigned long LnSz, SectorSz, WaySz, SetSz;
 
@@ -892,376 +1135,200 @@ static unsigned long __internal_daal_getCacheTotalLize(CPUIDinfo info)
     return (SetSz * WaySz * SectorSz * LnSz);
 }
 
-/*
- * __internal_daal_findEachCacheIndex
- *
- * Find the subleaf index of __internal_daal_cpuid leaf 4 corresponding to the input subleaf
- *
- * Arguments:
- *     maxCPUID - Maximum __internal_daal_cpuid Leaf number supported by the processor, provided by parent
- *     cache_subleaf - the cache subleaf encoding recognized by CPIUD instruction leaf 4 for the target cache level
- * Return: the sub-leaf index corresponding to the largest cache of specified cache type
- */
-static int __internal_daal_findEachCacheIndex(DWORD maxCPUID, unsigned cache_subleaf)
+// Derive parameters used to extract/decompose APIC ID for CPU topology.
+//
+// \param[in] maxCPUIDLeaf          Maximum supported CPUID leaf index
+// \param[out] hasLeafB             Flag to indicate whether CPUID leaf 0BH is supported
+// \param[out] PkgSelectMask        Mask to extract Pkg_ID field from APIC ID.
+//                                  Pkg_ID is an index of the physical package in the system,
+//                                  i.e. NUMA node index
+// \param[out] PkgSelectMaskShift   Shift count to right shift APIC ID before applying PkgSelectMask
+// \param[out] CoreSelectMask       Mask to extract Core_ID field from APIC ID.
+//                                  Core_ID is an index of the core in a physical package
+// \param[out] SMTSelectMask        Mask to extract SMT_ID (simultaneous multithreading)
+//                                  field from APIC ID.
+//                                  SMT_ID is an index of the logical processor in a core
+// \param[out] SMTMaskWidth         Width of the SMT_ID field in bits
+//
+// \return 0 if successful, non-zero if error occurred
+int cpuTopologyParams(unsigned maxCPUIDLeaf, bool & hasLeafB, unsigned & PkgSelectMask, unsigned & PkgSelectMaskShift, unsigned & CoreSelectMask,
+                      unsigned & SMTSelectMask, unsigned & SMTMaskWidth)
 {
-    unsigned i, type;
-    unsigned long cap;
-    CPUIDinfo info4;
-    int target_index = -1;
-
-    if (maxCPUID < 4)
-    {
-        // if we can't get detailed parameters from cpuid leaf 4, this is stub pointers for older processors
-        if (maxCPUID >= 2)
-        {
-            if (!cache_subleaf)
-            {
-                glbl_obj.cacheDetail[cache_subleaf].sizeKB = 0;
-                return cache_subleaf;
-            }
-        }
-        return -1;
-    }
-
-    __internal_daal_cpuid_(&info4, 4, cache_subleaf);
-    type = __internal_daal_getBitsFromDWORD(info4.EAX, 0, 4);
-    cap  = __internal_daal_getCacheTotalLize(info4);
-
-    if (type > 0)
-    {
-        glbl_obj.cacheDetail[cache_subleaf].level = __internal_daal_getBitsFromDWORD(info4.EAX, 5, 7);
-        glbl_obj.cacheDetail[cache_subleaf].type  = type;
-        for (i = 0; i <= cache_subleaf; i++)
-        {
-            if (glbl_obj.cacheDetail[i].type == type) glbl_obj.cacheDetail[i].how_many_caches_share_level++;
-        }
-        glbl_obj.cacheDetail[cache_subleaf].sizeKB = cap / 1024;
-        target_index                               = cache_subleaf;
-    }
-
-    return target_index;
-}
-
-/*
- * __internal_daal_initStructuredLeafBuffers
- *
- * Allocate buffers to store cpuid leaf data including buffers for subleaves within leaf 4 and 11
- *
- * Arguments: none
- * Return: none
- *
- */
-static void __internal_daal_initStructuredLeafBuffers()
-{
-    unsigned j, kk, qeidmsk;
-    unsigned maxCPUID;
-    CPUIDinfo info;
-
-    __internal_daal_cpuid(&info, 0);
-    maxCPUID                            = info.EAX;
-    glbl_obj.cpuid_values[0].subleaf[0] = (CPUIDinfo *)_INTERNAL_DAAL_MALLOC(sizeof(CPUIDinfo));
-    _INTERNAL_DAAL_MEMCPY(glbl_obj.cpuid_values[0].subleaf[0], sizeof(CPUIDinfo), &info, 4 * sizeof(unsigned int));
-    // Mark this combo of cpu, leaf, subleaf is valid
-    glbl_obj.cpuid_values[0].subleaf_max = 1;
-
-    for (j = 1; j <= maxCPUID; j++)
-    {
-        __internal_daal_cpuid(&info, j);
-        glbl_obj.cpuid_values[j].subleaf[0] = (CPUIDinfo *)_INTERNAL_DAAL_MALLOC(sizeof(CPUIDinfo));
-        _INTERNAL_DAAL_MEMCPY(glbl_obj.cpuid_values[j].subleaf[0], sizeof(CPUIDinfo), &info, 4 * sizeof(unsigned int));
-        glbl_obj.cpuid_values[j].subleaf_max = 1;
-
-        if (j == 0xd)
-        {
-            int subleaf                          = 2;
-            glbl_obj.cpuid_values[j].subleaf_max = 1;
-            __internal_daal_cpuid_(&info, j, subleaf);
-            while (info.EAX && subleaf < MAX_CACHE_SUBLEAFS)
-            {
-                glbl_obj.cpuid_values[j].subleaf_max = subleaf;
-                subleaf++;
-                __internal_daal_cpuid_(&info, j, subleaf);
-            }
-        }
-        else if (j == 0x10 || j == 0xf)
-        {
-            int subleaf = 1;
-            __internal_daal_cpuid_(&info, j, subleaf);
-            if (j == 0xf)
-                qeidmsk = info.EDX; // sub-leaf value are derived from valid resource id's
-            else
-                qeidmsk = info.EBX;
-            kk = 1;
-            while (kk < 32)
-            {
-                __internal_daal_cpuid_(&info, j, kk);
-                if ((qeidmsk & (1 << kk)) != 0) glbl_obj.cpuid_values[j].subleaf_max = kk;
-                kk++;
-            }
-        }
-        else if ((j == 0x4 || j == 0xb))
-        {
-            int subleaf       = 1;
-            unsigned int type = 1;
-            while (type && subleaf < MAX_CACHE_SUBLEAFS)
-            {
-                __internal_daal_cpuid_(&info, j, subleaf);
-                if (j == 0x4)
-                    type = __internal_daal_getBitsFromDWORD(info.EAX, 0, 4);
-                else
-                    type = 0xffff & info.EBX;
-                glbl_obj.cpuid_values[j].subleaf[subleaf] = (CPUIDinfo *)_INTERNAL_DAAL_MALLOC(sizeof(CPUIDinfo));
-                _INTERNAL_DAAL_MEMCPY(glbl_obj.cpuid_values[j].subleaf[subleaf], sizeof(CPUIDinfo), &info, 4 * sizeof(unsigned int));
-                subleaf++;
-                glbl_obj.cpuid_values[j].subleaf_max = subleaf;
-            }
-        }
-    }
-}
-
-/*
- * __internal_daal_eachCacheTopologyParams
- *
- * Calculates the select mask that can be used to extract Cache_ID from an APIC ID
- *          the caller must specify which target cache level it wishes to extract Cache_IDs
- *
- * Arguments:
- *     targ_subleaf - the subleaf index to execute CPIUD instruction leaf 4 for the target cache level, provided by parent
- *     maxCPUID - Maximum __internal_daal_cpuid Leaf number supported by the processor, provided by parent
- * Return: 0 is no error
- */
-static int __internal_daal_eachCacheTopologyParams(unsigned targ_subleaf, DWORD maxCPUID)
-{
-    unsigned long SMTMaxCntPerEachCache;
-    CPUIDinfo info;
-
-    __internal_daal_cpuid(&info, 1);
-    if (maxCPUID >= 4)
-    {
-        CPUIDinfo info4;
-        __internal_daal_cpuid_(&info4, 4, targ_subleaf);
-
-        SMTMaxCntPerEachCache = __internal_daal_getBitsFromDWORD(info4.EAX, 14, 25) + 1;
-    }
-    else if (__internal_daal_getBitsFromDWORD(info.EDX, 28, 28))
-    {
-        // no support for __internal_daal_cpuid leaf 4 but HT is supported
-        SMTMaxCntPerEachCache = __internal_daal_getBitsFromDWORD(info.EBX, 16, 23);
-    }
-    else
-    {
-        // no support for __internal_daal_cpuid leaf 4 and no HT
-        SMTMaxCntPerEachCache = 1;
-    }
-
-    glbl_obj.EachCacheSelectMask[targ_subleaf] = __internal_daal_createMask(SMTMaxCntPerEachCache, &glbl_obj.EachCacheMaskWidth[targ_subleaf]);
-
-    return 0;
-}
-
-// Calculate parameters used to extract/decompose APIC ID for cache topology
-// The algorithm assumes __internal_daal_cpuid feature symmetry across all physical packages.
-// Since __internal_daal_cpuid reporting by each logical processor in a physical package are identical, we only execute __internal_daal_cpuid
-// on one logical processor to derive these system-wide parameters
-// return 0 if successful, non-zero if error occurred
-static int __internal_daal_cacheTopologyParams()
-{
-    DWORD maxCPUID;
-    CPUIDinfo info;
-    int targ_index;
-
-    __internal_daal_cpuid_(&info, 0, 0);
-    maxCPUID = info.EAX;
-
-    // Let's also examine cache topology.
-    // As an example choose the largest unified cache as target level
-    if (maxCPUID >= 4)
-    {
-        unsigned subleaf;
-        __internal_daal_initStructuredLeafBuffers();
-
-        glbl_obj.maxCacheSubleaf = 0;
-
-        for (subleaf = 0; subleaf < glbl_obj.cpuid_values[4].subleaf_max; subleaf++)
-        {
-            targ_index = __internal_daal_findEachCacheIndex(maxCPUID, subleaf); // unified cache is type 3 under leaf 4
-            if (targ_index >= 0)
-            {
-                glbl_obj.maxCacheSubleaf = targ_index;
-                __internal_daal_eachCacheTopologyParams(targ_index, maxCPUID);
-            }
-            else
-            {
-                break;
-            }
-        }
-    }
-    else if (maxCPUID >= 2)
-    {
-        int subleaf;
-        glbl_obj.maxCacheSubleaf = 0;
-
-        for (subleaf = 0; subleaf < 4; subleaf++)
-        {
-            targ_index = __internal_daal_findEachCacheIndex(maxCPUID, subleaf);
-            if (targ_index >= 0)
-            {
-                glbl_obj.maxCacheSubleaf = targ_index;
-                __internal_daal_eachCacheTopologyParams(targ_index, maxCPUID);
-            }
-            else
-            {
-                break;
-            }
-        }
-    }
-
-    if (glbl_obj.error) return -1;
-
-    return 0;
-}
-
-// Derive parameters used to extract/decompose APIC ID for CPU topology
-// The algorithm assumes __internal_daal_cpuid feature symmetry across all physical packages.
-// Since __internal_daal_cpuid reporting by each logical processor in a physical package are
-// identical, we only execute __internal_daal_cpuid on one logical processor to derive these
-// system-wide parameters
-// return 0 if successful, non-zero if error occurred
-static int __internal_daal_cpuTopologyParams()
-{
-    DWORD maxCPUID; // highest __internal_daal_cpuid leaf index this processor supports
-    CPUIDinfo info; // data structure to store register data reported by __internal_daal_cpuid
-
-    __internal_daal_cpuid_(&info, 0, 0);
-    maxCPUID = info.EAX;
+    int error = 0;
+    CPUIDinfo info; // data structure to store register data reported by CPUID
 
     // cpuid leaf B detection
-    if (maxCPUID >= 0xB)
+    if (maxCPUIDLeaf >= 0xB)
     {
         CPUIDinfo CPUInfoB;
-        __internal_daal_cpuid_(&CPUInfoB, 0xB, 0);
-        //glbl_ptr points to assortment of global data, workspace, etc
-        glbl_obj.hasLeafB = (CPUInfoB.EBX != 0);
+        CPUInfoB.get(0xB, 0);
+        // glbl_ptr points to assortment of global data, workspace, etc
+        hasLeafB = (CPUInfoB.EBX != 0);
     }
 
-    __internal_daal_cpuid_(&info, 1, 0);
+    info.get(1, 0);
 
-    // Use HWMT feature flag __internal_daal_cpuid.01:EDX[28] to treat three configurations:
+    // Use HWMT feature flag CPUID.01:EDX[28] to treat three configurations:
     if (__internal_daal_getBitsFromDWORD(info.EDX, 28, 28))
     {
-        if (glbl_obj.hasLeafB)
+        // Processors that support Hyper-Threading
+        if (hasLeafB)
         {
-            // #1, Processors that support __internal_daal_cpuid leaf 0BH
-            // use __internal_daal_cpuid leaf B to derive extraction parameters
-            __internal_daal_cpuTopologyLeafBConstants();
+            // #1, Processors that support CPUID leaf 0BH
+            //     use CPUID leaf B to derive extraction parameters
+            error = cpuTopologyLeafBConstants(PkgSelectMask, PkgSelectMaskShift, CoreSelectMask, SMTSelectMask, SMTMaskWidth);
         }
         else
         {
-            //#2, Processors that support legacy parameters
-            //  using __internal_daal_cpuid leaf 1 and leaf 4
-            __internal_daal_cpuTopologyLegacyConstants(&info, maxCPUID);
+            // #2, Processors that support legacy parameters
+            //     using CPUID leaf 1 and leaf 4
+            error = cpuTopologyLegacyConstants(maxCPUIDLeaf, info, PkgSelectMask, PkgSelectMaskShift, CoreSelectMask, SMTSelectMask, SMTMaskWidth);
         }
     }
     else
     {
-        //#3, Prior to HT, there is only one logical processor in a physical package
-        glbl_obj.CoreSelectMask     = 0;
-        glbl_obj.SMTMaskWidth       = 0;
-        glbl_obj.PkgSelectMask      = (unsigned)(-1);
-        glbl_obj.PkgSelectMaskShift = 0;
-        glbl_obj.SMTSelectMask      = 0;
+        // #3, Prior to HT, there is only one logical processor in a physical package
+        CoreSelectMask     = 0;
+        SMTMaskWidth       = 0;
+        PkgSelectMask      = (unsigned)(-1);
+        PkgSelectMaskShift = 0;
+        SMTSelectMask      = 0;
     }
 
-    if (glbl_obj.error) return -1;
+    if (error) return error;
 
     return 0;
 }
 
-/*
- * __internal_daal_allocArrays
- *
- * allocate the dynamic arrays in the glbl_ptr containing various buffers for analyzing
- *  cpu topology and cache topology of a system with N logical processors
- *
- * Arguments: number of logical processors
- * Return: 0 is no error, -1 is error
- */
-static int __internal_daal_allocArrays(unsigned cpus)
+Dyn2Arr_str::Dyn2Arr_str(const unsigned xdim, const unsigned ydim, const unsigned value)
 {
-    unsigned i;
+    dim0 = xdim;
+    dim1 = ydim;
+    data = (unsigned *)_INTERNAL_DAAL_MALLOC(xdim * ydim * sizeof(unsigned));
+    if (!data)
+    {
+        return;
+    }
+    _INTERNAL_DAAL_MEMSET(data, value, xdim * ydim * sizeof(unsigned));
+}
 
-    i                           = cpus + 1;
-    glbl_obj.pApicAffOrdMapping = (idAffMskOrdMapping_t *)_INTERNAL_DAAL_MALLOC(i * sizeof(idAffMskOrdMapping_t));
-    _INTERNAL_DAAL_MEMSET(glbl_obj.pApicAffOrdMapping, 0, i * sizeof(idAffMskOrdMapping_t));
+Dyn2Arr_str::Dyn2Arr_str(const Dyn2Arr_str & other)
+{
+    if (this == &other) return; // self-assignment check
+    dim0            = other.dim0;
+    dim1            = other.dim1;
+    size_t dataSize = dim0 * dim1 * sizeof(unsigned);
+    data            = (unsigned *)_INTERNAL_DAAL_MALLOC(dataSize);
+    if (!data) return;
+    _INTERNAL_DAAL_MEMCPY(data, dataSize, other.data, dataSize);
+}
 
-    glbl_obj.perPkg_detectedCoresCount.data = (unsigned *)_INTERNAL_DAAL_MALLOC(i * sizeof(unsigned));
-    _INTERNAL_DAAL_MEMSET(glbl_obj.perPkg_detectedCoresCount.data, 0, i * sizeof(unsigned));
-    glbl_obj.perPkg_detectedCoresCount.dim[0] = i;
+Dyn2Arr_str::~Dyn2Arr_str()
+{
+    if (data)
+    {
+        _INTERNAL_DAAL_FREE(data);
+        data = NULL;
+    }
+    dim0 = 0;
+    dim1 = 0;
+}
 
-    glbl_obj.perCore_detectedThreadsCount.data = (unsigned *)_INTERNAL_DAAL_MALLOC(MAX_CORES * i * sizeof(unsigned));
-    _INTERNAL_DAAL_MEMSET(glbl_obj.perCore_detectedThreadsCount.data, 0, MAX_CORES * i * sizeof(unsigned));
-    glbl_obj.perCore_detectedThreadsCount.dim[0] = i;
-    glbl_obj.perCore_detectedThreadsCount.dim[1] = MAX_CORES;
+void Dyn2Arr_str::fill(const unsigned value)
+{
+    _INTERNAL_DAAL_MEMSET(data, value, dim0 * dim1 * sizeof(unsigned));
+}
 
-    // workspace for storing hierarchical counts relative to the cache topology
-    // of the largest unified cache (may be shared by several cores)
-    glbl_obj.perCache_detectedCoreCount.data = (unsigned *)_INTERNAL_DAAL_MALLOC(i * sizeof(unsigned));
-    _INTERNAL_DAAL_MEMSET(glbl_obj.perCache_detectedCoreCount.data, 0, i * sizeof(unsigned));
-    glbl_obj.perCache_detectedCoreCount.dim[0] = i;
+Dyn1Arr_str::Dyn1Arr_str(const unsigned xdim, const unsigned value)
+{
+    dim0 = xdim;
+    data = (unsigned *)_INTERNAL_DAAL_MALLOC(xdim * sizeof(unsigned));
+    if (!data)
+    {
+        return;
+    }
+    fill(value);
+}
 
-    glbl_obj.perEachCache_detectedThreadCount.data = (unsigned *)_INTERNAL_DAAL_MALLOC(MAX_CACHE_SUBLEAFS * i * sizeof(unsigned));
-    _INTERNAL_DAAL_MEMSET(glbl_obj.perEachCache_detectedThreadCount.data, 0, MAX_CACHE_SUBLEAFS * i * sizeof(unsigned));
-    glbl_obj.perEachCache_detectedThreadCount.dim[0] = i;
-    glbl_obj.perEachCache_detectedThreadCount.dim[1] = MAX_CACHE_SUBLEAFS;
+Dyn1Arr_str::Dyn1Arr_str(const Dyn1Arr_str & other)
+{
+    if (this == &other) return; // self-assignment check
+    dim0            = other.dim0;
+    size_t dataSize = dim0 * sizeof(unsigned);
+    data            = (unsigned *)_INTERNAL_DAAL_MALLOC(dataSize);
+    if (!data) return;
+    _INTERNAL_DAAL_MEMCPY(data, dataSize, other.data, dataSize);
+}
 
-    glbl_obj.cpuid_values = (CPUIDinfox *)_INTERNAL_DAAL_MALLOC(MAX_LEAFS * i * sizeof(CPUIDinfox));
-    _INTERNAL_DAAL_MEMSET(glbl_obj.cpuid_values, 0, MAX_LEAFS * i * sizeof(CPUIDinfox));
+Dyn1Arr_str::~Dyn1Arr_str()
+{
+    if (data)
+    {
+        _INTERNAL_DAAL_FREE(data);
+        data = NULL;
+    }
+    dim0 = 0;
+}
+
+void Dyn1Arr_str::fill(const unsigned value)
+{
+    _INTERNAL_DAAL_MEMSET(data, value, dim0 * sizeof(unsigned));
+}
+
+/*
+ * Allocate the dynamic arrays in the global object containing various buffers for analyzing
+ * cpu topology of a system with N logical processors in the process affinity mask.
+ *
+ * \param cpus  Number of logical processors
+ *
+ * \return 0 is no error, error code otherwise
+ */
+int glktsn::allocArrays(const unsigned cpus)
+{
+    pApicAffOrdMapping = (idAffMskOrdMapping_t *)_INTERNAL_DAAL_MALLOC(cpus * sizeof(idAffMskOrdMapping_t));
+    if (!pApicAffOrdMapping)
+    {
+        error = _MSGTYP_MEMORY_ALLOCATION_FAILED;
+        return error;
+    }
+    _INTERNAL_DAAL_MEMSET(pApicAffOrdMapping, 0, cpus * sizeof(idAffMskOrdMapping_t));
+
+    perPkg_detectedCoresCount    = Dyn1Arr_str(cpus);
+    perCore_detectedThreadsCount = Dyn2Arr_str(cpus, MAX_CORES);
+    if (perPkg_detectedCoresCount.isEmpty() || perCore_detectedThreadsCount.isEmpty())
+    {
+        error = _MSGTYP_MEMORY_ALLOCATION_FAILED;
+        return error;
+    }
+    perPkg_detectedCoresCount.fill(0);
+    perCore_detectedThreadsCount.fill(0);
 
     return 0;
 }
 
 /*
- * __internal_daal_parseIDS4EachThread
- *
  * after execution context has already bound to the target logical processor
  * Query the 32-bit x2APIC ID if the processor supports it, or
  * Query the 8bit initial APIC ID for older processors
  * Apply various system-wide topology constant to parse the APIC ID into various sub IDs
  *
  * Arguments:
- *      i - the ordinal index to reference a logical processor in the system
+ *      cpu - the ordinal index to reference a logical processor in the system
  *      numMappings - running count ot how many processors we've parsed
- * Return: 0 is no error
  */
-static unsigned __internal_daal_parseIDS4EachThread(unsigned i, unsigned numMappings)
+idAffMskOrdMapping_t::idAffMskOrdMapping_t(unsigned int cpu, bool hasLeafB, unsigned PkgSelectMask, unsigned PkgSelectMaskShift,
+                                           unsigned CoreSelectMask, unsigned SMTSelectMask, unsigned SMTMaskWidth)
 {
-    unsigned APICID;
-    unsigned subleaf;
+    initApicID(hasLeafB);
 
-    APICID = glbl_obj.pApicAffOrdMapping[numMappings].APICID = __internal_daal_getApicID();
-    glbl_obj.pApicAffOrdMapping[numMappings].OrdIndexOAMsk   = i; // this an ordinal number that can relate to generic affinitymask
-    glbl_obj.pApicAffOrdMapping[numMappings].pkg_IDAPIC      = ((APICID & glbl_obj.PkgSelectMask) >> glbl_obj.PkgSelectMaskShift);
-    glbl_obj.pApicAffOrdMapping[numMappings].Core_IDAPIC     = ((APICID & glbl_obj.CoreSelectMask) >> glbl_obj.SMTMaskWidth);
-    glbl_obj.pApicAffOrdMapping[numMappings].SMT_IDAPIC      = (APICID & glbl_obj.SMTSelectMask);
-
-    if (glbl_obj.maxCacheSubleaf != -1)
-    {
-        for (subleaf = 0; subleaf <= glbl_obj.maxCacheSubleaf; subleaf++)
-        {
-            glbl_obj.pApicAffOrdMapping[numMappings].EaCacheSMTIDAPIC[subleaf] = (APICID & glbl_obj.EachCacheSelectMask[subleaf]);
-            glbl_obj.pApicAffOrdMapping[numMappings].EaCacheIDAPIC[subleaf]    = (APICID & (-1 ^ glbl_obj.EachCacheSelectMask[subleaf]));
-        }
-    }
-
-    return 0;
+    OrdIndexOAMsk = cpu; // this an ordinal number that can relate to generic affinity mask
+    pkg_IDAPIC    = ((APICID & PkgSelectMask) >> PkgSelectMaskShift);
+    Core_IDAPIC   = ((APICID & CoreSelectMask) >> SMTMaskWidth);
+    SMT_IDAPIC    = (APICID & SMTSelectMask);
 }
 
 /*
- * __internal_daal_queryParseSubIDs
- *
- * Use OS specific service to find out how many logical processors can be accessed
- * by this application.
- * Querying __internal_daal_cpuid on each logical processor requires using OS-specific API to
+ * Querying CPUID on each logical processor requires using OS-specific API to
  * bind current context to each logical processor first.
  * After gathering the APIC ID's for each logical processor,
  * we can parse APIC ID into sub IDs for each topological levels
@@ -1271,140 +1338,138 @@ static unsigned __internal_daal_parseIDS4EachThread(unsigned i, unsigned numMapp
  * in a manner that abstract the OS-specific affinity mask data structure.
  * Here, we construct a generic affinity mask that can handle arbitrary number of logical processors.
  *
- * Arguments: none
  * Return: 0 is no error
  */
-static int __internal_daal_queryParseSubIDs(void)
+int glktsn::parseAPICIDs(const GenericAffinityMask & processAffinity, unsigned & maxPkgSelectMaskShift)
 {
-    unsigned i;
-    int numMappings = 0;
-    unsigned lcl_OSProcessorCount;
-    #if defined(__linux__) || defined(__FreeBSD__)
-    cpu_set_t pa;
-    #else
-        #if (_WIN32_WINNT >= 0x0601)
-    GROUP_AFFINITY pa;
-        #else // If SDK version does not support GROUP_AFFINITY,
-    DWORD_PTR pa;
-        #endif
-    #endif
-
-    // we already queried OS how many logical processor it sees.
-    lcl_OSProcessorCount = glbl_obj.OSProcessorCount;
-
-    // we will use our generic affinity bitmap that can be generalized from
-    // OS specific affinity mask constructs or the bitmap representation of an OS
-    if (__internal_daal_allocateGenericAffinityMask(&glbl_obj.cpu_generic_processAffinity, lcl_OSProcessorCount)) return -1;
-    if (__internal_daal_allocateGenericAffinityMask(&glbl_obj.cpu_generic_systemAffinity, lcl_OSProcessorCount)) return -1;
-
-    // Set the affinity bits of our generic affinity bitmap according to
-    // the system affinity mask and process affinity mask
-    __internal_daal_setChkProcessAffinityConsistency(lcl_OSProcessorCount);
-    if (glbl_obj.error)
-    {
-        __internal_daal_freeGenericAffinityMask(&glbl_obj.cpu_generic_processAffinity);
-        __internal_daal_freeGenericAffinityMask(&glbl_obj.cpu_generic_systemAffinity);
-        return -1;
-    }
-
-    for (i = 0; i < glbl_obj.OSProcessorCount; i++)
+    unsigned threadIndex  = 0;
+    maxPkgSelectMaskShift = 0;
+    for (unsigned i = 0; i < processAffinity.cpuCount; i++)
     {
         // can't asume OS affinity bit mask is contiguous,
         // but we are using our generic bitmap representation for affinity
-        if (__internal_daal_testGenericAffinityBit(&glbl_obj.cpu_generic_processAffinity, i) == 1)
+        unsigned char processAffinityBit = processAffinity.test(i);
+        if (processAffinityBit == 1)
         {
-            // bind the execution context to the ith logical processor
-            // using OS-specifi API
-            if (__internal_daal_bindContext(i, (void *)(&pa)))
+            // bind the execution context to the i-th logical processor
+            // using OS-specific API
+            ScopedThreadContext ctx(i);
+            if (ctx.error)
             {
-                glbl_obj.error |= _MSGTYP_UNKNOWNERR_OS;
+                // Failed to set thread affinity
+                error |= ctx.error;
                 break;
             }
 
-            // now the execution context is on the i'th cpu, call the parsing routine
-            __internal_daal_parseIDS4EachThread(i, numMappings);
-            __internal_daal_restoreContext((void *)(&pa));
+            // the following variables are parameters related to
+            // extracting sub IDs from an APIC ID, on heterogeneous systems can differ across cores
+            unsigned CoreSelectMask;
+            unsigned PkgSelectMask;
+            unsigned PkgSelectMaskShift;
+            unsigned SMTSelectMask;
+            unsigned SMTMaskWidth;
 
-            numMappings++;
+            error = cpuTopologyParams(maxCPUIDLeaf, hasLeafB, PkgSelectMask, PkgSelectMaskShift, CoreSelectMask, SMTSelectMask, SMTMaskWidth);
+            if (error)
+            {
+                // Failed to derive CPU topology parameters
+                break;
+            }
+
+            if (PkgSelectMaskShift > maxPkgSelectMaskShift)
+            {
+                maxPkgSelectMaskShift = PkgSelectMaskShift;
+            }
+
+            if (threadIndex >= EnumeratedThreadCount)
+            {
+                // should never happen
+                error |= _MSGTYP_INVALID_THREAD_INDEX;
+                break;
+            }
+            pApicAffOrdMapping[threadIndex++] =
+                idAffMskOrdMapping_t(i, hasLeafB, PkgSelectMask, PkgSelectMaskShift, CoreSelectMask, SMTSelectMask, SMTMaskWidth);
+            ctx.restoreContext();
+            if (ctx.error)
+            {
+                // Failed to set thread affinity
+                error |= ctx.error;
+                break;
+            }
+        }
+        else if (processAffinityBit == 0xff)
+        {
+            // should never happen
+            // i-th bit is out of bounds of the process affinity mask
+            error |= _MSGTYP_CANNOT_TEST_AFFINITY_BIT;
+            break;
         }
     }
 
-    glbl_obj.EnumeratedThreadCount = numMappings;
-
-    __internal_daal_freeGenericAffinityMask(&glbl_obj.cpu_generic_processAffinity);
-    __internal_daal_freeGenericAffinityMask(&glbl_obj.cpu_generic_systemAffinity);
-
-    if (glbl_obj.error) return -1;
-
-    return numMappings;
+    return error;
 }
 
 /*
- * __internal_daal_analyzeCPUHierarchy
- *
  * Analyze the Pkg_ID, Core_ID to derive hierarchical ordinal numbering scheme
  *
- * Arguments:
- *      numMappings - the number of logical processors successfully queried with SMT_ID, Core_ID, Pkg_ID extracted
- * Return: 0 is no error
+ * \return 0 is no error
  */
-static int __internal_daal_analyzeCPUHierarchy(unsigned numMappings)
+int glktsn::analyzeCPUHierarchy(unsigned PkgSelectMaskShift)
 {
-    unsigned i, ckDim, maxPackageDetetcted = 0;
-    unsigned packageID, coreID;
-    unsigned *pDetectCoreIDsperPkg, *pDetectedPkgIDs;
-
     // allocate workspace to sort parents and siblings in the topology
     // starting from pkg_ID and work our ways down each inner level
-    pDetectedPkgIDs = (unsigned *)_INTERNAL_DAAL_MALLOC(numMappings * sizeof(unsigned));
-    if (pDetectedPkgIDs == NULL) return -1;
+    Dyn1Arr_str pDetectedPkgIDs(EnumeratedThreadCount, 0xff);
 
     // we got a 1-D array to store unique Pkg_ID as we sort thru
     // each logical processor
-    _INTERNAL_DAAL_MEMSET(pDetectedPkgIDs, 0xff, numMappings * sizeof(unsigned));
-    ckDim                = numMappings * (1 << glbl_obj.PkgSelectMaskShift);
-    pDetectCoreIDsperPkg = (unsigned *)_INTERNAL_DAAL_MALLOC(ckDim * sizeof(unsigned));
-    if (pDetectCoreIDsperPkg == NULL)
-    {
-        _INTERNAL_DAAL_FREE(pDetectedPkgIDs);
-        return -1;
-    }
+    if (pDetectedPkgIDs.isEmpty()) return _MSGTYP_MEMORY_ALLOCATION_FAILED;
 
     // we got a 2-D array to store unique Core_ID within each Pkg_ID,
     // as we sort thru each logical processor
-    _INTERNAL_DAAL_MEMSET(pDetectCoreIDsperPkg, 0xff, ckDim * sizeof(unsigned));
+    Dyn2Arr_str pDetectCoreIDsperPkg(EnumeratedThreadCount, (1 << PkgSelectMaskShift), 0xff);
+    if (pDetectCoreIDsperPkg.isEmpty()) return _MSGTYP_MEMORY_ALLOCATION_FAILED;
 
     // iterate throught each logical processor in the system.
     // mark up each unique physical package with a zero-based numbering scheme
     // Within each distinct package, mark up distinct cores within that package
     // with a zero-based numbering scheme
-    for (i = 0; i < numMappings; i++)
+    unsigned maxPackageDetetcted = 0;
+    for (unsigned i = 0; i < EnumeratedThreadCount; i++)
     {
-        BOOL PkgMarked;
-        unsigned h;
-        packageID = glbl_obj.pApicAffOrdMapping[i].pkg_IDAPIC;
-        coreID    = glbl_obj.pApicAffOrdMapping[i].Core_IDAPIC;
+        bool PkgMarked     = false;
+        unsigned packageID = pApicAffOrdMapping[i].pkg_IDAPIC;
+        unsigned coreID    = pApicAffOrdMapping[i].Core_IDAPIC;
 
-        PkgMarked = FALSE;
-        for (h = 0; h < maxPackageDetetcted; h++)
+        if (maxPackageDetetcted >= EnumeratedThreadCount)
+        {
+            // should never happen
+            return _MSGTYP_INVALID_PACKAGE_INDEX;
+        }
+        for (unsigned h = 0; h < maxPackageDetetcted; h++)
         {
             if (pDetectedPkgIDs[h] == packageID)
             {
-                BOOL foundCore = FALSE;
-                unsigned k;
-                PkgMarked                                 = TRUE;
-                glbl_obj.pApicAffOrdMapping[i].packageORD = h;
+                bool foundCore = false;
+                PkgMarked      = true;
 
                 // look for core in marked packages
-                for (k = 0; k < glbl_obj.perPkg_detectedCoresCount.data[h]; k++)
+                for (unsigned k = 0; k < perPkg_detectedCoresCount[h]; k++)
                 {
-                    if (coreID == pDetectCoreIDsperPkg[h * numMappings + k])
+                    if (h * EnumeratedThreadCount + k >= pDetectCoreIDsperPkg.size())
                     {
-                        foundCore = TRUE;
+                        // should never happen
+                        return _MSGTYP_INVALID_CORE_INDEX;
+                    }
+                    if (coreID == pDetectCoreIDsperPkg[h * EnumeratedThreadCount + k])
+                    {
+                        foundCore = true;
                         // add thread - can't be that the thread already exists, breaks uniqe APICID spec
-                        glbl_obj.pApicAffOrdMapping[i].coreORD   = k;
-                        glbl_obj.pApicAffOrdMapping[i].threadORD = glbl_obj.perCore_detectedThreadsCount.data[h * MAX_CORES + k];
-                        glbl_obj.perCore_detectedThreadsCount.data[h * MAX_CORES + k]++;
+                        if (h * MAX_CORES + k >= perCore_detectedThreadsCount.size())
+                        {
+                            // should never happen
+                            return _MSGTYP_INVALID_THREAD_COUNT_INDEX;
+                        }
+                        perCore_detectedThreadsCount[h * MAX_CORES + k]++;
                         break;
                     }
                 }
@@ -1412,19 +1477,26 @@ static int __internal_daal_analyzeCPUHierarchy(unsigned numMappings)
                 if (!foundCore)
                 {
                     // mark up the Core_ID of an unmarked core in a marked package
-                    unsigned core                                = glbl_obj.perPkg_detectedCoresCount.data[h];
-                    pDetectCoreIDsperPkg[h * numMappings + core] = coreID;
+                    unsigned core = perPkg_detectedCoresCount[h];
+
+                    if (h * EnumeratedThreadCount + core >= pDetectCoreIDsperPkg.size())
+                    {
+                        // should never happen
+                        return _MSGTYP_INVALID_CORE_INDEX;
+                    }
+                    pDetectCoreIDsperPkg[h * EnumeratedThreadCount + core] = coreID;
 
                     // keep track of respective hierarchical counts
-                    glbl_obj.perCore_detectedThreadsCount.data[h * MAX_CORES + core] = 1;
-                    glbl_obj.perPkg_detectedCoresCount.data[h]++;
+                    if (h * MAX_CORES + core >= perCore_detectedThreadsCount.size())
+                    {
+                        // should never happen
+                        return _MSGTYP_INVALID_THREAD_COUNT_INDEX;
+                    }
+                    perCore_detectedThreadsCount[h * MAX_CORES + core] = 1;
+                    perPkg_detectedCoresCount[h]++;
 
-                    // build a set of numbering system to iterate each topological hierarchy
-                    glbl_obj.pApicAffOrdMapping[i].coreORD   = core;
-                    glbl_obj.pApicAffOrdMapping[i].threadORD = 0;
-                    glbl_obj.EnumeratedCoreCount++; // this is an unmarked core, increment system core count by 1
+                    EnumeratedCoreCount++; // this is an unmarked core, increment system core count by 1
                 }
-
                 break;
             }
         }
@@ -1432,371 +1504,44 @@ static int __internal_daal_analyzeCPUHierarchy(unsigned numMappings)
         if (!PkgMarked)
         {
             // mark up the pkg_ID and Core_ID of an unmarked package
-            pDetectedPkgIDs[maxPackageDetetcted]                        = packageID;
-            pDetectCoreIDsperPkg[maxPackageDetetcted * numMappings + 0] = coreID;
+            pDetectedPkgIDs[maxPackageDetetcted]                                  = packageID;
+            pDetectCoreIDsperPkg[maxPackageDetetcted * EnumeratedThreadCount + 0] = coreID;
 
             // keep track of respective hierarchical counts
-            glbl_obj.perPkg_detectedCoresCount.data[maxPackageDetetcted]                    = 1;
-            glbl_obj.perCore_detectedThreadsCount.data[maxPackageDetetcted * MAX_CORES + 0] = 1;
+            perPkg_detectedCoresCount[maxPackageDetetcted]                    = 1;
+            perCore_detectedThreadsCount[maxPackageDetetcted * MAX_CORES + 0] = 1;
 
-            // build a set of zero-based numbering acheme so that
-            // each logical processor in the same core can be referenced by a zero-based index
-            // each core in the same package can be referenced by another zero-based index
-            // each package in the system can be referenced by a third zero-based index scheme.
-            // each system wide index i can be mapped to a triplet of zero-based hierarchical indices
-            glbl_obj.pApicAffOrdMapping[i].packageORD = maxPackageDetetcted;
-            glbl_obj.pApicAffOrdMapping[i].coreORD    = 0;
-            glbl_obj.pApicAffOrdMapping[i].threadORD  = 0;
-
-            maxPackageDetetcted++;          // this is an unmarked pkg, increment pkg count by 1
-            glbl_obj.EnumeratedCoreCount++; // there is at least one core in a package
+            maxPackageDetetcted++; // this is an unmarked pkg, increment pkg count by 1
+            EnumeratedCoreCount++; // there is at least one core in a package
         }
     }
-
-    glbl_obj.EnumeratedPkgCount = maxPackageDetetcted;
-
-    _INTERNAL_DAAL_FREE(pDetectedPkgIDs);
-    _INTERNAL_DAAL_FREE(pDetectCoreIDsperPkg);
 
     return 0;
 }
 
 /*
- * __internal_daal_analyzeEachCHierarchy
- *
- *   this is an example illustrating cache topology analysis of the largest unified cache
- *   the largest unified cache may be shared by multiple cores
- *          parse APIC ID into sub IDs for each topological levels
- *  This example illustrates several mapping relationships:
- *      1. count distinct target level cache in the system;     2 count distinct cores sharing the same cache
- *      3. Establish a hierarchical numbering scheme (0-based, ordinal number) for each distinct entity within a hierarchical level
- *
- * Arguments:
- *      numMappings - the number of logical processors successfully queried with SMT_ID, Core_ID, Pkg_ID extracted
- * Return: 0 is no error
- */
-static int __internal_daal_analyzeEachCHierarchy(unsigned subleaf, unsigned numMappings)
-{
-    unsigned i;
-    unsigned maxCacheDetected = 0, maxThreadsDetected = 0;
-    unsigned threadID;
-    unsigned CacheID;
-    unsigned *pDetectThreadIDsperEachC, *pDetectedEachCIDs;
-    unsigned *pThreadIDsperEachC, *pEachCIDs;
-
-    if (glbl_obj.EachCacheMaskWidth[subleaf] == 0xffffffff) return -1;
-
-    pEachCIDs = (unsigned *)_INTERNAL_DAAL_MALLOC(numMappings * sizeof(unsigned));
-    if (pEachCIDs == NULL) return -1;
-    _INTERNAL_DAAL_MEMSET(pEachCIDs, 0xff, numMappings * sizeof(unsigned));
-
-    pThreadIDsperEachC = (unsigned *)_INTERNAL_DAAL_MALLOC(numMappings * sizeof(unsigned));
-    if (pThreadIDsperEachC == NULL)
-    {
-        _INTERNAL_DAAL_FREE(pEachCIDs);
-        return -1;
-    }
-    _INTERNAL_DAAL_MEMSET(pThreadIDsperEachC, 0xff, numMappings * sizeof(unsigned));
-
-    // enumerate distinct caches of the same subleaf index to get counts of how many caches only
-    // mark up each unique cache associated with subleaf index based on the cache_ID
-    maxCacheDetected = 0;
-    for (i = 0; i < numMappings; i++)
-    {
-        unsigned j;
-        for (j = 0; j < maxCacheDetected; j++)
-        {
-            if (pEachCIDs[j] == glbl_obj.pApicAffOrdMapping[i].EaCacheIDAPIC[subleaf])
-            {
-                break;
-            }
-        }
-        if (j >= maxCacheDetected)
-        {
-            pEachCIDs[maxCacheDetected++] = glbl_obj.pApicAffOrdMapping[i].EaCacheIDAPIC[subleaf];
-        }
-    }
-
-    // enumerate distinct SMT threads within a caches of the subleaf index only without relation to core topology
-    // mark up the distinct logical processors sharing a distinct cache level associated subleaf index
-    maxThreadsDetected = 0;
-    for (i = 0; i < numMappings; i++)
-    {
-        unsigned j;
-        for (j = 0; j < maxThreadsDetected; j++)
-        {
-            if (pThreadIDsperEachC[j] == glbl_obj.pApicAffOrdMapping[i].EaCacheSMTIDAPIC[subleaf])
-            {
-                break;
-            }
-        }
-
-        if (j >= maxThreadsDetected)
-        {
-            pThreadIDsperEachC[maxThreadsDetected++] = glbl_obj.pApicAffOrdMapping[i].EaCacheSMTIDAPIC[subleaf];
-        }
-    }
-
-    glbl_obj.EnumeratedEachCacheCount[subleaf] = maxCacheDetected;
-
-    _INTERNAL_DAAL_MEMSET(pEachCIDs, 0xff, numMappings * sizeof(unsigned));
-    _INTERNAL_DAAL_MEMSET(pThreadIDsperEachC, 0xff, numMappings * sizeof(unsigned));
-
-    pDetectedEachCIDs = (unsigned *)_INTERNAL_DAAL_MALLOC(numMappings * sizeof(unsigned));
-    if (pDetectedEachCIDs == NULL)
-    {
-        _INTERNAL_DAAL_FREE(pEachCIDs);
-        _INTERNAL_DAAL_FREE(pThreadIDsperEachC);
-        return -1;
-    }
-    _INTERNAL_DAAL_MEMSET(pDetectedEachCIDs, 0xff, numMappings * sizeof(unsigned));
-
-    pDetectThreadIDsperEachC = (unsigned *)_INTERNAL_DAAL_MALLOC(numMappings * maxCacheDetected * sizeof(unsigned));
-    if (pDetectThreadIDsperEachC == NULL)
-    {
-        _INTERNAL_DAAL_FREE(pEachCIDs);
-        _INTERNAL_DAAL_FREE(pThreadIDsperEachC);
-        _INTERNAL_DAAL_FREE(pDetectedEachCIDs);
-        return -1;
-    }
-    _INTERNAL_DAAL_MEMSET(pDetectThreadIDsperEachC, 0xff, numMappings * maxCacheDetected * sizeof(unsigned));
-
-    // enumerate distinct SMT threads and cores relative to a cache level of the subleaf index
-    // the enumeration below gets the counts and establishes zero-based numbering scheme for cores and SMT threads under each cache
-    maxCacheDetected = 0;
-
-    for (i = 0; i < numMappings; i++)
-    {
-        glbl_obj.pApicAffOrdMapping[i].EachCacheORD[subleaf] = (unsigned)-1;
-    }
-
-    for (i = 0; i < numMappings; i++)
-    {
-        BOOL CacheMarked;
-        unsigned h;
-
-        CacheID  = glbl_obj.pApicAffOrdMapping[i].EaCacheIDAPIC[subleaf]; // sub ID to enumerate different caches in the system
-        threadID = glbl_obj.pApicAffOrdMapping[i].EaCacheSMTIDAPIC[subleaf];
-
-        CacheMarked = FALSE;
-        for (h = 0; h < maxCacheDetected; h++)
-        {
-            if (pDetectedEachCIDs[h] == CacheID)
-            {
-                BOOL foundThread = FALSE;
-                unsigned k;
-
-                CacheMarked                                          = TRUE;
-                glbl_obj.pApicAffOrdMapping[i].EachCacheORD[subleaf] = h;
-
-                // look for cores sharing the same target cache level
-                for (k = 0; k < glbl_obj.perEachCache_detectedThreadCount.data[h * MAX_CACHE_SUBLEAFS + subleaf]; k++)
-                {
-                    if (threadID == pDetectThreadIDsperEachC[h * numMappings + k])
-                    {
-                        foundThread                                                 = TRUE;
-                        glbl_obj.pApicAffOrdMapping[i].threadPerEaCacheORD[subleaf] = k;
-                        break;
-                    }
-                }
-
-                if (!foundThread)
-                {
-                    // mark up the thread_ID of an unmarked core in a marked package
-                    unsigned thread = glbl_obj.perEachCache_detectedThreadCount.data[h * MAX_CACHE_SUBLEAFS + subleaf];
-                    pDetectThreadIDsperEachC[h * numMappings + thread] = threadID;
-
-                    // keep track of respective hierarchical counts
-                    glbl_obj.perEachCache_detectedThreadCount.data[h * MAX_CACHE_SUBLEAFS + subleaf]++;
-
-                    // build a set of numbering system to iterate the child hierarchy below the target cache
-                    glbl_obj.pApicAffOrdMapping[i].threadPerEaCacheORD[subleaf] = thread;
-                }
-
-                break;
-            }
-        }
-
-        if (!CacheMarked)
-        {
-            // mark up the pkg_ID and Core_ID of an unmarked package
-            pDetectedEachCIDs[maxCacheDetected]                          = CacheID;
-            pDetectThreadIDsperEachC[maxCacheDetected * numMappings + 0] = threadID;
-
-            // keep track of respective hierarchical counts
-            glbl_obj.perEachCache_detectedThreadCount.data[maxCacheDetected * MAX_CACHE_SUBLEAFS + subleaf] = 1;
-
-            // build a set of numbering system to iterate each topological hierarchy
-            glbl_obj.pApicAffOrdMapping[i].EachCacheORD[subleaf]        = maxCacheDetected;
-            glbl_obj.pApicAffOrdMapping[i].threadPerEaCacheORD[subleaf] = 0;
-
-            maxCacheDetected++; // this is an unmarked cache, increment cache count by 1
-        }
-    }
-
-    _INTERNAL_DAAL_FREE(pEachCIDs);
-    _INTERNAL_DAAL_FREE(pThreadIDsperEachC);
-    _INTERNAL_DAAL_FREE(pDetectedEachCIDs);
-    _INTERNAL_DAAL_FREE(pDetectThreadIDsperEachC);
-
-    return 0;
-}
-
-/*
- * __internal_daal_buildSystemTopologyTables
- *
  * Construct the processor topology tables and values necessary to
  * support the external functions that display CPU topology and/or
  * cache topology derived from system topology enumeration.
  *
- * Arguments: None
- * Return: None, sets glbl_obj.error if tables or values can not be calculated.
+ * Return: None, sets globalCPUTopology.error if tables or values can not be calculated.
  */
-static void __internal_daal_buildSystemTopologyTables()
+void glktsn::buildSystemTopologyTables(const GenericAffinityMask & processAffinity)
 {
-    unsigned lcl_OSProcessorCount, subleaf;
-    int numMappings = 0;
-
-    // call OS-specific service to find out how many logical processors
-    // are supported by the OS
-    glbl_obj.OSProcessorCount = lcl_OSProcessorCount = _internal_daal_GetMaxCPUSupportedByOS();
-
     // allocated the memory buffers within the global pointer
-    __internal_daal_allocArrays(lcl_OSProcessorCount);
-
-    // Gather all the system-wide constant parameters needed to derive topology information
-    if (__internal_daal_cpuTopologyParams()) return;
-    if (__internal_daal_cacheTopologyParams()) return;
 
     // For each logical processor, collect APIC ID and parse sub IDs for each APIC ID
-    numMappings = __internal_daal_queryParseSubIDs();
-    if (numMappings < 0) return;
-
+    unsigned maxPkgSelectMaskShift = 0;
+    error                          = parseAPICIDs(processAffinity, maxPkgSelectMaskShift);
+    if (error) return;
     // Derived separate numbering schemes for each level of the cpu topology
-    if (__internal_daal_analyzeCPUHierarchy(numMappings) < 0)
+    if (analyzeCPUHierarchy(maxPkgSelectMaskShift) < 0)
     {
-        glbl_obj.error |= _MSGTYP_TOPOLOGY_NOTANALYZED;
+        error |= _MSGTYP_TOPOLOGY_NOT_ANALYZED;
+        return;
     }
 
-    // an example of building cache topology info for each cache level
-    if (glbl_obj.maxCacheSubleaf != -1)
-    {
-        for (subleaf = 0; subleaf <= glbl_obj.maxCacheSubleaf; subleaf++)
-        {
-            if (glbl_obj.EachCacheMaskWidth[subleaf] != 0xffffffff)
-            {
-                // ensure there is at least one core in the target level cache
-                if (__internal_daal_analyzeEachCHierarchy(subleaf, numMappings) < 0) glbl_obj.error |= _MSGTYP_TOPOLOGY_NOTANALYZED;
-            }
-        }
-    }
-
-    glbl_obj.isInit = 1;
-}
-
-/*
- * __internal_daal_initCpuTopology
- *
- * Initialize the CPU topology structures if they have not already been initialized
- *
- * Arguments: None
- * Return: None
- */
-static void __internal_daal_initCpuTopology()
-{
-    if (!glbl_obj.isInit) __internal_daal_buildSystemTopologyTables();
-}
-
-/*
- * _internal_daal_GetEnumerateAPICID
- *
- * Returns APIC ID for the specified processor from enumerated table
- *
- * Arguments:
- *     processor - Os processor number of for which the the APIC ID is returned
- * Return: APIC ID for the specified processor
- */
-unsigned _internal_daal_GetEnumerateAPICID(unsigned processor)
-{
-    if (!glbl_obj.isInit) __internal_daal_initCpuTopology();
-
-    if (glbl_obj.error) return 0xffffffff;
-
-    if (processor >= glbl_obj.OSProcessorCount) return 0xffffffff; // allow caller to intercept error
-
-    return glbl_obj.pApicAffOrdMapping[processor].APICID;
-}
-
-/*
- * _internal_daal_GetEnumeratedCoreCount
- *
- * Returns numbers of cores active on a given package, based on enumerated result
- *
- * Arguments:
- *     package - ordinal
- * Return: number of cores active on specified package, 0 if can not calulate
- */
-unsigned _internal_daal_GetEnumeratedCoreCount(unsigned package_ordinal)
-{
-    if (!glbl_obj.isInit) __internal_daal_initCpuTopology();
-
-    if (glbl_obj.error || package_ordinal >= glbl_obj.EnumeratedPkgCount) return 0;
-
-    return glbl_obj.perPkg_detectedCoresCount.data[package_ordinal];
-}
-
-/*
- * _internal_daal_GetEnumeratedThreadCount
- *
- * Returns numbers of Threads active on a given package/core
- *
- * Arguments:
- *     package - ordinal and core ordinal
- * Return: number of threads active on specified package and core, 0 if can not calulate
- */
-unsigned _internal_daal_GetEnumeratedThreadCount(unsigned package_ordinal, unsigned core_ordinal)
-{
-    if (!glbl_obj.isInit) __internal_daal_initCpuTopology();
-
-    if (glbl_obj.error || package_ordinal >= glbl_obj.EnumeratedPkgCount) return 0;
-
-    if (core_ordinal >= glbl_obj.perPkg_detectedCoresCount.data[package_ordinal]) return 0;
-
-    return glbl_obj.perCore_detectedThreadsCount.data[package_ordinal * MAX_CORES + core_ordinal];
-}
-
-/*
- * _internal_daal_GetSysEachCacheCount
- *
- * Returns count of distinct target level cache in the system
- *
- * Arguments: None
- * Return: Number of caches or 0 if number can not be calculated
- */
-unsigned _internal_daal_GetSysEachCacheCount(unsigned subleaf)
-{
-    if (!glbl_obj.isInit) __internal_daal_initCpuTopology();
-
-    if (glbl_obj.error) return 0;
-
-    return glbl_obj.EnumeratedEachCacheCount[subleaf];
-}
-
-/*
- * _internal_daal_GetOSLogicalProcessorCount
- *
- * Returns count of logical processors in the system as seen by OS
- *
- * Arguments: None
- * Return: Number of logical processors or 0 if number can not be calculated
- */
-unsigned _internal_daal_GetOSLogicalProcessorCount()
-{
-    if (!glbl_obj.isInit) __internal_daal_initCpuTopology();
-
-    if (glbl_obj.error) return 0;
-
-    return glbl_obj.OSProcessorCount;
+    isInit = true;
 }
 
 /*
@@ -1809,11 +1554,9 @@ unsigned _internal_daal_GetOSLogicalProcessorCount()
  */
 unsigned _internal_daal_GetSysLogicalProcessorCount()
 {
-    if (!glbl_obj.isInit) __internal_daal_initCpuTopology();
+    if (globalCPUTopology.error) return 0;
 
-    if (glbl_obj.error) return 0;
-
-    return glbl_obj.EnumeratedThreadCount;
+    return globalCPUTopology.EnumeratedThreadCount;
 }
 
 /*
@@ -1826,87 +1569,27 @@ unsigned _internal_daal_GetSysLogicalProcessorCount()
  */
 unsigned _internal_daal_GetProcessorCoreCount()
 {
-    if (!glbl_obj.isInit) __internal_daal_initCpuTopology();
+    if (globalCPUTopology.error) return 0;
 
-    if (glbl_obj.error) return 0;
-
-    return glbl_obj.EnumeratedCoreCount;
-}
-
-/*
- * _internal_daal_GetSysProcessorPackageCount
- *
- * Returns count of processor packages in the system that were enumerated by this app
- *
- * Arguments: None
- * Return: Number of processor packages in the system or 0 if number can not be calculated
- */
-unsigned _internal_daal_GetSysProcessorPackageCount()
-{
-    if (!glbl_obj.isInit) __internal_daal_initCpuTopology();
-
-    if (glbl_obj.error) return 0;
-
-    return glbl_obj.EnumeratedPkgCount;
-}
-
-/*
- * _internal_daal_GetCoreCountPerEachCache
- *
- * Returns numbers of cores active sharing the target level cache
- *
- * Arguments: Cache ordinal
- * Return: number of cores active on specified target level cache, 0 if can not calulate
- */
-unsigned _internal_daal_GetCoreCountPerEachCache(unsigned subleaf, unsigned cache_ordinal)
-{
-    if (!glbl_obj.isInit) __internal_daal_initCpuTopology();
-
-    if (glbl_obj.error || cache_ordinal >= glbl_obj.EnumeratedEachCacheCount[subleaf]) return 0;
-
-    return glbl_obj.perEachCache_detectedThreadCount.data[cache_ordinal * MAX_CACHE_SUBLEAFS + subleaf];
+    return globalCPUTopology.EnumeratedCoreCount;
 }
 
 unsigned _internal_daal_GetLogicalProcessorQueue(int * queue)
 {
+    // this code runs only when the thread pinning is enabled, which can happen only via DAAL API.
     const int cpus = _internal_daal_GetSysLogicalProcessorCount();
-    int cores      = _internal_daal_GetProcessorCoreCount();
 
-    if (cores == 0) cores = 1;
-
-    int ht = cpus / cores;
-    if (ht < 1 || ht >= cpus)
+    // pinning j-th logical thread to j-th logical processor in the system.
+    for (unsigned j = 0; j < cpus; j++)
     {
-        glbl_obj.error |= _MSGTYP_GENERAL_ERROR;
-        return glbl_obj.error;
+        queue[j] = j;
     }
-
-    int q = 0;
-    for (unsigned pkg = 0; pkg < _internal_daal_GetSysProcessorPackageCount(); pkg++)
-    {
-        for (unsigned i = 0; i < _internal_daal_GetSysEachCacheCount(0); i++)
-        {
-            if (_internal_daal_GetCoreCountPerEachCache(0, i) > 0)
-            {
-                for (unsigned j = 0; j < _internal_daal_GetSysLogicalProcessorCount(); j++)
-                {
-                    if (glbl_obj.pApicAffOrdMapping[j].packageORD == pkg && glbl_obj.pApicAffOrdMapping[j].EachCacheORD[0] == i)
-                    {
-                        int jj = ((q / ht) + (cores * (q % ht))) % cpus;
-                        if (jj < cpus) queue[jj] = j;
-                        q++;
-                    }
-                }
-            }
-        }
-    }
-
-    return glbl_obj.error;
+    return globalCPUTopology.error;
 }
 
 unsigned _internal_daal_GetStatus()
 {
-    return glbl_obj.error;
+    return globalCPUTopology.error;
 }
 
 //service_environment.h implementation
@@ -1965,14 +1648,11 @@ static __inline void detect_data_caches(int cache_sizes_len, volatile long long 
     }
 }
 
-    #define MAX_CACHE_LEVELS 4
 volatile static bool cache_sizes_read                   = false;
-volatile static long long cache_sizes[MAX_CACHE_LEVELS] = { 0 };
+volatile static long long cache_sizes[MAX_CACHE_LEVELS] = { DEFAULT_L1_CACHE_SIZE, DEFAULT_L2_CACHE_SIZE, DEFAULT_LL_CACHE_SIZE, 0 };
 
 static __inline void update_cache_sizes()
 {
-    int cbwr_branch;
-
     if (cache_sizes_read) return;
 
     if (!cache_sizes_read) detect_data_caches(MAX_CACHE_LEVELS, cache_sizes);
@@ -2005,31 +1685,10 @@ size_t getLLCacheSize()
     return getCacheSize(3);
 }
 
-void glktsn::FreeArrays()
+void glktsn::freeArrays()
 {
-    isInit = 0;
+    isInit = false;
     _INTERNAL_DAAL_FREE(pApicAffOrdMapping);
-    _INTERNAL_DAAL_FREE(perPkg_detectedCoresCount.data);
-    _INTERNAL_DAAL_FREE(perCore_detectedThreadsCount.data);
-    _INTERNAL_DAAL_FREE(perCache_detectedCoreCount.data);
-    _INTERNAL_DAAL_FREE(perEachCache_detectedThreadCount.data);
-
-    if (cpuid_values)
-    {
-        for (unsigned int i = 0; i <= OSProcessorCount; i++)
-        {
-            _INTERNAL_DAAL_FREE(cpuid_values[i].subleaf[0]);
-
-            if ((i == 0x4 || i == 0xb))
-            {
-                for (unsigned int j = 1; j < cpuid_values[i].subleaf_max; j++)
-                {
-                    _INTERNAL_DAAL_FREE(cpuid_values[i].subleaf[j]);
-                }
-            }
-        }
-        _INTERNAL_DAAL_FREE(cpuid_values);
-    }
 }
 
 } // namespace internal
@@ -2076,7 +1735,7 @@ void delete_topology(void * ptr)
     daal::services::daal_free(ptr);
 }
 
-#else
+#else // DAAL_CPU_TOPO_DISABLED
 
 namespace daal
 {
@@ -2086,19 +1745,23 @@ namespace internal
 {
 size_t getL1CacheSize()
 {
-    return 32 * 1024;
+    return DEFAULT_L1_CACHE_SIZE;
 }
 
 size_t getL2CacheSize()
 {
-    return 256 * 1024;
+    return DEFAULT_L2_CACHE_SIZE;
 }
 
 size_t getLLCacheSize()
 {
-    return 25 * 1024 * 1024; //estimate based on mac pro
+    return DEFAULT_LL_CACHE_SIZE; //estimate based on mac pro
 }
 
+unsigned _internal_daal_GetStatus()
+{
+    return 0;
+}
 } // namespace internal
 } // namespace services
 } // namespace daal

--- a/cpp/daal/src/services/service_topo.h
+++ b/cpp/daal/src/services/service_topo.h
@@ -23,157 +23,25 @@
 
 #if !defined(DAAL_CPU_TOPO_DISABLED)
 
-    #if defined(__linux__) || defined(__FreeBSD__)
-
-        #ifndef _GNU_SOURCE
-            #define _GNU_SOURCE
-        #endif
-
-        #include <stdio.h>
-        #include <stdlib.h>
-        #include <unistd.h>
-        #include <string.h>
-        #include <sched.h>
-
-        #ifdef __FreeBSD__
-            #include <sys/param.h>
-            #include <sys/cpuset.h>
-typedef cpuset_t cpu_set_t;
-        #endif
-
-        #ifdef __linux__
-            #include <alloca.h>
-        #endif
-
-        #include <stdarg.h>
-
-        #ifdef __CPU_ISSET
-            #define MY_CPU_SET   __CPU_SET
-            #define MY_CPU_ZERO  __CPU_ZERO
-            #define MY_CPU_ISSET __CPU_ISSET
-        #else
-            #define MY_CPU_SET   CPU_SET
-            #define MY_CPU_ZERO  CPU_ZERO
-            #define MY_CPU_ISSET CPU_ISSET
-        #endif
-
-        #define __cdecl
-
-        #if defined(TARGET_X86_64)
-            #define LNX_PTR2INT unsigned long long
-            #define LNX_MY1CON  1LL
-        #elif defined(TARGET_ARM)
-using LNX_PTR2INT                = uintptr_t;
-constexpr LNX_PTR2INT LNX_MY1CON = 1LL;
-        #elif defined(TARGET_RISCV64)
-            #define LNX_PTR2INT uintptr_t
-            #define LNX_MY1CON  1LL
-        #else
-            #define LNX_PTR2INT unsigned int
-            #define LNX_MY1CON  1
-        #endif
-
-        #ifndef __int64
-            #define __int64 long long
-        #endif
-
-        #ifndef __int32
-            #define __int32 int
-        #endif
-
-        #ifndef DWORD
-            #define DWORD unsigned long
-        #endif
-
-        #ifndef DWORD_PTR
-            #define DWORD_PTR unsigned long *
-        #endif
-
-        #ifndef FALSE
-            #define FALSE 0
-        #endif
-
-        #ifndef TRUE
-            #define TRUE 1
-        #endif
-
-        #ifndef BYTE
-            #define BYTE unsigned char
-        #endif
-
-        #ifndef BOOL
-            #define BOOL char
-        #endif
-
-        #ifdef __x86_64__
-            #define AFFINITY_MASK unsigned __int64
-        #else
-            #define AFFINITY_MASK unsigned __int32
-        #endif
-
-    #else /* WINDOWS */
-        #define NOMINMAX
-        #include <windows.h>
-
-        #ifdef _M_IA64
-            #define LNX_PTR2INT unsigned long long
-            #define LNX_MY1CON  1LL
-        #else
-            #ifdef _M_X64
-                #define LNX_PTR2INT __int64
-                #define LNX_MY1CON  1LL
-            #else
-                #define LNX_PTR2INT unsigned int
-                #define LNX_MY1CON  1
-            #endif
-        #endif
-
-        #if defined(_MSC_VER)
-            #if (_MSC_FULL_VER >= 160040219)
-                #include <intrin.h>
-            #else
-                #error "min VS2010 SP1 compiler is required"
-            #endif
-        #endif
-
-        #if _MSC_VER < 1300
-            #ifndef DWORD_PTR
-                #define DWORD_PTR unsigned long *
-            #endif
-        #endif
-
-        #ifdef _M_IA64
-typedef unsigned __int64 AFFINITY_MASK;
-        #else
-typedef unsigned __int32 AFFINITY_MASK;
-        #endif
-
-    #endif /* WINDOWS */
-
-    #define MAX_LOG_CPU            (8 * sizeof(DWORD_PTR) * 8)
-    #define MAX_WIN7_LOG_CPU       (4 * sizeof(DWORD_PTR) * 8)
-    #define MAX_PREWIN7_LOG_CPU    (sizeof(DWORD_PTR) * 8)
-    #define MAX_PACKAGES           MAX_LOG_CPU
-    #define MAX_CORES              MAX_LOG_CPU
-    #define BLOCKSIZE_4K           4096
-    #define MAX_THREAD_GROUPS_WIN7 4
-
-    #define MAX_CPUS_ARRAY     64
-    #define MAX_LEAFS          80
-    #define MAX_CACHE_SUBLEAFS 16 // max allocation limit of data structure per sub leaf of cpuid leaf 4 enumerated results
-    #define MAX_LEAFS_EXT      MAX_LEAFS
-
-    #define ENUM_ALL (0xffffffff)
-
-    #define _MSGTYP_GENERAL_ERROR             0x80000000
-    #define _MSGTYP_ABORT                     0xc0000000
-    #define _MSGTYP_CHECKBIOS_CPUIDMAXSETTING 0x88000000
-    #define _MSGTYP_OSAFFCAP_ERROR            0xC4000000 // The # of processors supported by current OS exceed
-    //                      those of legacy win32 (32 processors) and win64 API (64)
-    #define _MSGTYP_UNKNOWNERR_OS         0xC2000000
-    #define _MSGTYP_USERAFFINITYERR       0xC1000000
-    #define _MSGTYP_TOPOLOGY_NOTANALYZED  0xC0800000
-    #define _MSGTYP_UNK_AFFINTY_OPERATION 0x84000000
+    #define _MSGTYP_GENERAL_ERROR                  0x80000000
+    #define _MSGTYP_INT_OVERFLOW                   0xA0000000
+    #define _MSGTYP_CANNOT_SET_AFFINITY_BIT        0x90000000
+    #define _MSGTYP_OS_PROC_COUNT_EXCEEDED         0x82000000 // The number of processors supported by current OS exceeded
+    #define _MSGTYP_OS_GROUP_COUNT_EXCEEDED        0x81000000 // The number of processor groups supported by current OS exceeded
+    #define _MSGTYP_INVALID_SNAPSHOT_HANDLE        0x80800000 // General unknown error. Do not confuse with
+    #define _MSGTYP_FAILED_TO_INIT_PROC_AFFINITY   0x80400000 // General unknown error. Do not confuse with
+    #define _MSGTYP_USER_AFFINITY_ERROR            0x80200000 // Error in user specified affinity mask
+    #define _MSGTYP_CANNOT_TEST_AFFINITY_BIT       0x80100000 // Cannot test bit in generalized affinity mask
+    #define _MSGTYP_MEMORY_ALLOCATION_FAILED       0x80080000
+    #define _MSGTYP_THREAD_REPORTING_FAILED        0x80040000
+    #define _MSGTYP_GET_THREAD_AFFINITY_FAILED     0x80020000 // Cannot get affinity for a thread
+    #define _MSGTYP_SET_THREAD_AFFINITY_FAILED     0x80010000 // Cannot set affinity for a thread
+    #define _MSGTYP_RESTORE_THREAD_AFFINITY_FAILED 0x80008000 // Cannot restore affinity for a thread
+    #define _MSGTYP_INVALID_THREAD_INDEX           0x80004000 // Thread index is greater than number of threads available in the affinity mask of the process
+    #define _MSGTYP_INVALID_PACKAGE_INDEX          0x80002000 // Package index is greater than number of threads available in the affinity mask of the process
+    #define _MSGTYP_INVALID_CORE_INDEX             0x80001000 // Core index is greater than the size of the allocated core ID array
+    #define _MSGTYP_INVALID_THREAD_COUNT_INDEX     0x80000800 // Thread count index is greater than the size of the allocated thread count array
+    #define _MSGTYP_TOPOLOGY_NOT_ANALYZED          0x80000400
 
 namespace daal
 {
@@ -181,189 +49,8 @@ namespace services
 {
 namespace internal
 {
-struct leaf2_cache_struct
-{
-    int L1;       // L1Data size
-    int L1i;      // L1 instruction size
-    int L1i_type; // L1 instruction type (0 == size in bytes, 1= size in trace cache uops)
-    int L2;       // L2 size
-    int L3;       // L3 size
-    int cl;       // cache line size
-    int sectored; // cache lines sectored
-};
-
-struct CPUIDinfo
-{
-    unsigned __int32 EAX = 0, EBX = 0, ECX = 0, EDX = 0;
-};
-
-struct CPUIDinfox
-{
-    CPUIDinfo * subleaf[MAX_CACHE_SUBLEAFS] = {};
-    unsigned __int32 subleaf_max            = 0;
-};
-
-struct GenericAffinityMask
-{
-    unsigned maxByteLength       = 0;
-    unsigned char * AffinityMask = nullptr;
-};
-// The width of affinity mask in legacy Windows API is 32 or 64, depending on
-// 32-bit or 64-bit OS.
-// Linux abstract its equivalent bitmap cpumask_t from direct programmer access,
-// cpumask_t can support more than 64 cpu, but is configured at kernel
-// compile time by configuration parameter.
-// To abstract the size difference of the bitmap used by different OSes
-// for topology analysis, we use an unsigned char buffer that can
-// map to different OS implementation's affinity mask data structure
-
-struct cacheDetail_str
-{
-    char description[256] = {};
-    char descShort[64]    = {};
-    unsigned level; // start at 1
-    unsigned type;  // cache type (instruction, data, combined)
-    unsigned sizeKB;
-    unsigned how_many_threads_share_cache;
-    unsigned how_many_caches_share_level;
-};
-
-struct Dyn2Arr_str
-{
-    unsigned dim[2] = { 0 };   // xdim and ydim
-    unsigned * data = nullptr; // data array to be malloc'd
-};
-
-struct Dyn1Arr_str
-{
-    unsigned dim[1] = { 0 };   // xdim
-    unsigned * data = nullptr; // data array to be malloc'd
-};
-
-struct DynCharBuf_str
-{
-    int size      = 0;
-    int used      = 0;
-    char * buffer = nullptr; // buffer to be malloc'd
-};
-
-struct idAffMskOrdMapping_t
-{
-    unsigned __int32 APICID;        // the full x2APIC ID or initial APIC ID of a logical
-                                    //  processor assigned by HW
-    unsigned __int32 OrdIndexOAMsk; // An ordinal index (zero-based) for each logical
-                                    //  processor in the system, 1:1 with "APICID"
-    // Next three members are the sub IDs for processor topology enumeration
-    unsigned __int32 pkg_IDAPIC;  // Pkg_ID field, subset of APICID bits
-                                  //  to distinguish different packages
-    unsigned __int32 Core_IDAPIC; // Core_ID field, subset of APICID bits to
-                                  //  distinguish different cores in a package
-    unsigned __int32 SMT_IDAPIC;  // SMT_ID field, subset of APICID bits to
-                                  //  distinguish different logical processors in a core
-    // the next three members stores a numbering scheme of ordinal index
-    // for each level of the processor topology.
-    unsigned __int32 packageORD; // a zero-based numbering scheme for each physical
-                                 //  package in the system
-    unsigned __int32 coreORD;    // a zero-based numbering scheme for each core in the same package
-    unsigned __int32 threadORD;  // a zero-based numbering scheme for each thread in the same core
-    // Next two members are the sub IDs for cache topology enumeration
-    unsigned __int32 EaCacheSMTIDAPIC[MAX_CACHE_SUBLEAFS] = {}; // SMT_ID field, subset of APICID bits
-                                                                // to distinguish different logical processors sharing the same cache level
-    unsigned __int32 EaCacheIDAPIC[MAX_CACHE_SUBLEAFS] = {};    // sub ID to enumerate different cache entities
-                                                                // of the cache level corresponding to the array index/cpuid leaf 4 subleaf index
-    // the next three members stores a numbering scheme of ordinal index
-    // for enumerating different cache entities of a cache level, and enumerating
-    // logical processors sharing the same cache entity.
-    unsigned __int32 EachCacheORD[MAX_CACHE_SUBLEAFS] = {};        // a zero-based numbering scheme
-                                                                   // for each cache entity of the specified cache level in the system
-    unsigned __int32 threadPerEaCacheORD[MAX_CACHE_SUBLEAFS] = {}; // a zero-based numbering scheme
-                                                                   // for each logical processor sharing the same cache of the specified cache level
-};
-
-// we are going to put an assortment of global variable, 1D and 2D arrays into
-// a data structure. This is the declaration
-struct glktsn
-{ // for each logical processor we need spaces to store APIC ID,
-    // sub IDs, affinity mappings, etc.
-    idAffMskOrdMapping_t * pApicAffOrdMapping = nullptr;
-
-    // workspace for storing hierarchical counts of each level
-    Dyn1Arr_str perPkg_detectedCoresCount;
-    Dyn2Arr_str perCore_detectedThreadsCount;
-    // workspace for storing hierarchical counts relative to the cache topology
-    // of the largest unified cache (may be shared by several cores)
-    Dyn1Arr_str perCache_detectedCoreCount;
-    Dyn2Arr_str perEachCache_detectedThreadCount;
-    // we use an error code to indicate any abnoral situation
-    unsigned error;
-    // If CPUID full reporting capability has been restricted, we need to be aware of it.
-    unsigned Alert_BiosCPUIDmaxLimitSetting;
-
-    unsigned OSProcessorCount = 0; // how many logical processor the OS sees
-    unsigned hasLeafB;             // flag to keep track of whether CPUID leaf 0BH is supported
-    unsigned maxCacheSubleaf;      // highest CPUID leaf 4 subleaf index in a processor
-
-    // the following global variables are the total counts in the system resulting from software enumeration
-    unsigned EnumeratedPkgCount;
-    unsigned EnumeratedCoreCount;
-    unsigned EnumeratedThreadCount;
-    // CPUID ID leaf 4 can report data for several cache levels, we'll keep track of each cache level
-    unsigned EnumeratedEachCacheCount[MAX_CACHE_SUBLEAFS] = {};
-    // the following global variables are parameters related to
-    //  extracting sub IDs from an APIC ID, common to all processors in the system
-    unsigned SMTSelectMask;
-    unsigned PkgSelectMask;
-    unsigned CoreSelectMask;
-    unsigned PkgSelectMaskShift;
-    unsigned SMTMaskWidth;
-    // We'll do sub ID extractions using parameters from each cache level
-    unsigned EachCacheSelectMask[MAX_CACHE_SUBLEAFS] = {};
-    unsigned EachCacheMaskWidth[MAX_CACHE_SUBLEAFS]  = {};
-
-    // the following global variables are used for product capability identification
-    unsigned HWMT_SMTperCore;
-    unsigned HWMT_SMTperPkg;
-    // a data structure that can store simple leaves and complex subleaves of all supported leaf indices of CPUID
-    CPUIDinfox * cpuid_values = nullptr;
-    // workspace of our generic affinitymask structure to allow iteration over each logical processors in the system
-    GenericAffinityMask cpu_generic_processAffinity;
-    GenericAffinityMask cpu_generic_systemAffinity;
-    // workspeace to assist text display of cache topology information
-    cacheDetail_str cacheDetail[MAX_CACHE_SUBLEAFS] = {};
-
-    unsigned isInit = 0;
-
-    void FreeArrays();
-
-    ~glktsn() { FreeArrays(); }
-};
-
-[[maybe_unused]] static unsigned long __internal_daal_getBitsFromDWORD(const unsigned int val, const char from, const char to);
-[[maybe_unused]] static unsigned __internal_daal_createMask(unsigned numEntries, unsigned * maskLength);
-[[maybe_unused]] static unsigned __internal_daal_slectOrdfromPkg(unsigned package, unsigned core, unsigned logical);
-[[maybe_unused]] static unsigned __internal_daal_getAPICID(unsigned processor);
-[[maybe_unused]] static void __internal_daal_initCpuTopology();
-[[maybe_unused]] static int __internal_daal_bindContext(unsigned cpu, void * prevAffinity);
-[[maybe_unused]] static void __internal_daal_restoreContext(void * prevAffinity);
-[[maybe_unused]] static void __internal_daal_setChkProcessAffinityConsistency(unsigned lcl_OSProcessorCount);
-[[maybe_unused]] static void __internal_daal_setGenericAffinityBit(GenericAffinityMask * pAffinityMap, unsigned cpu);
-[[maybe_unused]] static void __internal_daal_getCpuidInfo(CPUIDinfo * info, const unsigned int func, const unsigned int subfunc);
-[[maybe_unused]] static int __internal_daal_countBits(DWORD_PTR x);
-
-unsigned _internal_daal_GetMaxCPUSupportedByOS();
-unsigned _internal_daal_GetOSLogicalProcessorCount();
-unsigned _internal_daal_GetSysProcessorPackageCount();
 unsigned _internal_daal_GetProcessorCoreCount();
-unsigned _internal_daal_GetLogicalProcessorCount();
-unsigned _internal_daal_GetCoresPerPackageProcessorCount();
-unsigned _internal_daal_GetProcessorPackageCount();
-unsigned _internal_daal_GetEnumerateAPICID(unsigned processor);
-unsigned _internal_daal_GetLogicalPerCoreProcessorCount();
-unsigned _internal_daal_GetCoreCount(unsigned long package_ordinal);
-unsigned _internal_daal_GetThreadCount(unsigned long package_ordinal, unsigned long core_ordinal);
-unsigned _internal_daal_GetLogicalProcessorQueue(int * queue);
 unsigned _internal_daal_GetStatus();
-
 unsigned _internal_daal_GetSysLogicalProcessorCount();
 } // namespace internal
 } // namespace services
@@ -372,5 +59,19 @@ unsigned _internal_daal_GetSysLogicalProcessorCount();
 void read_topology(int & status, int & nthreads, int & max_threads, int ** cpu_queue);
 void delete_topology(void * ptr);
 
-#endif /* #if !defined (DAAL_CPU_TOPO_DISABLED) */
+#else /* #if !defined (DAAL_CPU_TOPO_DISABLED) */
+
+namespace daal
+{
+namespace services
+{
+namespace internal
+{
+unsigned _internal_daal_GetStatus();
+} // namespace internal
+} // namespace services
+} // namespace daal
+
+#endif
+
 #endif /* __SERVICE_TOPO_H__ */

--- a/cpp/oneapi/dal/common.hpp
+++ b/cpp/oneapi/dal/common.hpp
@@ -16,6 +16,19 @@
 
 #pragma once
 
+// TODO: Clean up this redefinition and import the defines globally.
+#if defined(__x86_64__) || defined(__x86_64) || defined(__amd64) || defined(_M_AMD64)
+#define TARGET_X86_64
+#endif
+
+#if defined(__ARM_ARCH) || defined(__aarch64__)
+#define TARGET_ARM
+#endif
+
+#if defined(__riscv) && (__riscv_xlen == 64)
+#define TARGET_RISCV64
+#endif
+
 #include <cstdint>
 #include <utility>
 

--- a/cpp/oneapi/dal/detail/cpu.hpp
+++ b/cpp/oneapi/dal/detail/cpu.hpp
@@ -22,19 +22,6 @@
 #include <map>
 #include <string>
 
-// TODO: Clean up this redefinition and import the defines globally.
-#if defined(__x86_64__) || defined(__x86_64) || defined(__amd64) || defined(_M_AMD64)
-#define TARGET_X86_64
-#endif
-
-#if defined(__ARM_ARCH) || defined(__aarch64__)
-#define TARGET_ARM
-#endif
-
-#if defined(__riscv) && (__riscv_xlen == 64)
-#define TARGET_RISCV64
-#endif
-
 namespace oneapi::dal::detail {
 namespace v1 {
 

--- a/cpp/oneapi/dal/detail/global_context_impl.cpp
+++ b/cpp/oneapi/dal/detail/global_context_impl.cpp
@@ -26,7 +26,15 @@ global_context_impl::global_context_impl() {
     using daal::services::Environment;
     // Call to `getCpuId` changes global settings, in particular,
     // changes default number of threads in the threading layer
-    auto cpuid = daal::services::Environment::getInstance()->getCpuId();
+    Environment* env = Environment::getInstance();
+    if (!env) {
+        int error = daal::services::Environment::getStatus();
+        throw std::runtime_error(
+            "Environment not initialized, cannot get processor info, error code: " +
+            std::to_string(error));
+    }
+    auto cpuid = env->getCpuId();
+
     cpu_info_ = cpu_info(from_daal_cpu_type(cpuid));
 }
 

--- a/cpp/oneapi/dal/detail/parameters/system_parameters_impl.cpp
+++ b/cpp/oneapi/dal/detail/parameters/system_parameters_impl.cpp
@@ -29,8 +29,17 @@ namespace v1 {
 system_parameters_impl::system_parameters_impl() {
     using daal::services::Environment;
     Environment* env = Environment::getInstance();
-    sys_info_["top_enabled_cpu_extension"] =
-        from_daal_cpu_type(DAAL_KERNEL_BUILD_MAX_INSTRUCTION_SET_ID);
+    if (!env) {
+        int error = daal::services::Environment::getStatus();
+        throw std::runtime_error(
+            "Environment not initialized, cannot get processor info, error code: " +
+            std::to_string(error));
+    }
+    // Call to `getCpuId` changes global settings, in particular,
+    // changes default number of threads in the threading layer
+    const int cpuid = env->getCpuId();
+
+    sys_info_["top_enabled_cpu_extension"] = from_daal_cpu_type(cpuid);
     sys_info_["max_number_of_threads"] = static_cast<std::uint32_t>(env->getNumberOfThreads());
 }
 


### PR DESCRIPTION
**Cherry-picking from main to 2025.11 release branch.**

The error handling in the global object that defines CPU topology in oneDAL/DAAL and in global daal::services::Environment object was improved. Several related bugs were fixed.

- cpp/daal/src/services/service_topo.h and cpp/daal/src/services/service_topo.cpp files re-worked to make it less error prone.
- The logic in setChkProcessAffinityConsistency() was changed to allow affinity masks that contain zeros. Previously having the process affinity mask with zeros lead to undefined behavior because the global object that defines CPU topology ended up in non-initialized state in that case.
- Out-of-bound memory access issues in CPU topology initialization were fixed.
- The constructor of daal::services::Environment class was updated to always call getCpuId() method which initializes the Environment instance. Without this call an uninitialized version of Environment might be used.
- The behavior of daal::services::Environment::getInstance() function that returns the pointer to a global DAAL's Environment object was changed. Now the function returns nullptr in case the global Environment object is uninitialized. The respective null pointer checks were added into the calling code.
- The behavior of daal::services::Environment::initNumberOfThreads() was changed to handle the case of hyper-threading correctly, setting the maximal number of threads available to oneDAL equal to the number of physical CPU cores.

## Description

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [ ] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [ ] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.
- [ ] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [ ] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least a summary table with measured data, if performance change is expected.
- [ ] I have provided justification why performance and/or quality metrics have changed or why changes are not expected.
- [ ] I have extended the benchmarking suite and provided a corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.

</details>
