### PR TITLE
Fix build errors with bazel '-c dbg' option

### DIFF
--- a/cpp/daal/src/algorithms/cordistance/cordistance_full_impl.i
+++ b/cpp/daal/src/algorithms/cordistance/cordistance_full_impl.i
@@ -75,7 +75,7 @@ services::Status corDistanceFull(const NumericTable * xTable, NumericTable * rTa
 
         for (size_t i = 0; i < blockSize1; i++)
         {
-            PRAGMA_VECTOR_ALWAYS
+            PRAGMA_OMP_SIMD
             for (size_t j = i; j < blockSize1; j++)
             {
                 rr[i * n + j] = buf[i * blockSize1 + j];
@@ -170,7 +170,7 @@ services::Status corDistanceFull(const NumericTable * xTable, NumericTable * rTa
 
             for (size_t i = 0; i < blockSize1; i++)
             {
-                PRAGMA_VECTOR_ALWAYS
+                PRAGMA_OMP_SIMD
                 for (size_t j = 0; j < blockSize2; j++)
                 {
                     buf[i * blockSize2 + j] = 1.0 - buf[i * blockSize2 + j] * r[i * nl + (shift1 + i)] * diag[j];
@@ -179,7 +179,7 @@ services::Status corDistanceFull(const NumericTable * xTable, NumericTable * rTa
 
             for (size_t i = 0; i < blockSize1; i++)
             {
-                PRAGMA_VECTOR_ALWAYS
+                PRAGMA_OMP_SIMD
                 for (size_t j = 0; j < blockSize2; j++)
                 {
                     rr[i * nl + j] = buf[i * blockSize2 + j];

--- a/cpp/daal/src/algorithms/cosdistance/cosdistance_full_impl.i
+++ b/cpp/daal/src/algorithms/cosdistance/cosdistance_full_impl.i
@@ -71,7 +71,7 @@ services::Status cosDistanceFull(const NumericTable * xTable, NumericTable * rTa
 
         for (size_t i = 0; i < blockSize1; i++)
         {
-            PRAGMA_VECTOR_ALWAYS
+            PRAGMA_OMP_SIMD
             for (size_t j = i; j < blockSize1; j++)
             {
                 rr[i * n + j] = buf[i * blockSize1 + j];
@@ -138,7 +138,7 @@ services::Status cosDistanceFull(const NumericTable * xTable, NumericTable * rTa
 
             for (size_t i = 0; i < blockSize1; i++)
             {
-                PRAGMA_VECTOR_ALWAYS
+                PRAGMA_OMP_SIMD
                 for (size_t j = 0; j < blockSize2; j++)
                 {
                     buf[i * blockSize2 + j] = 1.0 - buf[i * blockSize2 + j] * r[i * nl + (shift1 + i)] * diag[j];
@@ -147,7 +147,7 @@ services::Status cosDistanceFull(const NumericTable * xTable, NumericTable * rTa
 
             for (size_t i = 0; i < blockSize1; i++)
             {
-                PRAGMA_VECTOR_ALWAYS
+                PRAGMA_OMP_SIMD
                 for (size_t j = 0; j < blockSize2; j++)
                 {
                     rr[i * nl + j] = buf[i * blockSize2 + j];

--- a/cpp/daal/src/algorithms/dtrees/gbt/gbt_train_split_sorting.i
+++ b/cpp/daal/src/algorithms/dtrees/gbt/gbt_train_split_sorting.i
@@ -191,12 +191,16 @@ protected:
         const algorithmFPType * pgh = (const algorithmFPType *)_sharedData.ctx.grad(_sharedData.iTree);
         imp                         = _sharedData.ctx.grad(_sharedData.iTree)[aIdx[0]];
 
-        PRAGMA_VECTOR_ALWAYS
+        algorithmFPType gradient = imp.g;
+        algorithmFPType hessian  = imp.h;
+        PRAGMA_OMP_SIMD_ARGS(reduction(+ : gradient, hessian))
         for (size_t i = 1; i < n; ++i)
         {
-            imp.g += pgh[2 * aIdx[i]];
-            imp.h += pgh[2 * aIdx[i] + 1];
+            gradient += pgh[2 * aIdx[i]];
+            hessian += pgh[2 * aIdx[i] + 1];
         }
+        imp.g = gradient;
+        imp.h = hessian;
     }
 
     const size_t _iFeature;

--- a/cpp/daal/src/algorithms/dtrees/gbt/gbt_train_tree_builder.i
+++ b/cpp/daal/src/algorithms/dtrees/gbt/gbt_train_tree_builder.i
@@ -278,7 +278,7 @@ protected:
             localG = localH = 0;
             if (aSampleToF)
             {
-                PRAGMA_VECTOR_ALWAYS
+                PRAGMA_OMP_SIMD_ARGS(reduction(+ : localG, localH))
                 for (size_t i = start; i < end; i++)
                 {
                     localG += pgh[aSampleToF[i]].g;
@@ -287,7 +287,7 @@ protected:
             }
             else
             {
-                PRAGMA_VECTOR_ALWAYS
+                PRAGMA_OMP_SIMD_ARGS(reduction(+ : localG, localH))
                 for (size_t i = start; i < end; i++)
                 {
                     localG += pgh[i].g;

--- a/cpp/daal/src/algorithms/em/em_gmm_dense_default_batch_impl.i
+++ b/cpp/daal/src/algorithms/em/em_gmm_dense_default_batch_impl.i
@@ -66,13 +66,13 @@ services::Status EMKernelTask<algorithmFPType, method, cpu>::compute()
     DAAL_CHECK_STATUS(s, setStartValues())
 
     double diff             = 2 * threshold + 1;
-    double oldLogLikelyhood = 0;
+    double oldLogLikelihood = 0;
 
     daal::tls<Task<algorithmFPType, cpu> *> threadBuffer([=]() -> Task<algorithmFPType, cpu> * {
         return new Task<algorithmFPType, cpu>(dataTable, blockSizeDefault, nFeatures, nComponents, logAlpha, means, covs.get());
     });
     int & iterCounter               = iterCounterArray[0];
-    algorithmFPType & logLikelyhood = logLikelyhoodArray[0];
+    algorithmFPType & logLikelihood = logLikelihoodArray[0];
     while (diff > threshold && iterCounter < maxIterations)
     {
         DAAL_CHECK_STATUS(s, covs->computeSigmaInverse(iterCounter))
@@ -81,7 +81,7 @@ services::Status EMKernelTask<algorithmFPType, method, cpu>::compute()
 
         MathInst<algorithmFPType, cpu>::vLog(nComponents, alpha, logAlpha); // inplace: same memory as alpha
 
-        logLikelyhood = 0;
+        logLikelihood = 0;
 
         SafeStatus safeStat;
         daal::threader_for(nBlocks, nBlocks, [=, &threadBuffer, &safeStat](size_t iBlock) {
@@ -101,7 +101,7 @@ services::Status EMKernelTask<algorithmFPType, method, cpu>::compute()
 
             stepE(nVectorsInCurrentBlock, t, par.covarianceStorage);
 
-            t.logLikelyhood += computePartialLogLikelyhood(nVectorsInCurrentBlock, t);
+            t.logLikelihood += computePartialLogLikelihood(nVectorsInCurrentBlock, t);
 
             localStatus |= stepM_partial(nVectorsInCurrentBlock, t, par.covarianceStorage);
             DAAL_CHECK_STATUS_THR(localStatus);
@@ -110,9 +110,9 @@ services::Status EMKernelTask<algorithmFPType, method, cpu>::compute()
 
         setResultToZero();
 
-        threadBuffer.reduce([=, &logLikelyhood](Task<algorithmFPType, cpu> * e) -> void {
-            logLikelyhood += e->logLikelyhood;
-            e->logLikelyhood = 0;
+        threadBuffer.reduce([=, &logLikelihood](Task<algorithmFPType, cpu> * e) -> void {
+            logLikelihood += e->logLikelihood;
+            e->logLikelihood = 0;
             for (size_t k = 0; k < nComponents; k++)
             {
                 if (e->mergedWSums[k] > MinVal<algorithmFPType>::get())
@@ -123,15 +123,15 @@ services::Status EMKernelTask<algorithmFPType, method, cpu>::compute()
             }
             e->setMergedToZero();
         });
-        logLikelyhood -= logLikelyhoodCorrection;
+        logLikelihood -= logLikelihoodCorrection;
 
         DAAL_CHECK_STATUS(s, stepM_merge(iterCounter))
 
         if (iterCounter > 0)
         {
-            diff = logLikelyhood - oldLogLikelyhood;
+            diff = logLikelihood - oldLogLikelihood;
         }
-        oldLogLikelyhood = logLikelyhood;
+        oldLogLikelihood = logLikelihood;
 
         iterCounter++;
     }
@@ -272,13 +272,13 @@ void EMKernelTask<algorithmFPType, method, cpu>::stepE(const size_t nVectorsInCu
         }
     }
 
-    algorithmFPType likelyhood(0.0);
-    PRAGMA_OMP_SIMD_ARGS(reduction(+ : likelyhood))
+    algorithmFPType likelihood(0.0);
+    PRAGMA_OMP_SIMD_ARGS(reduction(+ : likelihood))
     for (size_t i = 0; i < nVectorsInCurrentBlock; i++)
     {
-        likelyhood += maxInRow[i];
+        likelihood += maxInRow[i];
     }
-    t.partLogLikelyhood = likelyhood;
+    t.partLogLikelihood = likelihood;
 
     PRAGMA_OMP_SIMD
     PRAGMA_VECTOR_ALWAYS
@@ -327,13 +327,13 @@ void EMKernelTask<algorithmFPType, method, cpu>::stepE(const size_t nVectorsInCu
  */
 
 template <typename algorithmFPType, Method method, CpuType cpu>
-algorithmFPType EMKernelTask<algorithmFPType, method, cpu>::computePartialLogLikelyhood(const size_t nVectorsInCurrentBlock,
+algorithmFPType EMKernelTask<algorithmFPType, method, cpu>::computePartialLogLikelihood(const size_t nVectorsInCurrentBlock,
                                                                                         Task<algorithmFPType, cpu> & t)
 {
     algorithmFPType * logRowSumInv = t.rowSumInv;
     MathInst<algorithmFPType, cpu>::vLog(nVectorsInCurrentBlock, t.rowSumInv, logRowSumInv);
 
-    algorithmFPType loglikPartial = t.partLogLikelyhood;
+    algorithmFPType loglikPartial = t.partLogLikelihood;
     PRAGMA_OMP_SIMD
     PRAGMA_VECTOR_ALWAYS
     for (size_t i = 0; i < nVectorsInCurrentBlock; i++)
@@ -430,7 +430,7 @@ EMKernelTask<algorithmFPType, method, cpu>::EMKernelTask(NumericTable & dataTabl
       nComponents(par.nComponents)
 {
     algorithmFPType pi      = 3.1415926535897932384626433;
-    logLikelyhoodCorrection = 0.5 * nVectors * nFeatures * MathInst<algorithmFPType, cpu>::sLog(2 * pi);
+    logLikelihoodCorrection = 0.5 * nVectors * nFeatures * MathInst<algorithmFPType, cpu>::sLog(2 * pi);
 
     nBlocks = nVectors / blockSizeDefault;
     nBlocks += (nBlocks * blockSizeDefault != nVectors);
@@ -483,8 +483,8 @@ Status EMKernelTask<algorithmFPType, method, cpu>::initialize()
     DAAL_CHECK(iterCounterArray, ErrorMemoryAllocationFailed);
     iterCounterArray[0] = 0;
 
-    logLikelyhoodArray = goalFunctionBD.set(resultGoalFunction, 0, 1);
-    DAAL_CHECK(logLikelyhoodArray, ErrorMemoryAllocationFailed);
+    logLikelihoodArray = goalFunctionBD.set(resultGoalFunction, 0, 1);
+    DAAL_CHECK(logLikelihoodArray, ErrorMemoryAllocationFailed);
 
     covs = initializeCovariances();
     DAAL_CHECK(covs, ErrorMemoryAllocationFailed);

--- a/cpp/daal/src/algorithms/em/em_gmm_dense_default_batch_impl.i
+++ b/cpp/daal/src/algorithms/em/em_gmm_dense_default_batch_impl.i
@@ -237,7 +237,6 @@ void EMKernelTask<algorithmFPType, method, cpu>::stepE(const size_t nVectorsInCu
         }
     }
 
-    t.partLogLikelyhood        = 0;
     algorithmFPType * maxInRow = t.rowSum;
     PRAGMA_OMP_SIMD
     PRAGMA_VECTOR_ALWAYS
@@ -273,12 +272,13 @@ void EMKernelTask<algorithmFPType, method, cpu>::stepE(const size_t nVectorsInCu
         }
     }
 
-    PRAGMA_OMP_SIMD
-    PRAGMA_VECTOR_ALWAYS
+    algorithmFPType likelyhood(0.0);
+    PRAGMA_OMP_SIMD_ARGS(reduction(+ : likelyhood))
     for (size_t i = 0; i < nVectorsInCurrentBlock; i++)
     {
-        t.partLogLikelyhood += maxInRow[i];
+        likelyhood += maxInRow[i];
     }
+    t.partLogLikelyhood = likelyhood;
 
     PRAGMA_OMP_SIMD
     PRAGMA_VECTOR_ALWAYS

--- a/cpp/daal/src/algorithms/em/em_gmm_dense_default_batch_kernel.h
+++ b/cpp/daal/src/algorithms/em/em_gmm_dense_default_batch_kernel.h
@@ -78,7 +78,7 @@ public:
     Status stepM_merge(size_t iteration);
 
     static void stepE(const size_t nVectorsInCurrentBlock, Task<algorithmFPType, cpu> & t, em_gmm::CovarianceStorageId covType);
-    static algorithmFPType computePartialLogLikelyhood(const size_t nVectorsInCurrentBlock, Task<algorithmFPType, cpu> & t);
+    static algorithmFPType computePartialLogLikelihood(const size_t nVectorsInCurrentBlock, Task<algorithmFPType, cpu> & t);
     static Status stepM_partial(const size_t nVectorsInCurrentBlock, Task<algorithmFPType, cpu> & t, em_gmm::CovarianceStorageId covType);
     static void stepM_mergePartialSums(algorithmFPType * cp_n, algorithmFPType * cp_m, algorithmFPType * mean_n, algorithmFPType * mean_m,
                                        algorithmFPType & w_n, algorithmFPType & w_m, size_t nFeatures, GmmModel<algorithmFPType, cpu> * covs);
@@ -87,7 +87,7 @@ public:
     algorithmFPType * means;
     algorithmFPType * logAlpha;
     int * iterCounterArray;
-    algorithmFPType * logLikelyhoodArray;
+    algorithmFPType * logLikelihoodArray;
 
     size_t blockSizeDefault;
     size_t nBlocks;
@@ -95,7 +95,7 @@ public:
     const DAAL_INT nFeatures;
     const DAAL_INT nVectors;
     const DAAL_INT nComponents;
-    algorithmFPType logLikelyhoodCorrection;
+    algorithmFPType logLikelihoodCorrection;
     const DAAL_INT maxIterations;
     const algorithmFPType threshold;
     TArray<WriteRows<algorithmFPType, cpu, NumericTable>, cpu> covsPtr;

--- a/cpp/daal/src/algorithms/em/em_gmm_dense_default_batch_task.h
+++ b/cpp/daal/src/algorithms/em/em_gmm_dense_default_batch_task.h
@@ -298,7 +298,7 @@ struct Task
           logSqrtInvDetSigma(_covs->getLogSqrtInvDetSigma()),
           nFeatures(_nFeatures),
           nComponents(_nComponents),
-          logLikelyhood(0)
+          logLikelihood(0)
     {
         size_t sizeOfOneCov           = covs->getOneCovSize();
         size_t memorySizeForOneThread = blockSizeDefault * nFeatures +   /* x_mu   */
@@ -367,7 +367,7 @@ struct Task
     const algorithmFPType * dataBlock;
     ReadRows<algorithmFPType, cpu, NumericTable> dataTableBD;
     TArray<algorithmFPType, cpu> threadBufferPtr;
-    algorithmFPType logLikelyhood;
+    algorithmFPType logLikelihood;
 
     algorithmFPType * x_mu;
     algorithmFPType * Ax_mu;
@@ -380,7 +380,7 @@ struct Task
     algorithmFPType * means;
     algorithmFPType ** invSigma;
     algorithmFPType * logSqrtInvDetSigma;
-    algorithmFPType partLogLikelyhood;
+    algorithmFPType partLogLikelihood;
 
     algorithmFPType * wSums;
     algorithmFPType * partialMeans;

--- a/cpp/daal/src/algorithms/em/em_gmm_init_dense_batch_fpt.cpp
+++ b/cpp/daal/src/algorithms/em/em_gmm_init_dense_batch_fpt.cpp
@@ -37,7 +37,7 @@ namespace internal
 template <typename algorithmFPType>
 ErrorID EMforKernel<algorithmFPType>::run(data_management::NumericTable & inputData, data_management::NumericTable & inputWeights,
                                           data_management::NumericTable & inputMeans, data_management::DataCollectionPtr & inputCov,
-                                          const em_gmm::CovarianceStorageId covType, algorithmFPType & loglikelyhood)
+                                          const em_gmm::CovarianceStorageId covType, algorithmFPType & loglikelihood)
 {
     this->input.set(daal::algorithms::em_gmm::data, NumericTablePtr(&inputData, EmptyDeleter()));
     this->input.set(daal::algorithms::em_gmm::inputWeights, NumericTablePtr(&inputWeights, EmptyDeleter()));
@@ -51,7 +51,7 @@ ErrorID EMforKernel<algorithmFPType>::run(data_management::NumericTable & inputD
     emResult->set(daal::algorithms::em_gmm::covariances, inputCov);
 
     services::Status status;
-    SharedPtr<HomogenNumericTable<algorithmFPType> > loglikelyhoodValueTable =
+    SharedPtr<HomogenNumericTable<algorithmFPType> > loglikelihoodValueTable =
         HomogenNumericTable<algorithmFPType>::create(1, 1, NumericTable::doAllocate, &status);
     if (!status)
     {
@@ -63,7 +63,7 @@ ErrorID EMforKernel<algorithmFPType>::run(data_management::NumericTable & inputD
     {
         return ErrorMemoryAllocationFailed;
     }
-    emResult->set(daal::algorithms::em_gmm::goalFunction, loglikelyhoodValueTable);
+    emResult->set(daal::algorithms::em_gmm::goalFunction, loglikelihoodValueTable);
     emResult->set(daal::algorithms::em_gmm::nIterations, nIterationsValueTable);
 
     this->setResult(emResult);
@@ -72,7 +72,7 @@ ErrorID EMforKernel<algorithmFPType>::run(data_management::NumericTable & inputD
     {
         return ErrorEMInitNoTrialConverges;
     }
-    loglikelyhood = loglikelyhoodValueTable->getArray()[0];
+    loglikelihood = loglikelihoodValueTable->getArray()[0];
     return ErrorID(0);
 }
 

--- a/cpp/daal/src/algorithms/em/em_gmm_init_dense_default_batch_impl.i
+++ b/cpp/daal/src/algorithms/em/em_gmm_init_dense_default_batch_impl.i
@@ -69,10 +69,10 @@ services::Status EMInitKernelTask<algorithmFPType, method, cpu>::compute()
 
         ErrorID errorId = runEM();
 
-        if (!errorId && (loglikelyhood > maxLoglikelyhood))
+        if (!errorId && (loglikelihood > maxLoglikelihood))
         {
             isInitialized    = true;
-            maxLoglikelyhood = loglikelyhood;
+            maxLoglikelihood = loglikelihood;
             DAAL_CHECK_STATUS(s, writeValuesToTables())
         }
     }
@@ -94,7 +94,7 @@ EMInitKernelTask<algorithmFPType, method, cpu>::EMInitKernelTask(NumericTable & 
       nTrials(parameter.nTrials),
       nIterations(parameter.nIterations),
       accuracyThreshold(parameter.accuracyThreshold),
-      maxLoglikelyhood(-MaxVal<algorithmFPType>::get()),
+      maxLoglikelihood(-MaxVal<algorithmFPType>::get()),
       nFeatures(data.getNumberOfColumns()),
       nVectors(data.getNumberOfRows()),
       covs(parameter.covarianceStorage, parameter.nComponents, data.getNumberOfColumns(), status),
@@ -189,10 +189,10 @@ ErrorID EMInitKernelTask<algorithmFPType, method, cpu>::runEM()
     EMforKernel<algorithmFPType> em(nComponents);
     em.parameter.maxIterations     = nIterations;
     em.parameter.accuracyThreshold = accuracyThreshold;
-    ErrorID returnErrorId          = em.run(data, *alpha, *means, covs.getSigma(), parameter.covarianceStorage, loglikelyhood);
+    ErrorID returnErrorId          = em.run(data, *alpha, *means, covs.getSigma(), parameter.covarianceStorage, loglikelihood);
     if (returnErrorId != 0)
     {
-        loglikelyhood = -MaxVal<algorithmFPType>::get();
+        loglikelihood = -MaxVal<algorithmFPType>::get();
     }
     return returnErrorId;
 }

--- a/cpp/daal/src/algorithms/em/em_gmm_init_dense_default_batch_kernel.h
+++ b/cpp/daal/src/algorithms/em/em_gmm_init_dense_default_batch_kernel.h
@@ -162,8 +162,8 @@ private:
     double accuracyThreshold;
     HomogenNTPtr alpha;
     HomogenNTPtr means;
-    algorithmFPType loglikelyhood;
-    algorithmFPType maxLoglikelyhood;
+    algorithmFPType loglikelihood;
+    algorithmFPType maxLoglikelihood;
     algorithmFPType * varianceArray;
     TArray<algorithmFPType, cpu> varianceArrayPtr;
     TArray<int, cpu> selectedSetPtr;
@@ -180,7 +180,7 @@ public:
     virtual ~EMforKernel() {}
 
     ErrorID run(data_management::NumericTable & inputData, data_management::NumericTable & inputWeights, data_management::NumericTable & inputMeans,
-                data_management::DataCollectionPtr & inputCov, const em_gmm::CovarianceStorageId covType, algorithmFPType & loglikelyhood);
+                data_management::DataCollectionPtr & inputCov, const em_gmm::CovarianceStorageId covType, algorithmFPType & loglikelihood);
 };
 
 } // namespace internal

--- a/cpp/daal/src/algorithms/kmeans/kmeans_plusplus_init_impl.i
+++ b/cpp/daal/src/algorithms/kmeans/kmeans_plusplus_init_impl.i
@@ -198,8 +198,7 @@ public:
         for (size_t iRow = 0u; iRow < nRowsToProcess; iRow++)
         {
             algorithmFPType dist2 = algorithmFPType(0);
-            PRAGMA_OMP_SIMD
-            PRAGMA_VECTOR_ALWAYS
+            PRAGMA_OMP_SIMD_ARGS(reduction(+ : dist2))
             for (size_t i = 0u; i < dim; i++)
             {
                 dist2 += (pData[iRow * dim + i] - pLastAddedCenter[i]) * (pData[iRow * dim + i] - pLastAddedCenter[i]);

--- a/cpp/daal/src/algorithms/pca/transform/pca_transform_dense_default_batch_impl.i
+++ b/cpp/daal/src/algorithms/pca/transform/pca_transform_dense_default_batch_impl.i
@@ -78,13 +78,12 @@ services::Status ComputeInvSigmas(NumericTable * pVariances, TArray<algorithmFPT
         DAAL_CHECK_BLOCK_STATUS(dataRows);
         const algorithmFPType * pRawVariances = dataRows.get();
 
-        PRAGMA_IVDEP
-        PRAGMA_VECTOR_ALWAYS
+        daal::internal::MathInst<algorithmFPType, cpu>::vInvSqrt(numFeatures, pRawVariances, pInvSigmas);
+        /* If variance is equal to 0, set inverse square root to 0 to avoid infinity */
+        PRAGMA_OMP_SIMD
         for (size_t varianceId = 0; varianceId < numFeatures; ++varianceId)
         {
-            pInvSigmas[varianceId] = pRawVariances[varianceId] ?
-                                         algorithmFPType(1.0) / daal::internal::MathInst<algorithmFPType, cpu>::sSqrt(pRawVariances[varianceId]) :
-                                         algorithmFPType(0.0);
+            pInvSigmas[varianceId] = pRawVariances[varianceId] ? pInvSigmas[varianceId] : algorithmFPType(0.0);
         }
     }
     return status;
@@ -181,15 +180,13 @@ services::Status TransformKernel<algorithmFPType, method, cpu>::compute(NumericT
             for (size_t rowId = 0; rowId < numRows; ++rowId)
             {
                 /* compute centering if numMeans != 0 */
-                PRAGMA_IVDEP
-                PRAGMA_VECTOR_ALWAYS
+                PRAGMA_OMP_SIMD
                 for (size_t colId = 0; colId < numMeans; ++colId)
                 {
                     pCopyBlock[rowId * numMeans + colId] = pDataBlock[rowId * numMeans + colId] - pRawMeans[colId];
                 }
                 /* compute normalization to unit variance if numInvSigmas!= 0 */
-                PRAGMA_IVDEP
-                PRAGMA_VECTOR_ALWAYS
+                PRAGMA_OMP_SIMD
                 for (size_t colId = 0; colId < numInvSigmas; ++colId)
                 {
                     pCopyBlock[rowId * numInvSigmas + colId] = pNormBlock[rowId * numInvSigmas + colId] * pInvSigmas[colId];
@@ -203,8 +200,7 @@ services::Status TransformKernel<algorithmFPType, method, cpu>::compute(NumericT
         {
             for (size_t rowId = 0; rowId < numRows; ++rowId)
             {
-                PRAGMA_IVDEP
-                PRAGMA_VECTOR_ALWAYS
+                PRAGMA_OMP_SIMD
                 for (size_t colId = 0; colId < numComponents; ++colId)
                 {
                     pTransformedBlock[rowId * numComponents + colId] = pTransformedBlock[rowId * numComponents + colId] * pInvEigenvalues[colId];

--- a/cpp/daal/src/externals/service_math.h
+++ b/cpp/daal/src/externals/service_math.h
@@ -90,6 +90,8 @@ struct Math
 
     static void vSqrt(SizeType n, const fpType * in, fpType * out) { _impl<fpType, cpu>::vSqrt(n, in, out); }
 
+    static void vInvSqrt(SizeType n, const fpType * a, fpType * b) { _impl<fpType, cpu>::vInvSqrt(n, a, b); }
+
     static void vInvSqrtI(SizeType n, const fpType * a, const SizeType inca, fpType * b, const SizeType incb)
     {
         _impl<fpType, cpu>::vInvSqrtI(n, a, inca, b, incb);

--- a/cpp/daal/src/externals/service_math_mkl.h
+++ b/cpp/daal/src/externals/service_math_mkl.h
@@ -142,6 +142,11 @@ struct MklMath<double, cpu>
         __DAAL_MKLFN_CALL_MATH(vmdSqrt, ((int)n, in, out, (VML_HA | VML_FTZDAZ_ON | VML_ERRMODE_IGNORE)));
     }
 
+    static void vInvSqrt(SizeType n, const double * a, double * b)
+    {
+        __DAAL_MKLFN_CALL_MATH(vmdInvSqrt, (n, a, b, (VML_HA | VML_FTZDAZ_ON | VML_ERRMODE_IGNORE)));
+    }
+
     static void vInvSqrtI(SizeType n, const double * a, const SizeType inca, double * b, const SizeType incb)
     {
         __DAAL_MKLFN_CALL_MATH(vmdInvSqrtI, (n, a, inca, b, incb, (VML_HA | VML_FTZDAZ_ON | VML_ERRMODE_IGNORE)));
@@ -261,6 +266,11 @@ struct MklMath<float, cpu>
     static void vSqrt(SizeType n, const float * in, float * out)
     {
         __DAAL_MKLFN_CALL_MATH(vmsSqrt, ((int)n, in, out, (VML_HA | VML_FTZDAZ_ON | VML_ERRMODE_IGNORE)));
+    }
+
+    static void vInvSqrt(SizeType n, const float * a, float * b)
+    {
+        __DAAL_MKLFN_CALL_MATH(vmsInvSqrt, (n, a, b, (VML_HA | VML_FTZDAZ_ON | VML_ERRMODE_IGNORE)));
     }
 
     static void vInvSqrtI(SizeType n, const float * a, const SizeType inca, float * b, const SizeType incb)

--- a/cpp/daal/src/externals/service_math_ref.h
+++ b/cpp/daal/src/externals/service_math_ref.h
@@ -137,6 +137,12 @@ struct RefMath<double, cpu>
         for (SizeType i = 0; i < n; ++i) out[i] = sqrt(in[i]);
     }
 
+    static void vInvSqrt(SizeType n, const double * a, double * b)
+    {
+#pragma omp simd
+        for (SizeType i = 0; i < n; ++i) b[i] = 1.0 / sqrt(a[i]);
+    }
+
     static void vInvSqrtI(SizeType n, const double * a, const SizeType inca, double * b, const SizeType incb)
     {
 #pragma omp simd
@@ -327,6 +333,12 @@ struct RefMath<float, cpu>
     {
 #pragma omp simd
         for (SizeType i = 0; i < n; ++i) out[i] = sqrt(in[i]);
+    }
+
+    static void vInvSqrt(SizeType n, const float * a, float * b)
+    {
+#pragma omp simd
+        for (SizeType i = 0; i < n; ++i) b[i] = 1.0f / sqrtf(a[i]);
     }
 
     static void vInvSqrtI(SizeType n, const float * a, const SizeType inca, float * b, const SizeType incb)

--- a/cpp/daal/src/externals/service_stat.h
+++ b/cpp/daal/src/externals/service_stat.h
@@ -136,7 +136,7 @@ struct Statistics
         const fpType invSum = 1 / (sum);
 
         // calcultate weightd means from sums
-        PRAGMA_VECTOR_ALWAYS
+        PRAGMA_OMP_SIMD
         for (size_t i = 0; i < nCols; i++)
         {
             weightedSum[i] = weightedSum[i] * invSum;

--- a/dev/bazel/README.md
+++ b/dev/bazel/README.md
@@ -147,7 +147,7 @@ The most used Bazel commands are `build`, `test` and `run`.
   `dbg` and `fastbuild`. \
   Possible values:
    - `opt` _(default)_ compiles everything with optimizations `-O2`.
-   - `dbg` enables `-g`, `-O0` compiler switches and **assertions**.
+   - `dbg` enables `-g`, `-O1` compiler switches and **assertions**.
    - `fastbuild` optimizes build time, no optimizations, no debug information.
      Useful when one introduces massive changes and wants to check whether they
      break the build.

--- a/dev/bazel/toolchains/cc_toolchain_lnx.bzl
+++ b/dev/bazel/toolchains/cc_toolchain_lnx.bzl
@@ -404,6 +404,10 @@ def configure_cc_toolchain_lnx(repo_ctx, reqs):
                     # Prefer -O1 because -O0 code may be painfully slow
                     "-O1",
 
+                    # Disable loop transformation warnings that appear with -O1
+                    # and are treated as errors in dbg configuration
+                    "-Wno-pass-failed",
+
                     # oneDAL specific defined to enabled assertions
                     "-DDEBUG_ASSERT",
                 ],


### PR DESCRIPTION
## Description

Fix build errors that appear with bazel `-c dbg` option.

The example of error that was fixed:

```
cpp/daal/src/algorithms/dtrees/gbt/gbt_train_tree_builder.i:282:17: error: loop not vectorized: the optimizer was unable to perform the requested transformation; the transformation might be disabled or specified as part of an unsupported transformation ordering [-Werror,-Wpass-failed=transform-warning]
  282 |                 for (size_t i = start; i < end; i++)
      |                 ^
cpp/daal/src/algorithms/dtrees/gbt/gbt_train_tree_builder.i:291:17: error: loop not vectorized: the optimizer was unable to perform the requested transformation; the transformation might be disabled or specified as part of an unsupported transformation ordering [-Werror,-Wpass-failed=transform-warning]
  291 |                 for (size_t i = start; i < end; i++)
      |                 ^
```

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.
- I have extended testing suite if new functionality was introduced in this PR.
No new functionality was introduced.

**Performance**

- I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least a summary table with measured data, if performance change is expected.

I haven't measured the performance, though the changes might affect the performance, but in my opinion there shouldn't be any significant performance impact.

</details>
