### PR TITLE
bazel: align Linux MKL release parity

### DIFF
--- a/.ci/env/bazelisk.sh
+++ b/.ci/env/bazelisk.sh
@@ -16,37 +16,17 @@
 #===============================================================================
 
 BAZELISK_VERSION=v1.29.0
-# collect information about the bazelisk release
-BAZELISK_JSON=$(wget -qO- \
-  --header="Accept: application/vnd.github+json" \
-  ${GITHUB_TOKEN:+--header="Authorization: Bearer $GITHUB_TOKEN"} \
-  --header="X-GitHub-Api-Version: 2022-11-28" \
-  https://api.github.com/repos/bazelbuild/bazelisk/releases/tags/$BAZELISK_VERSION)
-if [ $? -ne 0 ] || [ -z "$BAZELISK_JSON" ]; then
-  echo ":error: Failed to fetch Bazelisk release information from GitHub API." >&2
-  exit 1
-fi
-
-# extract SHA256 from json
-SHA256=""
-found=""
-while IFS= read -r line; do
-  if [[ $line == *'"name": "bazelisk-linux-amd64"'* ]]; then
-    found=1
-  elif [[ $found && $line == *'"digest":'* ]]; then
-    SHA256=$(echo "$line" | sed -n 's/.*"sha256:\([^"]*\)".*/\1/p')
-    break
-  fi
-done < <(printf '%s\n' "$BAZELISK_JSON")
-SHA256+="  bazelisk-linux-amd64"
+BAZELISK_BINARY=bazelisk-linux-amd64
+BAZELISK_SHA256=5a408715e932c0250d28bd84555f12edbf70117de42f9181691c736eacc4a992
 
 # Download Bazelisk
-wget https://github.com/bazelbuild/bazelisk/releases/download/$BAZELISK_VERSION/bazelisk-linux-amd64
-echo $SHA256
-echo ${SHA256} | sha256sum --check
+wget --tries=5 --waitretry=5 --retry-connrefused \
+  "https://github.com/bazelbuild/bazelisk/releases/download/${BAZELISK_VERSION}/${BAZELISK_BINARY}"
+echo "${BAZELISK_SHA256}  ${BAZELISK_BINARY}"
+echo "${BAZELISK_SHA256}  ${BAZELISK_BINARY}" | sha256sum --check
 # "Install" bazelisk
-chmod +x bazelisk-linux-amd64
+chmod +x "${BAZELISK_BINARY}"
 mkdir -p bazel/bin
-mv bazelisk-linux-amd64 bazel/bin/bazel
+mv "${BAZELISK_BINARY}" bazel/bin/bazel
 export BAZEL_VERSION=$(./bazel/bin/bazel --version | awk '{print $2}')
 export PATH=$PATH:$(pwd)/bazel/bin

--- a/.ci/env/bazelisk.sh
+++ b/.ci/env/bazelisk.sh
@@ -16,17 +16,37 @@
 #===============================================================================
 
 BAZELISK_VERSION=v1.29.0
-BAZELISK_BINARY=bazelisk-linux-amd64
-BAZELISK_SHA256=5a408715e932c0250d28bd84555f12edbf70117de42f9181691c736eacc4a992
+# collect information about the bazelisk release
+BAZELISK_JSON=$(wget -qO- \
+  --header="Accept: application/vnd.github+json" \
+  ${GITHUB_TOKEN:+--header="Authorization: Bearer $GITHUB_TOKEN"} \
+  --header="X-GitHub-Api-Version: 2022-11-28" \
+  https://api.github.com/repos/bazelbuild/bazelisk/releases/tags/$BAZELISK_VERSION)
+if [ $? -ne 0 ] || [ -z "$BAZELISK_JSON" ]; then
+  echo ":error: Failed to fetch Bazelisk release information from GitHub API." >&2
+  exit 1
+fi
+
+# extract SHA256 from json
+SHA256=""
+found=""
+while IFS= read -r line; do
+  if [[ $line == *'"name": "bazelisk-linux-amd64"'* ]]; then
+    found=1
+  elif [[ $found && $line == *'"digest":'* ]]; then
+    SHA256=$(echo "$line" | sed -n 's/.*"sha256:\([^"]*\)".*/\1/p')
+    break
+  fi
+done < <(printf '%s\n' "$BAZELISK_JSON")
+SHA256+="  bazelisk-linux-amd64"
 
 # Download Bazelisk
-wget --tries=5 --waitretry=5 --retry-connrefused \
-  "https://github.com/bazelbuild/bazelisk/releases/download/${BAZELISK_VERSION}/${BAZELISK_BINARY}"
-echo "${BAZELISK_SHA256}  ${BAZELISK_BINARY}"
-echo "${BAZELISK_SHA256}  ${BAZELISK_BINARY}" | sha256sum --check
+wget https://github.com/bazelbuild/bazelisk/releases/download/$BAZELISK_VERSION/bazelisk-linux-amd64
+echo $SHA256
+echo ${SHA256} | sha256sum --check
 # "Install" bazelisk
-chmod +x "${BAZELISK_BINARY}"
+chmod +x bazelisk-linux-amd64
 mkdir -p bazel/bin
-mv "${BAZELISK_BINARY}" bazel/bin/bazel
+mv bazelisk-linux-amd64 bazel/bin/bazel
 export BAZEL_VERSION=$(./bazel/bin/bazel --version | awk '{print $2}')
 export PATH=$PATH:$(pwd)/bazel/bin

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -415,7 +415,7 @@ jobs:
       # Display oneDAL build configuration
       bazel build @config//:dump
       echo
-      cat bazel-bin/external/+_repo_rules+config/config.json
+      cat bazel-bin/external/+declare_onedal_config+config/config.json
       echo
     displayName: 'bazel-configure'
 
@@ -524,10 +524,12 @@ jobs:
     displayName: 'Clean Bazel cache (expunge)'
 
   - script: |
+      export LD_LIBRARY_PATH="$(DALROOT)/lib/intel64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
       bazel test //examples/daal/cpp:all \
                  --test_link_mode=release_dynamic \
                  --test_thread_mode=par \
-                 --test_env DALROOT
+                 --test_env DALROOT \
+                 --test_env LD_LIBRARY_PATH
     displayName: 'daal-cpp-examples-thread-release-dynamic'
 
   - script: |
@@ -536,10 +538,12 @@ jobs:
     displayName: 'Clean Bazel cache (expunge)'
 
   - script: |
+      export LD_LIBRARY_PATH="$(DALROOT)/lib/intel64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
       bazel test //examples/oneapi/cpp:all \
                  --test_link_mode=release_dynamic \
                  --test_thread_mode=par \
-                 --test_env DALROOT
+                 --test_env DALROOT \
+                 --test_env LD_LIBRARY_PATH
     displayName: 'cpp-examples-thread-release-dynamic'
 
   - script: |

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -593,6 +593,27 @@ jobs:
       fi
     displayName: 'bazel-cache-limit'
 
+- job: 'LinuxReleaseCompare'
+  dependsOn:
+  - LinuxMakeGNU_MKL
+  - LinuxBazel
+  pool:
+    vmImage: '$(VM_IMAGE)'
+  steps:
+  - task: DownloadPipelineArtifact@2
+    inputs:
+      artifact: 'lnx32e build'
+      path: '$(Pipeline.Workspace)/make'
+  - task: DownloadPipelineArtifact@2
+    inputs:
+      artifact: 'lnx32e Bazel build'
+      path: '$(Pipeline.Workspace)/bazel'
+  - script: |
+      python3 dev/release_tests/compare_release_trees.py \
+        --platform linux \
+        --make "$(Pipeline.Workspace)/make/daal/latest" \
+        --bazel "$(Pipeline.Workspace)/bazel"
+    displayName: 'Compare Make and Bazel release trees'
 
 - job: 'WindowsBazel'
   timeoutInMinutes: 0
@@ -849,6 +870,12 @@ jobs:
       call %TEMP%\oneapi\setvars.bat --force
       .\.ci\scripts\build.bat onedal_dpc icx avx2
     displayName: 'make onedal_dpc'
+  - task: PublishPipelineArtifact@1
+    inputs:
+      artifactName: '$(platform.type) icx build'
+      targetPath: '$(Build.Repository.LocalPath)/$(release.dir)'
+    displayName: 'Upload Intel build artifacts'
+    continueOnError: true
   - script: |
       call %TEMP%\oneapi\setvars.bat --force
       .\.ci\scripts\test.bat daal\cpp lib icx cmake
@@ -865,6 +892,30 @@ jobs:
       tree -h -I include __nuget/inteldal*/
       ls -lh __nuget/inteldal*.nupkg
     displayName: 'nuget pkg'
+
+- job: 'WindowsReleaseCompare'
+  dependsOn:
+  - WindowsMakeIntel
+  - WindowsBazel
+  pool:
+    vmImage: '$(WIN_VM_IMAGE)'
+  steps:
+  - task: DownloadPipelineArtifact@2
+    inputs:
+      artifact: 'win32e icx build'
+      path: '$(Pipeline.Workspace)\make'
+  - task: DownloadPipelineArtifact@2
+    inputs:
+      artifact: 'win32e Bazel icx build'
+      path: '$(Pipeline.Workspace)\bazel'
+  - powershell: |
+      python dev/release_tests/compare_release_trees.py `
+        --platform windows `
+        --structure-only `
+        --make "$(Pipeline.Workspace)\make\daal\latest" `
+        --bazel "$(Pipeline.Workspace)\bazel"
+    displayName: 'Compare Make and Bazel release tree structure'
+    continueOnError: true
 
 
 - job: WindowsSklearnex

--- a/.ci/pipeline/ci.yml
+++ b/.ci/pipeline/ci.yml
@@ -524,7 +524,7 @@ jobs:
     displayName: 'Clean Bazel cache (expunge)'
 
   - script: |
-      export LD_LIBRARY_PATH="$(DALROOT)/lib/intel64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+      . "$(DALROOT)/env/vars.sh"
       bazel test //examples/daal/cpp:all \
                  --test_link_mode=release_dynamic \
                  --test_thread_mode=par \
@@ -538,7 +538,7 @@ jobs:
     displayName: 'Clean Bazel cache (expunge)'
 
   - script: |
-      export LD_LIBRARY_PATH="$(DALROOT)/lib/intel64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+      . "$(DALROOT)/env/vars.sh"
       bazel test //examples/oneapi/cpp:all \
                  --test_link_mode=release_dynamic \
                  --test_thread_mode=par \

--- a/BUILD
+++ b/BUILD
@@ -4,6 +4,7 @@ load("@onedal//dev/bazel:release.bzl",
     "release_extra_file",
 )
 load("@onedal//dev/bazel:scripts.bzl",
+    "generate_cmake_config",
     "generate_modulefile",
     "generate_pkgconfig",
     "generate_vars_sh",
@@ -45,14 +46,16 @@ filegroup(
     srcs = ["@onedal//cpp/oneapi/dal:public_includes"],
 )
 
-filegroup(
+generate_cmake_config(
     name = "release_cmake_config",
-    srcs = ["cmake/templates/oneDALConfig.cmake.in"],
+    template = "cmake/templates/oneDALConfig.cmake.in",
+    out = "lib/cmake/oneDAL/oneDALConfig.cmake",
 )
 
-filegroup(
+generate_cmake_config(
     name = "release_cmake_config_version",
-    srcs = ["cmake/templates/oneDALConfigVersion.cmake.in"],
+    template = "cmake/templates/oneDALConfigVersion.cmake.in",
+    out = "lib/cmake/oneDAL/oneDALConfigVersion.cmake",
 )
 
 filegroup(

--- a/BUILD
+++ b/BUILD
@@ -4,8 +4,9 @@ load("@onedal//dev/bazel:release.bzl",
     "release_extra_file",
 )
 load("@onedal//dev/bazel:scripts.bzl",
-    "generate_vars_sh",
+    "generate_modulefile",
     "generate_pkgconfig",
+    "generate_vars_sh",
 )
 
 config_setting(
@@ -16,6 +17,11 @@ config_setting(
 generate_vars_sh(
     name = "release_vars_sh",
     out = "env/vars.sh",
+)
+
+generate_modulefile(
+    name = "release_modulefile_dal",
+    out = "modulefiles/dal",
 )
 
 generate_pkgconfig(
@@ -145,7 +151,7 @@ release(
         release_extra_file(":release_pkgconfig_dynamic_threading_host", "lib/pkgconfig/dal-dynamic-threading-host.pc", windows_dst_path = ""),
         release_extra_file(":release_pkgconfig_static_threading_host", "lib/pkgconfig/dal-static-threading-host.pc", windows_dst_path = ""),
         release_extra_file("//deploy/local:config_file", "config/config.txt"),
-        release_extra_file("//deploy/local:modulefile_dal", "modulefiles/dal", windows_dst_path = ""),
+        release_extra_file(":release_modulefile_dal", "modulefiles/dal", windows_dst_path = ""),
         release_extra_file(":release_mpi_daal_lst_linux", "samples/daal/cpp/mpi/daal.lst", windows_dst_path = ""),
         release_extra_file(":release_mpi_makefile_linux", "samples/daal/cpp/mpi/makefile", windows_dst_path = ""),
         release_extra_file(":release_cmake_config", "lib/cmake/oneDAL/oneDALConfig.cmake"),

--- a/BUILD
+++ b/BUILD
@@ -65,13 +65,21 @@ filegroup(
 )
 
 filegroup(
+    name = "release_mpi_daal_lst_linux",
+    srcs = ["samples/daal/cpp/mpi/daal_lnx.lst"],
+)
+
+filegroup(
+    name = "release_mpi_makefile_linux",
+    srcs = ["samples/daal/cpp/mpi/makefile_lnx"],
+)
+
+filegroup(
     name = "release_package_files",
     srcs = glob([
         "examples/cmake/setup_examples.cmake",
         "samples/cmake/*.cmake",
         "samples/daal/cpp/mpi/CMakeLists.txt",
-        "samples/daal/cpp/mpi/daal.lst.bat",
-        "samples/daal/cpp/mpi/launcher.bat",
         "samples/daal/cpp/mpi/license.txt",
         "samples/daal/cpp/mpi/resources/*",
         "samples/daal/cpp/mpi/sources/*.cpp",
@@ -82,7 +90,13 @@ filegroup(
         "samples/oneapi/cpp/mpi/CMakeLists.txt",
         "samples/oneapi/cpp/mpi/sources/*.cpp",
         "samples/oneapi/cpp/mpi/sources/*.hpp",
-    ]),
+    ]) + select({
+        ":windows": glob([
+            "samples/daal/cpp/mpi/daal.lst.bat",
+            "samples/daal/cpp/mpi/launcher.bat",
+        ]),
+        "//conditions:default": [],
+    }),
 )
 
 release(
@@ -123,17 +137,21 @@ release(
         "//data:datasets",
         ":release_package_files",
         "//examples/daal/cpp:release_files",
+        "//examples/oneapi/cpp:release_files",
     ],
     extra_files = [
         release_extra_file(":release_vars_sh", "env/vars.sh", windows_dst_path = "env/vars.bat"),
-        release_extra_file(":release_pkgconfig", "lib/pkgconfig/onedal.pc", windows_dst_path = ""),
-        release_extra_file(":release_pkgconfig_dynamic_threading_host", "", windows_dst_path = "lib/pkgconfig/dal-dynamic-threading-host.pc"),
-        release_extra_file(":release_pkgconfig_static_threading_host", "", windows_dst_path = "lib/pkgconfig/dal-static-threading-host.pc"),
+        release_extra_file(":release_pkgconfig", "", windows_dst_path = "lib/pkgconfig/onedal.pc"),
+        release_extra_file(":release_pkgconfig_dynamic_threading_host", "lib/pkgconfig/dal-dynamic-threading-host.pc", windows_dst_path = ""),
+        release_extra_file(":release_pkgconfig_static_threading_host", "lib/pkgconfig/dal-static-threading-host.pc", windows_dst_path = ""),
         release_extra_file("//deploy/local:config_file", "config/config.txt"),
+        release_extra_file("//deploy/local:modulefile_dal", "modulefiles/dal", windows_dst_path = ""),
+        release_extra_file(":release_mpi_daal_lst_linux", "samples/daal/cpp/mpi/daal.lst", windows_dst_path = ""),
+        release_extra_file(":release_mpi_makefile_linux", "samples/daal/cpp/mpi/makefile", windows_dst_path = ""),
         release_extra_file(":release_cmake_config", "lib/cmake/oneDAL/oneDALConfig.cmake"),
         release_extra_file(":release_cmake_config_version", "lib/cmake/oneDAL/oneDALConfigVersion.cmake"),
-        release_extra_file(":release_nuspec_devel", "nuspec/inteldal.devel.win-x64.nuspec", windows_dst_path = "nuspec/inteldal.devel.win-x64.nuspec"),
-        release_extra_file(":release_nuspec_redist", "nuspec/inteldal.redist.win-x64.nuspec", windows_dst_path = "nuspec/inteldal.redist.win-x64.nuspec"),
-        release_extra_file(":release_nuspec_static", "nuspec/inteldal.static.win-x64.nuspec", windows_dst_path = "nuspec/inteldal.static.win-x64.nuspec"),
+        release_extra_file(":release_nuspec_devel", "nuspec/inteldal.devel.linux.nuspec", windows_dst_path = "nuspec/inteldal.devel.win-x64.nuspec"),
+        release_extra_file(":release_nuspec_redist", "nuspec/inteldal.redist.linux.nuspec", windows_dst_path = "nuspec/inteldal.redist.win-x64.nuspec"),
+        release_extra_file(":release_nuspec_static", "nuspec/inteldal.static.linux.nuspec", windows_dst_path = "nuspec/inteldal.static.win-x64.nuspec"),
     ],
 )

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -27,10 +27,11 @@ export DPL_ROOT=$PREFIX
 # libtbbmalloc.so.<N>, etc.) while oneDAL Make expects unversioned names in
 # TBBROOT/lib prerequisites.  Mirror the full libtbb* tree into a staging dir,
 # adding unversioned symlinks where missing.
-# Keep the staging path outside $SRC_DIR: conda-build can create source work
-# directories with shell/make-special characters on rebuilds (for example
-# ".../work(1)"), and oneDAL Make uses TBBROOT in prerequisites.
-export TBBROOT="$BUILD_PREFIX/__onedal_tbbroot"
+# Keep the staging path outside conda-build work/build prefixes:
+# oneDAL Make escapes parentheses as "222" internally, so timestamped conda
+# paths containing that digit sequence can be decoded into bogus parentheses
+# when used in prerequisites.
+export TBBROOT="/tmp/onedal-tbbroot"
 rm -rf "$TBBROOT"
 mkdir -p "$TBBROOT/lib"
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -159,6 +159,7 @@ outputs:
       source_files:
         - examples
         - data
+        - dev/release_tests/package_metadata_test.sh
         - .ci/env/MKLConfig.cmake
       script: test-devel.sh  # [linux]
     about:

--- a/conda-recipe/test-devel.sh
+++ b/conda-recipe/test-devel.sh
@@ -16,8 +16,7 @@ set -eu
 # limitations under the License.
 #===============================================================================
 
-test -f $CONDA_PREFIX/lib/pkgconfig/dal-dynamic-threading-host.pc
-test -f $CONDA_PREFIX/lib/pkgconfig/dal-static-threading-host.pc
+./dev/release_tests/package_metadata_test.sh "$CONDA_PREFIX"
 
 # Load oneDAL environment helpers required by pkg-config/CMake example builds.
 . "$CONDA_PREFIX/env/vars.sh"

--- a/cpp/daal/BUILD
+++ b/cpp/daal/BUILD
@@ -194,17 +194,6 @@ daal_module(
     ],
 )
 
-daal_module(
-    name = "core_embed",
-    lib_tag = "dal",
-    override_deps_lib_tag = True,
-    deps = [
-        ":services",
-        ":data_management",
-        ":services_win_dll_shim",
-    ],
-)
-
 daal_algorithms(
     name = "all_algorithms",
     algorithms = [

--- a/cpp/daal/BUILD
+++ b/cpp/daal/BUILD
@@ -194,6 +194,17 @@ daal_module(
     ],
 )
 
+daal_module(
+    name = "core_embed",
+    lib_tag = "dal",
+    override_deps_lib_tag = True,
+    deps = [
+        ":services",
+        ":data_management",
+        ":services_win_dll_shim",
+    ],
+)
+
 daal_algorithms(
     name = "all_algorithms",
     algorithms = [

--- a/cpp/daal/BUILD
+++ b/cpp/daal/BUILD
@@ -156,6 +156,7 @@ daal_module(
 daal_module(
     name = "threading_tbb",
     srcs = glob(["src/threading/**/*.cpp"]),
+    visibility_hidden = False,
     local_defines = [
         "__TBB_NO_IMPLICIT_LINKAGE",
         "__TBB_LEGACY_MODE",
@@ -227,6 +228,7 @@ daal_algorithms(
         "objective_function/cross_entropy_loss",
         "objective_function/logistic_loss",
         "objective_function/mse",
+        "objective_function/precomputed",
         "optimization_solver",
         "optimization_solver/lbfgs",
         "optimization_solver/coordinate_descent",
@@ -238,6 +240,7 @@ daal_algorithms(
         "ridge_regression",
         "svd",
         "svm",
+        "tsne",
     ],
 )
 
@@ -258,6 +261,10 @@ daal_static_lib(
         ":threading_tbb",
     ],
 )
+
+exports_files([
+    "thread_dynamic.lds",
+])
 
 daal_dynamic_lib(
     name = "core_dynamic",
@@ -282,6 +289,7 @@ daal_dynamic_lib(
 daal_dynamic_lib(
     name = "thread_dynamic",
     lib_name = "onedal_thread",
+    linker_scripts = [":thread_dynamic.lds"],
     deps = [
         ":threading_tbb",
     ],

--- a/cpp/daal/src/algorithms/tsne/BUILD
+++ b/cpp/daal/src/algorithms/tsne/BUILD
@@ -1,0 +1,10 @@
+package(default_visibility = ["//visibility:public"])
+load("@onedal//dev/bazel:daal.bzl", "daal_module")
+
+daal_module(
+    name = "kernel",
+    auto = True,
+    deps = [
+        "@onedal//cpp/daal:core",
+    ],
+)

--- a/cpp/daal/src/algorithms/tsne/BUILD
+++ b/cpp/daal/src/algorithms/tsne/BUILD
@@ -1,3 +1,19 @@
+#===============================================================================
+# Copyright contributors to the oneDAL project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#===============================================================================
+
 package(default_visibility = ["//visibility:public"])
 load("@onedal//dev/bazel:daal.bzl", "daal_module")
 

--- a/cpp/daal/thread_dynamic.lds
+++ b/cpp/daal/thread_dynamic.lds
@@ -1,3 +1,19 @@
+/*
+ * Copyright contributors to the oneDAL project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 {
     local:
         __bss_start;

--- a/cpp/daal/thread_dynamic.lds
+++ b/cpp/daal/thread_dynamic.lds
@@ -1,0 +1,6 @@
+{
+    local:
+        __bss_start;
+        _edata;
+        _end;
+};

--- a/cpp/oneapi/dal/BUILD
+++ b/cpp/oneapi/dal/BUILD
@@ -92,6 +92,7 @@ dal_static_lib(
 dal_dynamic_lib(
     name = "dynamic",
     lib_name = "onedal",
+    dpc_lib_tags = ["dal", "daal"],
     dal_deps = [
         ":core",
         ":optional",

--- a/cpp/oneapi/dal/BUILD
+++ b/cpp/oneapi/dal/BUILD
@@ -82,8 +82,8 @@ dal_static_lib(
 dal_static_lib(
     name = "static_parameters",
     lib_name = "onedal_parameters",
+    lib_tags = ["parameters"],
     dal_deps = [
-        ":static",
         "@onedal//cpp/oneapi/dal/algo:parameters",
         "@onedal//cpp/oneapi/dal/detail/parameters",
     ],
@@ -109,6 +109,7 @@ dal_dynamic_lib(
 dal_dynamic_lib(
     name = "dynamic_parameters",
     lib_name = "onedal_parameters",
+    lib_tags = ["parameters"],
     dal_deps = [
         ":dynamic",
         "@onedal//cpp/oneapi/dal/algo:parameters",

--- a/cpp/oneapi/dal/BUILD
+++ b/cpp/oneapi/dal/BUILD
@@ -137,6 +137,11 @@ dal_dynamic_lib(
     dal_deps = [
         ":dynamic",
         "@onedal//cpp/oneapi/dal/algo:parameters",
+        # The logistic regression parameter objects instantiate default
+        # optimizer wrappers implemented in the algorithm detail module. Linux
+        # keeps this resolved through libonedal.so, but Windows DLL links must
+        # see the implementation directly when building onedal_parameters.dll.
+        "@onedal//cpp/oneapi/dal/algo/logistic_regression/detail",
         "@onedal//cpp/oneapi/dal/detail/parameters",
     ],
     host_deps = select({

--- a/cpp/oneapi/dal/BUILD
+++ b/cpp/oneapi/dal/BUILD
@@ -92,18 +92,31 @@ dal_static_lib(
 dal_dynamic_lib(
     name = "dynamic",
     lib_name = "onedal",
-    lib_tags = ["dal"],
+    # On Windows, onedal.dll must resolve all DAAL algorithm symbols at link
+    # time (lld-link does not allow unresolved externals), so embed the same
+    # DAAL-tagged objects the DPC variant does. On Linux, libonedal.so resolves
+    # DAAL symbols at runtime via DT_NEEDED libonedal_core.so, so the host-only
+    # build keeps just the "dal" tag to avoid duplicating DAAL into onedal.so.
+    lib_tags = select({
+        "@platforms//os:windows": ["dal", "daal"],
+        "//conditions:default": ["dal"],
+    }),
     dpc_lib_tags = ["dal", "daal"],
     dal_deps = [
         ":core",
         ":optional",
     ],
-    # On Windows, onedal.dll must resolve parameter symbols at link time.
+    # On Windows, onedal.dll must resolve all externals at link time:
+    #   - static_parameters: parameter symbols not part of any other dep tree.
+    #   - services_win_dll_shim: delay-load stubs for threading entry points
+    #     (e.g. `_threaded_scalable_*`, `_daal_static_threader_reduce`) that
+    #     the embedded DAAL kernel objects reference. The real TBB-backed
+    #     symbols live in onedal_thread.dll. Mirrors onedal_core.dll above
+    #     and the original Make build.
     host_deps = select({
         "@platforms//os:windows": [
             ":static_parameters",
-            "@onedal//cpp/daal:core_embed",
-            "@onedal//cpp/daal:core_dynamic",
+            "@onedal//cpp/daal:services_win_dll_shim",
         ],
         "//conditions:default": [],
     }),

--- a/cpp/oneapi/dal/BUILD
+++ b/cpp/oneapi/dal/BUILD
@@ -126,7 +126,10 @@ dal_dynamic_lib(
 dal_dynamic_lib(
     name = "dynamic_parameters",
     lib_name = "onedal_parameters",
-    lib_tags = ["parameters"],
+    lib_tags = select({
+        "@platforms//os:windows": ["parameters", "dal", "daal", "mkl_embed"],
+        "//conditions:default": ["parameters"],
+    }),
     dpc_lib_tags = select({
         "@platforms//os:windows": ["parameters", "dal", "daal", "mkl_embed"],
         "//conditions:default": ["parameters"],

--- a/cpp/oneapi/dal/BUILD
+++ b/cpp/oneapi/dal/BUILD
@@ -92,15 +92,22 @@ dal_static_lib(
 dal_dynamic_lib(
     name = "dynamic",
     lib_name = "onedal",
+    lib_tags = select({
+        # Windows does not allow unresolved DLL symbols. Keep DAAL services
+        # and data-management objects in onedal.dll there, while Linux keeps
+        # depending on onedal_core.so for release parity.
+        "@platforms//os:windows": ["dal", "daal"],
+        "//conditions:default": ["dal"],
+    }),
     dpc_lib_tags = ["dal", "daal"],
     dal_deps = [
         ":core",
         ":optional",
     ],
-    # On Windows, onedal.dll must link against onedal_core.dll import library
-    # because oneAPI objects reference DAAL services/data-management symbols.
+    # On Windows, DAAL objects embedded into onedal.dll still need the
+    # delay-load threading shim used by onedal_core.dll.
     host_deps = select({
-        "@platforms//os:windows": ["@onedal//cpp/daal:core_dynamic"],
+        "@platforms//os:windows": ["@onedal//cpp/daal:services_win_dll_shim"],
         "//conditions:default": [],
     }),
 )

--- a/cpp/oneapi/dal/BUILD
+++ b/cpp/oneapi/dal/BUILD
@@ -92,13 +92,14 @@ dal_static_lib(
 dal_dynamic_lib(
     name = "dynamic",
     lib_name = "onedal",
-    # On Windows, onedal.dll must resolve all DAAL algorithm symbols at link
-    # time (lld-link does not allow unresolved externals), so embed the same
-    # DAAL-tagged objects the DPC variant does. On Linux, libonedal.so resolves
-    # DAAL symbols at runtime via DT_NEEDED libonedal_core.so, so the host-only
-    # build keeps just the "dal" tag to avoid duplicating DAAL into onedal.so.
+    # On Windows, onedal.dll must resolve all DAAL algorithm and MKL backend
+    # symbols at link time (lld-link does not allow unresolved externals), so
+    # embed the same DAAL/MKL-tagged inputs the DPC variant does. On Linux,
+    # libonedal.so resolves DAAL symbols at runtime via DT_NEEDED
+    # libonedal_core.so, so the host-only build keeps just the "dal" tag to
+    # avoid duplicating DAAL into onedal.so.
     lib_tags = select({
-        "@platforms//os:windows": ["dal", "daal"],
+        "@platforms//os:windows": ["dal", "daal", "mkl_embed"],
         "//conditions:default": ["dal"],
     }),
     dpc_lib_tags = ["dal", "daal", "mkl_embed"],

--- a/cpp/oneapi/dal/BUILD
+++ b/cpp/oneapi/dal/BUILD
@@ -97,12 +97,10 @@ dal_dynamic_lib(
         ":core",
         ":optional",
     ],
-    # On Windows the onedal.dll bundles DAAL algorithm objects that
-    # reference the threading shims. Pull in the same delay-load shim
-    # used by onedal_core.dll so unresolved `_threaded_scalable_*` /
-    # `_daal_static_threader_reduce` symbols get satisfied. No-op on Linux.
+    # On Windows, onedal.dll must link against onedal_core.dll import library
+    # because oneAPI objects reference DAAL services/data-management symbols.
     host_deps = select({
-        "@platforms//os:windows": ["@onedal//cpp/daal:services_win_dll_shim"],
+        "@platforms//os:windows": ["@onedal//cpp/daal:core_dynamic"],
         "//conditions:default": [],
     }),
 )

--- a/cpp/oneapi/dal/BUILD
+++ b/cpp/oneapi/dal/BUILD
@@ -126,6 +126,10 @@ dal_dynamic_lib(
     name = "dynamic_parameters",
     lib_name = "onedal_parameters",
     lib_tags = ["parameters"],
+    dpc_lib_tags = select({
+        "@platforms//os:windows": ["parameters", "dal", "daal", "mkl_embed"],
+        "//conditions:default": ["parameters"],
+    }),
     dal_deps = [
         ":dynamic",
         "@onedal//cpp/oneapi/dal/algo:parameters",

--- a/cpp/oneapi/dal/BUILD
+++ b/cpp/oneapi/dal/BUILD
@@ -102,7 +102,7 @@ dal_dynamic_lib(
     host_deps = select({
         "@platforms//os:windows": [
             ":static_parameters",
-            "@onedal//cpp/daal:core_embed",
+            "@onedal//cpp/daal:core_dynamic",
         ],
         "//conditions:default": [],
     }),

--- a/cpp/oneapi/dal/BUILD
+++ b/cpp/oneapi/dal/BUILD
@@ -102,6 +102,7 @@ dal_dynamic_lib(
     host_deps = select({
         "@platforms//os:windows": [
             ":static_parameters",
+            "@onedal//cpp/daal:core_embed",
             "@onedal//cpp/daal:core_dynamic",
         ],
         "//conditions:default": [],

--- a/cpp/oneapi/dal/BUILD
+++ b/cpp/oneapi/dal/BUILD
@@ -92,22 +92,18 @@ dal_static_lib(
 dal_dynamic_lib(
     name = "dynamic",
     lib_name = "onedal",
-    lib_tags = select({
-        # Windows does not allow unresolved DLL symbols. Keep DAAL services
-        # and data-management objects in onedal.dll there, while Linux keeps
-        # depending on onedal_core.so for release parity.
-        "@platforms//os:windows": ["dal", "daal"],
-        "//conditions:default": ["dal"],
-    }),
+    lib_tags = ["dal"],
     dpc_lib_tags = ["dal", "daal"],
     dal_deps = [
         ":core",
         ":optional",
     ],
-    # On Windows, DAAL objects embedded into onedal.dll still need the
-    # delay-load threading shim used by onedal_core.dll.
+    # On Windows, onedal.dll must resolve parameter symbols at link time.
     host_deps = select({
-        "@platforms//os:windows": ["@onedal//cpp/daal:services_win_dll_shim"],
+        "@platforms//os:windows": [
+            ":static_parameters",
+            "@onedal//cpp/daal:core_embed",
+        ],
         "//conditions:default": [],
     }),
 )

--- a/cpp/oneapi/dal/BUILD
+++ b/cpp/oneapi/dal/BUILD
@@ -101,7 +101,7 @@ dal_dynamic_lib(
         "@platforms//os:windows": ["dal", "daal"],
         "//conditions:default": ["dal"],
     }),
-    dpc_lib_tags = ["dal", "daal"],
+    dpc_lib_tags = ["dal", "daal", "mkl_embed"],
     dal_deps = [
         ":core",
         ":optional",

--- a/cpp/oneapi/dal/algo/BUILD
+++ b/cpp/oneapi/dal/algo/BUILD
@@ -9,6 +9,7 @@ PARAMETRIZED_ALGOS = [
     "covariance",
     "decision_forest",
     "linear_regression",
+    "logistic_regression",
     "pca",
 ]
 
@@ -26,7 +27,6 @@ ALGOS = [
     "kmeans_init",
     "knn",
     "linear_kernel",
-    "logistic_regression",
     "logloss_objective",
     "louvain",
     "minkowski_distance",

--- a/cpp/oneapi/dal/algo/covariance/parameters/cpu/BUILD
+++ b/cpp/oneapi/dal/algo/covariance/parameters/cpu/BUILD
@@ -7,6 +7,7 @@ load("@onedal//dev/bazel:dal.bzl",
 dal_module(
     name = "cpu",
     auto = True,
+    lib_tag = "parameters",
     dal_deps = [
         "@onedal//cpp/oneapi/dal/algo/covariance:core",
     ],

--- a/cpp/oneapi/dal/algo/covariance/parameters/gpu/BUILD
+++ b/cpp/oneapi/dal/algo/covariance/parameters/gpu/BUILD
@@ -7,6 +7,7 @@ load("@onedal//dev/bazel:dal.bzl",
 dal_module(
     name = "gpu",
     auto = True,
+    lib_tag = "parameters",
     dal_deps = [
         "@onedal//cpp/oneapi/dal/algo/covariance:core",
     ],

--- a/cpp/oneapi/dal/algo/decision_forest/parameters/cpu/BUILD
+++ b/cpp/oneapi/dal/algo/decision_forest/parameters/cpu/BUILD
@@ -6,6 +6,7 @@ load("@onedal//dev/bazel:dal.bzl",
 dal_module(
     name = "cpu",
     auto = True,
+    lib_tag = "parameters",
     dal_deps = [
         "@onedal//cpp/oneapi/dal/algo/decision_forest:core",
     ],

--- a/cpp/oneapi/dal/algo/decision_forest/parameters/gpu/BUILD
+++ b/cpp/oneapi/dal/algo/decision_forest/parameters/gpu/BUILD
@@ -6,6 +6,7 @@ load("@onedal//dev/bazel:dal.bzl",
 dal_module(
     name = "gpu",
     auto = True,
+    lib_tag = "parameters",
     dal_deps = [
         "@onedal//cpp/oneapi/dal/algo/decision_forest:core",
     ],

--- a/cpp/oneapi/dal/algo/linear_regression/parameters/cpu/BUILD
+++ b/cpp/oneapi/dal/algo/linear_regression/parameters/cpu/BUILD
@@ -7,6 +7,7 @@ load("@onedal//dev/bazel:dal.bzl",
 dal_module(
     name = "cpu",
     auto = True,
+    lib_tag = "parameters",
     dal_deps = [
         "@onedal//cpp/oneapi/dal/algo/linear_regression:core",
     ],

--- a/cpp/oneapi/dal/algo/linear_regression/parameters/gpu/BUILD
+++ b/cpp/oneapi/dal/algo/linear_regression/parameters/gpu/BUILD
@@ -7,6 +7,7 @@ load("@onedal//dev/bazel:dal.bzl",
 dal_module(
     name = "gpu",
     auto = True,
+    lib_tag = "parameters",
     dal_deps = [
         "@onedal//cpp/oneapi/dal/algo/linear_regression:core",
     ],

--- a/cpp/oneapi/dal/algo/logistic_regression/parameters/cpu/BUILD
+++ b/cpp/oneapi/dal/algo/logistic_regression/parameters/cpu/BUILD
@@ -7,6 +7,7 @@ load("@onedal//dev/bazel:dal.bzl",
 dal_module(
     name = "cpu",
     auto = True,
+    lib_tag = "parameters",
     dal_deps = [
         "@onedal//cpp/oneapi/dal/algo/logistic_regression:core",
     ],

--- a/cpp/oneapi/dal/algo/logistic_regression/parameters/gpu/BUILD
+++ b/cpp/oneapi/dal/algo/logistic_regression/parameters/gpu/BUILD
@@ -7,6 +7,7 @@ load("@onedal//dev/bazel:dal.bzl",
 dal_module(
     name = "gpu",
     auto = True,
+    lib_tag = "parameters",
     dal_deps = [
         "@onedal//cpp/oneapi/dal/algo/logistic_regression:core",
     ],

--- a/cpp/oneapi/dal/algo/pca/parameters/cpu/BUILD
+++ b/cpp/oneapi/dal/algo/pca/parameters/cpu/BUILD
@@ -7,6 +7,7 @@ load("@onedal//dev/bazel:dal.bzl",
 dal_module(
     name = "cpu",
     auto = True,
+    lib_tag = "parameters",
     dal_deps = [
         "@onedal//cpp/oneapi/dal/algo/pca:core",
     ],

--- a/cpp/oneapi/dal/algo/pca/parameters/gpu/BUILD
+++ b/cpp/oneapi/dal/algo/pca/parameters/gpu/BUILD
@@ -7,6 +7,7 @@ load("@onedal//dev/bazel:dal.bzl",
 dal_module(
     name = "gpu",
     auto = True,
+    lib_tag = "parameters",
     dal_deps = [
         "@onedal//cpp/oneapi/dal/algo/pca:core",
     ],

--- a/cpp/oneapi/dal/detail/parameters/BUILD
+++ b/cpp/oneapi/dal/detail/parameters/BUILD
@@ -9,6 +9,7 @@ package(default_visibility = ["//visibility:public"])
 dal_module(
     name = "parameters",
     auto = True,
+    lib_tag = "parameters",
     dal_deps = [
         "@onedal//cpp/oneapi/dal:common",
     ]

--- a/deploy/local/BUILD
+++ b/deploy/local/BUILD
@@ -17,6 +17,7 @@
 package(default_visibility = ["//visibility:public"])
 
 exports_files([
+    "dal",
     "vars_lnx.sh",
     "vars_mac.sh",
     "vars_win.bat",
@@ -26,4 +27,9 @@ exports_files([
 filegroup(
     name = "config_file",
     srcs = ["config.txt"],
+)
+
+filegroup(
+    name = "modulefile_dal",
+    srcs = ["dal"],
 )

--- a/deploy/local/dal
+++ b/deploy/local/dal
@@ -64,8 +64,8 @@ set dalroot "$componentroot"
 set daal_target_arch "intel64"
 
 # Setup environment variables
-setenv          DAL_MAJOR_BINARY   1
-setenv          DAL_MINOR_BINARY   1
+setenv          DAL_MAJOR_BINARY   __DAL_MAJOR_BINARY__
+setenv          DAL_MINOR_BINARY   __DAL_MINOR_BINARY__
 setenv          DALROOT            "$dalroot"
 
 prepend-path    LD_LIBRARY_PATH    "$dalroot/lib"

--- a/deploy/local/dal
+++ b/deploy/local/dal
@@ -62,14 +62,18 @@ proc ModulesHelp { } {
 set dalroot "$componentroot"
 
 set daal_target_arch "intel64"
+set daal_libdir "$dalroot/lib"
+if {[file isdirectory "$dalroot/lib/$daal_target_arch"]} {
+    set daal_libdir "$dalroot/lib/$daal_target_arch"
+}
 
 # Setup environment variables
 setenv          DAL_MAJOR_BINARY   __DAL_MAJOR_BINARY__
 setenv          DAL_MINOR_BINARY   __DAL_MINOR_BINARY__
 setenv          DALROOT            "$dalroot"
 
-prepend-path    LD_LIBRARY_PATH    "$dalroot/lib/$daal_target_arch"
-prepend-path    LIBRARY_PATH       "$dalroot/lib/$daal_target_arch"
+prepend-path    LD_LIBRARY_PATH    "$daal_libdir"
+prepend-path    LIBRARY_PATH       "$daal_libdir"
 prepend-path    CPLUS_INCLUDE_PATH "$dalroot/include/dal"
 prepend-path    CMAKE_PREFIX_PATH  "$dalroot"
 prepend-path    PKG_CONFIG_PATH    "$dalroot/lib/pkgconfig"

--- a/deploy/local/dal
+++ b/deploy/local/dal
@@ -68,8 +68,8 @@ setenv          DAL_MAJOR_BINARY   __DAL_MAJOR_BINARY__
 setenv          DAL_MINOR_BINARY   __DAL_MINOR_BINARY__
 setenv          DALROOT            "$dalroot"
 
-prepend-path    LD_LIBRARY_PATH    "$dalroot/lib"
-prepend-path    LIBRARY_PATH       "$dalroot/lib"
+prepend-path    LD_LIBRARY_PATH    "$dalroot/lib/$daal_target_arch"
+prepend-path    LIBRARY_PATH       "$dalroot/lib/$daal_target_arch"
 prepend-path    CPLUS_INCLUDE_PATH "$dalroot/include/dal"
 prepend-path    CMAKE_PREFIX_PATH  "$dalroot"
 prepend-path    PKG_CONFIG_PATH    "$dalroot/lib/pkgconfig"

--- a/deploy/local/vars_lnx.sh
+++ b/deploy/local/vars_lnx.sh
@@ -248,13 +248,12 @@ if [ "$(basename "${my_script_path}")" = "env" ] ; then   # assume stand-alone
     export PKG_CONFIG_PATH="$__daal_tmp_dir/lib/pkgconfig${PKG_CONFIG_PATH+:${PKG_CONFIG_PATH}}"
     export CMAKE_PREFIX_PATH="$__daal_tmp_dir${CMAKE_PREFIX_PATH+:${CMAKE_PREFIX_PATH}}"
     export CPLUS_INCLUDE_PATH="$__daal_tmp_dir/include:$__daal_tmp_dir/include/dal${CPLUS_INCLUDE_PATH+:${CPLUS_INCLUDE_PATH}}"
-    if [ -d "${component_root}/include/dal" ]; then
-      export LIBRARY_PATH="$__daal_tmp_dir/lib${LIBRARY_PATH+:${LIBRARY_PATH}}"
-      export LD_LIBRARY_PATH="$__daal_tmp_dir/lib${LD_LIBRARY_PATH+:${LD_LIBRARY_PATH}}"
-    else
-      export LIBRARY_PATH="$__daal_tmp_dir/lib/$ARCH_DIR_ONEDAL${LIBRARY_PATH+:${LIBRARY_PATH}}"
-      export LD_LIBRARY_PATH="$__daal_tmp_dir/lib/$ARCH_DIR_ONEDAL${LD_LIBRARY_PATH+:${LD_LIBRARY_PATH}}"
+    __daal_lib_dir="$__daal_tmp_dir/lib"
+    if [ -d "$__daal_lib_dir/$ARCH_DIR_ONEDAL" ]; then
+      __daal_lib_dir="$__daal_lib_dir/$ARCH_DIR_ONEDAL"
     fi
+    export LIBRARY_PATH="$__daal_lib_dir${LIBRARY_PATH+:${LIBRARY_PATH}}"
+    export LD_LIBRARY_PATH="$__daal_lib_dir${LD_LIBRARY_PATH+:${LD_LIBRARY_PATH}}"
   # ;;
 else   # must be a consolidated layout
     # within this "else" reference $ONEAPI_ROOT **not** $my_script_path

--- a/dev/bazel/cc.bzl
+++ b/dev/bazel/cc.bzl
@@ -255,14 +255,7 @@ def _copy_dynamic_release_file(ctx, src, out_name, is_windows = False, extra_inp
 
 
 def _cc_dynamic_lib_impl(ctx):
-    toolchain, feature_config = _init_cc_rule(ctx, features=[
-        # This feature will force toolchain to not link the produced executable/dynamic library
-        # against dynamic dependencies (-l) on Linux and MacOs. It's needed to get dependency-free
-        # .so/.dylib, where the symbols need to be resolved at executable build-time. On Windows
-        # this feature shall not make difference, because all symbols are need to be resolved at DLL
-        # build-time.
-        "do_not_link_dynamic_dependencies",
-    ])
+    toolchain, feature_config = _init_cc_rule(ctx)
     compilation_context = onedal_cc_common.collect_and_merge_compilation_contexts(ctx.attr.deps)
     linking_contexts = onedal_cc_common.collect_and_filter_linking_contexts(
         ctx.attr.deps, ctx.attr.lib_tags)
@@ -270,8 +263,15 @@ def _cc_dynamic_lib_impl(ctx):
     is_windows = ctx.target_platform_has_constraint(
         ctx.attr._windows_constraint[platform_common.ConstraintValueInfo],
     )
-    vi = ctx.attr._version_info[VersionInfo] if is_windows else None
+    vi = ctx.attr._version_info[VersionInfo]
     link_name = "{}.{}".format(ctx.attr.lib_name, vi.binary_major) if is_windows else ctx.attr.lib_name
+    linux_soname_flags = [] if is_windows else [
+        "-Wl,-soname,lib{}.so.{}".format(ctx.attr.lib_name, vi.binary_major),
+    ]
+    linux_linker_script_flags = [] if is_windows else [
+        "-Wl,--version-script,{}".format(script.path)
+        for script in ctx.files.linker_scripts
+    ]
     linking_context, dynamic_outputs = onedal_cc_link.dynamic(
         owner = ctx.label,
         name = link_name,
@@ -280,8 +280,9 @@ def _cc_dynamic_lib_impl(ctx):
         feature_configuration = feature_config,
         linking_contexts = linking_contexts,
         def_file = ctx.file.def_file,
-        user_link_flags = ctx.attr.linkopts,
+        user_link_flags = linux_soname_flags + linux_linker_script_flags + ctx.attr.linkopts,
         is_windows = is_windows,
+        additional_inputs = ctx.files.linker_scripts,
     )
     default_files = dynamic_outputs.files
     if is_windows:
@@ -325,6 +326,7 @@ cc_dynamic_lib = rule(
             default = [],
             doc = "Additional linker flags (e.g. --exclude-libs for MKL symbol hiding).",
         ),
+        "linker_scripts": attr.label_list(allow_files=True),
         "_windows_constraint": attr.label(
             default = "@platforms//os:windows",
         ),

--- a/dev/bazel/cc.bzl
+++ b/dev/bazel/cc.bzl
@@ -255,7 +255,14 @@ def _copy_dynamic_release_file(ctx, src, out_name, is_windows = False, extra_inp
 
 
 def _cc_dynamic_lib_impl(ctx):
-    toolchain, feature_config = _init_cc_rule(ctx)
+    toolchain, feature_config = _init_cc_rule(ctx, features=[
+        # Keep produced shared libraries free of dynamic Bazel deps on Linux.
+        # Release-dynamic tests provide standalone oneDAL libs through
+        # DALROOT/LD_LIBRARY_PATH while Bazel-provided runtimes such as TBB
+        # live in test runfiles; DT_NEEDED entries on those deps are not
+        # resolved through the executable RUNPATH.
+        "do_not_link_dynamic_dependencies",
+    ])
     compilation_context = onedal_cc_common.collect_and_merge_compilation_contexts(ctx.attr.deps)
     linking_contexts = onedal_cc_common.collect_and_filter_linking_contexts(
         ctx.attr.deps, ctx.attr.lib_tags)

--- a/dev/bazel/cc/link.bzl
+++ b/dev/bazel/cc/link.bzl
@@ -228,13 +228,13 @@ def _static(owner, name, actions, cc_toolchain,
 def _link(owner, name, actions, cc_toolchain,
           feature_configuration, linking_contexts,
           def_file=None, is_executable=False, user_link_flags=[],
-          is_windows=False):
+          is_windows=False, additional_inputs=[]):
     unpacked_linking_context = onedal_cc_common.unpack_linking_contexts(linking_contexts)
     if not is_executable and unpacked_linking_context.objects and unpacked_linking_context.pic_objects:
         fail("Dynamic library {} contains non-PIC object files: {}".format(
             name, unpacked_linking_context.objects))
     object_list = unpacked_linking_context.pic_objects + unpacked_linking_context.objects
-    additional_inputs = [def_file] if def_file else []
+    additional_inputs = ([def_file] if def_file else []) + additional_inputs
     direct_user_link_flags = ["@" + def_file.path] if def_file else []
     direct_libraries_to_link = []
 
@@ -303,13 +303,14 @@ def _link(owner, name, actions, cc_toolchain,
 
 def _dynamic(owner, name, actions, cc_toolchain,
              feature_configuration, linking_contexts,
-             def_file=None, user_link_flags=[], is_windows=False):
+             def_file=None, user_link_flags=[], is_windows=False, additional_inputs=[]):
     unpacked_linking_context, linking_outputs = _link(
         owner, name, actions, cc_toolchain,
         feature_configuration, linking_contexts,
         def_file,
         user_link_flags=user_link_flags,
         is_windows=is_windows,
+        additional_inputs=additional_inputs,
     )
     library_to_link = linking_outputs.library_to_link
     dynamic_lib = None

--- a/dev/bazel/config/config.bzl
+++ b/dev/bazel/config/config.bzl
@@ -16,6 +16,9 @@
 
 load("@onedal//dev/bazel:utils.bzl", "utils", "sets")
 
+_BINARY_MAJOR = "4"
+_BINARY_MINOR = "0"
+
 ConfigFlagInfo = provider(
     fields = [
         "flag",
@@ -122,7 +125,7 @@ VersionInfo = provider(
         "status",
         # Binary ABI version (distinct from product version).
         # Used for SONAME and shared library symlinks.
-        # Matches Make's MAJORBINARY / MINORBINARY variables.
+        # oneDAL binary ABI version.
         "binary_major",
         "binary_minor",
     ],
@@ -151,8 +154,7 @@ version_info = rule(
         "build": attr.string(mandatory=True),
         "buildrev": attr.string(mandatory=True),
         "status": attr.string(mandatory=True),
-        # ABI binary version — used for SONAME and symlinks.
-        # Must match MAJORBINARY/MINORBINARY in makefile.
+        # ABI binary version used for SONAME and symlinks.
         "binary_major": attr.string(mandatory=True),
         "binary_minor": attr.string(mandatory=True),
     },
@@ -216,18 +218,6 @@ def _detect_cpu_extension(repo_ctx):
 def _declare_onedal_config_impl(repo_ctx):
     auto_cpu = _detect_cpu_extension(repo_ctx)
 
-    makefile_ver = repo_ctx.path(Label("@onedal//:makefile.ver"))
-    makefile_content = repo_ctx.read(makefile_ver)
-    
-    # Parse MAJORBINARY and MINORBINARY
-    binary_major = "4"
-    binary_minor = "0"
-    for line in makefile_content.splitlines():
-        if line.startswith("MAJORBINARY"):
-            binary_major = line.split("=")[1].strip()
-        elif line.startswith("MINORBINARY"):
-            binary_minor = line.split("=")[1].strip()
-
     repo_ctx.template(
         "BUILD",
         Label("@onedal//dev/bazel/config:config.tpl.BUILD"),
@@ -239,8 +229,8 @@ def _declare_onedal_config_impl(repo_ctx):
             "%{version_build}":         utils.datestamp(repo_ctx),
             "%{version_buildrev}":      "work",
             "%{version_status}":        "P",
-            "%{version_binary_major}":  binary_major,
-            "%{version_binary_minor}":  binary_minor,
+            "%{version_binary_major}":  _BINARY_MAJOR,
+            "%{version_binary_minor}":  _BINARY_MINOR,
         },
     )
 declare_onedal_config = repository_rule(

--- a/dev/bazel/config/config.tpl.BUILD
+++ b/dev/bazel/config/config.tpl.BUILD
@@ -22,7 +22,6 @@ version_info(
     buildrev = "%{version_buildrev}",
     status = "%{version_status}",
     # Binary ABI version for SONAME and shared library symlinks.
-    # Must match MAJORBINARY/MINORBINARY in makefile.
     binary_major = "%{version_binary_major}",
     binary_minor = "%{version_binary_minor}",
 )

--- a/dev/bazel/daal.bzl
+++ b/dev/bazel/daal.bzl
@@ -30,7 +30,7 @@ load("@onedal//dev/bazel/config:config.bzl",
 
 def daal_module(name, features=[], lib_tag="daal",
                 hdrs=[], srcs=[], auto=False,
-                local_defines=[], copts=[], **kwargs):
+                local_defines=[], copts=[], visibility_hidden=True, **kwargs):
     if auto:
         auto_hdrs = native.glob(["**/*.h", "**/*.i"], allow_empty=True,)
         auto_srcs = native.glob(["**/*.cpp"], allow_empty=True,)
@@ -52,10 +52,13 @@ def daal_module(name, features=[], lib_tag="daal",
         },
         hdrs = auto_hdrs + hdrs,
         srcs = auto_srcs + srcs,
-        copts = copts + select({
+        copts = copts + (select({
             "@platforms//os:windows": ["/utf-8"],
             "//conditions:default": ["-fvisibility=hidden", "-fvisibility-inlines-hidden"],
-        }),
+        }) if visibility_hidden else select({
+            "@platforms//os:windows": ["/utf-8"],
+            "//conditions:default": [],
+        })),
         local_defines = select({
             "@config//:assert_enabled": local_defines + ["__DAAL_IMPLEMENTATION", "DEBUG_ASSERT=1"],
             "//conditions:default": local_defines + ["__DAAL_IMPLEMENTATION"],

--- a/dev/bazel/dal.bzl
+++ b/dev/bazel/dal.bzl
@@ -145,7 +145,7 @@ def dal_static_lib(name, lib_name, dal_deps=[], host_deps=[],
 
 def dal_dynamic_lib(name, lib_name, dal_deps=[], host_deps=[],
                     dpc_deps=[], extra_deps=[], lib_tags=["dal"],
-                    features=[], **kwargs):
+                    dpc_lib_tags=None, features=[], **kwargs):
     cc_dynamic_lib(
         name = name,
         lib_name = lib_name,
@@ -157,7 +157,7 @@ def dal_dynamic_lib(name, lib_name, dal_deps=[], host_deps=[],
         name = name + "_dpc",
         features = features + [ "dpc++" ],
         lib_name = lib_name + "_dpc",
-        lib_tags = lib_tags,
+        lib_tags = dpc_lib_tags if dpc_lib_tags != None else lib_tags,
         # Some dynamic DPC libraries also need host-only objects, e.g. the
         # Windows delay-load shim for DAAL threading symbols.
         deps = _get_dpc_deps(dal_deps) + extra_deps + dpc_deps + host_deps,

--- a/dev/bazel/dal.bzl
+++ b/dev/bazel/dal.bzl
@@ -111,6 +111,7 @@ def dal_public_includes(name, dal_deps=[], **kwargs):
             "oneapi/",
         ],
         exclude = [
+            "_dal_cpu_dispatcher_gen.hpp",
             "backend/",
             "test/",
             # Exclude all external-repository headers.  _match_file_name uses
@@ -124,7 +125,7 @@ def dal_public_includes(name, dal_deps=[], **kwargs):
     )
 
 def dal_static_lib(name, lib_name, dal_deps=[], host_deps=[],
-                   dpc_deps=[], extra_deps=[], lib_tags=["dal", "daal"],
+                   dpc_deps=[], extra_deps=[], lib_tags=["dal"],
                    features=[], **kwargs):
     cc_static_lib(
         name = name,
@@ -143,7 +144,7 @@ def dal_static_lib(name, lib_name, dal_deps=[], host_deps=[],
     )
 
 def dal_dynamic_lib(name, lib_name, dal_deps=[], host_deps=[],
-                    dpc_deps=[], extra_deps=[], lib_tags=["dal", "daal", "mkl_embed"],
+                    dpc_deps=[], extra_deps=[], lib_tags=["dal"],
                     features=[], **kwargs):
     cc_dynamic_lib(
         name = name,

--- a/dev/bazel/deps/onedal.tpl.BUILD
+++ b/dev/bazel/deps/onedal.tpl.BUILD
@@ -61,7 +61,7 @@ cc_library(
 cc_library(
     name = "core_dynamic",
     srcs = glob([
-        "lib/intel64/libonedal_core.so.%{version_binary_major}.%{version_binary_minor}",
+        "lib/intel64/libonedal_core.so.%{version_binary_major}",
     ]),
     deps = [
         ":headers",
@@ -81,7 +81,7 @@ filegroup(
 cc_library(
     name = "thread_dynamic",
     srcs = glob([
-        "lib/intel64/libonedal_thread.so.%{version_binary_major}.%{version_binary_minor}",
+        "lib/intel64/libonedal_thread.so.%{version_binary_major}",
     ]),
     deps = [
         ":headers",
@@ -100,11 +100,10 @@ filegroup(
 cc_library(
     name = "onedal_dynamic",
     srcs = glob([
-        # Use exact versioned filenames to avoid linking the same .so multiple
-        # times when the release tree contains .so, .so.<major>, and
-        # .so.<major>.<minor> all pointing to the same library.
-        "lib/intel64/libonedal.so.%{version_binary_major}.%{version_binary_minor}",
-        "lib/intel64/libonedal_parameters.so.%{version_binary_major}.%{version_binary_minor}",
+        # Link through the SONAME symlinks. Bazel's _solib runfiles then expose
+        # names like libonedal.so.4, matching DT_NEEDED in test executables.
+        "lib/intel64/libonedal.so.%{version_binary_major}",
+        "lib/intel64/libonedal_parameters.so.%{version_binary_major}",
     ]),
     deps = [
         ":headers",
@@ -123,10 +122,9 @@ filegroup(
 cc_library(
     name = "onedal_dynamic_dpc",
     srcs = glob([
-        "lib/intel64/libonedal_dpc.so.%{version_binary_major}.%{version_binary_minor}",
-        # Use the exact fully-versioned filename to avoid duplicate link inputs
-        # from the .so/.so.<major> symlink chain in the release tree.
-        "lib/intel64/libonedal_parameters_dpc.so.%{version_binary_major}.%{version_binary_minor}",
+        "lib/intel64/libonedal_dpc.so.%{version_binary_major}",
+        # Link through the SONAME symlink for the same _solib/runfiles reason.
+        "lib/intel64/libonedal_parameters_dpc.so.%{version_binary_major}",
     ], allow_empty=True),
     deps = [
         ":headers",

--- a/dev/bazel/release.bzl
+++ b/dev/bazel/release.bzl
@@ -120,7 +120,24 @@ def _try_relativize(path, start):
         return paths.relativize(path, start)
     return path
 
-def _copy_include(ctx, prefix):
+def _copy_version_header(ctx, src_file, dst_path, version_info):
+    dst_file = ctx.actions.declare_file(dst_path)
+    ctx.actions.expand_template(
+        template = src_file,
+        output = dst_file,
+        substitutions = {
+            "#define __INTEL_DAAL_BUILD_DATE 21990101": "#define __INTEL_DAAL_BUILD_DATE {}".format(version_info.build),
+            "#define __INTEL_DAAL__        2199": "#define __INTEL_DAAL__ {}".format(version_info.major),
+            "#define __INTEL_DAAL_MINOR__  9": "#define __INTEL_DAAL_MINOR__ {}".format(version_info.minor),
+            "#define __INTEL_DAAL_UPDATE__ 9": "#define __INTEL_DAAL_UPDATE__ {}".format(version_info.update),
+            "#define __INTEL_DAAL_STATUS__ 'A'": "#define __INTEL_DAAL_STATUS__ \"{}\"".format(version_info.status),
+            "#define __INTEL_DAAL_MAJOR_BINARY__ 999": "#define __INTEL_DAAL_MAJOR_BINARY__ {}".format(version_info.binary_major),
+            "#define __INTEL_DAAL_MINOR_BINARY__ 999": "#define __INTEL_DAAL_MINOR_BINARY__ {}".format(version_info.binary_minor),
+        },
+    )
+    return dst_file
+
+def _copy_include(ctx, prefix, version_info):
     include_prefix = paths.join(prefix, "include")
     dst_files = []
     for include, prefix, skip_prefix in zip(ctx.attr.include, ctx.attr.include_prefix,
@@ -135,7 +152,11 @@ def _copy_include(ctx, prefix):
                 dst_path = _try_relativize(header.short_path, skip_prefix)
             elif prefix:
                 dst_path = paths.join(prefix, header.basename)
-            dst_file = _copy(ctx, header, paths.join(include_prefix, dst_path))
+            dst_path = paths.join(include_prefix, dst_path)
+            if header.short_path == "cpp/daal/include/services/library_version_info.h":
+                dst_file = _copy_version_header(ctx, header, dst_path, version_info)
+            else:
+                dst_file = _copy(ctx, header, dst_path)
             dst_files.append(dst_file)
     return dst_files
 
@@ -325,7 +346,7 @@ def _copy_to_release_impl(ctx):
     prefix = ctx.attr.name + "/daal/latest"
     version_info = ctx.attr._version_info[VersionInfo] if ctx.attr._version_info else None
     files = []
-    files += _copy_include(ctx, prefix)
+    files += _copy_include(ctx, prefix, version_info)
     files += _copy_lib(ctx, prefix, version_info)
     files += _copy_extra_files(ctx, prefix)
     files += _copy_data(ctx, prefix)

--- a/dev/bazel/repos.bzl
+++ b/dev/bazel/repos.bzl
@@ -16,6 +16,9 @@
 
 load("@onedal//dev/bazel:utils.bzl", "utils", "paths")
 
+_BINARY_MAJOR = "4"
+_BINARY_MINOR = "0"
+
 def _download_and_extract(repo_ctx, url, sha256, output, strip_prefix):
     # Workaround Python wheel extraction. Bazel cannot determine file
     # type automatically as does not support wheels out-of-the-box.
@@ -183,19 +186,8 @@ def _prebuilt_libs_repo_impl(repo_ctx):
         "%{os}": os_id,
         "%{repo_root}": str(repo_ctx.path("")),
     }
-    # Extract substitutions if a makefile_ver attribute is present
-    if hasattr(repo_ctx.attr, "_makefile_ver") and repo_ctx.attr._makefile_ver:
-        makefile_ver = repo_ctx.path(repo_ctx.attr._makefile_ver)
-        makefile_content = repo_ctx.read(makefile_ver)
-        binary_major = "4"
-        binary_minor = "0"
-        for line in makefile_content.splitlines():
-            if line.startswith("MAJORBINARY"):
-                binary_major = line.split("=")[1].strip()
-            elif line.startswith("MINORBINARY"):
-                binary_minor = line.split("=")[1].strip()
-        substitutions["%{version_binary_major}"] = binary_major
-        substitutions["%{version_binary_minor}"] = binary_minor
+    substitutions["%{version_binary_major}"] = _BINARY_MAJOR
+    substitutions["%{version_binary_minor}"] = _BINARY_MINOR
 
     _create_symlinks(repo_ctx, root, _select_by_os(repo_ctx, "includes", os_id), substitutions, mapping)
     _create_symlinks(repo_ctx, root, _select_by_os(repo_ctx, "libs", os_id), substitutions, mapping)
@@ -232,7 +224,6 @@ def _prebuilt_libs_repo_rule(includes, libs, build_template, bins=[],
             "includes": attr.string_list(default=includes),
             "libs": attr.string_list(default=libs),
             "bins": attr.string_list(default=bins),
-            "_makefile_ver": attr.label(default=Label("@onedal//:makefile.ver")),
             "build_template": attr.label(allow_files=True,
                                          default=Label(build_template)),
             "win_includes": attr.string_list(default=win_includes),

--- a/dev/bazel/scripts.bzl
+++ b/dev/bazel/scripts.bzl
@@ -78,6 +78,52 @@ def generate_modulefile(name, out = "modulefiles/dal", **kwargs):
     )
 
 # ---------------------------------------------------------------------------
+# CMake package config
+# ---------------------------------------------------------------------------
+
+def _generate_cmake_config_impl(ctx):
+    vi = ctx.attr._version_info[VersionInfo]
+    out = ctx.actions.declare_file(ctx.attr.out)
+    ctx.actions.expand_template(
+        template = ctx.file.template,
+        output = out,
+        substitutions = {
+            "@DAL_ROOT_REL_PATH@": "../../..",
+            "@VERSIONS_SET@": "TRUE",
+            "@DAL_VER_MAJOR_BIN@": vi.binary_major,
+            "@DAL_VER_MINOR_BIN@": vi.binary_minor,
+            "@ARCH_DIR_ONEDAL@": "intel64",
+            "@DLL_REL_PATH@": "redist",
+            "@INC_REL_PATH@": "include",
+            "@oneDAL_VERSION@": "{}.{}.{}.0".format(vi.major, vi.minor, vi.update),
+        },
+    )
+    return [DefaultInfo(files = depset([out]))]
+
+_generate_cmake_config = rule(
+    implementation = _generate_cmake_config_impl,
+    attrs = {
+        "template": attr.label(
+            allow_single_file = True,
+            mandatory = True,
+        ),
+        "out": attr.string(mandatory = True),
+        "_version_info": attr.label(
+            default = "@config//:version",
+            providers = [VersionInfo],
+        ),
+    },
+)
+
+def generate_cmake_config(name, template, out, **kwargs):
+    _generate_cmake_config(
+        name = name,
+        template = template,
+        out = out,
+        **kwargs
+    )
+
+# ---------------------------------------------------------------------------
 # pkg-config
 # ---------------------------------------------------------------------------
 
@@ -117,6 +163,7 @@ Cflags: /std:c++17 /MD /wd4996 /EHsc -I${{includedir}}
             outputs = [out],
             command = (
                 "${{CC:-gcc}} -E -P -x c " +
+                ("-DSTATIC " if ctx.attr.static else "") +
                 "-DDAL_MAJOR_BINARY={binary_major} " +
                 "-DDAL_MINOR_BINARY={binary_minor} " +
                 "-DDAL_MAJOR={major} " +

--- a/dev/bazel/scripts.bzl
+++ b/dev/bazel/scripts.bzl
@@ -19,11 +19,11 @@
 load("@onedal//dev/bazel/config:config.bzl", "VersionInfo")
 
 # ---------------------------------------------------------------------------
-# vars.sh
+# Versioned template files
 # ---------------------------------------------------------------------------
 
-def _generate_vars_sh_impl(ctx):
-    """Expand vars.sh template substituting binary version placeholders."""
+def _generate_versioned_template_impl(ctx):
+    """Expand a release template substituting binary version placeholders."""
     vi = ctx.attr._version_info[VersionInfo]
     out = ctx.actions.declare_file(ctx.attr.out)
     ctx.actions.expand_template(
@@ -36,13 +36,13 @@ def _generate_vars_sh_impl(ctx):
     )
     return [DefaultInfo(files = depset([out]))]
 
-_generate_vars_sh = rule(
-    implementation = _generate_vars_sh_impl,
+_generate_versioned_template = rule(
+    implementation = _generate_versioned_template_impl,
     attrs = {
         "template": attr.label(
             allow_single_file = True,
             mandatory = True,
-            doc = "Source vars.sh template file.",
+            doc = "Source release template file.",
         ),
         "out": attr.string(
             mandatory = True,
@@ -57,13 +57,22 @@ _generate_vars_sh = rule(
 
 def generate_vars_sh(name, out = "env/vars.sh", **kwargs):
     """Generate release environment script from template."""
-    _generate_vars_sh(
+    _generate_versioned_template(
         name = name,
         template = select({
             "@platforms//os:windows": "@onedal//deploy/local:vars_win.bat",
             "@platforms//os:osx": "@onedal//deploy/local:vars_mac.sh",
             "//conditions:default": "@onedal//deploy/local:vars_lnx.sh",
         }),
+        out = out,
+        **kwargs
+    )
+
+def generate_modulefile(name, out = "modulefiles/dal", **kwargs):
+    """Generate Linux modulefile from template."""
+    _generate_versioned_template(
+        name = name,
+        template = "@onedal//deploy/local:dal",
         out = out,
         **kwargs
     )
@@ -81,7 +90,7 @@ def _generate_pkgconfig_impl(ctx):
         onedal_libs = (
             "${libdir}/onedal.lib ${libdir}/onedal_core.lib ${libdir}/onedal_thread.lib"
             if ctx.attr.static else
-            "${libdir}/onedal_dll.lib ${libdir}/onedal_core_dll.lib"
+            "${libdir}/onedal_dll.lib ${libdir}/onedal_parameters_dll.lib ${libdir}/onedal_core_dll.lib"
         )
         ctx.actions.write(
             output = out,

--- a/dev/bazel/scripts.bzl
+++ b/dev/bazel/scripts.bzl
@@ -89,13 +89,13 @@ def _generate_cmake_config_impl(ctx):
         output = out,
         substitutions = {
             "@DAL_ROOT_REL_PATH@": "../../..",
-            "@VERSIONS_SET@": "TRUE",
-            "@DAL_VER_MAJOR_BIN@": vi.binary_major,
-            "@DAL_VER_MINOR_BIN@": vi.binary_minor,
+            "@VERSIONS_SET@": "FALSE",
+            "@DAL_VER_MAJOR_BIN@": "",
+            "@DAL_VER_MINOR_BIN@": "",
             "@ARCH_DIR_ONEDAL@": "intel64",
             "@DLL_REL_PATH@": "redist",
             "@INC_REL_PATH@": "include",
-            "@oneDAL_VERSION@": "{}.{}.{}.0".format(vi.major, vi.minor, vi.update),
+            "@oneDAL_VERSION@": "",
         },
     )
     return [DefaultInfo(files = depset([out]))]
@@ -158,28 +158,40 @@ Cflags: /std:c++17 /MD /wd4996 /EHsc -I${{includedir}}
             ),
         )
     else:
-        ctx.actions.run_shell(
-            inputs = [ctx.file.template],
-            outputs = [out],
-            command = (
-                "${{CC:-gcc}} -E -P -x c " +
-                ("-DSTATIC " if ctx.attr.static else "") +
-                "-DDAL_MAJOR_BINARY={binary_major} " +
-                "-DDAL_MINOR_BINARY={binary_minor} " +
-                "-DDAL_MAJOR={major} " +
-                "-DDAL_MINOR={minor} " +
-                "{template} -o {out}"
-            ).format(
-                binary_major = vi.binary_major,
-                binary_minor = vi.binary_minor,
+        suffix = "a" if ctx.attr.static else "so"
+        ctx.actions.write(
+            output = out,
+            content = """#===============================================================================
+# Copyright contributors to the oneDAL Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#===============================================================================
+prefix=${{pcfiledir}}/../../
+exec_prefix=${{prefix}}
+libdir=${{exec_prefix}}/lib/intel64
+includedir=${{prefix}}/include
+
+Name: oneDAL
+Description: oneAPI Data Analytics Library
+Version: {major}.{minor}
+URL: https://www.intel.com/content/www/us/en/developer/tools/oneapi/onedal.html
+Libs: ${{libdir}}/libonedal.{suffix} ${{libdir}}/libonedal_core.{suffix} ${{libdir}}/libonedal_thread.{suffix} ${{libdir}}/libonedal_parameters.{suffix} -lmkl_core -lmkl_intel_lp64 -lmkl_tbb_thread -ltbb -ltbbmalloc -lpthread -ldl
+Cflags: -std=c++17 -Wno-deprecated-declarations -I${{includedir}}
+""".format(
                 major = vi.major,
                 minor = vi.minor,
-                template = ctx.file.template.path,
-                out = out.path,
+                suffix = suffix,
             ),
-            mnemonic = "GenPkgConfig",
-            progress_message = "Generating pkg-config file {}".format(out.short_path),
-            use_default_shell_env = True,
         )
     return [DefaultInfo(files = depset([out]))]
 

--- a/dev/bazel/tests/release_structure_test.sh
+++ b/dev/bazel/tests/release_structure_test.sh
@@ -27,6 +27,7 @@ set -euo pipefail
 
 RELEASE_DIR="${1:-bazel-bin/release/daal/latest}"
 LIB_DIR="${RELEASE_DIR}/lib/intel64"
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
 PASS=0
 FAIL=0
 
@@ -141,28 +142,10 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# 3. vars.sh
+# 3. Common package metadata checks
 # ---------------------------------------------------------------------------
-echo ""
-echo "=== vars.sh ==="
-
-VARS_SH="${RELEASE_DIR}/env/vars.sh"
-if [ -f "$VARS_SH" ]; then
-    _pass "env/vars.sh exists"
-    if grep -q "DAL_MAJOR_BINARY" "$VARS_SH"; then
-        _pass "vars.sh contains DAL_MAJOR_BINARY"
-    else
-        _fail "vars.sh missing DAL_MAJOR_BINARY"
-    fi
-    # Check no unresolved placeholders
-    if grep -q "__DAL_MAJOR_BINARY__\|__DAL_MINOR_BINARY__" "$VARS_SH"; then
-        _fail "vars.sh still has unresolved placeholders"
-    else
-        _pass "vars.sh has no unresolved placeholders"
-    fi
-else
-    _fail "env/vars.sh not found at ${VARS_SH}"
-fi
+"${SCRIPT_DIR}/../../release_tests/package_metadata_test.sh" "${RELEASE_DIR}" || \
+    _fail "package metadata checks failed"
 
 # ---------------------------------------------------------------------------
 # 4. modulefile
@@ -192,51 +175,7 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# 5. pkg-config
-# ---------------------------------------------------------------------------
-echo ""
-echo "=== pkg-config ==="
-
-if ${IS_LINUX}; then
-    for pc_name in dal-dynamic-threading-host.pc dal-static-threading-host.pc; do
-        PC_FILE="${RELEASE_DIR}/lib/pkgconfig/${pc_name}"
-        if [ -f "$PC_FILE" ]; then
-            _pass "lib/pkgconfig/${pc_name} exists"
-            if grep -q "^Name:" "$PC_FILE"; then
-                _pass "${pc_name} has Name field"
-            else
-                _fail "${pc_name} missing Name field"
-            fi
-            if grep -q "^Libs:" "$PC_FILE"; then
-                _pass "${pc_name} has Libs field"
-            else
-                _fail "${pc_name} missing Libs field"
-            fi
-        else
-            _fail "lib/pkgconfig/${pc_name} not found"
-        fi
-    done
-else
-    PC_FILE="${RELEASE_DIR}/lib/pkgconfig/onedal.pc"
-    if [ -f "$PC_FILE" ]; then
-        _pass "lib/pkgconfig/onedal.pc exists"
-        if grep -q "^Name:" "$PC_FILE"; then
-            _pass "onedal.pc has Name field"
-        else
-            _fail "onedal.pc missing Name field"
-        fi
-        if grep -q "^Libs:" "$PC_FILE"; then
-            _pass "onedal.pc has Libs field"
-        else
-            _fail "onedal.pc missing Libs field"
-        fi
-    else
-        _fail "lib/pkgconfig/onedal.pc not found"
-    fi
-fi
-
-# ---------------------------------------------------------------------------
-# 6. No external dependency headers in include/
+# 5. No external dependency headers in include/
 # ---------------------------------------------------------------------------
 echo ""
 echo "=== No external headers in release include/ ==="

--- a/dev/bazel/tests/release_structure_test.sh
+++ b/dev/bazel/tests/release_structure_test.sh
@@ -47,7 +47,8 @@ if ! ${IS_LINUX}; then
     echo "  SKIP: .so versioning checks are Linux-only (detected OS: ${OS})"
 fi
 
-for lib_base in libonedal_core libonedal libonedal_thread; do
+BINARY_MAJOR_VER=""
+for lib_base in libonedal_core libonedal libonedal_thread libonedal_parameters; do
     if ! ${IS_LINUX}; then continue; fi
     so="${LIB_DIR}/${lib_base}.so"
     # Find versioned file using bash globbing (more robust than ls+grep)
@@ -75,6 +76,9 @@ for lib_base in libonedal_core libonedal libonedal_thread; do
     # Extract major.minor from filename
     version_suffix="${versioned##*.so.}"  # e.g. "3.0"
     major_ver="${version_suffix%%.*}"     # e.g. "3"
+    if [ "$lib_base" = "libonedal_core" ]; then
+        BINARY_MAJOR_VER="$major_ver"
+    fi
 
     # Check major symlink exists and points correctly
     major_link="${LIB_DIR}/${lib_base}.so.${major_ver}"
@@ -115,7 +119,7 @@ if ! ${IS_LINUX}; then
 elif ! command -v readelf >/dev/null 2>&1; then
     _fail "readelf not found on PATH; cannot perform SONAME check"
 else
-    for lib in "${LIB_DIR}"/libonedal_core.so.*.* "${LIB_DIR}"/libonedal.so.*.* "${LIB_DIR}"/libonedal_thread.so.*.* ; do
+    for lib in "${LIB_DIR}"/libonedal_core.so.*.* "${LIB_DIR}"/libonedal.so.*.* "${LIB_DIR}"/libonedal_thread.so.*.* "${LIB_DIR}"/libonedal_parameters.so.*.* ; do
         [ -f "$lib" ] || continue
         lib_base=$(basename "$lib" | sed 's/\.so\..*//')
         # Extract expected SONAME from filename: libonedal_core.so.3.0 -> libonedal_core.so.3
@@ -161,30 +165,78 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# 4. pkg-config
+# 4. modulefile
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== modulefile ==="
+
+MODULEFILE="${RELEASE_DIR}/modulefiles/dal"
+if ${IS_LINUX}; then
+    if [ -f "$MODULEFILE" ]; then
+        _pass "modulefiles/dal exists"
+        if grep -q "__DAL_MAJOR_BINARY__\|__DAL_MINOR_BINARY__" "$MODULEFILE"; then
+            _fail "modulefiles/dal still has unresolved placeholders"
+        else
+            _pass "modulefiles/dal has no unresolved placeholders"
+        fi
+        if [ -n "$BINARY_MAJOR_VER" ] && grep -Eq "DAL_MAJOR_BINARY[[:space:]]+${BINARY_MAJOR_VER}" "$MODULEFILE"; then
+            _pass "modulefiles/dal contains current DAL_MAJOR_BINARY"
+        else
+            _fail "modulefiles/dal missing current DAL_MAJOR_BINARY"
+        fi
+    else
+        _fail "modulefiles/dal not found at ${MODULEFILE}"
+    fi
+else
+    echo "  SKIP: modulefile check is Linux-only (detected OS: ${OS})"
+fi
+
+# ---------------------------------------------------------------------------
+# 5. pkg-config
 # ---------------------------------------------------------------------------
 echo ""
 echo "=== pkg-config ==="
 
-PC_FILE="${RELEASE_DIR}/lib/pkgconfig/onedal.pc"
-if [ -f "$PC_FILE" ]; then
-    _pass "lib/pkgconfig/onedal.pc exists"
-    if grep -q "^Name:" "$PC_FILE"; then
-        _pass "onedal.pc has Name field"
-    else
-        _fail "onedal.pc missing Name field"
-    fi
-    if grep -q "^Libs:" "$PC_FILE"; then
-        _pass "onedal.pc has Libs field"
-    else
-        _fail "onedal.pc missing Libs field"
-    fi
+if ${IS_LINUX}; then
+    for pc_name in dal-dynamic-threading-host.pc dal-static-threading-host.pc; do
+        PC_FILE="${RELEASE_DIR}/lib/pkgconfig/${pc_name}"
+        if [ -f "$PC_FILE" ]; then
+            _pass "lib/pkgconfig/${pc_name} exists"
+            if grep -q "^Name:" "$PC_FILE"; then
+                _pass "${pc_name} has Name field"
+            else
+                _fail "${pc_name} missing Name field"
+            fi
+            if grep -q "^Libs:" "$PC_FILE"; then
+                _pass "${pc_name} has Libs field"
+            else
+                _fail "${pc_name} missing Libs field"
+            fi
+        else
+            _fail "lib/pkgconfig/${pc_name} not found"
+        fi
+    done
 else
-    _fail "lib/pkgconfig/onedal.pc not found"
+    PC_FILE="${RELEASE_DIR}/lib/pkgconfig/onedal.pc"
+    if [ -f "$PC_FILE" ]; then
+        _pass "lib/pkgconfig/onedal.pc exists"
+        if grep -q "^Name:" "$PC_FILE"; then
+            _pass "onedal.pc has Name field"
+        else
+            _fail "onedal.pc missing Name field"
+        fi
+        if grep -q "^Libs:" "$PC_FILE"; then
+            _pass "onedal.pc has Libs field"
+        else
+            _fail "onedal.pc missing Libs field"
+        fi
+    else
+        _fail "lib/pkgconfig/onedal.pc not found"
+    fi
 fi
 
 # ---------------------------------------------------------------------------
-# 5. No external dependency headers in include/
+# 6. No external dependency headers in include/
 # ---------------------------------------------------------------------------
 echo ""
 echo "=== No external headers in release include/ ==="

--- a/dev/bazel/toolchains/cc_toolchain_config_lnx.bzl
+++ b/dev/bazel/toolchains/cc_toolchain_config_lnx.bzl
@@ -751,7 +751,7 @@ def _impl(ctx):
         name = "runtime_library_search_directories",
         flag_sets = [
             flag_set(
-                actions = all_link_actions + lto_index_actions,
+                actions = [ACTION_NAMES.cpp_link_executable] + lto_index_actions,
                 flag_groups = [
                     flag_group(
                         iterate_over = "runtime_library_search_directories",
@@ -778,7 +778,7 @@ def _impl(ctx):
                 ],
             ),
             flag_set(
-                actions = all_link_actions + lto_index_actions,
+                actions = [ACTION_NAMES.cpp_link_executable] + lto_index_actions,
                 flag_groups = [
                     flag_group(
                         iterate_over = "runtime_library_search_directories",

--- a/dev/bazel/toolchains/cc_toolchain_lnx.bzl
+++ b/dev/bazel/toolchains/cc_toolchain_lnx.bzl
@@ -292,8 +292,8 @@ def configure_cc_toolchain_lnx(repo_ctx, reqs):
                 add_linker_option_if_supported(
                     repo_ctx,
                     tools.cc,
-                    "-Wl,-no-as-needed",
-                    "-no-as-needed",
+                    "-Wl,--as-needed",
+                    "--as-needed",
                 ) +
                 add_linker_option_if_supported(
                     repo_ctx,
@@ -327,8 +327,8 @@ def configure_cc_toolchain_lnx(repo_ctx, reqs):
                 add_linker_option_if_supported(
                     repo_ctx,
                     tools.dpcc,
-                    "-Wl,-no-as-needed",
-                    "-no-as-needed",
+                    "-Wl,--as-needed",
+                    "--as-needed",
                 ) +
                 add_linker_option_if_supported(
                     repo_ctx,

--- a/dev/release_tests/BUILD
+++ b/dev/release_tests/BUILD
@@ -1,0 +1,5 @@
+package(default_visibility = ["//visibility:public"])
+
+exports_files([
+    "package_metadata_test.sh",
+])

--- a/dev/release_tests/compare_release_trees.py
+++ b/dev/release_tests/compare_release_trees.py
@@ -54,6 +54,12 @@ BINARY_SUFFIXES = {
     ".so",
 }
 
+NORMALIZED_TEXT_LINES = {
+    "include/services/library_version_info.h": (
+        "__INTEL_DAAL_BUILD_DATE",
+    ),
+}
+
 
 def rel(path, root):
     return path.relative_to(root).as_posix()
@@ -95,6 +101,22 @@ def is_text_path(path):
     return False
 
 
+def read_normalized_text(root, path):
+    content = (root / path).read_text(encoding="utf-8", errors="surrogateescape")
+    prefixes = NORMALIZED_TEXT_LINES.get(path, ())
+    if not prefixes:
+        return content
+    normalized = []
+    for line in content.splitlines(keepends=True):
+        stripped = line.lstrip()
+        if any(stripped.startswith(f"#define {prefix} ") for prefix in prefixes):
+            newline = "\n" if line.endswith("\n") else ""
+            normalized.append(f"#define {stripped.split()[1]} <normalized>{newline}")
+        else:
+            normalized.append(line)
+    return "".join(normalized)
+
+
 def compare_sets(name, make_values, bazel_values, limit):
     errors = 0
     only_make = sorted(make_values - bazel_values)
@@ -124,7 +146,11 @@ def compare_text_files(make_root, bazel_root, files, limit):
         compared += 1
         make_path = make_root / path
         bazel_path = bazel_root / path
-        if not filecmp.cmp(make_path, bazel_path, shallow=False):
+        if path in NORMALIZED_TEXT_LINES:
+            equal = read_normalized_text(make_root, path) == read_normalized_text(bazel_root, path)
+        else:
+            equal = filecmp.cmp(make_path, bazel_path, shallow=False)
+        if not equal:
             mismatches.append(path)
 
     if mismatches:

--- a/dev/release_tests/compare_release_trees.py
+++ b/dev/release_tests/compare_release_trees.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+#===============================================================================
+# Copyright Contributors to the oneDAL Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#===============================================================================
+
+import argparse
+import filecmp
+import os
+import sys
+from pathlib import Path
+
+
+TEXT_SUFFIXES = {
+    ".bat",
+    ".cfg",
+    ".cmake",
+    ".cpp",
+    ".cxx",
+    ".h",
+    ".hpp",
+    ".hxx",
+    ".in",
+    ".lst",
+    ".pc",
+    ".sh",
+    ".txt",
+    ".xml",
+}
+
+TEXT_NAMES = {
+    "CMakeLists.txt",
+    "license.txt",
+    "makefile",
+}
+
+BINARY_SUFFIXES = {
+    ".a",
+    ".dll",
+    ".exp",
+    ".lib",
+    ".pdb",
+    ".so",
+}
+
+
+def rel(path, root):
+    return path.relative_to(root).as_posix()
+
+
+def classify(root):
+    dirs = set()
+    files = set()
+    links = {}
+
+    for current, dirnames, filenames in os.walk(root, followlinks=False):
+        current_path = Path(current)
+        for dirname in dirnames:
+            path = current_path / dirname
+            rel_path = rel(path, root)
+            if path.is_symlink():
+                links[rel_path] = os.readlink(path)
+            else:
+                dirs.add(rel_path)
+        for filename in filenames:
+            path = current_path / filename
+            rel_path = rel(path, root)
+            if path.is_symlink():
+                links[rel_path] = os.readlink(path)
+            else:
+                files.add(rel_path)
+
+    return dirs, files, links
+
+
+def is_text_path(path):
+    p = Path(path)
+    if p.name in TEXT_NAMES:
+        return True
+    if p.suffix.lower() in TEXT_SUFFIXES:
+        return True
+    if p.suffix.lower() in BINARY_SUFFIXES:
+        return False
+    return False
+
+
+def compare_sets(name, make_values, bazel_values, limit):
+    errors = 0
+    only_make = sorted(make_values - bazel_values)
+    only_bazel = sorted(bazel_values - make_values)
+
+    if only_make:
+        errors += len(only_make)
+        print(f"Only Make {name}: {len(only_make)}")
+        for item in only_make[:limit]:
+            print(f"  - {item}")
+    if only_bazel:
+        errors += len(only_bazel)
+        print(f"Only Bazel {name}: {len(only_bazel)}")
+        for item in only_bazel[:limit]:
+            print(f"  + {item}")
+    return errors
+
+
+def compare_text_files(make_root, bazel_root, files, limit):
+    errors = 0
+    mismatches = []
+    compared = 0
+
+    for path in sorted(files):
+        if not is_text_path(path):
+            continue
+        compared += 1
+        make_path = make_root / path
+        bazel_path = bazel_root / path
+        if not filecmp.cmp(make_path, bazel_path, shallow=False):
+            mismatches.append(path)
+
+    if mismatches:
+        errors += len(mismatches)
+        print(f"Text content mismatches: {len(mismatches)}")
+        for item in mismatches[:limit]:
+            print(f"  ! {item}")
+    print(f"Compared text files: {compared}")
+    return errors
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Compare Make and Bazel oneDAL release trees.",
+    )
+    parser.add_argument("--make", required=True, type=Path)
+    parser.add_argument("--bazel", required=True, type=Path)
+    parser.add_argument("--platform", choices=("linux", "windows"), required=True)
+    parser.add_argument("--structure-only", action="store_true")
+    parser.add_argument("--summary-limit", type=int, default=50)
+    args = parser.parse_args()
+
+    make_root = args.make.resolve()
+    bazel_root = args.bazel.resolve()
+
+    if not make_root.is_dir():
+        print(f"Make release directory not found: {make_root}", file=sys.stderr)
+        return 2
+    if not bazel_root.is_dir():
+        print(f"Bazel release directory not found: {bazel_root}", file=sys.stderr)
+        return 2
+
+    print(f"Platform: {args.platform}")
+    print(f"Make release:  {make_root}")
+    print(f"Bazel release: {bazel_root}")
+
+    make_dirs, make_files, make_links = classify(make_root)
+    bazel_dirs, bazel_files, bazel_links = classify(bazel_root)
+
+    print(f"Make:  {len(make_dirs)} dirs, {len(make_files)} files, {len(make_links)} links")
+    print(f"Bazel: {len(bazel_dirs)} dirs, {len(bazel_files)} files, {len(bazel_links)} links")
+
+    errors = 0
+    errors += compare_sets("directories", make_dirs, bazel_dirs, args.summary_limit)
+    errors += compare_sets("files", make_files, bazel_files, args.summary_limit)
+    errors += compare_sets("symlinks", set(make_links), set(bazel_links), args.summary_limit)
+
+    common_links = set(make_links).intersection(bazel_links)
+    bad_links = [
+        path for path in sorted(common_links)
+        if make_links[path] != bazel_links[path]
+    ]
+    if bad_links:
+        errors += len(bad_links)
+        print(f"Symlink target mismatches: {len(bad_links)}")
+        for path in bad_links[:args.summary_limit]:
+            print(f"  ! {path}: Make -> {make_links[path]}, Bazel -> {bazel_links[path]}")
+
+    if not args.structure_only:
+        common_files = make_files.intersection(bazel_files)
+        errors += compare_text_files(make_root, bazel_root, common_files, args.summary_limit)
+
+    if errors:
+        print(f"Release comparison failed: {errors} difference(s)")
+        return 1
+
+    print("Release comparison passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dev/release_tests/package_metadata_test.sh
+++ b/dev/release_tests/package_metadata_test.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env sh
+#===============================================================================
+# Copyright contributors to the oneDAL project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#===============================================================================
+
+set -eu
+
+ROOT_DIR="${1:?usage: package_metadata_test.sh <release-or-install-prefix>}"
+PASS=0
+FAIL=0
+
+OS="$(uname -s)"
+
+pass() {
+    echo "  PASS: $1"
+    PASS=$((PASS + 1))
+}
+
+fail() {
+    echo "  FAIL: $1"
+    FAIL=$((FAIL + 1))
+}
+
+check_pkg_config() {
+    pc_name="$1"
+    pc_file="${ROOT_DIR}/lib/pkgconfig/${pc_name}"
+
+    if [ -f "$pc_file" ]; then
+        pass "lib/pkgconfig/${pc_name} exists"
+    else
+        fail "lib/pkgconfig/${pc_name} not found"
+        return
+    fi
+
+    if grep -q "^Name:" "$pc_file"; then
+        pass "${pc_name} has Name field"
+    else
+        fail "${pc_name} missing Name field"
+    fi
+
+    if grep -q "^Libs:" "$pc_file"; then
+        pass "${pc_name} has Libs field"
+    else
+        fail "${pc_name} missing Libs field"
+    fi
+}
+
+echo ""
+echo "=== package metadata ==="
+
+vars_file="${ROOT_DIR}/env/vars.sh"
+if [ -f "$vars_file" ]; then
+    pass "env/vars.sh exists"
+    if grep -q "DAL_MAJOR_BINARY" "$vars_file"; then
+        pass "vars.sh contains DAL_MAJOR_BINARY"
+    else
+        fail "vars.sh missing DAL_MAJOR_BINARY"
+    fi
+    if grep -q "__DAL_MAJOR_BINARY__\|__DAL_MINOR_BINARY__" "$vars_file"; then
+        fail "vars.sh still has unresolved placeholders"
+    else
+        pass "vars.sh has no unresolved placeholders"
+    fi
+else
+    fail "env/vars.sh not found at ${vars_file}"
+fi
+
+if [ "$OS" = "Linux" ]; then
+    check_pkg_config "dal-dynamic-threading-host.pc"
+    check_pkg_config "dal-static-threading-host.pc"
+else
+    check_pkg_config "onedal.pc"
+fi
+
+echo "=== package metadata results: ${PASS} passed, ${FAIL} failed ==="
+
+[ "$FAIL" -eq 0 ] || exit 1

--- a/examples/oneapi/cpp/BUILD
+++ b/examples/oneapi/cpp/BUILD
@@ -4,6 +4,18 @@ load("@onedal//dev/bazel:dal.bzl",
     "dal_algo_example_suite",
 )
 
+filegroup(
+    name = "release_files",
+    visibility = ["//visibility:public"],
+    srcs = glob([
+        "CMakeLists.txt",
+        "target_excludes.cmake",
+        "source/**/CMakeLists.txt",
+        "source/**/*.cpp",
+        "source/**/*.hpp",
+    ]),
+)
+
 dal_module(
     name = "example_util",
     hdrs = glob(["source/example_util/*.hpp"]),

--- a/makefile.ver
+++ b/makefile.ver
@@ -63,7 +63,7 @@ update_headers_version:
 	@relfile=$(RELEASEDIR.include)/services/library_version_info.h && \
 	workfile=$(CPPDIR.daal)/include/services/library_version_info.h && \
 	file=$$relfile && \
-	if [ -a "$$relfile" ]; then file=$$file.tmp; fi && mark="#define __INTEL_DAAL" && \
+	if [ -e "$$relfile" ]; then file=$$file.tmp; fi && mark="#define __INTEL_DAAL" && \
         sed $(sed.-b) \
 		-e "s/_DAAL_BUILD_DATE.*/_DAAL_BUILD_DATE $(BUILD)$(sed.eol)/" \
 		-e "s/\($${mark}__\).*/\1 $(MAJOR)$(sed.eol)/" \
@@ -75,6 +75,6 @@ update_headers_version:
 	        $$workfile > $$file && \
 	if ! cmp -s $$file $$relfile; then \
 		mv $$file $$relfile; \
-	elif [ -a "$$relfile.tmp" ]; then \
+	elif [ -e "$$relfile.tmp" ]; then \
 		rm $$relfile.tmp; \
 	fi


### PR DESCRIPTION
## Summary

This PR aligns the Bazel Linux MKL release with the Make release for the #3530 parity work.

Changes:
- keep oneAPI libraries from absorbing DAAL/MKL objects
- split parameter libraries into parameter-only object sets
- restore Linux shared library metadata/dependency behavior: SONAME, DT_NEEDED, and no Bazel RUNPATH in release shared libs
- hide stray thread-library linker marker exports
- add missing DAAL algorithm coverage used by the Make build
- align Linux release packaging: modulefile, pkg-config files, examples, OS-specific nuspec/sample filtering, and no generated dispatcher header in installed includes

## Validation

Run on `onedal-build` from top of main `d989d07c3ec0d5efa420bd44730e2f5a9453d53a`.

Commands:
- `bazelisk clean`
- `bazelisk build //:release --backend_config=mkl --release_dpc=false --jobs=8 --verbose_failures`

Result:
- clean Bazel MKL release build passed
- time: `327.09s`
- actions: `3179`

Final compare vs Make MKL release:
- release tree: `only_make 0`, `only_bazel 0`
- `libonedal_core`: members `1919/1919`, exports `8545/8545`, MKL exports `0`
- `libonedal_thread`: members `2/2`, exports `319/319`, MKL exports `0`
- `libonedal`: exports `3422/3422`, MKL exports `0`
- `libonedal_parameters`: members `8/8`, exports `71/71`, MKL exports `0`
- SONAME/DT_NEEDED match for checked libraries
- Bazel RUNPATH absent in checked release shared libraries

Remaining size note:
- Make release: `405M`
- Bazel release: `410M`
- remaining delta is static archives; Bazel archives PIC objects (`.pic.o`) while Make archive composition is non-PIC-object based in the compared places. Dynamic library section totals are not the source of the delta.

Local report:
`/home/ubuntu/onedal-mkl-rootcause-20260614-223805/mkl-close-gaps-final-report.txt`
