### PR TITLE
Fix: Remove Naive Bayes samples from the list of DAAL MPI samples

### DIFF
--- a/samples/daal/cpp/mpi/daal.lst.bat
+++ b/samples/daal/cpp/mpi/daal.lst.bat
@@ -28,8 +28,6 @@ set MPI_SAMPLE_LIST=svd_fast_distributed_mpi                      ^
                     pca_svd_distributed_mpi                       ^
                     covariance_dense_distributed_mpi              ^
                     covariance_csr_distributed_mpi                ^
-                    multinomial_naive_bayes_dense_distributed_mpi ^
-                    multinomial_naive_bayes_csr_distributed_mpi   ^
                     kmeans_dense_distributed_mpi                  ^
                     kmeans_csr_distributed_mpi                    ^
                     kmeans_init_dense_distributed_mpi             ^

--- a/samples/daal/cpp/mpi/daal_lnx.lst
+++ b/samples/daal/cpp/mpi/daal_lnx.lst
@@ -27,8 +27,6 @@ MPI  =  svd_fast_distributed_mpi                           \
         pca_svd_distributed_mpi                            \
         covariance_dense_distributed_mpi                   \
         covariance_csr_distributed_mpi                     \
-        multinomial_naive_bayes_dense_distributed_mpi      \
-        multinomial_naive_bayes_csr_distributed_mpi        \
         kmeans_dense_distributed_mpi                       \
         kmeans_csr_distributed_mpi                         \
         kmeans_init_dense_distributed_mpi                  \


### PR DESCRIPTION
## Description

The respective samples were removed in 2026.0, but the lists were not updated.
Updating them now.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

**Performance**
 
not applicable

</details>
