### PR TITLE
bazel: add debug/sanitizer configs and expand build documentation

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -187,7 +187,8 @@ common:dbg-symbols \
 common:asan \
     --copt=-fsanitize=address \
     --copt=-fno-omit-frame-pointer \
-    --linkopt=-fsanitize=address
+    --linkopt=-fsanitize=address \
+    --config=dbg-symbols
 
 # Configuration: 'asan-static'
 # AddressSanitizer with static libasan linkage.
@@ -196,7 +197,8 @@ common:asan-static \
     --copt=-fsanitize=address \
     --copt=-fno-omit-frame-pointer \
     --linkopt=-fsanitize=address \
-    --linkopt=-static-libasan
+    --linkopt=-static-libasan \
+    --config=dbg-symbols
 
 
 # Configuration: 'tsan'
@@ -206,7 +208,8 @@ common:asan-static \
 common:tsan \
     --copt=-fsanitize=thread \
     --copt=-fno-omit-frame-pointer \
-    --linkopt=-fsanitize=thread
+    --linkopt=-fsanitize=thread \
+    --config=dbg-symbols
 
 
 # Configuration: 'ubsan'
@@ -216,7 +219,8 @@ common:tsan \
 common:ubsan \
     --copt=-fsanitize=undefined \
     --copt=-fno-omit-frame-pointer \
-    --linkopt=-fsanitize=undefined
+    --linkopt=-fsanitize=undefined \
+    --config=dbg-symbols
 
 
 # =============================================================================
@@ -228,6 +232,24 @@ common:ubsan \
 # Or persist in user-local ~/.bazelrc:
 #   build --copt=-your-flag
 # =============================================================================
+
+# Configuration: 'msan'
+# MemorySanitizer build.
+# Note: Requires Clang or ICPX. GCC does not support MSan.
+#   bazel test //cpp/oneapi/dal:tests --config=msan
+common:msan \
+    --copt=-fsanitize=memory \
+    --copt=-fno-omit-frame-pointer \
+    --linkopt=-fsanitize=memory \
+    --config=dbg-symbols
+
+# Configuration: 'type'
+# Type sanitizer build.
+common:type \
+    --copt=-fsanitize=type \
+    --copt=-fno-omit-frame-pointer \
+    --linkopt=-fsanitize=type \
+    --config=dbg-symbols
 
 # On Windows, dev/bazel/toolchains/cc_toolchain_win.bzl selects the custom
 # Intel oneAPI icx/icpx cc_toolchain by default (icx must be on PATH,

--- a/.bazelrc
+++ b/.bazelrc
@@ -160,11 +160,11 @@ build:dev \
 
 # Configuration: 'dbg'
 # Debug build with assertions enabled.
-# Equivalent to Make: REQDBG=1
+# Equivalent to Make: REQDBG=yes
 # Adds: -g debug symbols, -DDEBUG_ASSERT, -DONEDAL_ENABLE_ASSERT
 #   bazel build //:release --config=dbg
 #   bazel test //cpp/oneapi/dal:tests --config=dbg
-common:dbg \
+build:dbg \
     --compilation_mode=dbg \
     --enable_assert=True
 
@@ -173,7 +173,7 @@ common:dbg \
 # Equivalent to Make: REQDBG=symbols
 # Adds -g to the default opt build; preserves -O2/-O3 optimization.
 #   bazel build //:release --config=dbg-symbols
-common:dbg-symbols \
+build:dbg-symbols \
     --copt=-g \
     --cxxopt=-g
 
@@ -183,7 +183,7 @@ common:dbg-symbols \
 # Equivalent to Make: REQSAN=address
 # Note: combine with --config=dbg for best results (Make recommendation).
 #   bazel test //cpp/oneapi/dal:tests --config=asan --config=dbg
-common:asan \
+build:asan \
     --copt=-fsanitize=address \
     --copt=-fno-omit-frame-pointer \
     --linkopt=-fsanitize=address \
@@ -192,7 +192,7 @@ common:asan \
 # Configuration: 'asan-static'
 # AddressSanitizer with static libasan linkage.
 # Equivalent to Make: REQSAN=static
-common:asan-static \
+build:asan-static \
     --copt=-fsanitize=address \
     --copt=-fno-omit-frame-pointer \
     --linkopt=-fsanitize=address \
@@ -204,7 +204,7 @@ common:asan-static \
 # ThreadSanitizer build.
 # Equivalent to Make: REQSAN=thread
 #   bazel test //cpp/oneapi/dal:tests --config=tsan
-common:tsan \
+build:tsan \
     --copt=-fsanitize=thread \
     --copt=-fno-omit-frame-pointer \
     --linkopt=-fsanitize=thread \
@@ -215,7 +215,7 @@ common:tsan \
 # UndefinedBehaviorSanitizer build.
 # Equivalent to Make: REQSAN=undefined
 #   bazel test //cpp/oneapi/dal:tests --config=ubsan
-common:ubsan \
+build:ubsan \
     --copt=-fsanitize=undefined \
     --copt=-fno-omit-frame-pointer \
     --linkopt=-fsanitize=undefined \
@@ -230,13 +230,17 @@ common:ubsan \
 #   bazel build //:release --linkopt=-Wl,--as-needed
 # Or persist in user-local ~/.bazelrc:
 #   build --copt=-your-flag
+# Bazel combines repeated --copt/--cxxopt/--linkopt values from configs and
+# user flags; avoid passing conflicting flags such as multiple optimization
+# levels unless you intentionally want compiler-specific "last option wins"
+# behavior.
 # =============================================================================
 
 # Configuration: 'msan'
 # MemorySanitizer build.
 # Note: Requires a Clang/LLVM toolchain and lld; GCC does not support MSan.
 #   bazel test //cpp/oneapi/dal:tests --config=msan
