### PR TITLE
fixes for events in rf hist_random

### DIFF
--- a/cpp/oneapi/dal/algo/decision_forest/backend/gpu/train_kernel_hist_impl_dpc.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/gpu/train_kernel_hist_impl_dpc.cpp
@@ -486,12 +486,10 @@ train_kernel_hist_impl<Float, Bin, Index, Task>::gen_feature_list(
 
     de::check_mul_overflow((node_count + 1), ctx.selected_ftr_count_);
 
-    auto selected_features_com =
-        pr::ndarray<Index, 1>::empty(queue_,
-                                     { node_count * ctx.selected_ftr_count_ },
-                                     alloc::shared);
+    auto selected_features_host =
+        pr::ndarray<Index, 1>::empty({ node_count * ctx.selected_ftr_count_ });
 
-    auto selected_features_host_ptr = selected_features_com.get_mutable_data();
+    auto selected_features_host_ptr = selected_features_host.get_mutable_data();
 
     if (ctx.selected_ftr_count_ != ctx.column_count_) {
         for (Index node = 0; node < node_count; ++node) {
@@ -511,7 +509,15 @@ train_kernel_hist_impl<Float, Bin, Index, Task>::gen_feature_list(
         }
     }
 
-    return std::tuple{ selected_features_com, sycl::event() };
+    auto selected_features_com =
+        pr::ndarray<Index, 1>::empty(queue_,
+                                     { node_count * ctx.selected_ftr_count_ },
+                                     alloc::device);
+    auto copy_event = selected_features_com.assign_from_host(queue_,
+                                                             selected_features_host_ptr,
+                                                             selected_features_host.get_count());
+
+    return std::tuple{ selected_features_com, copy_event };
 }
 
 template <typename Float, typename Bin, typename Index, typename Task>
@@ -527,10 +533,8 @@ train_kernel_hist_impl<Float, Bin, Index, Task>::gen_random_thresholds(
 
     auto node_vs_tree_map_list_host = node_vs_tree_map.to_host(queue_);
 
-    auto random_bins_com = pr::ndarray<Float, 1>::empty(queue_,
-                                                        { node_count * ctx.selected_ftr_count_ },
-                                                        alloc::shared);
-    auto random_bins_host_ptr = random_bins_com.get_mutable_data();
+    auto random_bins_host = pr::ndarray<Float, 1>::empty({ node_count * ctx.selected_ftr_count_ });
+    auto random_bins_host_ptr = random_bins_host.get_mutable_data();
 
     // Generate random bins for selected features
     pr::uniform<Float>(ctx.selected_ftr_count_ * node_count,
@@ -539,7 +543,14 @@ train_kernel_hist_impl<Float, Bin, Index, Task>::gen_random_thresholds(
                        0.0f,
                        1.0f);
 
-    return std::tuple{ random_bins_com, sycl::event() };
+    auto random_bins_com = pr::ndarray<Float, 1>::empty(queue_,
+                                                        { node_count * ctx.selected_ftr_count_ },
+                                                        alloc::device);
+    auto copy_event = random_bins_com.assign_from_host(queue_,
+                                                       random_bins_host_ptr,
+                                                       random_bins_host.get_count());
+
+    return std::tuple{ random_bins_com, copy_event };
 };
 
 template <typename Float, typename Index, typename Task>
@@ -1918,13 +1929,11 @@ train_result<Task> train_kernel_hist_impl<Float, Bin, Index, Task>::operator()(
             auto node_list = level_node_lists[level];
             imp_data_t left_child_imp_data(queue_, ctx, node_count);
 
-            auto [selected_features_com, event] =
+            auto [selected_features_com, ftr_list_event] =
                 gen_feature_list(ctx, node_count, node_vs_tree_map_list, engine_gpu);
-            event.wait_and_throw();
 
             auto [random_bins_com, gen_bins_event] =
                 gen_random_thresholds(ctx, node_count, node_vs_tree_map_list, engine_gpu);
-            gen_bins_event.wait_and_throw();
 
             if (ctx.mdi_required_) {
                 node_imp_decrease_list =
@@ -1944,7 +1953,7 @@ train_result<Task> train_kernel_hist_impl<Float, Bin, Index, Task>::operator()(
                                             node_imp_decrease_list,
                                             ctx.mdi_required_,
                                             node_count,
-                                            { last_event });
+                                            { last_event, ftr_list_event, gen_bins_event });
             last_event.wait_and_throw();
 
             tree_level_record_t level_record(queue_,


### PR DESCRIPTION
## Summary

Fixes a host/device memory ordering hazard in the GPU histogram-based Random Forest training kernel. The two helpers that produce per-node random data for split selection (`gen_feature_list` and `gen_random_thresholds`) were filling shared-USM buffers on the host and returning an empty `sycl::event`, then the caller blocked the host on `event.wait_and_throw()` before launching the consumer kernel. With shared USM, host writes that race a device kernel on the same allocation can be observed inconsistently — and the empty event provided no actual ordering guarantee against subsequent device work.

## What changed

File: `cpp/oneapi/dal/algo/decision_forest/backend/gpu/train_kernel_hist_impl_dpc.cpp`

### `gen_feature_list`
- Allocate the staging buffer as a plain host `ndarray` (`selected_features_host`) instead of shared USM.
- Allocate a device-only buffer (`selected_features_com`, `alloc::device`) and copy host → device with `assign_from_host`, returning the resulting `sycl::event` (was previously an empty event).

### `gen_random_thresholds`
- Same pattern: host `ndarray` for the RNG fill, then a device buffer + `assign_from_host` whose event is returned.

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least a summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance and/or quality metrics have changed or why changes are not expected.
- [x] I have extended the benchmarking suite and provided a corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.

</details>
