### PR TITLE
deps: update fmt to 12.2

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -20,7 +20,7 @@ bazel_dep(name = "platforms", version = "1.1.0")
 bazel_dep(name = "bazel_skylib", version = "1.9.0")
 bazel_dep(name = "rules_cc", version = "0.2.18")
 bazel_dep(name = "rules_shell", version = "0.8.0")
-bazel_dep(name = "fmt", version = "12.1.0")
+bazel_dep(name = "fmt", version = "12.2.0")
 
 cc_configure = use_extension("@rules_cc//cc:extensions.bzl", "cc_configure_extension")
 use_repo(cc_configure, "local_config_cc", "local_config_cc_toolchains")

--- a/cpp/oneapi/dal/test/engine/common.hpp
+++ b/cpp/oneapi/dal/test/engine/common.hpp
@@ -21,7 +21,7 @@
 #include <iostream>
 #include <type_traits>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "oneapi/dal/train.hpp"
 #include "oneapi/dal/infer.hpp"

--- a/dev/l0_tools/zeinfo.cpp
+++ b/dev/l0_tools/zeinfo.cpp
@@ -18,7 +18,7 @@
 #include <thread>
 #include <iostream>
 #include <optional>
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "zexx.hpp"
 #include "utils.hpp"

--- a/dev/l0_tools/zeinfo.cpp
+++ b/dev/l0_tools/zeinfo.cpp
@@ -18,6 +18,7 @@
 #include <thread>
 #include <iostream>
 #include <optional>
+
 #include <fmt/format.h>
 
 #include "zexx.hpp"

--- a/dev/l0_tools/zexx.hpp
+++ b/dev/l0_tools/zexx.hpp
@@ -21,7 +21,7 @@
 #include <vector>
 #include <optional>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <level_zero/ze_api.h>
 #include <level_zero/zes_api.h>
 


### PR DESCRIPTION
# Summary

Fix build errors with the updated `{fmt}` version by including `<fmt/format.h>` explicitly in files that use `fmt::format`.

# Reason

Newer `{fmt}` versions changed the behavior of `<fmt/core.h>`. According to the `{fmt}` changelog, `<fmt/core.h>` is now equivalent to `<fmt/base.h>` by default and no longer pulls in `<fmt/format.h>`.

As a result, code that relies on `fmt::format` being available through `<fmt/core.h>` or other transitive includes fails to compile with errors like: 'format' is not a member of 'fmt'

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least a summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance and/or quality metrics have changed or why changes are not expected.
- [x] I have extended the benchmarking suite and provided a corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.

</details>