-common:msan \
+build:msan \
     --copt=-fsanitize=memory \
     --copt=-fsanitize-memory-track-origins \
     --copt=-fno-omit-frame-pointer \
@@ -247,7 +251,7 @@ common:msan \
 # Configuration: 'type'
 # Type sanitizer build.
 # Note: Requires Clang; GCC and ICPX do not support TypeSanitizer.
-common:type \
+build:type \
     --copt=-fsanitize=type \
     --copt=-fsanitize-recover=all \
     --copt=-fno-omit-frame-pointer \

--- a/.bazelrc
+++ b/.bazelrc
@@ -239,6 +239,7 @@ common:ubsan \
 #   bazel test //cpp/oneapi/dal:tests --config=msan
 common:msan \
     --copt=-fsanitize=memory \
+    --copt=-fsanitize-memory-track-origins \
     --copt=-fno-omit-frame-pointer \
     --linkopt=-fsanitize=memory \
     --config=dbg-symbols

--- a/.bazelrc
+++ b/.bazelrc
@@ -136,19 +136,18 @@ test:dpc-private \
 
 # Configuration: 'release-dpc'
 # Build release artifacts including DPC++ libs.
-# The //:release target automatically builds all ISA variants when
-# --cpu is unset (auto). Use --cpu=<isa> to restrict for CI speed.
-#   bazel build //:release                       # CPU only, all ISAs
-#   bazel build //:release --config=release-dpc  # with DPC++ libs
-#   bazel build //:release --cpu=avx2            # CI: avx2 only
+# Use --cpu=all for full ISA coverage, or --cpu=<isa> to restrict for CI speed.
+#   bazel build //:release --cpu=all                       # CPU only, all ISAs
+#   bazel build //:release --config=release-dpc --cpu=all  # with DPC++ libs
+#   bazel build //:release --cpu=avx2                      # CI: avx2 only
 build:release-dpc \
-    --release_dpc=true
+    --release_dpc=True
 
 
 # Configuration: 'dev'
-# Fast local development build — compiles only for the host machine's
-# highest ISA (auto-detected). Use this to speed up iterative builds.
-# NOT suitable for release/packaging.
+# Fast local development build — compiles for the host machine's
+# highest ISA (auto-detected), plus the baseline sse2 variant. Use this
+# to speed up iterative builds. NOT suitable for release/packaging.
 #   bazel build //cpp/oneapi/dal:tests --config=dev
 build:dev \
     --cpu=auto
@@ -235,19 +234,22 @@ common:ubsan \
 
 # Configuration: 'msan'
 # MemorySanitizer build.
-# Note: Requires Clang or ICPX. GCC does not support MSan.
+# Note: Requires a Clang/LLVM toolchain and lld; GCC does not support MSan.
 #   bazel test //cpp/oneapi/dal:tests --config=msan
 common:msan \
     --copt=-fsanitize=memory \
     --copt=-fsanitize-memory-track-origins \
     --copt=-fno-omit-frame-pointer \
     --linkopt=-fsanitize=memory \
+    --linkopt=-fuse-ld=lld \
     --config=dbg-symbols
 
 # Configuration: 'type'
 # Type sanitizer build.
+# Note: Requires Clang; GCC and ICPX do not support TypeSanitizer.
 common:type \
     --copt=-fsanitize=type \
+    --copt=-fsanitize-recover=all \
     --copt=-fno-omit-frame-pointer \
     --linkopt=-fsanitize=type \
     --config=dbg-symbols

--- a/.bazelrc
+++ b/.bazelrc
@@ -165,17 +165,18 @@ build:dev \
 # Adds: -g debug symbols, -DDEBUG_ASSERT, -DONEDAL_ENABLE_ASSERT
 #   bazel build //:release --config=dbg
 #   bazel test //cpp/oneapi/dal:tests --config=dbg
-build:dbg \
+common:dbg \
     --compilation_mode=dbg \
     --enable_assert=True
 
 # Configuration: 'dbg-symbols'
-# Debug symbols only — no assertion checking.
+# Debug symbols only — no assertion checking, no -O0.
 # Equivalent to Make: REQDBG=symbols
-# Adds: -g debug symbols only
+# Adds -g to the default opt build; preserves -O2/-O3 optimization.
 #   bazel build //:release --config=dbg-symbols
-build:dbg-symbols \
-    --compilation_mode=dbg
+common:dbg-symbols \
+    --copt=-g \
+    --cxxopt=-g
 
 
 # Configuration: 'asan'
@@ -183,16 +184,15 @@ build:dbg-symbols \
 # Equivalent to Make: REQSAN=address
 # Note: combine with --config=dbg for best results (Make recommendation).
 #   bazel test //cpp/oneapi/dal:tests --config=asan --config=dbg
-build:asan \
+common:asan \
     --copt=-fsanitize=address \
     --copt=-fno-omit-frame-pointer \
-    --linkopt=-fsanitize=address \
-    --linkopt=-shared-libasan
+    --linkopt=-fsanitize=address
 
 # Configuration: 'asan-static'
 # AddressSanitizer with static libasan linkage.
 # Equivalent to Make: REQSAN=static
-build:asan-static \
+common:asan-static \
     --copt=-fsanitize=address \
     --copt=-fno-omit-frame-pointer \
     --linkopt=-fsanitize=address \
@@ -203,7 +203,7 @@ build:asan-static \
 # ThreadSanitizer build.
 # Equivalent to Make: REQSAN=thread
 #   bazel test //cpp/oneapi/dal:tests --config=tsan
-build:tsan \
+common:tsan \
     --copt=-fsanitize=thread \
     --copt=-fno-omit-frame-pointer \
     --linkopt=-fsanitize=thread
