### PR TITLE
fix: conda-recipe and linuxbazel jobs

### DIFF
--- a/.github/workflows/ci-conda-recipe.yml
+++ b/.github/workflows/ci-conda-recipe.yml
@@ -68,9 +68,8 @@ jobs:
         run: conda create -y -q -n build-env conda-build
       - name: Conda build and test
         run: |
-          . /usr/share/miniconda/etc/profile.d/conda.sh
-          conda activate build-env
-          conda build . --variants "{cxx_compiler: ${{ matrix.cxx_compiler }}, cxx_compiler_version: ${{ matrix.cxx_compiler_version }}}"
+          conda run -n build-env conda build . \
+            --variants "{cxx_compiler: ${{ matrix.cxx_compiler }}, cxx_compiler_version: ${{ matrix.cxx_compiler_version }}}"
         env:
           # Note: AVX2 is used as the most common denominator for CI systems
           REQCPU: avx2

--- a/.github/workflows/ci-conda-recipe.yml
+++ b/.github/workflows/ci-conda-recipe.yml
@@ -64,11 +64,10 @@ jobs:
           conda config --add channels conda-forge
           conda config --set channel_priority strict
           conda update -y -q conda python
-      - name: Conda create
-        run: conda create -y -q -n build-env conda-build
+          conda install -y -q -n base conda-build
       - name: Conda build and test
         run: |
-          conda run -n build-env conda build . \
+          conda build . \
             --variants "{cxx_compiler: ${{ matrix.cxx_compiler }}, cxx_compiler_version: ${{ matrix.cxx_compiler_version }}}"
         env:
           # Note: AVX2 is used as the most common denominator for CI systems

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -18,7 +18,7 @@ module(name = "onedal")
 
 bazel_dep(name = "platforms", version = "1.0.0")
 bazel_dep(name = "bazel_skylib", version = "1.9.0")
-bazel_dep(name = "rules_cc", version = "0.2.17")
+bazel_dep(name = "rules_cc", version = "0.2.18")
 bazel_dep(name = "rules_shell", version = "0.7.1")
 bazel_dep(name = "fmt", version = "12.1.0")
 

--- a/dev/bazel/AGENTS.md
+++ b/dev/bazel/AGENTS.md
@@ -39,7 +39,7 @@ module(
     version = "1.0.0",
 )
 
-bazel_dep(name = "rules_cc", version = "0.2.16")
+bazel_dep(name = "rules_cc", version = "0.2.18")
 bazel_dep(name = "catch2", version = "3.9.1")
 ```
 

--- a/dev/bazel/deps/mkl.tpl.BUILD
+++ b/dev/bazel/deps/mkl.tpl.BUILD
@@ -38,7 +38,6 @@ cc_library(
     defines = [
         "MKL_ILP64"
     ],
-    alwayslink = 1,
     linkstatic = 1,
 )
 


### PR DESCRIPTION
## Fix conda-recipe and linuxbazel jobs

- Force-installed `conda-build` in the conda recipe jobs to avoid missing dependency issues during the build stage.
- Removed `alwayslink=1` from Bazel configuration in linuxbazel jobs since it was unnecessary and caused linking-related side effects.

This stabilizes the CI pipeline and simplifies the Bazel linking behavior on Linux builds.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least a summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance and/or quality metrics have changed or why changes are not expected.
- [x] I have extended the benchmarking suite and provided a corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.

</details>
