### PR TITLE
Fix Bazel build fail for hyphenated versioned libs

### DIFF
--- a/dev/bazel/deps/opencl.tpl.BUILD
+++ b/dev/bazel/deps/opencl.tpl.BUILD
@@ -8,7 +8,7 @@ cc_library(
             "*.so.*",
         ],
         allow_empty = True,
-        exclude = ["*.py", "*.cmake", "*.a", "*-*"],
+        exclude = ["*.py", "*.cmake", "*.a", "*.so.*-*"],
     ),
     linkopts = ["-lOpenCL"],
     visibility = ["//visibility:public"],

--- a/dev/bazel/deps/opencl.tpl.BUILD
+++ b/dev/bazel/deps/opencl.tpl.BUILD
@@ -8,7 +8,7 @@ cc_library(
             "*.so.*",
         ],
         allow_empty = True,
-        exclude = ["*.py", "*.cmake", "*.a"],
+        exclude = ["*.py", "*.cmake", "*.a", "*-*"],
     ),
     linkopts = ["-lOpenCL"],
     visibility = ["//visibility:public"],


### PR DESCRIPTION
## Description

  - Exclude shared libraries with hyphenated version strings (e.g., `libsycl.so.9.0.0-0`) from `cc_library` srcs in the OpenCL Bazel dependency
  - `rules_cc`'s extension check only accepts numeric dot-separated versions (`.so.X.Y.Z`), rejecting the `-N` suffix introduced in newer compiler releases
  - The unversioned (`libsycl.so`) and major-version (`libsycl.so.9`) symlinks remain in srcs and are sufficient for linking and SONAME resolution

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least a summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance and/or quality metrics have changed or why changes are not expected.
- [x] I have extended the benchmarking suite and provided a corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.

</details>