@@ -213,7 +213,7 @@ build:tsan \
 # UndefinedBehaviorSanitizer build.
 # Equivalent to Make: REQSAN=undefined
 #   bazel test //cpp/oneapi/dal:tests --config=ubsan
-build:ubsan \
+common:ubsan \
     --copt=-fsanitize=undefined \
     --copt=-fno-omit-frame-pointer \
     --linkopt=-fsanitize=undefined

--- a/.bazelrc
+++ b/.bazelrc
@@ -134,6 +134,101 @@ test:dpc-private \
     --test_tag_filters="dpc,-public"
 
 
+# Configuration: 'release-dpc'
+# Build release artifacts including DPC++ libs.
+# The //:release target automatically builds all ISA variants when
+# --cpu is unset (auto). Use --cpu=<isa> to restrict for CI speed.
+#   bazel build //:release                       # CPU only, all ISAs
+#   bazel build //:release --config=release-dpc  # with DPC++ libs
+#   bazel build //:release --cpu=avx2            # CI: avx2 only
+build:release-dpc \
+    --release_dpc=true
+
+
+# Configuration: 'dev'
+# Fast local development build — compiles only for the host machine's
+# highest ISA (auto-detected). Use this to speed up iterative builds.
+# NOT suitable for release/packaging.
+#   bazel build //cpp/oneapi/dal:tests --config=dev
+build:dev \
+    --cpu=auto
+
+
+# =============================================================================
+# Debug and Sanitizer Configurations
+# Equivalent to Make REQDBG / REQSAN options
+# =============================================================================
+
+# Configuration: 'dbg'
+# Debug build with assertions enabled.
+# Equivalent to Make: REQDBG=1
+# Adds: -g debug symbols, -DDEBUG_ASSERT, -DONEDAL_ENABLE_ASSERT
+#   bazel build //:release --config=dbg
+#   bazel test //cpp/oneapi/dal:tests --config=dbg
+build:dbg \
+    --compilation_mode=dbg \
+    --enable_assert=True
+
+# Configuration: 'dbg-symbols'
+# Debug symbols only — no assertion checking.
+# Equivalent to Make: REQDBG=symbols
+# Adds: -g debug symbols only
+#   bazel build //:release --config=dbg-symbols
+build:dbg-symbols \
+    --compilation_mode=dbg
+
+
+# Configuration: 'asan'
+# AddressSanitizer build.
+# Equivalent to Make: REQSAN=address
+# Note: combine with --config=dbg for best results (Make recommendation).
+#   bazel test //cpp/oneapi/dal:tests --config=asan --config=dbg
+build:asan \
+    --copt=-fsanitize=address \
+    --copt=-fno-omit-frame-pointer \
+    --linkopt=-fsanitize=address \
+    --linkopt=-shared-libasan
+
+# Configuration: 'asan-static'
+# AddressSanitizer with static libasan linkage.
+# Equivalent to Make: REQSAN=static
+build:asan-static \
+    --copt=-fsanitize=address \
+    --copt=-fno-omit-frame-pointer \
+    --linkopt=-fsanitize=address \
+    --linkopt=-static-libasan
+
+
+# Configuration: 'tsan'
+# ThreadSanitizer build.
+# Equivalent to Make: REQSAN=thread
+#   bazel test //cpp/oneapi/dal:tests --config=tsan
+build:tsan \
+    --copt=-fsanitize=thread \
+    --copt=-fno-omit-frame-pointer \
+    --linkopt=-fsanitize=thread
+
+
+# Configuration: 'ubsan'
+# UndefinedBehaviorSanitizer build.
+# Equivalent to Make: REQSAN=undefined
+#   bazel test //cpp/oneapi/dal:tests --config=ubsan
+build:ubsan \
+    --copt=-fsanitize=undefined \
+    --copt=-fno-omit-frame-pointer \
+    --linkopt=-fsanitize=undefined
+
+
+# =============================================================================
+# Custom flags
+# For injecting arbitrary compiler/linker flags (equivalent to Make COPT/CXXFLAGS):
+#   bazel build //:release --copt=-march=native
+#   bazel build //:release --copt=-O2
+#   bazel build //:release --linkopt=-Wl,--as-needed
+# Or persist in user-local ~/.bazelrc:
+#   build --copt=-your-flag
+# =============================================================================
+
 # On Windows, dev/bazel/toolchains/cc_toolchain_win.bzl selects the custom
 # Intel oneAPI icx/icpx cc_toolchain by default (icx must be on PATH,
 # typically via %ONEAPI_ROOT%\setvars.bat). To fall back to the stock

--- a/.bazelrc
+++ b/.bazelrc
@@ -252,6 +252,7 @@ common:type \
     --copt=-fsanitize-recover=all \
     --copt=-fno-omit-frame-pointer \
     --linkopt=-fsanitize=type \
+    --linkopt=-fuse-ld=lld \
     --config=dbg-symbols
 
 # On Windows, dev/bazel/toolchains/cc_toolchain_win.bzl selects the custom

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -420,6 +420,21 @@ jobs:
     displayName: 'bazel-configure'
 
   - script: |
+      set -euo pipefail
+
+      for config in dbg dbg-symbols asan asan-static tsan ubsan msan type; do
+        echo "Checking Bazel config: ${config}"
+        bazel build --nobuild :release --config="${config}"
+      done
+
+      echo "Checking Bazel config: release-dpc"
+      bazel build --nobuild :release --config=release-dpc --cpu=all
+
+      echo "Checking Bazel config: dev"
+      bazel build --nobuild //cpp/oneapi/dal:tests --config=dev
+    displayName: 'Bazel config smoke checks'
+
+  - script: |
       bazel build :release
     displayName: 'release'
 

