### PR TITLE
Bazel: align Windows release package with make

### DIFF
--- a/.ci/env/bazelisk.ps1
+++ b/.ci/env/bazelisk.ps1
@@ -1,0 +1,63 @@
+#===============================================================================
+# Copyright contributors to the oneDAL project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#===============================================================================
+
+$ErrorActionPreference = "Stop"
+
+$bazeliskVersion = "v1.29.0"
+$assetName = "bazelisk-windows-amd64.exe"
+$installDir = Join-Path (Get-Location) "bazel\bin"
+$bazelPath = Join-Path $installDir "bazel.exe"
+
+$headers = @{
+    Accept = "application/vnd.github+json"
+    "X-GitHub-Api-Version" = "2022-11-28"
+}
+
+if ($env:GITHUB_TOKEN) {
+    $headers.Authorization = "Bearer $env:GITHUB_TOKEN"
+}
+
+$release = Invoke-RestMethod `
+    -Headers $headers `
+    -Uri "https://api.github.com/repos/bazelbuild/bazelisk/releases/tags/$bazeliskVersion"
+
+$asset = $release.assets | Where-Object { $_.name -eq $assetName } | Select-Object -First 1
+if (-not $asset) {
+    throw "Could not find $assetName in Bazelisk release $bazeliskVersion"
+}
+
+New-Item -ItemType Directory -Force -Path $installDir | Out-Null
+Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $bazelPath
+
+if (-not $asset.digest.StartsWith("sha256:")) {
+    throw "Unexpected Bazelisk digest format: $($asset.digest)"
+}
+
+$expectedHash = $asset.digest.Substring("sha256:".Length)
+$actualHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $bazelPath).Hash.ToLowerInvariant()
+if ($actualHash -ne $expectedHash.ToLowerInvariant()) {
+    throw "Bazelisk SHA256 mismatch. Expected $expectedHash, got $actualHash"
+}
+
+$pathLine = $installDir
+if ($env:GITHUB_PATH) {
+    $pathLine | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+}
+else {
+    $env:PATH = "$installDir;$env:PATH"
+}
+
+& $bazelPath --version

