### PR TITLE
DAAL quality metrics bazel hotfix

### DIFF
--- a/examples/daal/cpp/BUILD
+++ b/examples/daal/cpp/BUILD
@@ -341,23 +341,6 @@ dal_example_suite(
 )
 
 dal_example_suite(
-    name = "quality_metrics",
-    compile_as = [ "c++" ],
-    srcs = glob(["source/quality_metrics/*.cpp"]),
-    dal_deps = [
-        "@onedal//cpp/daal/src/algorithms/svm:kernel",
-        "@onedal//cpp/daal/src/algorithms/kernel_function:kernel",
-        "@onedal//cpp/daal/src/algorithms/multiclassclassifier:kernel",
-        "@onedal//cpp/daal/src/algorithms/pca:kernel",
-        "@onedal//cpp/daal/src/algorithms/pca/transform:kernel",
-        "@onedal//cpp/daal/src/algorithms/pca/metrics:kernel",
-        "@onedal//cpp/daal/src/algorithms/linear_regression:kernel",
-    ],
-    data = _DATA_DEPS,
-    extra_deps = _TEST_DEPS
-)
-
-dal_example_suite(
     name = "quantiles",
     compile_as = [ "c++" ],
     srcs = glob(["source/quantiles/*.cpp"]),


### PR DESCRIPTION
## Description

The pr introduces fix for bazel daal quality metrics example.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least a summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance and/or quality metrics have changed or why changes are not expected.
- [x] I have extended the benchmarking suite and provided a corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.

</details>