--- a/dev/bazel/README.md
+++ b/dev/bazel/README.md
@@ -573,9 +573,6 @@ standard library implementations.
 Equivalent to Make `COPT` / `CXXFLAGS`. Use `--copt` for C and C++ flags, `--cxxopt` for C++-only flags, and `--linkopt` for linker flags:
 
 ```sh
-# Architecture/optimization flags (C and C++)
-bazel build //:release --copt=-march=native
-
 # Override optimization level (C and C++)
 bazel build //:release --copt=-O2
 

--- a/dev/bazel/README.md
+++ b/dev/bazel/README.md
@@ -453,9 +453,11 @@ Equivalent to Make `REQDBG=symbols`:
 bazel build //:release --config=dbg-symbols
 ```
 
-> Note: The `libonedal_dpc.so` library does not support debug mode due to
-> excessive debug information causing long link times. Use the static library
-> variant for DPC++ debugging.
+> Note: DPC++ targets can be built with debug/sanitizer configurations when
+> the selected compiler/runtime supports them. Debug builds of
+> `libonedal_dpc.so` may still produce excessive debug information and very long
+> link times; for practical DPC++ debugging, the static variant can be easier to
+> work with.
 
 ### AddressSanitizer (ASan)
 
@@ -489,15 +491,25 @@ bazel test //cpp/oneapi/dal:tests --config=ubsan
 
 ### MemorySanitizer (MSan)
 
-Requires Clang or ICPX. GCC does not support MSan.
-The `msan` config enables `-fsanitize-memory-track-origins` for better origin diagnostics.
-If your toolchain requires lld for MSan/TSan linking, add:
+Equivalent to Make `REQSAN=memory`. Requires a Clang/LLVM toolchain and lld;
+GCC does not support MSan. The `msan` config enables
+`-fsanitize-memory-track-origins` for better origin diagnostics and passes
+`--linkopt=-fuse-ld=lld` for the linker.
+
+Bazel applies the sanitizer flags to the oneDAL build, but it does not make the
+rest of the toolchain and dependencies (for example `libstdc++`) MSan-instrumented.
+Uninstrumented dependencies can produce false positives or incomplete reports;
+use an MSan-instrumented sysroot/runtime when investigating MSan findings.
 
 ```sh
-bazel test //cpp/oneapi/dal:tests --config=msan --linkopt=-fuse-ld=lld
+bazel test //cpp/oneapi/dal:tests --config=msan
 ```
 
 ### Type Sanitizer
+
+The `type` config enables Clang TypeSanitizer and adds
+`-fsanitize-recover=all` so the runtime can report multiple findings in one run.
+GCC and ICPX do not support TypeSanitizer.
 
 ```sh
 bazel test //cpp/oneapi/dal:tests --config=type
@@ -508,16 +520,15 @@ bazel test //cpp/oneapi/dal:tests --config=type
 
 ## Release Build
 
-Build the full release artifact (all ISA variants: sse2, sse42, avx2, avx512):
+Build the full release artifact with all ISA variants (sse2, avx2, avx512):
 
 ```sh
-bazel build //:release
+bazel build //:release --cpu=all
 ```
 
-The `//:release` target automatically compiles all ISA variants when `--cpu`
-is left at its default value (`auto`). If `--cpu` is set explicitly — e.g. in
-a personal `~/.bazelrc` or passed in CI — the transition respects that value.
-To restrict ISA coverage (e.g., for faster CI):
+By default, `--cpu=auto` builds the baseline `sse2` variant plus the detected
+host ISA. Use `--cpu=all` for full release coverage, or set a specific ISA to
+restrict coverage (e.g., for faster CI):
 
 ```sh
 bazel build //:release --cpu=avx2
@@ -526,18 +537,23 @@ bazel build //:release --cpu=avx2
 To include DPC++ libraries:
 
 ```sh
-bazel build //:release --config=release-dpc
+bazel build //:release --config=release-dpc --cpu=all
 ```
 
 ---
 
 ### Standard Library Assertions
 
-To enable C++ standard library assertions (e.g., `std::vector` bounds checking), inject the preprocessor macro via `--cxxopt` (C++-only flag):
+To enable GNU libstdc++ assertions (e.g., `std::vector` bounds checking),
+inject the preprocessor macro via `--cxxopt` (C++-only flag):
 
 ```sh
 bazel test //cpp/oneapi/dal:tests --config=dbg --cxxopt=-D_GLIBCXX_DEBUG
 ```
+
+This applies only when the build uses GNU libstdc++ headers (for example GCC,
+or ICX configured to use libstdc++). It is not portable to non-GNU standard
+library implementations.
 
 ---
 
@@ -558,6 +574,11 @@ bazel build //:release --cxxopt=-std=c++17
 # Add a linker flag
 bazel build //:release --linkopt=-Wl,--as-needed
 ```
+
+Avoid `-march=native` for release artifacts: oneDAL relies on runtime CPU
+feature dispatching and portable baseline objects. Native architecture flags are
+appropriate only for local experiments where the artifact will run on the same
+machine.
 
 To make flags permanent for your local environment, add them to `~/.bazelrc`:
 
@@ -580,12 +601,12 @@ build --linkopt=-your-link-flag
 | `REQSAN=static` | `--config=asan-static` | ASan with static libasan |
 | `REQSAN=thread` | `--config=tsan` | ThreadSanitizer |
 | `REQSAN=undefined` | `--config=ubsan` | UBSan |