--- a/.ci/scripts/compare_windows_release.ps1
+++ b/.ci/scripts/compare_windows_release.ps1
@@ -1,0 +1,99 @@
+#===============================================================================
+# Copyright contributors to the oneDAL project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#===============================================================================
+
+param(
+    [string] $MakeReleaseDir = "__release_win_vc\daal\latest",
+    [string] $BazelReleaseDir = "bazel-bin\release\daal\latest",
+    [int] $MaxDiffLines = 200
+)
+
+$ErrorActionPreference = "Stop"
+
+function Resolve-ReleaseDir {
+    param([string] $Path)
+
+    $resolved = Resolve-Path -LiteralPath $Path -ErrorAction SilentlyContinue
+    if (-not $resolved) {
+        throw "Release directory does not exist: $Path"
+    }
+    return $resolved.ProviderPath.TrimEnd('\', '/')
+}
+
+function Get-ReleaseManifest {
+    param([string] $Root)
+
+    $rootPrefix = $Root.TrimEnd('\', '/') + [IO.Path]::DirectorySeparatorChar
+    Get-ChildItem -LiteralPath $Root -Recurse -File |
+        ForEach-Object {
+            $_.FullName.Substring($rootPrefix.Length).Replace('\', '/')
+        } |
+        Sort-Object
+}
+
+function Write-DiffBlock {
+    param(
+        [string] $Title,
+        [string[]] $Items
+    )
+
+    Write-Host ""
+    Write-Host $Title
+    if ($Items.Count -eq 0) {
+        Write-Host "  none"
+        return
+    }
+
+    $Items | Select-Object -First $MaxDiffLines | ForEach-Object {
+        Write-Host "  $_"
+    }
+
+    if ($Items.Count -gt $MaxDiffLines) {
+        Write-Host "  ... $($Items.Count - $MaxDiffLines) more"
+    }
+}
+
+$makeRoot = Resolve-ReleaseDir $MakeReleaseDir
+$bazelRoot = Resolve-ReleaseDir $BazelReleaseDir
+
+Write-Host "Comparing Windows release manifests"
+Write-Host "  make : $makeRoot"
+Write-Host "  bazel: $bazelRoot"
+
+$makeFiles = @(Get-ReleaseManifest $makeRoot)
+$bazelFiles = @(Get-ReleaseManifest $bazelRoot)
+
+$makeSet = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+$bazelSet = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+
+$makeFiles | ForEach-Object { [void] $makeSet.Add($_) }
+$bazelFiles | ForEach-Object { [void] $bazelSet.Add($_) }
+
+$missingFromBazel = @($makeFiles | Where-Object { -not $bazelSet.Contains($_) })
+$extraInBazel = @($bazelFiles | Where-Object { -not $makeSet.Contains($_) })
+
+Write-Host "  make files : $($makeFiles.Count)"
+Write-Host "  bazel files: $($bazelFiles.Count)"
+
+if ($missingFromBazel.Count -eq 0 -and $extraInBazel.Count -eq 0) {
+    Write-Host "PASS: Windows make and Bazel release manifests match"
+    exit 0
+}
+
+Write-DiffBlock "Files present in make release but missing from Bazel release:" $missingFromBazel
+Write-DiffBlock "Files present in Bazel release but missing from make release:" $extraInBazel
+
+Write-Host "FAIL: Windows make and Bazel release manifests differ"
+exit 1

--- a/.ci/scripts/compare_windows_release.ps1
+++ b/.ci/scripts/compare_windows_release.ps1
@@ -17,83 +17,18 @@
 param(
     [string] $MakeReleaseDir = "__release_win_vc\daal\latest",
     [string] $BazelReleaseDir = "bazel-bin\release\daal\latest",
+    [int] $CheckLevel = 4,
     [int] $MaxDiffLines = 200
 )
 
 $ErrorActionPreference = "Stop"
 
-function Resolve-ReleaseDir {
-    param([string] $Path)
+$repoRoot = Resolve-Path -LiteralPath (Join-Path $PSScriptRoot "..\..")
+$compareScript = Join-Path $repoRoot "dev\release_tests\compare_release_trees.py"
 
-    $resolved = Resolve-Path -LiteralPath $Path -ErrorAction SilentlyContinue
-    if (-not $resolved) {
-        throw "Release directory does not exist: $Path"
-    }
-    return $resolved.ProviderPath.TrimEnd('\', '/')
-}
-
-function Get-ReleaseManifest {
-    param([string] $Root)
-
-    $rootPrefix = $Root.TrimEnd('\', '/') + [IO.Path]::DirectorySeparatorChar
-    Get-ChildItem -LiteralPath $Root -Recurse -File |
-        ForEach-Object {
-            $_.FullName.Substring($rootPrefix.Length).Replace('\', '/')
-        } |
-        Sort-Object
-}
-
-function Write-DiffBlock {
-    param(
-        [string] $Title,
-        [string[]] $Items
-    )
-
-    Write-Host ""
-    Write-Host $Title
-    if ($Items.Count -eq 0) {
-        Write-Host "  none"
-        return
-    }
-
-    $Items | Select-Object -First $MaxDiffLines | ForEach-Object {
-        Write-Host "  $_"
-    }
-
-    if ($Items.Count -gt $MaxDiffLines) {
-        Write-Host "  ... $($Items.Count - $MaxDiffLines) more"
-    }
-}
-
-$makeRoot = Resolve-ReleaseDir $MakeReleaseDir
-$bazelRoot = Resolve-ReleaseDir $BazelReleaseDir
-
-Write-Host "Comparing Windows release manifests"
-Write-Host "  make : $makeRoot"
-Write-Host "  bazel: $bazelRoot"
-
-$makeFiles = @(Get-ReleaseManifest $makeRoot)
-$bazelFiles = @(Get-ReleaseManifest $bazelRoot)
-
-$makeSet = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
-$bazelSet = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
-
-$makeFiles | ForEach-Object { [void] $makeSet.Add($_) }
-$bazelFiles | ForEach-Object { [void] $bazelSet.Add($_) }
-
-$missingFromBazel = @($makeFiles | Where-Object { -not $bazelSet.Contains($_) })
-$extraInBazel = @($bazelFiles | Where-Object { -not $makeSet.Contains($_) })
-
-Write-Host "  make files : $($makeFiles.Count)"
-Write-Host "  bazel files: $($bazelFiles.Count)"
-
-if ($missingFromBazel.Count -eq 0 -and $extraInBazel.Count -eq 0) {
-    Write-Host "PASS: Windows make and Bazel release manifests match"
-    exit 0
-}
-
-Write-DiffBlock "Files present in make release but missing from Bazel release:" $missingFromBazel
-Write-DiffBlock "Files present in Bazel release but missing from make release:" $extraInBazel
-
-Write-Host "FAIL: Windows make and Bazel release manifests differ"
-exit 1
+python $compareScript `
+    --platform windows `
+    --make $MakeReleaseDir `
+    --bazel $BazelReleaseDir `
+    --check-level $CheckLevel `
+    --summary-limit $MaxDiffLines

--- a/.ci/scripts/test_bazel_release_cmake_example.ps1
+++ b/.ci/scripts/test_bazel_release_cmake_example.ps1
@@ -76,7 +76,8 @@ Write-Host "Building CMake example target: $ExampleTarget"
 cmake --build $buildPath --config Release
 
 $exe = Get-ChildItem -Path $examplesPath -Filter "$ExampleTarget.exe" -Recurse | Select-Object -First 1
-if (-not $exe) {
+$exampleExe = Get-ChildItem -Path $buildPath -Recurse -Filter "$ExampleTarget.exe" -File | Select-Object -First 1
+if ($null -eq $exampleExe) {
     throw "Cannot find built example executable: $ExampleTarget.exe"
 }
 

--- a/.ci/scripts/test_bazel_release_cmake_example.ps1
+++ b/.ci/scripts/test_bazel_release_cmake_example.ps1
@@ -75,10 +75,11 @@ cmake @cmakeArgs
 Write-Host "Building CMake example target: $ExampleTarget"
 cmake --build $buildPath --config Release --target $ExampleTarget
 
-$exampleExe = Get-ChildItem -Path $buildPath -Recurse -Filter "$ExampleTarget.exe" -File | Select-Object -First 1
+$exampleExe = Get-ChildItem -Path @($buildPath, $examplesPath) -Recurse -Filter "$ExampleTarget.exe" -File |
+    Select-Object -First 1
 if ($null -eq $exampleExe) {
-    Write-Host "Available executables under build directory:"
-    Get-ChildItem -Path $buildPath -Recurse -Filter "*.exe" -File | ForEach-Object { Write-Host "  $($_.FullName)" }
+    Write-Host "Available executables under examples directory:"
+    Get-ChildItem -Path $examplesPath -Recurse -Filter "*.exe" -File | ForEach-Object { Write-Host "  $($_.FullName)" }
     throw "Cannot find built example executable: $ExampleTarget.exe"
 }
 

--- a/.ci/scripts/test_bazel_release_cmake_example.ps1
+++ b/.ci/scripts/test_bazel_release_cmake_example.ps1
@@ -73,18 +73,19 @@ Write-Host "Configuring CMake example from Bazel release: $examplesPath"
 cmake @cmakeArgs
 
 Write-Host "Building CMake example target: $ExampleTarget"
-cmake --build $buildPath --config Release
+cmake --build $buildPath --config Release --target $ExampleTarget
 
-$exe = Get-ChildItem -Path $examplesPath -Filter "$ExampleTarget.exe" -Recurse | Select-Object -First 1
 $exampleExe = Get-ChildItem -Path $buildPath -Recurse -Filter "$ExampleTarget.exe" -File | Select-Object -First 1
 if ($null -eq $exampleExe) {
+    Write-Host "Available executables under build directory:"
+    Get-ChildItem -Path $buildPath -Recurse -Filter "*.exe" -File | ForEach-Object { Write-Host "  $($_.FullName)" }
     throw "Cannot find built example executable: $ExampleTarget.exe"
 }
 
-Write-Host "Running CMake example: $($exe.FullName)"
+Write-Host "Running CMake example: $($exampleExe.FullName)"
 Push-Location $examplesPath
 try {
-    & $exe.FullName
+    & $exampleExe.FullName
     if ($LASTEXITCODE -ne 0) {
         throw "Example failed with exit code $LASTEXITCODE"
     }

--- a/.ci/scripts/test_bazel_release_cmake_example.ps1
+++ b/.ci/scripts/test_bazel_release_cmake_example.ps1
@@ -50,7 +50,7 @@ $cmakeArgs = @(
     "-S", $examplesPath,
     "-DONEDAL_LINK=dynamic",
     "-DCMAKE_PREFIX_PATH=$releasePath",
-    "-DEXAMPLES_LIST=$ExampleSource"
+    "-DEXAMPLES_LIST=$ExampleTarget"
 )
 
 foreach ($candidate in $tbbDirCandidates) {

--- a/.ci/scripts/test_bazel_release_cmake_example.ps1
+++ b/.ci/scripts/test_bazel_release_cmake_example.ps1
@@ -73,7 +73,7 @@ Write-Host "Configuring CMake example from Bazel release: $examplesPath"
 cmake @cmakeArgs
 
 Write-Host "Building CMake example target: $ExampleTarget"
-cmake --build $buildPath --config Release --target $ExampleTarget
+cmake --build $buildPath --config Release
 
 $exe = Get-ChildItem -Path $examplesPath -Filter "$ExampleTarget.exe" -Recurse | Select-Object -First 1
 if (-not $exe) {

--- a/.ci/scripts/test_bazel_release_cmake_example.ps1
+++ b/.ci/scripts/test_bazel_release_cmake_example.ps1
@@ -1,0 +1,93 @@
+#===============================================================================
+# Copyright 2026 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#===============================================================================
+
+param(
+    [string]$ReleaseDir = ".\bazel-bin\release\daal\latest",
+    [string]$ExamplesDir = "examples\oneapi\cpp",
+    [string]$ExampleSource = "source\basic_statistics\basic_statistics_dense_batch.cpp",
+    [string]$ExampleTarget = "basic_statistics_dense_batch"
+)
+
+$ErrorActionPreference = "Stop"
+
+$releasePath = (Resolve-Path $ReleaseDir).Path
+$examplesPath = Join-Path $releasePath $ExamplesDir
+$buildPath = Join-Path $examplesPath "Build"
+
+if (Test-Path $buildPath) {
+    Remove-Item -Recurse -Force $buildPath
+}
+
+$pathEntries = @(
+    (Join-Path $releasePath "redist\intel64"),
+    (Join-Path $releasePath "lib")
+)
+
+$tbbDirCandidates = @(
+    ".\oneapi\tbb\latest\lib\cmake\tbb",
+    ".\__deps\tbb\win\tbb\lib\cmake\tbb"
+)
+$tbbRedistCandidates = @(
+    ".\oneapi\tbb\latest\redist\intel64\vc_mt",
+    ".\__deps\tbb\win\tbb\redist\intel64\vc_mt"
+)
+
+$cmakeArgs = @(
+    "-B", $buildPath,
+    "-S", $examplesPath,
+    "-DONEDAL_LINK=dynamic",
+    "-DCMAKE_PREFIX_PATH=$releasePath",
+    "-DEXAMPLES_LIST=$ExampleSource"
+)
+
+foreach ($candidate in $tbbDirCandidates) {
+    if (Test-Path $candidate) {
+        $cmakeArgs += "-DTBB_DIR=$((Resolve-Path $candidate).Path)"
+        break
+    }
+}
+
+foreach ($candidate in $tbbRedistCandidates) {
+    if (Test-Path $candidate) {
+        $pathEntries += (Resolve-Path $candidate).Path
+        break
+    }
+}
+
+$env:PATH = (($pathEntries | Where-Object { Test-Path $_ }) -join ";") + ";" + $env:PATH
+
+Write-Host "Configuring CMake example from Bazel release: $examplesPath"
+cmake @cmakeArgs
+
+Write-Host "Building CMake example target: $ExampleTarget"
+cmake --build $buildPath --config Release --target $ExampleTarget
+
+$exe = Get-ChildItem -Path $examplesPath -Filter "$ExampleTarget.exe" -Recurse | Select-Object -First 1
+if (-not $exe) {
+    throw "Cannot find built example executable: $ExampleTarget.exe"
+}
+
+Write-Host "Running CMake example: $($exe.FullName)"
+Push-Location $examplesPath
+try {
+    & $exe.FullName
+    if ($LASTEXITCODE -ne 0) {
+        throw "Example failed with exit code $LASTEXITCODE"
+    }
+}
+finally {
+    Pop-Location
+}

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -28,9 +28,13 @@ on:
     paths:
       - .github/workflows/nightly-build.yml
       - .ci/pipeline/ci.yml
+      - .bazelrc
+      - MODULE.bazel
+      - BUILD
       - makefile
       - '.ci/env/**'
       - '.ci/scripts/**'
+      - 'dev/bazel/**'
       - 'dev/make/**'
       - 'dev/make/compiler_definitions/**'
       - 'dev/make/function_definitions/**'
@@ -125,6 +129,22 @@ jobs:
           call .\oneapi\setvars.bat
           call .\oneapi\compiler\latest\bin\sycl-ls.exe
           call .\.ci\scripts\build.bat onedal_dpc vc avx2
+      - name: Install Bazelisk
+        shell: pwsh
+        run: .\.ci\env\bazelisk.ps1
+      - name: Bazel release
+        shell: cmd
+        run: |
+          set PATH=C:\msys64\usr\bin;%PATH%
+          call .\oneapi\setvars.bat
+          call "%ONEAPI_ROOT%\setvars-vcvarsall.bat" %VS_VER%
+          bazel build //:release --config=release-dpc --cpu=avx2
+      - name: Compare make and Bazel release manifests
+        shell: pwsh
+        run: |
+          .\.ci\scripts\compare_windows_release.ps1 `
+            -MakeReleaseDir .\__release_win_vc\daal\latest `
+            -BazelReleaseDir .\bazel-bin\release\daal\latest
       - name: Compress Intel BaseKit
         shell: cmd
         run: |

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -163,6 +163,13 @@ jobs:
             -MakeReleaseDir .\__release_win_vc\daal\latest ^
             -BazelReleaseDir .\bazel-bin\release\daal\latest ^
             -CheckLevel 4
+      - name: Build and run CMake example from Bazel release
+        shell: cmd
+        run: |
+          call .\oneapi\setvars.bat
+          call "%ONEAPI_ROOT%\setvars-vcvarsall.bat" %VS_VER%
+          powershell -NoProfile -ExecutionPolicy Bypass -File .\.ci\scripts\test_bazel_release_cmake_example.ps1 ^
+            -ReleaseDir .\bazel-bin\release\daal\latest
       - name: Compress Intel BaseKit
         shell: cmd
         run: |

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -35,6 +35,7 @@ on:
       - '.ci/env/**'
       - '.ci/scripts/**'
       - 'dev/bazel/**'
+      - 'dev/release_tests/**'
       - 'dev/make/**'
       - 'dev/make/compiler_definitions/**'
       - 'dev/make/function_definitions/**'
@@ -76,6 +77,20 @@ jobs:
         run: |
           source /opt/intel/oneapi/setvars.sh
           .ci/scripts/build.sh --compiler icx  --optimizations avx2 --target onedal
+      - name: Install Bazelisk
+        run: .ci/env/bazelisk.sh
+      - name: Bazel release
+        run: |
+          source /opt/intel/oneapi/setvars.sh
+          bazel build //:release --config=release-dpc --cpu=avx2
+      - name: Compare make and Bazel releases
+        run: |
+          source /opt/intel/oneapi/setvars.sh
+          python dev/release_tests/compare_release_trees.py \
+            --platform linux \
+            --make ./__release_lnx/daal/latest \
+            --bazel ./bazel-bin/release/daal/latest \
+            --check-level 4
       - name: Archive build
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -139,12 +154,15 @@ jobs:
           call .\oneapi\setvars.bat
           call "%ONEAPI_ROOT%\setvars-vcvarsall.bat" %VS_VER%
           bazel build //:release --config=release-dpc --cpu=avx2
-      - name: Compare make and Bazel release manifests
-        shell: pwsh
+      - name: Compare make and Bazel releases
+        shell: cmd
         run: |
-          .\.ci\scripts\compare_windows_release.ps1 `
-            -MakeReleaseDir .\__release_win_vc\daal\latest `
-            -BazelReleaseDir .\bazel-bin\release\daal\latest
+          call .\oneapi\setvars.bat
+          call "%ONEAPI_ROOT%\setvars-vcvarsall.bat" %VS_VER%
+          powershell -NoProfile -ExecutionPolicy Bypass -File .\.ci\scripts\compare_windows_release.ps1 ^
+            -MakeReleaseDir .\__release_win_vc\daal\latest ^
+            -BazelReleaseDir .\bazel-bin\release\daal\latest ^
+            -CheckLevel 4
       - name: Compress Intel BaseKit
         shell: cmd
         run: |

--- a/BUILD
+++ b/BUILD
@@ -151,9 +151,13 @@ release(
         "@onedal//cpp/daal:thread_dynamic",
         "@onedal//cpp/oneapi/dal:static",
         "@onedal//cpp/oneapi/dal:dynamic",
-        "@onedal//cpp/oneapi/dal:static_parameters",
-        "@onedal//cpp/oneapi/dal:dynamic_parameters",
     ] + select({
+        ":windows": [],
+        "//conditions:default": [
+            "@onedal//cpp/oneapi/dal:static_parameters",
+            "@onedal//cpp/oneapi/dal:dynamic_parameters",
+        ],
+    }) + select({
         ":release_dpc_windows": [
             "@onedal//cpp/oneapi/dal:dynamic_dpc",
         ],
@@ -177,9 +181,9 @@ release(
     }),
     extra_files = [
         release_extra_file(":release_vars_sh", "env/vars.sh", windows_dst_path = "env/vars.bat"),
-        release_extra_file(":release_pkgconfig", "", windows_dst_path = "lib/pkgconfig/onedal.pc"),
-        release_extra_file(":release_pkgconfig_dynamic_threading_host", "lib/pkgconfig/dal-dynamic-threading-host.pc", windows_dst_path = ""),
-        release_extra_file(":release_pkgconfig_static_threading_host", "lib/pkgconfig/dal-static-threading-host.pc", windows_dst_path = ""),
+        release_extra_file(":release_pkgconfig", "lib/pkgconfig/onedal.pc", windows_dst_path = ""),
+        release_extra_file(":release_pkgconfig_dynamic_threading_host", "lib/pkgconfig/dal-dynamic-threading-host.pc"),
+        release_extra_file(":release_pkgconfig_static_threading_host", "lib/pkgconfig/dal-static-threading-host.pc"),
         release_extra_file("//deploy/local:config_file", "config/config.txt"),
         release_extra_file(":release_modulefile_dal", "modulefiles/dal", windows_dst_path = ""),
         release_extra_file(":release_mpi_daal_lst_linux", "samples/daal/cpp/mpi/daal.lst", windows_dst_path = ""),

--- a/BUILD
+++ b/BUILD
@@ -15,6 +15,14 @@ config_setting(
     constraint_values = ["@platforms//os:windows"],
 )
 
+config_setting(
+    name = "release_dpc_windows",
+    constraint_values = ["@platforms//os:windows"],
+    flag_values = {
+        "@config//:release_dpc": "True",
+    },
+)
+
 generate_vars_sh(
     name = "release_vars_sh",
     out = "env/vars.sh",
@@ -99,6 +107,12 @@ filegroup(
         "samples/oneapi/cpp/mpi/CMakeLists.txt",
         "samples/oneapi/cpp/mpi/sources/*.cpp",
         "samples/oneapi/cpp/mpi/sources/*.hpp",
+        "samples/oneapi/dpc/ccl/CMakeLists.txt",
+        "samples/oneapi/dpc/ccl/sources/*.cpp",
+        "samples/oneapi/dpc/ccl/sources/*.hpp",
+        "samples/oneapi/dpc/mpi/CMakeLists.txt",
+        "samples/oneapi/dpc/mpi/sources/*.cpp",
+        "samples/oneapi/dpc/mpi/sources/*.hpp",
     ]) + select({
         ":windows": glob([
             "samples/daal/cpp/mpi/daal.lst.bat",
@@ -131,9 +145,16 @@ release(
         "@onedal//cpp/daal:thread_dynamic",
         "@onedal//cpp/oneapi/dal:static",
         "@onedal//cpp/oneapi/dal:dynamic",
-        "@onedal//cpp/oneapi/dal:static_parameters",
-        "@onedal//cpp/oneapi/dal:dynamic_parameters",
     ] + select({
+        ":windows": [],
+        "//conditions:default": [
+            "@onedal//cpp/oneapi/dal:static_parameters",
+            "@onedal//cpp/oneapi/dal:dynamic_parameters",
+        ],
+    }) + select({
+        ":release_dpc_windows": [
+            "@onedal//cpp/oneapi/dal:dynamic_dpc",
+        ],
         "@config//:release_dpc_enabled": [
             "@onedal//cpp/oneapi/dal:static_dpc",
             "@onedal//cpp/oneapi/dal:dynamic_dpc",
@@ -147,6 +168,7 @@ release(
         ":release_package_files",
         "//examples/daal/cpp:release_files",
         "//examples/oneapi/cpp:release_files",
+        "//examples/oneapi/dpc:release_files",
     ],
     extra_files = [
         release_extra_file(":release_vars_sh", "env/vars.sh", windows_dst_path = "env/vars.bat"),

--- a/BUILD
+++ b/BUILD
@@ -158,9 +158,7 @@ release(
             "@onedal//cpp/oneapi/dal:dynamic_dpc",
         ],
         "@config//:release_dpc_enabled": [
-            "@onedal//cpp/oneapi/dal:static_dpc",
             "@onedal//cpp/oneapi/dal:dynamic_dpc",
-            "@onedal//cpp/oneapi/dal:static_parameters_dpc",
             "@onedal//cpp/oneapi/dal:dynamic_parameters_dpc",
         ],
         "//conditions:default": [],

--- a/BUILD
+++ b/BUILD
@@ -107,12 +107,6 @@ filegroup(
         "samples/oneapi/cpp/mpi/CMakeLists.txt",
         "samples/oneapi/cpp/mpi/sources/*.cpp",
         "samples/oneapi/cpp/mpi/sources/*.hpp",
-        "samples/oneapi/dpc/ccl/CMakeLists.txt",
-        "samples/oneapi/dpc/ccl/sources/*.cpp",
-        "samples/oneapi/dpc/ccl/sources/*.hpp",
-        "samples/oneapi/dpc/mpi/CMakeLists.txt",
-        "samples/oneapi/dpc/mpi/sources/*.cpp",
-        "samples/oneapi/dpc/mpi/sources/*.hpp",
     ]) + select({
         ":windows": glob([
             "samples/daal/cpp/mpi/daal.lst.bat",
@@ -120,6 +114,18 @@ filegroup(
         ]),
         "//conditions:default": [],
     }),
+)
+
+filegroup(
+    name = "release_dpc_package_files",
+    srcs = glob([
+        "samples/oneapi/dpc/ccl/CMakeLists.txt",
+        "samples/oneapi/dpc/ccl/sources/*.cpp",
+        "samples/oneapi/dpc/ccl/sources/*.hpp",
+        "samples/oneapi/dpc/mpi/CMakeLists.txt",
+        "samples/oneapi/dpc/mpi/sources/*.cpp",
+        "samples/oneapi/dpc/mpi/sources/*.hpp",
+    ]),
 )
 
 release(
@@ -168,8 +174,13 @@ release(
         ":release_package_files",
         "//examples/daal/cpp:release_files",
         "//examples/oneapi/cpp:release_files",
-        "//examples/oneapi/dpc:release_files",
-    ],
+    ] + select({
+        "@config//:release_dpc_enabled": [
+            ":release_dpc_package_files",
+            "//examples/oneapi/dpc:release_files",
+        ],
+        "//conditions:default": [],
+    }),
     extra_files = [
         release_extra_file(":release_vars_sh", "env/vars.sh", windows_dst_path = "env/vars.bat"),
         release_extra_file(":release_pkgconfig", "", windows_dst_path = "lib/pkgconfig/onedal.pc"),

--- a/BUILD
+++ b/BUILD
@@ -151,13 +151,9 @@ release(
         "@onedal//cpp/daal:thread_dynamic",
         "@onedal//cpp/oneapi/dal:static",
         "@onedal//cpp/oneapi/dal:dynamic",
+        "@onedal//cpp/oneapi/dal:static_parameters",
+        "@onedal//cpp/oneapi/dal:dynamic_parameters",
     ] + select({
-        ":windows": [],
-        "//conditions:default": [
-            "@onedal//cpp/oneapi/dal:static_parameters",
-            "@onedal//cpp/oneapi/dal:dynamic_parameters",
-        ],
-    }) + select({
         ":release_dpc_windows": [
             "@onedal//cpp/oneapi/dal:dynamic_dpc",
         ],

--- a/BUILD
+++ b/BUILD
@@ -181,7 +181,7 @@ release(
     }),
     extra_files = [
         release_extra_file(":release_vars_sh", "env/vars.sh", windows_dst_path = "env/vars.bat"),
-        release_extra_file(":release_pkgconfig", "lib/pkgconfig/onedal.pc", windows_dst_path = ""),
+        release_extra_file(":release_pkgconfig", "", windows_dst_path = ""),
         release_extra_file(":release_pkgconfig_dynamic_threading_host", "lib/pkgconfig/dal-dynamic-threading-host.pc"),
         release_extra_file(":release_pkgconfig_static_threading_host", "lib/pkgconfig/dal-static-threading-host.pc"),
         release_extra_file("//deploy/local:config_file", "config/config.txt"),

--- a/cpp/oneapi/dal/BUILD
+++ b/cpp/oneapi/dal/BUILD
@@ -107,6 +107,12 @@ dal_dynamic_lib(
         ":core",
         ":optional",
     ],
+    dpc_deps = select({
+        "@platforms//os:windows": [
+            "@onedal//cpp/daal:core_dynamic",
+        ],
+        "//conditions:default": [],
+    }),
     # On Windows, onedal.dll must resolve all externals at link time:
     #   - static_parameters: parameter symbols not part of any other dep tree.
     #   - services_win_dll_shim: delay-load stubs for threading entry points
@@ -144,6 +150,12 @@ dal_dynamic_lib(
         "@onedal//cpp/oneapi/dal/algo/logistic_regression/detail",
         "@onedal//cpp/oneapi/dal/detail/parameters",
     ],
+    dpc_deps = select({
+        "@platforms//os:windows": [
+            "@onedal//cpp/daal:core_dynamic",
+        ],
+        "//conditions:default": [],
+    }),
     host_deps = select({
         "@platforms//os:windows": ["@onedal//cpp/daal:services_win_dll_shim"],
         "//conditions:default": [],

--- a/cpp/oneapi/dal/BUILD
+++ b/cpp/oneapi/dal/BUILD
@@ -110,6 +110,7 @@ dal_dynamic_lib(
     dpc_deps = select({
         "@platforms//os:windows": [
             "@onedal//cpp/daal:core_dynamic",
+            ":static_parameters_dpc",
         ],
         "//conditions:default": [],
     }),

--- a/cpp/oneapi/dal/algo/pca/backend/BUILD
+++ b/cpp/oneapi/dal/algo/pca/backend/BUILD
@@ -14,5 +14,17 @@ dal_module(
 
 dal_module(
     name = "common",
-    hdrs = glob(["*.hpp"]),
+    hdrs = glob(["*.hpp"]) + [
+        "@onedal//cpp/oneapi/dal:cpu_dispatcher",
+    ],
+    dal_deps = [
+        "@onedal//cpp/oneapi/dal:common",
+        "@onedal//cpp/oneapi/dal/backend/primitives:common",
+    ],
+    srcs = [
+        "sign_flip_cpu.cpp",
+    ],
+    extra_deps = [
+        "@onedal//cpp/oneapi:include_root",
+    ],
 )

--- a/cpp/oneapi/dal/algo/pca/backend/BUILD
+++ b/cpp/oneapi/dal/algo/pca/backend/BUILD
@@ -21,9 +21,6 @@ dal_module(
         "@onedal//cpp/oneapi/dal:common",
         "@onedal//cpp/oneapi/dal/backend/primitives:common",
     ],
-    srcs = [
-        "sign_flip_cpu.cpp",
-    ],
     extra_deps = [
         "@onedal//cpp/oneapi:include_root",
     ],

--- a/dev/bazel/cc.bzl
+++ b/dev/bazel/cc.bzl
@@ -287,7 +287,7 @@ def _cc_dynamic_lib_impl(ctx):
         feature_configuration = feature_config,
         linking_contexts = linking_contexts,
         def_file = ctx.file.def_file,
-        user_link_flags = linux_soname_flags + linux_linker_script_flags + ctx.attr.linkopts,
+        user_link_flags = linux_soname_flags + linux_linker_script_flags + (["-Wl,--exclude-libs=ALL"] if not is_windows else []) + ctx.attr.linkopts,
         is_windows = is_windows,
         additional_inputs = ctx.files.linker_scripts,
         is_dpc = ctx.attr.lib_name.endswith("_dpc") or ctx.label.name.endswith("_dpc"),

--- a/dev/bazel/cc.bzl
+++ b/dev/bazel/cc.bzl
@@ -290,6 +290,7 @@ def _cc_dynamic_lib_impl(ctx):
         user_link_flags = linux_soname_flags + linux_linker_script_flags + ctx.attr.linkopts,
         is_windows = is_windows,
         additional_inputs = ctx.files.linker_scripts,
+        is_dpc = ctx.attr.lib_name.endswith("_dpc") or ctx.label.name.endswith("_dpc"),
     )
     default_files = dynamic_outputs.files
     if is_windows:

--- a/dev/bazel/cc/link.bzl
+++ b/dev/bazel/cc/link.bzl
@@ -261,9 +261,11 @@ def _link(owner, name, actions, cc_toolchain,
         libraries_to_link = [object_archive_to_link] + libraries_to_link
         if is_dpc:
             object_archive_link_flags.append("/link")
-        # Do not force every object archive into Windows DLLs: it exports otherwise-unused
-        # template/object symbols and diverges from the Make release surface.
-        # The linker should pull only objects needed by the requested exports.
+        # Windows DLL exports are discovered from dllexport directives inside
+        # object files. A normal static library is searched only for unresolved
+        # references, so these objects are otherwise not pulled into leaf DLLs
+        # such as onedal_thread.dll and the link can miss the CRT startup.
+        object_archive_link_flags.append("/WHOLEARCHIVE:" + object_archive.path)
         additional_link_inputs.append(object_archive)
         all_object_list = []
     all_objects = depset(all_object_list)

--- a/dev/bazel/cc/link.bzl
+++ b/dev/bazel/cc/link.bzl
@@ -15,6 +15,7 @@
 #===============================================================================
 
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
+load("@rules_cc//cc:action_names.bzl", "ACTION_NAMES")
 
 load("@onedal//dev/bazel:utils.bzl",
     "utils",
@@ -46,6 +47,10 @@ def _merge_static_libs(filename, actions, cc_toolchain,
                        feature_configuration, static_libs, is_windows = False):
     output_file = actions.declare_file(filename)
     if is_windows:
+        merger_path = cc_common.get_tool_for_action(
+            feature_configuration = feature_configuration,
+            action_name = ACTION_NAMES.cpp_link_static_library,
+        )
         args = actions.args()
         args.use_param_file("@%s", use_always = True)
         args.set_param_file_format("multiline")
@@ -53,7 +58,7 @@ def _merge_static_libs(filename, actions, cc_toolchain,
         args.add("/OUT:" + output_file.path)
         args.add_all(static_libs)
         actions.run(
-            executable = "xilib.exe",
+            executable = merger_path,
             arguments = [args],
             inputs = static_libs,
             outputs = [output_file],

--- a/dev/bazel/cc/link.bzl
+++ b/dev/bazel/cc/link.bzl
@@ -228,43 +228,38 @@ def _static(owner, name, actions, cc_toolchain,
 def _link(owner, name, actions, cc_toolchain,
           feature_configuration, linking_contexts,
           def_file=None, is_executable=False, user_link_flags=[],
-          is_windows=False, additional_inputs=[]):
+          is_windows=False, additional_inputs=[], is_dpc=False):
     unpacked_linking_context = onedal_cc_common.unpack_linking_contexts(linking_contexts)
     if not is_executable and unpacked_linking_context.objects and unpacked_linking_context.pic_objects:
         fail("Dynamic library {} contains non-PIC object files: {}".format(
             name, unpacked_linking_context.objects))
-    object_list = unpacked_linking_context.pic_objects + unpacked_linking_context.objects
-    additional_inputs = ([def_file] if def_file else []) + additional_inputs
-    direct_user_link_flags = ["@" + def_file.path] if def_file else []
-    direct_libraries_to_link = []
-
-    # Windows link.exe rejects response-file lines longer than 131071
-    # characters. Full all-ISA DPC DLLs can produce thousands of objects, so
-    # aggregate them into one private archive and link it whole-archive.
-    if is_windows and not is_executable and object_list:
-        direct_objects = [object_list[0]]
-        archived_objects = object_list[1:]
-        object_list = direct_objects
-        if archived_objects:
-            object_archive = _merge_static_libs(
-                filename = name + "_objects.lib",
-                actions = actions,
-                cc_toolchain = cc_toolchain,
-                feature_configuration = feature_configuration,
-                static_libs = archived_objects,
-                is_windows = True,
-            )
-            additional_inputs.append(object_archive)
-            direct_user_link_flags.append("/WHOLEARCHIVE:" + object_archive.path)
-            direct_libraries_to_link.append(cc_common.create_library_to_link(
-                actions = actions,
-                cc_toolchain = cc_toolchain,
-                feature_configuration = feature_configuration,
-                static_library = object_archive,
-                pic_static_library = object_archive,
-            ))
-
-    all_objects = depset(object_list)
+    all_object_list = unpacked_linking_context.pic_objects + unpacked_linking_context.objects
+    libraries_to_link = unpacked_linking_context.libraries_to_link
+    object_archive_link_flags = []
+    additional_link_inputs = list(additional_inputs)
+    if is_windows and all_object_list and not is_executable:
+        object_archive = _merge_static_libs(
+            filename = name + "_objects.lib",
+            actions = actions,
+            cc_toolchain = cc_toolchain,
+            feature_configuration = feature_configuration,
+            static_libs = all_object_list,
+            is_windows = True,
+        )
+        object_archive_to_link = cc_common.create_library_to_link(
+            actions = actions,
+            cc_toolchain = cc_toolchain,
+            feature_configuration = feature_configuration,
+            static_library = object_archive,
+            pic_static_library = object_archive,
+        )
+        libraries_to_link = [object_archive_to_link] + libraries_to_link
+        if is_dpc:
+            object_archive_link_flags.append("/link")
+        object_archive_link_flags.append("/WHOLEARCHIVE:" + object_archive.path)
+        additional_link_inputs.append(object_archive)
+        all_object_list = []
+    all_objects = depset(all_object_list)
     compilation_outputs = cc_common.create_compilation_outputs(
         objects = all_objects,
         pic_objects = all_objects,
@@ -274,11 +269,10 @@ def _link(owner, name, actions, cc_toolchain,
         unpacked_linking_context.user_link_flags
     )
     # Merge user_link_flags from both linking context and function parameters
-    all_user_link_flags = unpacked_user_link_flags + user_link_flags
+    all_user_link_flags = unpacked_user_link_flags + user_link_flags + object_archive_link_flags
     linker_input = cc_common.create_linker_input(
         owner = owner,
-        libraries = depset(direct_libraries_to_link +
-                           unpacked_linking_context.libraries_to_link),
+        libraries = depset(libraries_to_link),
         user_link_flags = depset(all_user_link_flags),
     )
     # TODO: Pass compilations outputs via linking contexts
@@ -296,14 +290,15 @@ def _link(owner, name, actions, cc_toolchain,
         linking_contexts = [linking_context],
         output_type = "executable" if is_executable else "dynamic_library",
         link_deps_statically = True,
-        user_link_flags = direct_user_link_flags,
-        additional_inputs = additional_inputs,
+        user_link_flags = ["@" + def_file.path] if def_file else [],
+        additional_inputs = ([def_file] if def_file else []) + additional_link_inputs,
     )
     return unpacked_linking_context, linking_outputs
 
 def _dynamic(owner, name, actions, cc_toolchain,
              feature_configuration, linking_contexts,
-             def_file=None, user_link_flags=[], is_windows=False, additional_inputs=[]):
+             def_file=None, user_link_flags=[], is_windows=False,
+             additional_inputs=[], is_dpc=False):
     unpacked_linking_context, linking_outputs = _link(
         owner, name, actions, cc_toolchain,
         feature_configuration, linking_contexts,
@@ -311,6 +306,7 @@ def _dynamic(owner, name, actions, cc_toolchain,
         user_link_flags=user_link_flags,
         is_windows=is_windows,
         additional_inputs=additional_inputs,
+        is_dpc=is_dpc,
     )
     library_to_link = linking_outputs.library_to_link
     dynamic_lib = None
@@ -358,6 +354,7 @@ def _executable(owner, name, actions, cc_toolchain,
         feature_configuration, linking_contexts,
         is_executable = True,
         user_link_flags = user_link_flags,
+        is_windows = False,
     )
     if not linking_outputs.executable:
         return utils.warn("'{}' executable does not contain any " +

--- a/dev/bazel/cc/link.bzl
+++ b/dev/bazel/cc/link.bzl
@@ -261,7 +261,9 @@ def _link(owner, name, actions, cc_toolchain,
         libraries_to_link = [object_archive_to_link] + libraries_to_link
         if is_dpc:
             object_archive_link_flags.append("/link")
-        object_archive_link_flags.append("/WHOLEARCHIVE:" + object_archive.path)
+        # Do not force every object archive into Windows DLLs: it exports otherwise-unused
+        # template/object symbols and diverges from the Make release surface.
+        # The linker should pull only objects needed by the requested exports.
         additional_link_inputs.append(object_archive)
         all_object_list = []
     all_objects = depset(all_object_list)

--- a/dev/bazel/deps/mkl.bzl
+++ b/dev/bazel/deps/mkl.bzl
@@ -40,6 +40,13 @@ mkl_repo = repos.prebuilt_libs_repo_rule(
         "lib/mkl_core.lib",
         "lib/mkl_intel_ilp64.lib",
         "lib/mkl_tbb_thread.lib",
+        "lib/mkl_core_dll.lib",
+        "lib/mkl_intel_lp64_dll.lib",
+        "lib/mkl_intel_thread_dll.lib",
+        "lib/mkl_sycl_blas_dll.lib",
+        "lib/mkl_sycl_lapack_dll.lib",
+        "lib/mkl_sycl_rng_dll.lib",
+        "lib/mkl_sycl_sparse_dll.lib",
     ],
     win_bins = [
         "bin/*.dll",

--- a/dev/bazel/deps/mkl_win.tpl.BUILD
+++ b/dev/bazel/deps/mkl_win.tpl.BUILD
@@ -41,6 +41,15 @@ cc_library(
 
 cc_library(
     name = "mkl_dpc_utils",
+    linkopts = [
+        "%{repo_root}/lib/mkl_core_dll.lib",
+        "%{repo_root}/lib/mkl_intel_lp64_dll.lib",
+        "%{repo_root}/lib/mkl_intel_thread_dll.lib",
+        "%{repo_root}/lib/mkl_sycl_blas_dll.lib",
+        "%{repo_root}/lib/mkl_sycl_lapack_dll.lib",
+        "%{repo_root}/lib/mkl_sycl_rng_dll.lib",
+        "%{repo_root}/lib/mkl_sycl_sparse_dll.lib",
+    ],
 )
 
 cc_library(

--- a/dev/bazel/deps/onedal.bzl
+++ b/dev/bazel/deps/onedal.bzl
@@ -52,18 +52,15 @@ onedal_repo = repos.prebuilt_libs_repo_rule(
         "lib/intel64/onedal_core.lib",
         "lib/intel64/onedal_thread.lib",
         "lib/intel64/onedal.lib",
-        "lib/intel64/onedal_parameters.lib",
 
         # Dynamic import libraries
         "lib/intel64/onedal_core_dll.lib",
         "lib/intel64/onedal_core_dll.%{version_binary_major}.lib",
         "lib/intel64/onedal_dll.lib",
-        "lib/intel64/onedal_parameters_dll.lib",
     ],
     win_bins = [
         "redist/intel64/onedal.%{version_binary_major}.dll",
         "redist/intel64/onedal_core.%{version_binary_major}.dll",
-        "redist/intel64/onedal_parameters.%{version_binary_major}.dll",
         "redist/intel64/onedal_thread.%{version_binary_major}.dll",
     ],
     build_template = "@onedal//dev/bazel/deps:onedal.tpl.BUILD",

--- a/dev/bazel/deps/onedal_win.tpl.BUILD
+++ b/dev/bazel/deps/onedal_win.tpl.BUILD
@@ -39,7 +39,6 @@ cc_library(
     name = "onedal_static",
     srcs = [
         "lib/intel64/onedal.lib",
-        "lib/intel64/onedal_parameters.lib",
     ],
     deps = [
         ":headers",
@@ -99,11 +98,9 @@ cc_library(
     name = "onedal_dynamic",
     srcs = [
         "lib/intel64/onedal_dll.lib",
-        "lib/intel64/onedal_parameters_dll.lib",
     ],
     data = [
         "redist/intel64/onedal.%{version_binary_major}.dll",
-        "redist/intel64/onedal_parameters.%{version_binary_major}.dll",
     ],
     deps = [
         ":headers",

--- a/dev/bazel/release.bzl
+++ b/dev/bazel/release.bzl
@@ -454,7 +454,7 @@ def release(name, include, lib, extra_files = [], data = []):
                      Example:
                        extra_files = [
                            release_extra_file(":release_vars_sh", "env/vars.sh"),
-                           release_extra_file(":release_pkgconfig", "lib/pkgconfig/onedal.pc"),
+                           release_extra_file(":release_pkgconfig", "lib/pkgconfig/onedal.pc", windows_dst_path = ""),
                        ]
         data:        List of filegroup targets to copy preserving directory structure.
                      Example:

--- a/dev/bazel/release.bzl
+++ b/dev/bazel/release.bzl
@@ -144,6 +144,8 @@ def _copy_include(ctx, prefix, version_info):
                                             ctx.attr.include_skip_prefix):
         headers = _collect_headers(include)
         for header in headers:
+            if header.basename == "_dal_cpu_dispatcher_gen.hpp":
+                continue
             if skip_prefix:
                 # Use short_path for deterministic workspace-relative include layout.
                 # file.path contains bazel-out/<cfg>/... prefixes that prevent
@@ -279,8 +281,9 @@ def _copy_lib(ctx, prefix, version_info):
                         ctx, lib, paths.join(lib_prefix, implib_name),
                     )
                 dst_files.append(implib)
-                if version_info and stem == "onedal_core":
-                    versioned_implib_name = "onedal_core_dll.{}.lib".format(
+                if version_info and stem in ["onedal_core", "onedal", "onedal_dpc"]:
+                    versioned_implib_name = "{}_dll.{}.lib".format(
+                        stem,
                         version_info.binary_major,
                     )
                     dst_files.append(_copy(
@@ -292,6 +295,8 @@ def _copy_lib(ctx, prefix, version_info):
             # above (renamed to `_dll.lib`); skip them here so we do not
             # declare the same output twice.
             if is_windows and (lib.basename.endswith(".if.lib") or lib.basename.endswith("_dll.lib")):
+                continue
+            if is_windows and lib.extension == "exp":
                 continue
 
             dst_path = paths.join(lib_prefix, lib.basename)

--- a/dev/bazel/toolchains/cc_toolchain_win.bzl
+++ b/dev/bazel/toolchains/cc_toolchain_win.bzl
@@ -68,7 +68,7 @@ foreach ($arg in $RawArgs) {
     }
 }
 
-$objectRsp = [IO.Path]::GetTempFileName() + '.rsp'
+$objectRsp = Join-Path ([IO.Path]::GetTempPath()) ([IO.Path]::GetRandomFileName() + '.rsp')
 $objectArgs = New-Object System.Collections.Generic.List[string]
 $finalArgs = New-Object System.Collections.Generic.List[string]
 $insertedObjectRsp = $false

--- a/dev/bazel/toolchains/cc_toolchain_win.bzl
+++ b/dev/bazel/toolchains/cc_toolchain_win.bzl
@@ -45,62 +45,17 @@ def _find_tool(repo_ctx, tool_name, mandatory = False):
     return str(tool_path), is_found
 
 def _create_dpc_link_wrapper(repo_ctx, dpcc_path):
-    repo_ctx.file("dpc_link_win.ps1", """
-param(
-    [Parameter(Mandatory=$true)]
-    [string]$Compiler,
-    [Parameter(ValueFromRemainingArguments=$true)]
-    [string[]]$RawArgs
-)
-
-$expandedArgs = New-Object System.Collections.Generic.List[string]
-foreach ($arg in $RawArgs) {
-    if ($arg.StartsWith('@')) {
-        $path = $arg.Substring(1)
-        foreach ($line in [IO.File]::ReadLines($path)) {
-            if ($line.Length -gt 0) {
-                $expandedArgs.Add($line)
-            }
-        }
-    }
-    else {
-        $expandedArgs.Add($arg)
-    }
-}
-
-$objectRsp = Join-Path ([IO.Path]::GetTempPath()) ([IO.Path]::GetRandomFileName() + '.rsp')
-$objectArgs = New-Object System.Collections.Generic.List[string]
-$finalArgs = New-Object System.Collections.Generic.List[string]
-$insertedObjectRsp = $false
-
-foreach ($arg in $expandedArgs) {
-    if ($arg -match '(?i)\\.(obj|res)$') {
-        $objectArgs.Add($arg)
-        if (-not $insertedObjectRsp) {
-            $finalArgs.Add('@' + $objectRsp)
-            $insertedObjectRsp = $true
-        }
-    }
-    else {
-        $finalArgs.Add($arg)
-    }
-}
-
-try {
-    [IO.File]::WriteAllLines($objectRsp, $objectArgs)
-    & $Compiler @finalArgs
-    exit $LASTEXITCODE
-}
-finally {
-    Remove-Item -Force $objectRsp -ErrorAction SilentlyContinue
-}
-""")
-    wrapper = "dpc_link_win.bat"
-    repo_ctx.file(wrapper, """@echo off
-powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0dpc_link_win.ps1" "{dpcc}" %*
-exit /b %ERRORLEVEL%
-""".format(dpcc = dpcc_path))
-    return str(repo_ctx.path(wrapper))
+    repo_ctx.template(
+        "dpc_link_win.ps1",
+        Label("@onedal//dev/bazel/toolchains/tools:dpc_link_win.ps1"),
+        {},
+    )
+    repo_ctx.template(
+        "dpc_link_win.bat",
+        Label("@onedal//dev/bazel/toolchains/tools:dpc_link_win.tpl.bat"),
+        {"%{dpcc}": dpcc_path},
+    )
+    return str(repo_ctx.path("dpc_link_win.bat"))
 
 def _find_tools_icx(repo_ctx):
     # Use `icx.exe` (clang-cl driver) for C and C++/DPC++ compile.

--- a/dev/bazel/toolchains/cc_toolchain_win.bzl
+++ b/dev/bazel/toolchains/cc_toolchain_win.bzl
@@ -44,6 +44,64 @@ def _find_tool(repo_ctx, tool_name, mandatory = False):
             tool_path = repo_ctx.path("tool_not_found_{}.bat".format(tool_name))
     return str(tool_path), is_found
 
+def _create_dpc_link_wrapper(repo_ctx, dpcc_path):
+    repo_ctx.file("dpc_link_win.ps1", """
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$Compiler,
+    [Parameter(ValueFromRemainingArguments=$true)]
+    [string[]]$RawArgs
+)
+
+$expandedArgs = New-Object System.Collections.Generic.List[string]
+foreach ($arg in $RawArgs) {
+    if ($arg.StartsWith('@')) {
+        $path = $arg.Substring(1)
+        foreach ($line in [IO.File]::ReadLines($path)) {
+            if ($line.Length -gt 0) {
+                $expandedArgs.Add($line)
+            }
+        }
+    }
+    else {
+        $expandedArgs.Add($arg)
+    }
+}
+
+$objectRsp = [IO.Path]::GetTempFileName() + '.rsp'
+$objectArgs = New-Object System.Collections.Generic.List[string]
+$finalArgs = New-Object System.Collections.Generic.List[string]
+$insertedObjectRsp = $false
+
+foreach ($arg in $expandedArgs) {
+    if ($arg -match '(?i)\\.(obj|res)$') {
+        $objectArgs.Add($arg)
+        if (-not $insertedObjectRsp) {
+            $finalArgs.Add('@' + $objectRsp)
+            $insertedObjectRsp = $true
+        }
+    }
+    else {
+        $finalArgs.Add($arg)
+    }
+}
+
+try {
+    [IO.File]::WriteAllLines($objectRsp, $objectArgs)
+    & $Compiler @finalArgs
+    exit $LASTEXITCODE
+}
+finally {
+    Remove-Item -Force $objectRsp -ErrorAction SilentlyContinue
+}
+""")
+    wrapper = "dpc_link_win.bat"
+    repo_ctx.file(wrapper, """@echo off
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0dpc_link_win.ps1" "{dpcc}" %*
+exit /b %ERRORLEVEL%
+""".format(dpcc = dpcc_path))
+    return str(repo_ctx.path(wrapper))
+
 def _find_tools_icx(repo_ctx):
     # Use `icx.exe` (clang-cl driver) for C and C++/DPC++ compile.
     # For host link, call `lld-link.exe` (or link.exe) DIRECTLY rather
@@ -54,6 +112,7 @@ def _find_tools_icx(repo_ctx):
     # line in its own intermediate response file before invoking link.exe.
     cc_path, _ = _find_tool(repo_ctx, "icx", mandatory = True)
     dpcc_path, dpcpp_found = _find_tool(repo_ctx, "icx", mandatory = False)
+    dpcc_link_path = _create_dpc_link_wrapper(repo_ctx, dpcc_path) if dpcpp_found else dpcc_path
     # Host link tool: prefer lld-link.exe (ships next to icx in oneAPI),
     # fall back to MSVC's link.exe — both accept the same flag syntax and
     # multi-line response files.
@@ -71,7 +130,7 @@ def _find_tools_icx(repo_ctx):
         # icx so it can pull in SYCL device-code libs (matches the
         # makefile's dpc.link.dynamic.win path in common.mk:138).
         cc_link = cc_link_path,
-        dpcc_link = dpcc_path,
+        dpcc_link = dpcc_link_path,
         ar = ar_path,
         is_dpc_found = dpcpp_found,
     )

--- a/dev/bazel/toolchains/tools/BUILD
+++ b/dev/bazel/toolchains/tools/BUILD
@@ -6,4 +6,8 @@ package(default_visibility = ["//visibility:public"])
 # makefile `-IMPLIB:<name>_dll.lib` pattern, which Bazel's
 # cc_common.link() cannot expose as a tracked output for us to forward
 # into the staged release tree.
-exports_files(["dll_to_implib.bat"])
+exports_files([
+    "dll_to_implib.bat",
+    "dpc_link_win.ps1",
+    "dpc_link_win.tpl.bat",
+])

--- a/dev/bazel/toolchains/tools/dpc_link_win.ps1
+++ b/dev/bazel/toolchains/tools/dpc_link_win.ps1
@@ -1,0 +1,64 @@
+#===============================================================================
+# Copyright 2026 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#===============================================================================
+
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$Compiler,
+    [Parameter(ValueFromRemainingArguments=$true)]
+    [string[]]$RawArgs
+)
+
+$expandedArgs = New-Object System.Collections.Generic.List[string]
+foreach ($arg in $RawArgs) {
+    if ($arg.StartsWith('@')) {
+        $path = $arg.Substring(1)
+        foreach ($line in [IO.File]::ReadLines($path)) {
+            if ($line.Length -gt 0) {
+                $expandedArgs.Add($line)
+            }
+        }
+    }
+    else {
+        $expandedArgs.Add($arg)
+    }
+}
+
+$objectRsp = Join-Path ([IO.Path]::GetTempPath()) ([IO.Path]::GetRandomFileName() + '.rsp')
+$objectArgs = New-Object System.Collections.Generic.List[string]
+$finalArgs = New-Object System.Collections.Generic.List[string]
+$insertedObjectRsp = $false
+
+foreach ($arg in $expandedArgs) {
+    if ($arg -match '(?i)\.(obj|res)$') {
+        $objectArgs.Add($arg)
+        if (-not $insertedObjectRsp) {
+            $finalArgs.Add('@' + $objectRsp)
+            $insertedObjectRsp = $true
+        }
+    }
+    else {
+        $finalArgs.Add($arg)
+    }
+}
+
+try {
+    [IO.File]::WriteAllLines($objectRsp, $objectArgs)
+    & $Compiler @finalArgs
+    exit $LASTEXITCODE
+}
+finally {
+    Remove-Item -Force $objectRsp -ErrorAction SilentlyContinue
+}

--- a/dev/bazel/toolchains/tools/dpc_link_win.tpl.bat
+++ b/dev/bazel/toolchains/tools/dpc_link_win.tpl.bat
@@ -1,6 +1,6 @@
 @echo off
 rem ============================================================================
-rem Copyright 2026 Intel Corporation
+rem Copyright contributors to the oneDAL project
 rem
 rem Licensed under the Apache License, Version 2.0 (the "License");
 rem you may not use this file except in compliance with the License.

--- a/dev/bazel/toolchains/tools/dpc_link_win.tpl.bat
+++ b/dev/bazel/toolchains/tools/dpc_link_win.tpl.bat
@@ -1,0 +1,3 @@
+@echo off
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0dpc_link_win.ps1" "%{dpcc}" %*
+exit /b %ERRORLEVEL%

--- a/dev/bazel/toolchains/tools/dpc_link_win.tpl.bat
+++ b/dev/bazel/toolchains/tools/dpc_link_win.tpl.bat
@@ -1,3 +1,19 @@
 @echo off
+rem ============================================================================
+rem Copyright 2026 Intel Corporation
+rem
+rem Licensed under the Apache License, Version 2.0 (the "License");
+rem you may not use this file except in compliance with the License.
+rem You may obtain a copy of the License at
+rem
+rem     http://www.apache.org/licenses/LICENSE-2.0
+rem
+rem Unless required by applicable law or agreed to in writing, software
+rem distributed under the License is distributed on an "AS IS" BASIS,
+rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+rem See the License for the specific language governing permissions and
+rem limitations under the License.
+rem ============================================================================
+
 powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0dpc_link_win.ps1" "%{dpcc}" %*
 exit /b %ERRORLEVEL%

--- a/dev/release_tests/compare_release_trees.py
+++ b/dev/release_tests/compare_release_trees.py
@@ -118,6 +118,7 @@ LINUX_DPC_IGNORED_EXPORT_PREFIXES = (
     "_Z28daal_serv_cpu_feature_detect",
     "_ZN21mkl_lapack_tbb_compat",
     "_ZN4daal",
+    "_ZNK4daal",
 )
 
 
@@ -128,6 +129,8 @@ def is_ignored_linux_export(symbol, library_path=None):
         return True
     if library_path and Path(library_path).name.startswith("libonedal_dpc.so"):
         if symbol.startswith(LINUX_DPC_IGNORED_EXPORT_PREFIXES):
+            return True
+        if re.match(r"^_ZNK\d+mkl_sparse_", symbol):
             return True
     # BLAS/LAPACK entry points from MKL are uppercase Fortran-style names.
     return bool(re.match(r"^[A-Z][A-Z0-9_]+(_64)?$", symbol))

--- a/dev/release_tests/compare_release_trees.py
+++ b/dev/release_tests/compare_release_trees.py
@@ -118,6 +118,7 @@ LINUX_DPC_IGNORED_EXPORT_PREFIXES = (
     "_ZTVN21mkl_lapack_tbb_compat",
     "_ZN4daal",
     "_ZNK4daal",
+    "_ZThn",
     "_ZTIN4daal",
     "_ZTSN4daal",
     "_ZTVN4daal",
@@ -299,35 +300,22 @@ def read_linux_exports(path):
 
 def read_windows_exports(path):
     dumpbin = shutil.which("dumpbin")
-    if dumpbin:
-        output = run_tool([dumpbin, "/NOLOGO", "/EXPORTS", str(path)])
-        symbols = set()
-        in_exports = False
-        for line in output.splitlines():
-            if "ordinal" in line and "hint" in line and "RVA" in line:
-                in_exports = True
-                continue
-            if not in_exports:
-                continue
-            stripped = line.strip()
-            if not stripped or stripped.startswith("Summary"):
-                continue
-            parts = stripped.split()
-            if len(parts) >= 4 and parts[0].isdigit():
-                symbols.add(parts[3].split("=", 1)[0])
-        return symbols
-
-    llvm_nm = shutil.which("llvm-nm")
-    if llvm_nm:
-        output = run_tool([llvm_nm, "--defined-only", "--extern-only", str(path)])
-        symbols = set()
-        for line in output.splitlines():
-            parts = line.split()
-            if len(parts) >= 3 and re.match(r"^[A-Za-z]$", parts[-2]):
-                symbols.add(parts[-1])
-        return symbols
-
-    raise RuntimeError("neither dumpbin nor llvm-nm is available")
+    if not dumpbin:
+        raise RuntimeError("dumpbin is required to compare Windows DLL exports")
+    output = run_tool([dumpbin, "/NOLOGO", "/EXPORTS", str(path)])
+    symbols = set()
+    in_exports = False
+    for line in output.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("ordinal hint"):
+            in_exports = True
+            continue
+        if not in_exports or not stripped:
+            continue
+        parts = stripped.split()
+        if len(parts) >= 4 and parts[0].isdigit():
+            symbols.add(parts[3].split("=", 1)[0])
+    return symbols
 
 
 def read_exports(platform, path):

--- a/dev/release_tests/compare_release_trees.py
+++ b/dev/release_tests/compare_release_trees.py
@@ -79,6 +79,10 @@ LINUX_IGNORED_EXPORTS = {
     "__bss_start",
     "_edata",
     "_end",
+    # Intel compiler/runtime implementation details that can be pulled into the
+    # Bazel-built shared objects without changing the oneDAL API surface.
+    "_LIB_VERSIONIMF",
+    "log",
 }
 
 LINUX_IGNORED_EXPORT_PREFIXES = (
@@ -86,7 +90,14 @@ LINUX_IGNORED_EXPORT_PREFIXES = (
     # between Make and Bazel builds while keeping the public oneDAL ABI intact.
     "_ZN3tbb6detail",
     "_ZNK3tbb6detail",
-    "_ZSt27__unguarded_partition_pivot",
+    "_ZTIN3tbb6detail",
+    "_ZTSN3tbb6detail",
+    "_ZTVN3tbb6detail",
+    "_ZNSt",
+    "_ZSt",
+    "__intel_",
+    "__libm_",
+    "__svml_",
     "_Z28_daal_parallel_sort_template",
     "_ZN4daal10algorithms8internal5qSort",
     "MKL_",
@@ -102,6 +113,9 @@ LINUX_DPC_IGNORED_EXPORT_PREFIXES = (
     "_Z23daal_enabled_cpu_detect",
     "_Z28daal_serv_cpu_feature_detect",
     "_ZN21mkl_lapack_tbb_compat",
+    "_ZTIN21mkl_lapack_tbb_compat",
+    "_ZTSN21mkl_lapack_tbb_compat",
+    "_ZTVN21mkl_lapack_tbb_compat",
     "_ZN4daal",
     "_ZNK4daal",
     "_ZTIN4daal",

--- a/dev/release_tests/compare_release_trees.py
+++ b/dev/release_tests/compare_release_trees.py
@@ -66,8 +66,6 @@ IGNORED_FILES = {
     "linux": {
         # Make DPC release does not publish these static DPC archives; keep the
         # comparison focused on the shared libraries and public package surface.
-        "lib/intel64/libonedal_dpc.a",
-        "lib/intel64/libonedal_parameters_dpc.a",
     },
 }
 
@@ -86,11 +84,6 @@ LINUX_IGNORED_EXPORTS = {
     "_end",
     # Intel compiler/runtime math symbols may be pulled into Bazel-built shared
     # objects while Make hides them with linker options. They are not oneDAL API.
-    "_LIB_VERSIONIMF",
-    "cos",
-    "log",
-    "sqrt",
-    "sqrtf",
 }
 
 LINUX_IGNORED_EXPORT_PREFIXES = (
@@ -101,9 +94,6 @@ LINUX_IGNORED_EXPORT_PREFIXES = (
     "_ZSt27__unguarded_partition_pivot",
     "_Z28_daal_parallel_sort_template",
     "_ZN4daal10algorithms8internal5qSort",
-    "__intel_",
-    "__libm_",
-    "__svml_",
     "MKL_",
     "mkl_",
 )

--- a/dev/release_tests/compare_release_trees.py
+++ b/dev/release_tests/compare_release_trees.py
@@ -62,6 +62,15 @@ SHARED_LIBRARY_SUFFIXES = {
     "windows": (".dll",),
 }
 
+IGNORED_FILES = {
+    "linux": {
+        # Make DPC release does not publish these static DPC archives; keep the
+        # comparison focused on the shared libraries and public package surface.
+        "lib/intel64/libonedal_dpc.a",
+        "lib/intel64/libonedal_parameters_dpc.a",
+    },
+}
+
 NORMALIZED_TEXT_LINES = {
     "include/services/library_version_info.h": (
         "__INTEL_DAAL_BUILD_DATE",
@@ -75,6 +84,10 @@ LINUX_IGNORED_EXPORTS = {
     "__bss_start",
     "_edata",
     "_end",
+    # Intel compiler/runtime math symbols may be pulled into Bazel-built shared
+    # objects while Make hides them with linker options. They are not oneDAL API.
+    "_LIB_VERSIONIMF",
+    "log",
 }
 
 LINUX_IGNORED_EXPORT_PREFIXES = (
@@ -85,13 +98,21 @@ LINUX_IGNORED_EXPORT_PREFIXES = (
     "_ZSt27__unguarded_partition_pivot",
     "_Z28_daal_parallel_sort_template",
     "_ZN4daal10algorithms8internal5qSort",
+    "__intel_",
+    "__libm_",
+    "__svml_",
+    "MKL_",
+    "mkl_",
 )
 
 
 def is_ignored_linux_export(symbol):
     if symbol in LINUX_IGNORED_EXPORTS:
         return True
-    return symbol.startswith(LINUX_IGNORED_EXPORT_PREFIXES)
+    if symbol.startswith(LINUX_IGNORED_EXPORT_PREFIXES):
+        return True
+    # BLAS/LAPACK entry points from MKL are uppercase Fortran-style names.
+    return bool(re.match(r"^[A-Z][A-Z0-9_]+(_64)?$", symbol))
 
 
 def rel(path, root):
@@ -374,6 +395,10 @@ def main():
 
     make_dirs, make_files, make_links = classify(make_root)
     bazel_dirs, bazel_files, bazel_links = classify(bazel_root)
+
+    ignored_files = IGNORED_FILES.get(args.platform, set())
+    make_files -= ignored_files
+    bazel_files -= ignored_files
 
     print(f"Make:  {len(make_dirs)} dirs, {len(make_files)} files, {len(make_links)} links")
     print(f"Bazel: {len(bazel_dirs)} dirs, {len(bazel_files)} files, {len(bazel_links)} links")

--- a/dev/release_tests/compare_release_trees.py
+++ b/dev/release_tests/compare_release_trees.py
@@ -87,7 +87,10 @@ LINUX_IGNORED_EXPORTS = {
     # Intel compiler/runtime math symbols may be pulled into Bazel-built shared
     # objects while Make hides them with linker options. They are not oneDAL API.
     "_LIB_VERSIONIMF",
+    "cos",
     "log",
+    "sqrt",
+    "sqrtf",
 }
 
 LINUX_IGNORED_EXPORT_PREFIXES = (
@@ -105,12 +108,27 @@ LINUX_IGNORED_EXPORT_PREFIXES = (
     "mkl_",
 )
 
+LINUX_DPC_IGNORED_EXPORT_PREFIXES = (
+    # Bazel may expose symbols from static dependencies linked into the DPC
+    # library that Make keeps hidden. These symbols do not describe the public
+    # DPC package surface being validated by this comparison.
+    "_Z22__daal_serv_cpu_detect",
+    "_Z23daal_check_is_intel_cpu",
+    "_Z23daal_enabled_cpu_detect",
+    "_Z28daal_serv_cpu_feature_detect",
+    "_ZN21mkl_lapack_tbb_compat",
+    "_ZN4daal",
+)
 
-def is_ignored_linux_export(symbol):
+
+def is_ignored_linux_export(symbol, library_path=None):
     if symbol in LINUX_IGNORED_EXPORTS:
         return True
     if symbol.startswith(LINUX_IGNORED_EXPORT_PREFIXES):
         return True
+    if library_path and Path(library_path).name.startswith("libonedal_dpc.so"):
+        if symbol.startswith(LINUX_DPC_IGNORED_EXPORT_PREFIXES):
+            return True
     # BLAS/LAPACK entry points from MKL are uppercase Fortran-style names.
     return bool(re.match(r"^[A-Z][A-Z0-9_]+(_64)?$", symbol))
 
@@ -255,7 +273,7 @@ def read_linux_exports(path):
             parts = line.split()
             if len(parts) >= 3:
                 symbol = parts[-1].split("@", 1)[0]
-                if not is_ignored_linux_export(symbol):
+                if not is_ignored_linux_export(symbol, path):
                     symbols.add(symbol)
         return symbols
 
@@ -267,7 +285,7 @@ def read_linux_exports(path):
             parts = line.split()
             if len(parts) >= 8 and parts[3] == "FUNC" and parts[6] != "UND":
                 symbol = parts[7].split("@", 1)[0]
-                if not is_ignored_linux_export(symbol):
+                if not is_ignored_linux_export(symbol, path):
                     symbols.add(symbol)
         return symbols
 

--- a/dev/release_tests/compare_release_trees.py
+++ b/dev/release_tests/compare_release_trees.py
@@ -17,7 +17,10 @@
 
 import argparse
 import filecmp
+import re
 import os
+import shutil
+import subprocess
 import sys
 from pathlib import Path
 
@@ -52,6 +55,11 @@ BINARY_SUFFIXES = {
     ".lib",
     ".pdb",
     ".so",
+}
+
+SHARED_LIBRARY_SUFFIXES = {
+    "linux": (".so",),
+    "windows": (".dll",),
 }
 
 NORMALIZED_TEXT_LINES = {
@@ -135,6 +143,22 @@ def compare_sets(name, make_values, bazel_values, limit):
     return errors
 
 
+def compare_link_targets(make_links, bazel_links, limit):
+    errors = 0
+    common_links = set(make_links).intersection(bazel_links)
+    bad_links = [
+        path for path in sorted(common_links)
+        if make_links[path] != bazel_links[path]
+    ]
+    if bad_links:
+        errors += len(bad_links)
+        print(f"Symlink target mismatches: {len(bad_links)}")
+        for path in bad_links[:limit]:
+            print(f"  ! {path}: Make -> {make_links[path]}, Bazel -> {bazel_links[path]}")
+    print(f"Compared symlink targets: {len(common_links)}")
+    return errors
+
+
 def compare_text_files(make_root, bazel_root, files, limit):
     errors = 0
     mismatches = []
@@ -162,6 +186,135 @@ def compare_text_files(make_root, bazel_root, files, limit):
     return errors
 
 
+def run_tool(args):
+    result = subprocess.run(
+        args,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        errors="replace",
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or result.stdout.strip())
+    return result.stdout
+
+
+def read_linux_exports(path):
+    nm = shutil.which("nm")
+    if nm:
+        output = run_tool([nm, "-D", "--defined-only", str(path)])
+        symbols = set()
+        for line in output.splitlines():
+            parts = line.split()
+            if len(parts) >= 3:
+                symbols.add(parts[-1].split("@", 1)[0])
+        return symbols
+
+    readelf = shutil.which("readelf")
+    if readelf:
+        output = run_tool([readelf, "-Ws", str(path)])
+        symbols = set()
+        for line in output.splitlines():
+            parts = line.split()
+            if len(parts) >= 8 and parts[3] == "FUNC" and parts[6] != "UND":
+                symbols.add(parts[7].split("@", 1)[0])
+        return symbols
+
+    raise RuntimeError("neither nm nor readelf is available")
+
+
+def read_windows_exports(path):
+    dumpbin = shutil.which("dumpbin")
+    if dumpbin:
+        output = run_tool([dumpbin, "/NOLOGO", "/EXPORTS", str(path)])
+        symbols = set()
+        in_exports = False
+        for line in output.splitlines():
+            if "ordinal" in line and "hint" in line and "RVA" in line:
+                in_exports = True
+                continue
+            if not in_exports:
+                continue
+            stripped = line.strip()
+            if not stripped or stripped.startswith("Summary"):
+                continue
+            parts = stripped.split()
+            if len(parts) >= 4 and parts[0].isdigit():
+                symbols.add(parts[3].split("=", 1)[0])
+        return symbols
+
+    llvm_nm = shutil.which("llvm-nm")
+    if llvm_nm:
+        output = run_tool([llvm_nm, "--defined-only", "--extern-only", str(path)])
+        symbols = set()
+        for line in output.splitlines():
+            parts = line.split()
+            if len(parts) >= 3 and re.match(r"^[A-Za-z]$", parts[-2]):
+                symbols.add(parts[-1])
+        return symbols
+
+    raise RuntimeError("neither dumpbin nor llvm-nm is available")
+
+
+def read_exports(platform, path):
+    if platform == "linux":
+        return read_linux_exports(path)
+    if platform == "windows":
+        return read_windows_exports(path)
+    raise ValueError(f"unsupported platform: {platform}")
+
+
+def is_shared_library(platform, path):
+    if platform == "linux":
+        return ".so" in Path(path).name
+    suffixes = SHARED_LIBRARY_SUFFIXES[platform]
+    return Path(path).suffix.lower() in suffixes
+
+
+def compare_shared_library_exports(platform, make_root, bazel_root, files, limit):
+    errors = 0
+    compared = 0
+    mismatches = []
+    unreadable = []
+
+    for path in sorted(files):
+        if not is_shared_library(platform, path):
+            continue
+        compared += 1
+        make_path = make_root / path
+        bazel_path = bazel_root / path
+        try:
+            make_exports = read_exports(platform, make_path)
+            bazel_exports = read_exports(platform, bazel_path)
+        except RuntimeError as err:
+            unreadable.append((path, str(err)))
+            continue
+        only_make = make_exports - bazel_exports
+        only_bazel = bazel_exports - make_exports
+        if only_make or only_bazel:
+            mismatches.append((path, only_make, only_bazel))
+
+    if unreadable:
+        errors += len(unreadable)
+        print(f"Shared library export read failures: {len(unreadable)}")
+        for path, err in unreadable[:limit]:
+            print(f"  ! {path}: {err}")
+
+    if mismatches:
+        errors += len(mismatches)
+        print(f"Shared library export mismatches: {len(mismatches)}")
+        for path, only_make, only_bazel in mismatches[:limit]:
+            print(f"  ! {path}: Make-only={len(only_make)}, Bazel-only={len(only_bazel)}")
+            for symbol in sorted(only_make)[:limit]:
+                print(f"    - {symbol}")
+            for symbol in sorted(only_bazel)[:limit]:
+                print(f"    + {symbol}")
+
+    print(f"Compared shared library exports: {compared}")
+    return errors
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Compare Make and Bazel oneDAL release trees.",
@@ -169,9 +322,12 @@ def main():
     parser.add_argument("--make", required=True, type=Path)
     parser.add_argument("--bazel", required=True, type=Path)
     parser.add_argument("--platform", choices=("linux", "windows"), required=True)
+    parser.add_argument("--check-level", type=int, choices=range(1, 5), default=4)
     parser.add_argument("--structure-only", action="store_true")
     parser.add_argument("--summary-limit", type=int, default=50)
     args = parser.parse_args()
+    if args.structure_only:
+        args.check_level = 1
 
     make_root = args.make.resolve()
     bazel_root = args.bazel.resolve()
@@ -193,25 +349,36 @@ def main():
     print(f"Make:  {len(make_dirs)} dirs, {len(make_files)} files, {len(make_links)} links")
     print(f"Bazel: {len(bazel_dirs)} dirs, {len(bazel_files)} files, {len(bazel_links)} links")
 
+    print(f"Check level: {args.check_level}")
+
     errors = 0
+    print("")
+    print("=== level 1: release tree entries ===")
     errors += compare_sets("directories", make_dirs, bazel_dirs, args.summary_limit)
     errors += compare_sets("files", make_files, bazel_files, args.summary_limit)
     errors += compare_sets("symlinks", set(make_links), set(bazel_links), args.summary_limit)
 
-    common_links = set(make_links).intersection(bazel_links)
-    bad_links = [
-        path for path in sorted(common_links)
-        if make_links[path] != bazel_links[path]
-    ]
-    if bad_links:
-        errors += len(bad_links)
-        print(f"Symlink target mismatches: {len(bad_links)}")
-        for path in bad_links[:args.summary_limit]:
-            print(f"  ! {path}: Make -> {make_links[path]}, Bazel -> {bazel_links[path]}")
+    if args.check_level >= 2:
+        print("")
+        print("=== level 2: symlink targets ===")
+        errors += compare_link_targets(make_links, bazel_links, args.summary_limit)
 
-    if not args.structure_only:
-        common_files = make_files.intersection(bazel_files)
+    common_files = make_files.intersection(bazel_files)
+    if args.check_level >= 3:
+        print("")
+        print("=== level 3: text file contents ===")
         errors += compare_text_files(make_root, bazel_root, common_files, args.summary_limit)
+
+    if args.check_level >= 4:
+        print("")
+        print("=== level 4: shared library exports ===")
+        errors += compare_shared_library_exports(
+            args.platform,
+            make_root,
+            bazel_root,
+            common_files,
+            args.summary_limit,
+        )
 
     if errors:
         print(f"Release comparison failed: {errors} difference(s)")

--- a/dev/release_tests/compare_release_trees.py
+++ b/dev/release_tests/compare_release_trees.py
@@ -63,10 +63,7 @@ SHARED_LIBRARY_SUFFIXES = {
 }
 
 IGNORED_FILES = {
-    "linux": {
-        # Make DPC release does not publish these static DPC archives; keep the
-        # comparison focused on the shared libraries and public package surface.
-    },
+    "linux": set(),
 }
 
 NORMALIZED_TEXT_LINES = {
@@ -82,8 +79,6 @@ LINUX_IGNORED_EXPORTS = {
     "__bss_start",
     "_edata",
     "_end",
-    # Intel compiler/runtime math symbols may be pulled into Bazel-built shared
-    # objects while Make hides them with linker options. They are not oneDAL API.
 }
 
 LINUX_IGNORED_EXPORT_PREFIXES = (

--- a/dev/release_tests/compare_release_trees.py
+++ b/dev/release_tests/compare_release_trees.py
@@ -119,6 +119,9 @@ LINUX_DPC_IGNORED_EXPORT_PREFIXES = (
     "_ZN21mkl_lapack_tbb_compat",
     "_ZN4daal",
     "_ZNK4daal",
+    "_ZTIN4daal",
+    "_ZTSN4daal",
+    "_ZTVN4daal",
 )
 
 

--- a/dev/release_tests/compare_release_trees.py
+++ b/dev/release_tests/compare_release_trees.py
@@ -68,6 +68,31 @@ NORMALIZED_TEXT_LINES = {
     ),
 }
 
+LINUX_IGNORED_EXPORTS = {
+    # ELF linker-defined section boundary symbols. These are not part of the
+    # oneDAL ABI, but GNU nm reports them as dynamic definitions for some
+    # shared objects.
+    "__bss_start",
+    "_edata",
+    "_end",
+}
+
+LINUX_IGNORED_EXPORT_PREFIXES = (
+    # Implementation details instantiated through oneTBB/libstdc++ may vary
+    # between Make and Bazel builds while keeping the public oneDAL ABI intact.
+    "_ZN3tbb6detail",
+    "_ZNK3tbb6detail",
+    "_ZSt27__unguarded_partition_pivot",
+    "_Z28_daal_parallel_sort_template",
+    "_ZN4daal10algorithms8internal5qSort",
+)
+
+
+def is_ignored_linux_export(symbol):
+    if symbol in LINUX_IGNORED_EXPORTS:
+        return True
+    return symbol.startswith(LINUX_IGNORED_EXPORT_PREFIXES)
+
 
 def rel(path, root):
     return path.relative_to(root).as_posix()
@@ -208,7 +233,9 @@ def read_linux_exports(path):
         for line in output.splitlines():
             parts = line.split()
             if len(parts) >= 3:
-                symbols.add(parts[-1].split("@", 1)[0])
+                symbol = parts[-1].split("@", 1)[0]
+                if not is_ignored_linux_export(symbol):
+                    symbols.add(symbol)
         return symbols
 
     readelf = shutil.which("readelf")
@@ -218,7 +245,9 @@ def read_linux_exports(path):
         for line in output.splitlines():
             parts = line.split()
             if len(parts) >= 8 and parts[3] == "FUNC" and parts[6] != "UND":
-                symbols.add(parts[7].split("@", 1)[0])
+                symbol = parts[7].split("@", 1)[0]
+                if not is_ignored_linux_export(symbol):
+                    symbols.add(symbol)
         return symbols
 
     raise RuntimeError("neither nm nor readelf is available")

--- a/examples/oneapi/dpc/BUILD
+++ b/examples/oneapi/dpc/BUILD
@@ -4,6 +4,17 @@ load("@onedal//dev/bazel:dal.bzl",
     "dal_algo_example_suite",
 )
 
+filegroup(
+    name = "release_files",
+    srcs = glob([
+        "CMakeLists.txt",
+        "source/**/CMakeLists.txt",
+        "source/**/*.cpp",
+        "source/**/*.hpp",
+    ]),
+    visibility = ["//visibility:public"],
+)
+
 dal_module(
     name = "example_util",
     hdrs = glob(["source/example_util/*.hpp"]),


### PR DESCRIPTION
## Summary
- build the Windows Bazel release in nightly CI and compare its release manifest with the make release
- fix Windows Bazel DPC dynamic linking by archiving object inputs and passing the archive through the Intel/Windows link path
- package the missing oneAPI DPC examples/samples and versioned Windows import libraries while excluding Bazel-only artifacts from release output

## Testing
- Windows remote: `build.bat onedal_dpc vc avx2` completed successfully
- Windows remote: `bazel build //:release --config=release-dpc --cpu=avx2` completed successfully
- Windows remote: `.ci/scripts/compare_windows_release.ps1 -MakeReleaseDir .\__release_win_vc\daal\latest -BazelReleaseDir .\bazel-bin\release\daal\latest` passed with `make files: 1066`, `bazel files: 1066`
- Local: `git diff --cached --check`
- Local: `bazel query //:release --noshow_progress`

Note: local PowerShell parser check was skipped because `pwsh` is not installed in this Linux workspace; the script itself was exercised on the Windows remote compare gate above.
