### PR TITLE
Test for the issue #3648

### DIFF
--- a/cpp/oneapi/dal/algo/decision_forest/test/batch.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/test/batch.cpp
@@ -378,6 +378,30 @@ DF_BATCH_REG_TEST("df reg base check with default params") {
     this->infer_base_checks(desc, data_test, this->get_homogen_table_id(), model, checker_list);
 }
 
+// Reproduces the bug described in this issue:
+// https://github.com/uxlfoundation/oneDAL/issues/3648
+DF_BATCH_REG_TEST("df reg check with large max_bins parameter") {
+    SKIP_IF(this->not_available_on_device());
+    SKIP_IF(this->not_float64_friendly());
+
+    // requre MSE == 0.0
+    const auto [data, data_test, checker_list] = this->get_reg_dataframe_base(0.0);
+
+    const splitter_mode splitter_mode_val =
+        GENERATE_COPY(splitter_mode::best, splitter_mode::random);
+    auto desc = this->get_default_descriptor();
+
+    desc.set_max_bins(data.get_row_count());
+    desc.set_splitter_mode(splitter_mode_val);
+
+    INFO("splitter node = " +
+         std::string(splitter_mode_val == splitter_mode::best ? "best" : "random"));
+
+    const auto train_result = this->train_base_checks(desc, data, this->get_homogen_table_id());
+    const auto model = train_result.get_model();
+    this->infer_base_checks(desc, data_test, this->get_homogen_table_id(), model, checker_list);
+}
+
 DF_BATCH_REG_TEST("df reg base check with default params and train weights") {
     SKIP_IF(this->not_available_on_device());
     SKIP_IF(this->not_float64_friendly());

--- a/cpp/oneapi/dal/algo/decision_forest/test/fixture.hpp
+++ b/cpp/oneapi/dal/algo/decision_forest/test/fixture.hpp
@@ -136,8 +136,7 @@ public:
         return std::make_tuple(data, data_test, checker_list);
     }
 
-    auto get_reg_dataframe_base() {
-        const double required_mse = 0.05;
+    auto get_reg_dataframe_base(const double required_mse = 0.05) {
         constexpr std::int64_t row_count_train = 10;
         constexpr std::int64_t row_count_test = 5;
         constexpr std::int64_t column_count = 3;


### PR DESCRIPTION
## Description

Adds a reproducer for the https://github.com/uxlfoundation/oneDAL/issues/3648

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [ ] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [ ] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.
- [ ] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [ ] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least a summary table with measured data, if performance change is expected.
- [ ] I have provided justification why performance and/or quality metrics have changed or why changes are not expected.
- [ ] I have extended the benchmarking suite and provided a corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.

</details>