-| | `--config=msan` | MemorySanitizer (Clang/ICPX only) |
-| | `--config=type` | Type Sanitizer |
+| `REQSAN=memory` | `--config=msan` | MemorySanitizer (Clang/LLVM + lld; instrumented dependencies recommended) |
+| TypeSanitizer | `--config=type` | Clang-only; GCC/ICPX unsupported |
 | `COMPILER=gnu` | `CC=gcc bazel build ...` | Override compiler via `CC` env |
 | `OPTFLAG=O2` | `--copt=-O2` | Override optimization level |
 | `COPT=-flag` | `--copt=-flag` (C+C++) / `--cxxopt=-flag` (C++ only) | Arbitrary compiler flag |
 | `--cpu=<isa>` (Make `PLAT`) | `--cpu=<isa>` | ISA selection |
-| (Make default all ISAs) | `bazel build //:release` | Transition forces all ISAs |
+| (Make default all ISAs) | `bazel build //:release --cpu=all` | Explicit full ISA coverage |
 | (CI: single ISA) | `--cpu=avx2` | Override for CI speed |
 

--- a/dev/bazel/README.md
+++ b/dev/bazel/README.md
@@ -459,6 +459,16 @@ bazel build //:release --config=dbg-symbols
 > link times; for practical DPC++ debugging, the static variant can be easier to
 > work with.
 
+#### Sanitized DPC++ builds
+
+DPC++ libraries can be combined with sanitizers (ASan, TSAN, UBSan) when the
+DPC++ runtime supports them. Use `--release_dpc=True` alongside the sanitizer config:
+
+```sh
+bazel build //:release --config=asan --release_dpc=True --cpu=all
+bazel test //cpp/oneapi/dal:tests --config=ubsan --release_dpc=True
+```
+
 ### AddressSanitizer (ASan)
 
 Equivalent to Make `REQSAN=address`. Sanitizers do not automatically enable assertions or unoptimized debug builds. It is highly recommended to combine them with `--config=dbg` (for full debug + assertions) or `--enable_assert=True`:
@@ -552,8 +562,9 @@ bazel test //cpp/oneapi/dal:tests --config=dbg --cxxopt=-D_GLIBCXX_DEBUG
 ```
 
 This applies only when the build uses GNU libstdc++ headers (for example GCC,
-or ICX configured to use libstdc++). It is not portable to non-GNU standard
-library implementations.
+or ICX configured to use libstdc++). If ICX is configured to use libc++ (default
+on some systems), this flag will have no effect. It is not portable to non-GNU
+standard library implementations.
 
 ---
 

--- a/dev/bazel/README.md
+++ b/dev/bazel/README.md
@@ -531,24 +531,27 @@ bazel build //:release --config=release-dpc
 
 ### Standard Library Assertions
 
-To enable C++ standard library assertions (e.g., `std::vector` bounds checking), inject the preprocessor macro via `--copt`:
+To enable C++ standard library assertions (e.g., `std::vector` bounds checking), inject the preprocessor macro via `--cxxopt` (C++-only flag):
 
 ```sh
-bazel test //cpp/oneapi/dal:tests --config=dbg --copt=-D_GLIBCXX_DEBUG
+bazel test //cpp/oneapi/dal:tests --config=dbg --cxxopt=-D_GLIBCXX_DEBUG
 ```
 
 ---
 
 ## Custom Compiler and Linker Flags
 
-Equivalent to Make `COPT` / `CXXFLAGS`. Pass via `--copt` and `--linkopt`:
+Equivalent to Make `COPT` / `CXXFLAGS`. Use `--copt` for C and C++ flags, `--cxxopt` for C++-only flags, and `--linkopt` for linker flags:
 
 ```sh
-# Add a custom compiler flag
+# Architecture/optimization flags (C and C++)
 bazel build //:release --copt=-march=native
 
-# Override optimization level
+# Override optimization level (C and C++)
 bazel build //:release --copt=-O2
+
+# C++-only preprocessor/language flags
+bazel build //:release --cxxopt=-std=c++17
 
 # Add a linker flag
 bazel build //:release --linkopt=-Wl,--as-needed
@@ -558,7 +561,8 @@ To make flags permanent for your local environment, add them to `~/.bazelrc`:
 
 ```
 # ~/.bazelrc (user-local, not committed)
-build --copt=-your-flag
+build --copt=-your-c-and-cxx-flag
+build --cxxopt=-your-cxx-only-flag
 build --linkopt=-your-link-flag
 ```
 
@@ -578,7 +582,7 @@ build --linkopt=-your-link-flag
 | | `--config=type` | Type Sanitizer |
 | `COMPILER=gnu` | `CC=gcc bazel build ...` | Override compiler via `CC` env |
 | `OPTFLAG=O2` | `--copt=-O2` | Override optimization level |
-| `COPT=-flag` | `--copt=-flag` | Arbitrary compiler flag |
+| `COPT=-flag` | `--copt=-flag` (C+C++) / `--cxxopt=-flag` (C++ only) | Arbitrary compiler flag |
 | `--cpu=<isa>` (Make `PLAT`) | `--cpu=<isa>` | ISA selection |
 | (Make default all ISAs) | `bazel build //:release` | Transition forces all ISAs |
 | (CI: single ISA) | `--cpu=avx2` | Override for CI speed |

--- a/dev/bazel/README.md
+++ b/dev/bazel/README.md
@@ -487,8 +487,13 @@ Equivalent to Make `REQSAN=undefined`:
 bazel test //cpp/oneapi/dal:tests --config=ubsan
 ```
 
-> Note: Not all compilers support all sanitizers. GCC will fail with
-> `REQSAN=memory` by design. Use icpx or clang for memory sanitizer.
+> Note: Not all compilers support all sanitizers. There is currently no
+> `--config=msan` preset. To use MemorySanitizer, use a compiler that supports
+> it (icpx or clang) and pass flags manually:
+> ```sh
+> bazel test //cpp/oneapi/dal:tests --copt=-fsanitize=memory --linkopt=-fsanitize=memory
+> ```
+> GCC does not support MemorySanitizer and will fail by design.
 
 ---
 
@@ -500,8 +505,10 @@ Build the full release artifact (all ISA variants: sse2, sse42, avx2, avx512):
 bazel build //:release
 ```
 
