### PR TITLE
Fix OpenBLAS thread safety race condition (#3329)

### DIFF
--- a/cpp/daal/src/externals/service_thread_declar_ref.h
+++ b/cpp/daal/src/externals/service_thread_declar_ref.h
@@ -24,6 +24,8 @@
 #ifndef __SERVICE_THREAD_DECLAR_REF_H__
 #define __SERVICE_THREAD_DECLAR_REF_H__
 
+#include <mutex>
+
 namespace daal
 {
 namespace internal
@@ -36,18 +38,37 @@ extern "C"
     extern int openblas_get_num_threads(void);
 }
 
+/* OpenBLAS lacks a thread-local equivalent to mkl_set_num_threads_local(),
+   so openblas_set_num_threads() modifies global state. A static mutex
+   serializes the save-set-restore sequence to prevent race conditions
+   when multiple threads enter single-threaded BLAS/LAPACK calls concurrently.
+   See: https://github.com/uxlfoundation/oneDAL/issues/3329 */
 class openblas_thread_setter
 {
 public:
     openblas_thread_setter(int n_threads = 1)
     {
+        mutex().lock();
         previous_thread_count = openblas_get_num_threads();
         openblas_set_num_threads(n_threads);
     }
-    ~openblas_thread_setter() { openblas_set_num_threads(previous_thread_count); }
+    ~openblas_thread_setter()
+    {
+        openblas_set_num_threads(previous_thread_count);
+        mutex().unlock();
+    }
+
+    openblas_thread_setter(const openblas_thread_setter &) = delete;
+    openblas_thread_setter & operator=(const openblas_thread_setter &) = delete;
 
 private:
     int previous_thread_count = 1;
+
+    static std::mutex & mutex()
+    {
+        static std::mutex m;
+        return m;
+    }
 };
 
 } // namespace ref

--- a/cpp/daal/src/externals/service_thread_declar_ref.h
+++ b/cpp/daal/src/externals/service_thread_declar_ref.h
@@ -58,7 +58,7 @@ public:
         mutex().unlock();
     }
 
-    openblas_thread_setter(const openblas_thread_setter &) = delete;
+    openblas_thread_setter(const openblas_thread_setter &)             = delete;
     openblas_thread_setter & operator=(const openblas_thread_setter &) = delete;
 
 private:


### PR DESCRIPTION
## Motivation

Fix Issue #3329: OpenBLAS backend has thread safety issues in multi-threaded environments.

### Root Cause
When oneDAL uses OpenBLAS as the BLAS/LAPACK backend, it calls \openblas_set_num_threads()\ to set single-threaded mode. However, OpenBLAS lacks a thread-local API equivalent to MKL's \mkl_set_num_threads_local()\, causing:

1. **Race condition**: Multiple threads modify the global thread count configuration simultaneously
2. **Incorrect state restoration**: Thread save/restore operations overwrite each other, potentially corrupting global state

## Changes

Add a static mutex to the \openblas_thread_setter\ class to serialize the save-set-restore sequence:

- Use Meyers singleton pattern (function-local static) to manage the mutex
- Lock in constructor, unlock in destructor
- Disable copy construction and assignment to prevent accidental copies

### Modified Files
- \cpp/daal/src/externals/service_thread_declar_ref.h\

## Testing

- Maintains API compatibility
- Does not affect MKL backend behavior
- Resolves race condition in multi-threaded environments

## Checklist

- [x] Code follows the project's coding standards
- [x] Changes are minimal and focused on the issue
- [x] API compatibility is maintained
- [x] Commit messages follow conventional format

Closes #3329