### PR TITLE
fix(build): correct sed.eow to use word-boundary, not EOL

### DIFF
--- a/dev/make/common.mk
+++ b/dev/make/common.mk
@@ -178,7 +178,7 @@ sed.eol.win = \r
 sed.eol.lnx =
 
 # sed's end of word
-sed.eow = $(sed.eol.$(_OS))
+sed.eow = $(sed.eow.$(_OS))
 # macOS default sed doesn't support it
 sed.eow.mac =
 sed.eow.win = \b


### PR DESCRIPTION

## Description

`sed.eow` referenced `sed.eol.$(_OS)` instead of `sed.eow.$(_OS)`, so on Windows it expanded to `\r` instead of the word boundary `\b` that was most likely intended.

`sed.eow` builds the regex that strips unused `#define DAAL_KERNEL_<ISA>` lines from daal_kernel_defines.h during a partial build. With the typo the pattern matched only CRLF headers, so on LF sources the AVX512 define was left in and the dispatcher referenced AVX512 symbols that were never built, causing LNK2019 unresolved externals.

Using `\b` makes the stripping line-ending agnostic (works for LF and CRLF). The same pattern is built in arm.mk and riscv64.mk, so this potentially affected partial builds there too. Full builds were unaffected.


---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.


</details>