-The `//:release` target automatically compiles all ISA variants regardless of
-the `--cpu` flag default. To restrict ISA coverage (e.g., for faster CI):
+The `//:release` target automatically compiles all ISA variants when `--cpu`
+is left at its default value (`auto`). If `--cpu` is set explicitly — e.g. in
+a personal `~/.bazelrc` or passed in CI — the transition respects that value.
+To restrict ISA coverage (e.g., for faster CI):
 
 ```sh
 bazel build //:release --cpu=avx2

--- a/dev/bazel/README.md
+++ b/dev/bazel/README.md
@@ -615,10 +615,9 @@ build --linkopt=-your-link-flag
 | `REQSAN=thread`                | `--config=tsan`                                              | ThreadSanitizer                                                            |
 | `REQSAN=undefined`             | `--config=ubsan`                                             | UBSan                                                                      |
 | `REQSAN=memory`                | `--config=msan`                                              | MemorySanitizer (Clang/LLVM + lld; instrumented dependencies recommended)  |
-| TypeSanitizer                  | `--config=type`                                              | Clang-only; GCC/ICPX unsupported                                           |
+| `REQSAN=type`                  | `--config=type`                                              | TypeSanitizer; Clang-only; GCC/ICPX unsupported                            |
 | `COMPILER=gnu`                 | `CC=gcc bazel build ...`                                     | Override compiler via `CC` env                                             |
 | `OPTFLAG=O2`                   | `--copt=-O2`                                                 | Override optimization level                                                |
 | `COPT=-flag`                   | `--copt=-flag` (C+C++) / `--cxxopt=-flag` (C++ only)         | Arbitrary compiler flag                                                    |
-| `--cpu=<isa>` (Make `PLAT`)    | `--cpu=<isa>`                                                | ISA selection                                                              |
+| `PLAT=<isa>`                   | `--cpu=<isa>`                                                | ISA selection                                                              |
 | (Make default all ISAs)        | `bazel build //:release --cpu=all`                           | Explicit full ISA coverage                                                 |
-| (CI: single ISA)               | `--cpu=avx2`                                                 | Override for CI speed                                                      |

