### PR TITLE
FIX: Fix forest thresholds for impurity being determined from X's dtype

### DIFF
--- a/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_train_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_train_dense_default_impl.i
@@ -114,8 +114,8 @@ protected: //enables specific functions for UnorderedRespHelperBest
     {
         intermSummFPType delta = (2. * totalWeights - moveWeights) * imp.var + 2. * (imp.hist[iClass] - totalWeights);
         imp.var                = isZero<intermSummFPType, cpu>((totalWeights - moveWeights) * (totalWeights - moveWeights)) ?
-                      1. :
-                      (imp.var + moveWeights * delta / ((totalWeights - moveWeights) * (totalWeights - moveWeights)));
+                                     1. :
+                                     (imp.var + moveWeights * delta / ((totalWeights - moveWeights) * (totalWeights - moveWeights)));
         imp.hist[iClass] -= moveWeights;
     }
 
@@ -569,14 +569,14 @@ public:
         if (noWeights)
         {
             return split.featureUnordered ? static_cast<const crtp *>(this)->findSplitCategoricalFeature(
-                       featureVal, aIdx, n, nMinSplitPart, accuracy, curImpurity, split, minWeightLeaf, totalWeights) :
+                                                featureVal, aIdx, n, nMinSplitPart, accuracy, curImpurity, split, minWeightLeaf, totalWeights) :
                                             static_cast<const crtp *>(this)->template findSplitOrderedFeature<true>(
                                                 featureVal, aIdx, n, nMinSplitPart, accuracy, curImpurity, split, minWeightLeaf, totalWeights);
         }
         else
         {
             return split.featureUnordered ? static_cast<const crtp *>(this)->findSplitCategoricalFeature(
-                       featureVal, aIdx, n, nMinSplitPart, accuracy, curImpurity, split, minWeightLeaf, totalWeights) :
+                                                featureVal, aIdx, n, nMinSplitPart, accuracy, curImpurity, split, minWeightLeaf, totalWeights) :
                                             static_cast<const crtp *>(this)->template findSplitOrderedFeature<false>(
                                                 featureVal, aIdx, n, nMinSplitPart, accuracy, curImpurity, split, minWeightLeaf, totalWeights);
         }

--- a/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_train_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_train_dense_default_impl.i
@@ -569,14 +569,14 @@ public:
         if (noWeights)
         {
             return split.featureUnordered ? static_cast<const crtp *>(this)->findSplitCategoricalFeature(
-                                                featureVal, aIdx, n, nMinSplitPart, accuracy, curImpurity, split, minWeightLeaf, totalWeights) :
+                       featureVal, aIdx, n, nMinSplitPart, accuracy, curImpurity, split, minWeightLeaf, totalWeights) :
                                             static_cast<const crtp *>(this)->template findSplitOrderedFeature<true>(
                                                 featureVal, aIdx, n, nMinSplitPart, accuracy, curImpurity, split, minWeightLeaf, totalWeights);
         }
         else
         {
             return split.featureUnordered ? static_cast<const crtp *>(this)->findSplitCategoricalFeature(
-                                                featureVal, aIdx, n, nMinSplitPart, accuracy, curImpurity, split, minWeightLeaf, totalWeights) :
+                       featureVal, aIdx, n, nMinSplitPart, accuracy, curImpurity, split, minWeightLeaf, totalWeights) :
                                             static_cast<const crtp *>(this)->template findSplitOrderedFeature<false>(
                                                 featureVal, aIdx, n, nMinSplitPart, accuracy, curImpurity, split, minWeightLeaf, totalWeights);
         }
@@ -672,7 +672,10 @@ public:
 #endif
 
 protected:
