### PR TITLE
Fix: trees random splitter

### DIFF
--- a/cpp/daal/src/algorithms/dtrees/forest/regression/df_regression_train_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/regression/df_regression_train_dense_default_impl.i
@@ -1262,7 +1262,7 @@ bool OrderedRespHelperRandom<algorithmFPType, cpu>::findBestSplitOrderedFeature(
 
     if (!((leftWeights < minWeightLeaf) || (rightWeights < minWeightLeaf)) && leftWeights && rightWeights)
     {
-        const intermSummFPType v = left.var + right.var;
+        const intermSummFPType v = leftWeights * left.var + rightWeights * right.var;
         if (v < vBest)
         {
             vBest             = v;
@@ -1278,9 +1278,8 @@ bool OrderedRespHelperRandom<algorithmFPType, cpu>::findBestSplitOrderedFeature(
     split.impurityDecrease = curImpurity.var - vBest / totalWeights;
     split.nLeft            = iBest;
     split.totalWeights     = totalWeights;
-    split.left.var /= (isPositive<intermSummFPType, cpu>(split.leftWeights) ? split.leftWeights : 1.);
-    split.iStart       = 0;
-    split.featureValue = idx;
+    split.iStart           = 0;
+    split.featureValue     = idx;
     return true;
 }
 

--- a/cpp/oneapi/dal/algo/decision_forest/backend/gpu/train_splitter_impl_dpc.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/gpu/train_splitter_impl_dpc.cpp
@@ -696,11 +696,13 @@ sycl::event train_splitter_impl<Float, Bin, Index, Task>::best_split(
                         }
                     }
                     // Select best split among bin block
-                    for (Index i = act_bin_block / 2; i > 0; i >>= 1) {
+                    for (Index offset = 1; offset < act_bin_block; offset <<= 1) {
                         item.barrier(sycl::access::fence_space::local_space);
-                        if (local_id < i && (local_id + i) < act_bin_block) {
+                        const Index reduce_mask = (offset << 1) - 1;
+                        if (((local_id & reduce_mask) == 0) &&
+                            (local_id + offset < act_bin_block)) {
                             split_scalar_t& s1 = local_scalars[local_id];
-                            split_scalar_t& s2 = local_scalars[local_id + i];
+                            split_scalar_t& s2 = local_scalars[local_id + offset];
                             if (sp_hlp.test_split_is_best(s1, s2, min_obs_leaf)) {
                                 s1.copy(s2);
                             }
@@ -760,14 +762,16 @@ sycl::event train_splitter_impl<Float, Bin, Index, Task>::best_split(
             }
 
             // Select best split among working group
-            for (Index i = local_size / 2; i > 0; i >>= 1) {
+            const Index reduce_count = sycl::min(local_size, ftr_count);
+            for (Index offset = 1; offset < reduce_count; offset <<= 1) {
                 item.barrier(sycl::access::fence_space::local_space);
-                if (local_id < i && (local_id + i) < ftr_count) {
+                const Index reduce_mask = (offset << 1) - 1;
+                if (((local_id & reduce_mask) == 0) && (local_id + offset < reduce_count)) {
                     split_scalar_t& s1 = node_splits[local_id];
-                    split_scalar_t& s2 = node_splits[local_id + i];
+                    split_scalar_t& s2 = node_splits[local_id + offset];
                     if (sp_hlp.test_split_is_best(s1, s2, min_obs_leaf)) {
                         s1.copy(s2);
-                        ftr_indices[local_id] = ftr_indices[local_id + i];
+                        ftr_indices[local_id] = ftr_indices[local_id + offset];
                     }
                 }
             }

--- a/cpp/oneapi/dal/algo/decision_forest/backend/gpu/train_splitter_impl_dpc.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/gpu/train_splitter_impl_dpc.cpp
@@ -194,7 +194,10 @@ sycl::event train_splitter_impl<Float, Bin, Index, Task>::random_split(
                                             maximum<Index>());
 
                 const Float rand_val = ftr_rnd_ptr[node_id * selected_ftr_count + ftr_idx];
-                const Index random_bin_ofs = static_cast<Index>(rand_val * (max_bin - min_bin + 1));
+                const Index random_bin_count = sycl::max(max_bin - min_bin, Index(1));
+                const Index random_bin_ofs =
+                    sycl::min(static_cast<Index>(rand_val * random_bin_count),
+                              random_bin_count - Index(1));
                 ts_scal.ftr_bin = min_bin + random_bin_ofs;
 
                 const Index count = Index(bin <= ts_scal.ftr_bin);

--- a/cpp/oneapi/dal/algo/decision_forest/test/batch.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/test/batch.cpp
@@ -378,6 +378,30 @@ DF_BATCH_REG_TEST("df reg base check with default params") {
     this->infer_base_checks(desc, data_test, this->get_homogen_table_id(), model, checker_list);
 }
 
+// Reproduces the bug described in this issue:
+// https://github.com/uxlfoundation/oneDAL/issues/3648
+DF_BATCH_REG_TEST("df reg check with large max_bins parameter") {
+    SKIP_IF(this->not_available_on_device());
+    SKIP_IF(this->not_float64_friendly());
+
+    // requre MSE == 0.0
+    const auto [data, data_test, checker_list] = this->get_reg_dataframe_base(0.0);
+
+    const splitter_mode splitter_mode_val =
+        GENERATE_COPY(splitter_mode::best, splitter_mode::random);
+    auto desc = this->get_default_descriptor();
+
+    desc.set_max_bins(data.get_row_count());
+    desc.set_splitter_mode(splitter_mode_val);
+
+    INFO("splitter node = " +
+         std::string(splitter_mode_val == splitter_mode::best ? "best" : "random"));
+
+    const auto train_result = this->train_base_checks(desc, data, this->get_homogen_table_id());
+    const auto model = train_result.get_model();
+    this->infer_base_checks(desc, data_test, this->get_homogen_table_id(), model, checker_list);
+}
+
 DF_BATCH_REG_TEST("df reg base check with default params and train weights") {
     SKIP_IF(this->not_available_on_device());
     SKIP_IF(this->not_float64_friendly());

--- a/cpp/oneapi/dal/algo/decision_forest/test/batch.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/test/batch.cpp
@@ -380,26 +380,30 @@ DF_BATCH_REG_TEST("df reg base check with default params") {
 
 // Reproduces the bug described in this issue:
 // https://github.com/uxlfoundation/oneDAL/issues/3648
-DF_BATCH_REG_TEST("df reg check with large max_bins parameter") {
+DF_BATCH_REG_TEST("df reg random splitter fits training data with large max_bins parameter") {
     SKIP_IF(this->not_available_on_device());
     SKIP_IF(this->not_float64_friendly());
 
-    // requre MSE == 0.0
-    const auto [data, data_test, checker_list] = this->get_reg_dataframe_base(0.0);
+    // Require MSE == 0.0 on the training data.
+    [[maybe_unused]] const auto [data, data_test, checker_list] = this->get_reg_dataframe_base(0.0);
 
     const splitter_mode splitter_mode_val =
         GENERATE_COPY(splitter_mode::best, splitter_mode::random);
     auto desc = this->get_default_descriptor();
 
+    desc.set_tree_count(1);
+    desc.set_bootstrap(false);
+    desc.set_min_observations_in_leaf_node(1);
+    desc.set_min_bin_size(1);
     desc.set_max_bins(data.get_row_count());
     desc.set_splitter_mode(splitter_mode_val);
 
-    INFO("splitter node = " +
+    INFO("splitter mode = " +
          std::string(splitter_mode_val == splitter_mode::best ? "best" : "random"));
 
     const auto train_result = this->train_base_checks(desc, data, this->get_homogen_table_id());
     const auto model = train_result.get_model();
-    this->infer_base_checks(desc, data_test, this->get_homogen_table_id(), model, checker_list);
+    this->infer_base_checks(desc, data, this->get_homogen_table_id(), model, checker_list);
 }
 
 DF_BATCH_REG_TEST("df reg base check with default params and train weights") {

--- a/cpp/oneapi/dal/algo/decision_forest/test/fixture.hpp
+++ b/cpp/oneapi/dal/algo/decision_forest/test/fixture.hpp
@@ -136,8 +136,7 @@ public:
         return std::make_tuple(data, data_test, checker_list);
     }
 
-    auto get_reg_dataframe_base() {
-        const double required_mse = 0.05;
+    auto get_reg_dataframe_base(const double required_mse = 0.05) {
         constexpr std::int64_t row_count_train = 10;
         constexpr std::int64_t row_count_test = 5;
         constexpr std::int64_t column_count = 3;


### PR DESCRIPTION
## Description

Fixes #3648.

This PR fixes three decision-forest splitter issues:

- Corrects the regression impurity calculation in the random splitter sorted-feature path.
  The previous calculation could evaluate candidate splits with inconsistent left/right statistics.

- Prevents the GPU random splitter from choosing the maximum bin as a threshold.
  That choice creates an all-left/empty-right split, so the node can stop instead of splitting.

- Fixes GPU best-split reductions for non-power-of-two candidate counts.
  The previous local reduction could fail to propagate a valid best candidate to slot 0.

---

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [X] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [X] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [X] I have run it locally and tested the changes extensively.
- [X] All CI jobs are green or I have provided justification why they aren't.
- [X] @Vika-F and I have extended testing suite if new functionality was introduced in this PR.

</details>