--- a/dev/bazel/README.md
+++ b/dev/bazel/README.md
@@ -432,3 +432,128 @@ dal_test_suite(
 
 ## What is missing in this guide
 - How to get make-like release structure
+
+## Debug and Sanitizer Builds
+
+### Debug build with assertions
+
+Equivalent to Make `REQDBG=1` — adds debug symbols, enables `DEBUG_ASSERT`
+and `ONEDAL_ENABLE_ASSERT`:
+
+```sh
+bazel build //:release --config=dbg
+bazel test //cpp/oneapi/dal:tests --config=dbg
+```
+
+### Debug symbols only (no assertion checks)
+
+Equivalent to Make `REQDBG=symbols`:
+
+```sh
+bazel build //:release --config=dbg-symbols
+```
+
+> Note: The `libonedal_dpc.so` library does not support debug mode due to
+> excessive debug information causing long link times. Use the static library
+> variant for DPC++ debugging.
+
+### AddressSanitizer (ASan)
+
+Equivalent to Make `REQSAN=address`. Recommended to combine with `--config=dbg`:
+
+```sh
+bazel test //cpp/oneapi/dal:tests --config=asan --config=dbg
+```
+
+For static libasan linkage (equivalent to Make `REQSAN=static`):
+
+```sh
+bazel test //cpp/oneapi/dal:tests --config=asan-static --config=dbg
+```
+
+### ThreadSanitizer (TSan)
+
+Equivalent to Make `REQSAN=thread`:
+
+```sh
+bazel test //cpp/oneapi/dal:tests --config=tsan
+```
+
+### UndefinedBehaviorSanitizer (UBSan)
+
+Equivalent to Make `REQSAN=undefined`:
+
+```sh
+bazel test //cpp/oneapi/dal:tests --config=ubsan
+```
+
+> Note: Not all compilers support all sanitizers. GCC will fail with
+> `REQSAN=memory` by design. Use icpx or clang for memory sanitizer.
+
+---
+
+## Release Build
+
+Build the full release artifact (all ISA variants: sse2, sse42, avx2, avx512):
+
+```sh
+bazel build //:release
+```
+
+The `//:release` target automatically compiles all ISA variants regardless of
+the `--cpu` flag default. To restrict ISA coverage (e.g., for faster CI):
+
+```sh
+bazel build //:release --cpu=avx2
+```
+
+To include DPC++ libraries:
+
+```sh
+bazel build //:release --config=release-dpc
+```
+
+---
+
+## Custom Compiler and Linker Flags
+
+Equivalent to Make `COPT` / `CXXFLAGS`. Pass via `--copt` and `--linkopt`:
+
+```sh
+# Add a custom compiler flag
+bazel build //:release --copt=-march=native
+
+# Override optimization level
+bazel build //:release --copt=-O2
+
+# Add a linker flag
+bazel build //:release --linkopt=-Wl,--as-needed
+```
+
+To make flags permanent for your local environment, add them to `~/.bazelrc`:
+
+```
+# ~/.bazelrc (user-local, not committed)
+build --copt=-your-flag
+build --linkopt=-your-link-flag
+```
+
+---
+
+## Make → Bazel Flag Reference
+
+| Make option | Bazel equivalent | Notes |
+|---|---|---|
+| `REQDBG=1` | `--config=dbg` | Debug symbols + assertions |
+| `REQDBG=symbols` | `--config=dbg-symbols` | Debug symbols only |
+| `REQSAN=address` | `--config=asan` | AddressSanitizer |
+| `REQSAN=static` | `--config=asan-static` | ASan with static libasan |
+| `REQSAN=thread` | `--config=tsan` | ThreadSanitizer |
+| `REQSAN=undefined` | `--config=ubsan` | UBSan |
+| `COMPILER=gnu` | `CC=gcc bazel build ...` | Override compiler via `CC` env |
+| `OPTFLAG=O2` | `--copt=-O2` | Override optimization level |
+| `COPT=-flag` | `--copt=-flag` | Arbitrary compiler flag |
+| `--cpu=<isa>` (Make `PLAT`) | `--cpu=<isa>` | ISA selection |
+| (Make default all ISAs) | `bazel build //:release` | Transition forces all ISAs |
+| (CI: single ISA) | `--cpu=avx2` | Override for CI speed |
+

--- a/dev/bazel/README.md
+++ b/dev/bazel/README.md
@@ -437,7 +437,7 @@ dal_test_suite(
 
 ### Debug build with assertions
 
-Equivalent to Make `REQDBG=1` — adds debug symbols, enables `DEBUG_ASSERT`
+Equivalent to Make `REQDBG=yes` — adds debug symbols, enables `DEBUG_ASSERT`
 and `ONEDAL_ENABLE_ASSERT`:
 
 ```sh
@@ -456,8 +456,7 @@ bazel build //:release --config=dbg-symbols
 > Note: DPC++ targets can be built with debug/sanitizer configurations when
 > the selected compiler/runtime supports them. Debug builds of
 > `libonedal_dpc.so` may still produce excessive debug information and very long
-> link times; for practical DPC++ debugging, the static variant can be easier to
-> work with.
+> link times.
 
 #### Sanitized DPC++ builds
 
@@ -583,6 +582,12 @@ bazel build //:release --cxxopt=-std=c++17
 bazel build //:release --linkopt=-Wl,--as-needed
 ```
 
+Bazel combines repeated `--copt`, `--cxxopt`, and `--linkopt` values from named
+configs and user-provided flags. For example, `--config=dbg-symbols --copt=-O2`
+keeps the config's `-g` flag and also passes the user `-O2` flag. If flags
+conflict, the compiler/toolchain decides how to interpret the final option list,
+so users should avoid conflicting custom flags unless that behavior is intended.
+
 Avoid `-march=native` for release artifacts: oneDAL relies on runtime CPU
 feature dispatching and portable baseline objects. Native architecture flags are
 appropriate only for local experiments where the artifact will run on the same
@@ -601,20 +606,19 @@ build --linkopt=-your-link-flag
 
 ## Make → Bazel Flag Reference
 
-| Make option | Bazel equivalent | Notes |
-|---|---|---|
-| `REQDBG=1` | `--config=dbg` | Debug symbols + assertions |
-| `REQDBG=symbols` | `--config=dbg-symbols` | Debug symbols only |
-| `REQSAN=address` | `--config=asan` | AddressSanitizer |
-| `REQSAN=static` | `--config=asan-static` | ASan with static libasan |
-| `REQSAN=thread` | `--config=tsan` | ThreadSanitizer |
-| `REQSAN=undefined` | `--config=ubsan` | UBSan |
-| `REQSAN=memory` | `--config=msan` | MemorySanitizer (Clang/LLVM + lld; instrumented dependencies recommended) |
-| TypeSanitizer | `--config=type` | Clang-only; GCC/ICPX unsupported |
-| `COMPILER=gnu` | `CC=gcc bazel build ...` | Override compiler via `CC` env |
-| `OPTFLAG=O2` | `--copt=-O2` | Override optimization level |
-| `COPT=-flag` | `--copt=-flag` (C+C++) / `--cxxopt=-flag` (C++ only) | Arbitrary compiler flag |
-| `--cpu=<isa>` (Make `PLAT`) | `--cpu=<isa>` | ISA selection |
-| (Make default all ISAs) | `bazel build //:release --cpu=all` | Explicit full ISA coverage |
-| (CI: single ISA) | `--cpu=avx2` | Override for CI speed |
-
+| Make option                    | Bazel equivalent                                             | Notes                                                                      |
+|--------------------------------|--------------------------------------------------------------|----------------------------------------------------------------------------|
+| `REQDBG=yes`                   | `--config=dbg`                                               | Debug symbols + assertions                                                 |
+| `REQDBG=symbols`               | `--config=dbg-symbols`                                       | Debug symbols only                                                         |
+| `REQSAN=address`               | `--config=asan`                                              | AddressSanitizer                                                           |
+| `REQSAN=static`                | `--config=asan-static`                                       | ASan with static libasan                                                   |
+| `REQSAN=thread`                | `--config=tsan`                                              | ThreadSanitizer                                                            |
+| `REQSAN=undefined`             | `--config=ubsan`                                             | UBSan                                                                      |
+| `REQSAN=memory`                | `--config=msan`                                              | MemorySanitizer (Clang/LLVM + lld; instrumented dependencies recommended)  |
+| TypeSanitizer                  | `--config=type`                                              | Clang-only; GCC/ICPX unsupported                                           |
+| `COMPILER=gnu`                 | `CC=gcc bazel build ...`                                     | Override compiler via `CC` env                                             |
+| `OPTFLAG=O2`                   | `--copt=-O2`                                                 | Override optimization level                                                |
+| `COPT=-flag`                   | `--copt=-flag` (C+C++) / `--cxxopt=-flag` (C++ only)         | Arbitrary compiler flag                                                    |
+| `--cpu=<isa>` (Make `PLAT`)    | `--cpu=<isa>`                                                | ISA selection                                                              |
+| (Make default all ISAs)        | `bazel build //:release --cpu=all`                           | Explicit full ISA coverage                                                 |
+| (CI: single ISA)               | `--cpu=avx2`                                                 | Override for CI speed                                                      |

--- a/dev/bazel/README.md
+++ b/dev/bazel/README.md
@@ -459,7 +459,7 @@ bazel build //:release --config=dbg-symbols
 
 ### AddressSanitizer (ASan)
 
-Equivalent to Make `REQSAN=address`. Recommended to combine with `--config=dbg`:
+Equivalent to Make `REQSAN=address`. Sanitizers do not automatically enable assertions or unoptimized debug builds. It is highly recommended to combine them with `--config=dbg` (for full debug + assertions) or `--enable_assert=True`:
 
 ```sh
 bazel test //cpp/oneapi/dal:tests --config=asan --config=dbg
@@ -487,13 +487,20 @@ Equivalent to Make `REQSAN=undefined`:
 bazel test //cpp/oneapi/dal:tests --config=ubsan
 ```
 
-> Note: Not all compilers support all sanitizers. There is currently no
-> `--config=msan` preset. To use MemorySanitizer, use a compiler that supports
-> it (icpx or clang) and pass flags manually:
-> ```sh
-> bazel test //cpp/oneapi/dal:tests --copt=-fsanitize=memory --linkopt=-fsanitize=memory
-> ```
-> GCC does not support MemorySanitizer and will fail by design.
+### MemorySanitizer (MSan)
+
+Requires Clang or ICPX. GCC does not support MSan.
+
+```sh
+bazel test //cpp/oneapi/dal:tests --config=msan
+```
+
+### Type Sanitizer
+
+```sh
+bazel test //cpp/oneapi/dal:tests --config=type
+```
+
 
 ---
 
@@ -518,6 +525,16 @@ To include DPC++ libraries:
 
 ```sh
 bazel build //:release --config=release-dpc
+```
+
+---
+
+### Standard Library Assertions
+
+To enable C++ standard library assertions (e.g., `std::vector` bounds checking), inject the preprocessor macro via `--copt`:
+
+```sh
+bazel test //cpp/oneapi/dal:tests --config=dbg --copt=-D_GLIBCXX_DEBUG
 ```
 
 ---
@@ -557,6 +574,8 @@ build --linkopt=-your-link-flag
 | `REQSAN=static` | `--config=asan-static` | ASan with static libasan |
 | `REQSAN=thread` | `--config=tsan` | ThreadSanitizer |
 | `REQSAN=undefined` | `--config=ubsan` | UBSan |
+| | `--config=msan` | MemorySanitizer (Clang/ICPX only) |
+| | `--config=type` | Type Sanitizer |
 | `COMPILER=gnu` | `CC=gcc bazel build ...` | Override compiler via `CC` env |
 | `OPTFLAG=O2` | `--copt=-O2` | Override optimization level |
 | `COPT=-flag` | `--copt=-flag` | Arbitrary compiler flag |

--- a/dev/bazel/README.md
+++ b/dev/bazel/README.md
@@ -490,9 +490,11 @@ bazel test //cpp/oneapi/dal:tests --config=ubsan
 ### MemorySanitizer (MSan)
 
 Requires Clang or ICPX. GCC does not support MSan.
+The `msan` config enables `-fsanitize-memory-track-origins` for better origin diagnostics.
+If your toolchain requires lld for MSan/TSan linking, add:
 
 ```sh
-bazel test //cpp/oneapi/dal:tests --config=msan
+bazel test //cpp/oneapi/dal:tests --config=msan --linkopt=-fuse-ld=lld
 ```
 
 ### Type Sanitizer


### PR DESCRIPTION
## Summary

Addresses BLOCKER 5 and BLOCKER 6 from #3530.

## BLOCKER 5: Build options parity with Make

Adds `.bazelrc` configurations matching Make `REQDBG` / `REQSAN` options:

| Make option | Bazel equivalent | Notes |
|---|---|---|
| `REQDBG=1` | `--config=dbg` | debug symbols + assertions |
| `REQDBG=symbols` | `--config=dbg-symbols` | debug symbols only |
| `REQSAN=address` | `--config=asan` | AddressSanitizer |
| `REQSAN=static` | `--config=asan-static` | ASan, static libasan |
| `REQSAN=thread` | `--config=tsan` | ThreadSanitizer |
| `REQSAN=undefined` | `--config=ubsan` | UBSan |
| `COPT=-flag` | `--copt=-flag` | custom compiler flag |

Example usage:
```sh
# Debug build with assertions (equivalent to Make REQDBG=1)
bazel test //cpp/oneapi/dal:tests --config=dbg

# ASan (equivalent to Make REQSAN=address)
bazel test //cpp/oneapi/dal:tests --config=asan --config=dbg

# Custom flag (equivalent to Make COPT=-flag)
bazel build //:release --copt=-march=native
```

## BLOCKER 6: Build documentation

Expands `dev/bazel/README.md` with:
- Debug and sanitizer builds section
- Release build section (ISA variants, DPC++ option)
- Custom compiler/linker flags section
- Make → Bazel flag reference table

## Changes

- `.bazelrc`: new `dbg`, `dbg-symbols`, `asan`, `asan-static`, `tsan`, `ubsan` configs
- `dev/bazel/README.md`: new sections appended to existing guide

## Testing

No functional code changes — configuration and documentation only.

`--config=dbg` uses existing toolchain `dbg_compile_flags` (`-g` already wired in `cc_toolchain_lnx.bzl`).
`enable_assert` flag already connected to `ONEDAL_ENABLE_ASSERT` / `DEBUG_ASSERT` defines.

Part of #3530.