-    size_t nClasses() const { return this->_nClasses; }
+    size_t nClasses() const
+    {
+        return this->_nClasses;
+    }
 
     void computeRightHistogramm(const Histogramm & total, const Histogramm & left, Histogramm & right) const
     {

--- a/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_train_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/classification/df_classification_train_dense_default_impl.i
@@ -114,8 +114,8 @@ protected: //enables specific functions for UnorderedRespHelperBest
     {
         intermSummFPType delta = (2. * totalWeights - moveWeights) * imp.var + 2. * (imp.hist[iClass] - totalWeights);
         imp.var                = isZero<intermSummFPType, cpu>((totalWeights - moveWeights) * (totalWeights - moveWeights)) ?
-                                     1. :
-                                     (imp.var + moveWeights * delta / ((totalWeights - moveWeights) * (totalWeights - moveWeights)));
+                      1. :
+                      (imp.var + moveWeights * delta / ((totalWeights - moveWeights) * (totalWeights - moveWeights)));
         imp.hist[iClass] -= moveWeights;
     }
 
@@ -672,10 +672,7 @@ public:
 #endif
 
 protected:
-    size_t nClasses() const
-    {
-        return this->_nClasses;
-    }
+    size_t nClasses() const { return this->_nClasses; }
 
     void computeRightHistogramm(const Histogramm & total, const Histogramm & left, Histogramm & right) const
     {
@@ -1641,7 +1638,7 @@ Status TreeThreadCtx<algorithmFPType, cpu>::finalizeOOBError(const NumericTable 
     DAAL_CHECK_BLOCK_STATUS(y);
     Atomic<size_t> nPredicted(0);
     Atomic<size_t> nError(0);
-    const intermSummFPType eps = services::internal::EpsilonVal<algorithmFPType>::get();
+    const intermSummFPType eps = services::internal::EpsilonVal<intermSummFPType>::get();
     daal::threader_for(nSamples, nSamples, [&](size_t i) {
         const OOBClassificationData * ptr = ((const OOBClassificationData *)this->oobBuf) + i * _nClasses;
         const size_t classLabel(y.get()[i]);

--- a/cpp/daal/src/algorithms/dtrees/forest/df_train_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/df_train_dense_default_impl.i
@@ -47,7 +47,6 @@ namespace training
 {
 namespace internal
 {
-
 //////////////////////////////////////////////////////////////////////////////////////////
 // Service class, it uses to keep information about nodes
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -546,7 +545,8 @@ protected:
           _memorySavingMode(false),
           _hyperparameter(hyperparameter)
     {
-        if (_impurityThreshold < _accuracy) _impurityThreshold = _accuracy;
+        if (_impurityThreshold < daal::services::internal::EpsilonVal<intermSummFPType>::get())
+            _impurityThreshold = daal::services::internal::EpsilonVal<intermSummFPType>::get();
 
         _memorySavingMode = indexedFeatures == nullptr;
         const daal::algorithms::decision_forest::training::interface2::Parameter * algParameter =

--- a/cpp/daal/src/algorithms/dtrees/forest/df_train_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/df_train_dense_default_impl.i
@@ -272,14 +272,12 @@ void TreeThreadCtxBase<algorithmFPType, cpu>::finalizeVarImp(training::VariableI
         }
         if (!isPositive<algorithmFPType, cpu>(maxVal)) return;
         const algorithmFPType div = 1. / maxVal;
-        for (size_t i = 0; i < nVars; varImp[i++] *= div)
-            ;
+        for (size_t i = 0; i < nVars; varImp[i++] *= div);
     }
     else
     {
         sum = 1. / sum;
-        for (size_t i = 0; i < nVars; varImp[i++] *= sum)
-            ;
+        for (size_t i = 0; i < nVars; varImp[i++] *= sum);
     }
 #endif
 }
@@ -1312,8 +1310,7 @@ services::Status TrainBatchTaskBase<algorithmFPType, BinIndexType, DataHelper, H
         {
             TArray<IndexType, cpu> permutation(nOOB);
             DAAL_CHECK_MALLOC(permutation.get());
-            for (size_t i = 0; i < nOOB; permutation[i] = i, ++i)
-                ;
+            for (size_t i = 0; i < nOOB; permutation[i] = i, ++i);
             const size_t nTrees         = _threadCtx.nTrees;
             const intermSummFPType div1 = 1.0 / static_cast<intermSummFPType>(nTrees);
             for (size_t i = 0, n = nFeatures(); i < n; ++i)

--- a/cpp/daal/src/algorithms/dtrees/forest/df_train_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/df_train_dense_default_impl.i
@@ -272,12 +272,14 @@ void TreeThreadCtxBase<algorithmFPType, cpu>::finalizeVarImp(training::VariableI
         }
         if (!isPositive<algorithmFPType, cpu>(maxVal)) return;
         const algorithmFPType div = 1. / maxVal;
-        for (size_t i = 0; i < nVars; varImp[i++] *= div);
+        for (size_t i = 0; i < nVars; varImp[i++] *= div)
+            ;
     }
     else
     {
         sum = 1. / sum;
-        for (size_t i = 0; i < nVars; varImp[i++] *= sum);
+        for (size_t i = 0; i < nVars; varImp[i++] *= sum)
+            ;
     }
 #endif
 }
@@ -1310,7 +1312,8 @@ services::Status TrainBatchTaskBase<algorithmFPType, BinIndexType, DataHelper, H
         {
             TArray<IndexType, cpu> permutation(nOOB);
             DAAL_CHECK_MALLOC(permutation.get());
-            for (size_t i = 0; i < nOOB; permutation[i] = i, ++i);
+            for (size_t i = 0; i < nOOB; permutation[i] = i, ++i)
+                ;
             const size_t nTrees         = _threadCtx.nTrees;
             const intermSummFPType div1 = 1.0 / static_cast<intermSummFPType>(nTrees);
             for (size_t i = 0, n = nFeatures(); i < n; ++i)


### PR DESCRIPTION
## Description

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

ref https://github.com/uxlfoundation/scikit-learn-intelex/pull/3224#issuecomment-4591685801

Fixes an issue in which the stopping criteria in random forests are determined from the machine epsilon corresponding to X's data dtype, while the impurity calculations on which they apply are done in float64 precision regardless.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.

</details>
