### PR TITLE
DOC: Correct version of clang-format pointed out in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ Public and private CIs are enabled for the repository. Your PR should pass all o
 
 ### ClangFormat
 
-**Prerequisites:** ClangFormat `9.0.0` or later
+**Prerequisites:** ClangFormat `14.0.6`.
 
 Our repository contains [clang-format configurations](https://github.com/uxlfoundation/oneDAL/blob/main/.clang-format) that you should use on your code. To do this, run:
 
@@ -64,6 +64,8 @@ clang-format style=file <your file>
 ```
 
 Refer to [ClangFormat documentation](https://clang.llvm.org/docs/ClangFormat.html) for more information.
+
+Note that different clang-format versions will produce different linting, so the version of clang-format needs to match exactly.
 
 ### editorconfig-checker
 


### PR DESCRIPTION
## Description

<!--
Add a comprehensive description of proposed changes

List associated issue number(s) if exist(s)

List associated documentation and benchmarks PR(s) if needed
-->

Corrects the file mentioning clang-format to point to the version that will make the CI jobs green.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

</details>
