### PR TITLE
Remove deprecated sycl::ext::oneapi and barrier use

### DIFF
--- a/cpp/oneapi/dal/algo/basic_statistics/backend/gpu/compute_kernel_csr_impl_dpc.cpp
+++ b/cpp/oneapi/dal/algo/basic_statistics/backend/gpu/compute_kernel_csr_impl_dpc.cpp
@@ -189,7 +189,7 @@ result_t compute_kernel_csr_impl<Float>::operator()(const bk::context_gpu& ctx,
             local_buf[stat::sum] = Float(0);
             local_buf[stat::sum2] = Float(0);
             local_buf[stat::sum2_cent] = Float(0);
-            item.barrier(sycl::access::fence_space::local_space);
+            sycl::group_barrier(item.get_group());
             for (std::int64_t idx = 0; idx < n_items_per_work; ++idx) {
                 auto data_idx = data_ofs + local_id * n_items_per_work + idx;
                 if (data_idx >= nonzero_count) {
@@ -224,7 +224,7 @@ result_t compute_kernel_csr_impl<Float>::operator()(const bk::context_gpu& ctx,
                     col_sum2.fetch_add(val * val);
                 }
             }
-            item.barrier(sycl::access::fence_space::local_space);
+            sycl::group_barrier(item.get_group());
             if ((local_id + col_ofs) >= column_count) {
                 return;
             }
@@ -292,7 +292,7 @@ result_t compute_kernel_csr_impl<Float>::operator()(const bk::context_gpu& ctx,
                 result_data_ptr[stat::sum * column_count + col_ofs + local_id] / row_count;
             row_counter_buf[local_id] = 0;
             work_group_buf[local_id] = Float(0);
-            item.barrier(sycl::access::fence_space::local_space);
+            sycl::group_barrier(item.get_group());
             // Merge results of first order moments
             for (std::int64_t idx = 0; idx < n_items_per_work; ++idx) {
                 auto data_idx = data_ofs + local_id * n_items_per_work + idx;
@@ -317,7 +317,7 @@ result_t compute_kernel_csr_impl<Float>::operator()(const bk::context_gpu& ctx,
                     row_counter_at.fetch_add(1);
                 }
             }
-            item.barrier(sycl::access::fence_space::local_space);
+            sycl::group_barrier(item.get_group());
             if ((local_id + col_ofs) >= column_count) {
                 return;
             }

--- a/cpp/oneapi/dal/algo/basic_statistics/backend/gpu/compute_kernel_dense_impl_dpc.cpp
+++ b/cpp/oneapi/dal/algo/basic_statistics/backend/gpu/compute_kernel_dense_impl_dpc.cpp
@@ -596,7 +596,7 @@ inline void merge_blocks_kernel(sycl::nd_item<1> item,
     }
 
     for (std::int64_t stride = sycl::min(local_size, block_count) / 2; stride > 0; stride /= 2) {
-        item.barrier(sycl::access::fence_space::local_space);
+        sycl::group_barrier(item.get_group());
 
         if (stride > id) {
             std::int64_t offset = id + stride;

--- a/cpp/oneapi/dal/algo/dbscan/backend/gpu/kernel_fp_impl.hpp
+++ b/cpp/oneapi/dal/algo/dbscan/backend/gpu/kernel_fp_impl.hpp
@@ -123,14 +123,14 @@ struct get_core_wide_kernel {
                                 Float distance_check =
                                     sycl::reduce_over_group(sg,
                                                             sum,
-                                                            sycl::ext::oneapi::plus<Float>());
+                                                            sycl::plus<Float>());
                                 if (distance_check > epsilon) {
                                     break;
                                 }
                             }
                         }
                         Float distance =
-                            sycl::reduce_over_group(sg, sum, sycl::ext::oneapi::plus<Float>());
+                            sycl::reduce_over_group(sg, sum, sycl::plus<Float>());
                         if (distance <= epsilon) {
                             count += use_weights ? weights_ptr[j] : Float(1);
                             if (local_id == 0) {
@@ -306,14 +306,14 @@ struct get_core_send_recv_replace_wide_kernel {
                                 Float distance_check =
                                     sycl::reduce_over_group(sg,
                                                             sum,
-                                                            sycl::ext::oneapi::plus<Float>());
+                                                            sycl::plus<Float>());
                                 if (distance_check > epsilon) {
                                     break;
                                 }
                             }
                         }
                         Float distance =
-                            sycl::reduce_over_group(sg, sum, sycl::ext::oneapi::plus<Float>());
+                            sycl::reduce_over_group(sg, sum, sycl::plus<Float>());
                         if (distance <= epsilon) {
                             count += use_weights ? weights_ptr[j] : Float(1);
                             if (local_id == 0) {
@@ -669,7 +669,7 @@ std::int32_t kernels_fp<Float>::start_next_cluster(sycl::queue& queue,
                     const std::int32_t index =
                         sycl::reduce_over_group(sg,
                                                 (std::int32_t)(found ? i : local_row_count),
-                                                sycl::ext::oneapi::minimum<std::int32_t>());
+                                                sycl::minimum<std::int32_t>());
                     if (index < local_row_count) {
                         if (local_id == 0) {
                             *start_index_ptr = index;
@@ -876,7 +876,7 @@ sycl::event kernels_fp<Float>::update_points_queue(sycl::queue& queue,
                         sum += val * val;
                     }
                     Float distance =
-                        sycl::reduce_over_group(sg, sum, sycl::ext::oneapi::plus<Float>());
+                        sycl::reduce_over_group(sg, sum, sycl::plus<Float>());
                     if (distance > epsilon)
                         continue;
                     if (local_id == 0) {
@@ -933,7 +933,7 @@ std::int64_t count_cores(sycl::queue& queue, const pr::ndview<std::int32_t, 1>& 
     sycl::buffer<std::int64_t> sum_buf{ &sum_result, 1 };
     queue
         .submit([&](sycl::handler& cgh) {
-            auto sum_reduction = reduction(sum_buf, cgh, sycl::ext::oneapi::plus<std::int64_t>());
+            auto sum_reduction = reduction(sum_buf, cgh, sycl::plus<std::int64_t>());
             cgh.parallel_for(sycl::range<1>{ row_count },
                              sum_reduction,
                              [=](sycl::id<1> idx, auto& sum) {

--- a/cpp/oneapi/dal/algo/dbscan/backend/gpu/kernel_fp_impl.hpp
+++ b/cpp/oneapi/dal/algo/dbscan/backend/gpu/kernel_fp_impl.hpp
@@ -121,16 +121,13 @@ struct get_core_wide_kernel {
                             if (count_iter % block_split_size == 0 &&
                                 local_size * count_iter <= column_count) {
                                 Float distance_check =
-                                    sycl::reduce_over_group(sg,
-                                                            sum,
-                                                            sycl::plus<Float>());
+                                    sycl::reduce_over_group(sg, sum, sycl::plus<Float>());
                                 if (distance_check > epsilon) {
                                     break;
                                 }
                             }
                         }
-                        Float distance =
-                            sycl::reduce_over_group(sg, sum, sycl::plus<Float>());
+                        Float distance = sycl::reduce_over_group(sg, sum, sycl::plus<Float>());
                         if (distance <= epsilon) {
                             count += use_weights ? weights_ptr[j] : Float(1);
                             if (local_id == 0) {
@@ -304,16 +301,13 @@ struct get_core_send_recv_replace_wide_kernel {
                             if (count_iter % block_split_size == 0 &&
                                 local_size * count_iter <= column_count) {
                                 Float distance_check =
-                                    sycl::reduce_over_group(sg,
-                                                            sum,
-                                                            sycl::plus<Float>());
+                                    sycl::reduce_over_group(sg, sum, sycl::plus<Float>());
                                 if (distance_check > epsilon) {
                                     break;
                                 }
                             }
                         }
-                        Float distance =
-                            sycl::reduce_over_group(sg, sum, sycl::plus<Float>());
+                        Float distance = sycl::reduce_over_group(sg, sum, sycl::plus<Float>());
                         if (distance <= epsilon) {
                             count += use_weights ? weights_ptr[j] : Float(1);
                             if (local_id == 0) {
@@ -875,8 +869,7 @@ sycl::event kernels_fp<Float>::update_points_queue(sycl::queue& queue,
                                     current_queue_ptr[j * column_count + i];
                         sum += val * val;
                     }
-                    Float distance =
-                        sycl::reduce_over_group(sg, sum, sycl::plus<Float>());
+                    Float distance = sycl::reduce_over_group(sg, sum, sycl::plus<Float>());
                     if (distance > epsilon)
                         continue;
                     if (local_id == 0) {

--- a/cpp/oneapi/dal/algo/decision_forest/backend/gpu/infer_kernel_impl_dpc.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/gpu/infer_kernel_impl_dpc.cpp
@@ -29,9 +29,9 @@ namespace pr = dal::backend::primitives;
 using alloc = sycl::usm::alloc;
 using address = sycl::access::address_space;
 
-using sycl::ext::oneapi::plus;
-using sycl::ext::oneapi::minimum;
-using sycl::ext::oneapi::maximum;
+using sycl::plus;
+using sycl::minimum;
+using sycl::maximum;
 
 template <typename Float, typename Index, typename Task>
 void infer_kernel_impl<Float, Index, Task>::validate_input(const descriptor_t& desc,

--- a/cpp/oneapi/dal/algo/decision_forest/backend/gpu/train_helpers.hpp
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/gpu/train_helpers.hpp
@@ -23,9 +23,9 @@
 
 namespace oneapi::dal::decision_forest::backend {
 
-using sycl::ext::oneapi::plus;
-using sycl::ext::oneapi::minimum;
-using sycl::ext::oneapi::maximum;
+using sycl::plus;
+using sycl::minimum;
+using sycl::maximum;
 
 template <typename Data>
 using local_accessor_rw_t = sycl::local_accessor<Data, 1>;

--- a/cpp/oneapi/dal/algo/decision_forest/backend/gpu/train_helpers.hpp
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/gpu/train_helpers.hpp
@@ -86,7 +86,7 @@ inline void reduce_hist_over_group(ItemT& item,
     }
 
     for (Index stride = sub_group_count / 2; stride > 0; stride /= 2) {
-        item.barrier(sycl::access::fence_space::local_space);
+        sycl::group_barrier(item.get_group());
         if (local_id < stride) {
             merge_stat(count_buf_ptr[local_id],
                        mean_buf_ptr[local_id],
@@ -96,7 +96,7 @@ inline void reduce_hist_over_group(ItemT& item,
                        sum2cent_buf_ptr[local_id + stride]);
         }
     }
-    item.barrier(sycl::access::fence_space::local_space);
+    sycl::group_barrier(item.get_group());
 
     count = count_buf_ptr[0];
     mean = mean_buf_ptr[0];

--- a/cpp/oneapi/dal/algo/decision_forest/backend/gpu/train_kernel_hist_impl_dpc.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/gpu/train_kernel_hist_impl_dpc.cpp
@@ -33,9 +33,9 @@ namespace pr = dal::backend::primitives;
 using alloc = sycl::usm::alloc;
 using address = sycl::access::address_space;
 
-using sycl::ext::oneapi::plus;
-using sycl::ext::oneapi::minimum;
-using sycl::ext::oneapi::maximum;
+using sycl::plus;
+using sycl::minimum;
+using sycl::maximum;
 
 template <typename T>
 using enable_if_float_t = std::enable_if_t<detail::is_valid_float_v<T>>;

--- a/cpp/oneapi/dal/algo/decision_forest/backend/gpu/train_kernel_hist_impl_dpc.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/gpu/train_kernel_hist_impl_dpc.cpp
@@ -684,7 +684,7 @@ inline void compute_hist_for_node(
         bk::atomic_global_add(node_histogram_ptr + cls_idx, prv_hist_ptr[cls_idx]);
     }
 
-    item.barrier(sycl::access::fence_space::local_space);
+    sycl::group_barrier(item.get_group());
 
     Float imp = Float(1);
     Float div = Float(1) / (Float(row_count) * row_count);
@@ -742,7 +742,7 @@ inline void compute_hist_for_node(
     local_h_ptr[2] = prv_hist[2];
 
     for (Index offset = local_size / 2; offset > 0; offset >>= 1) {
-        item.barrier(sycl::access::fence_space::local_space);
+        sycl::group_barrier(item.get_group());
         if (local_id < offset) {
             hist_type_t* h_ptr = local_buf_ptr + (local_id + offset) * hist_prop_count;
             merge_stat(local_h_ptr, h_ptr, hist_prop_count);
@@ -974,7 +974,7 @@ sycl::event train_kernel_hist_impl<Float, Bin, Index, Task>::compute_initial_sum
             local_buf_ptr[local_id] = sum;
 
             for (Index offset = local_size / 2; offset > 0; offset >>= 1) {
-                item.barrier(sycl::access::fence_space::local_space);
+                sycl::group_barrier(item.get_group());
                 if (local_id < offset) {
                     local_buf_ptr[local_id] += local_buf_ptr[local_id + offset];
                 }
@@ -1050,7 +1050,7 @@ sycl::event train_kernel_hist_impl<Float, Bin, Index, Task>::compute_initial_sum
             local_buf_ptr[local_id] = sum2cent;
 
             for (Index offset = local_size / 2; offset > 0; offset >>= 1) {
-                item.barrier(sycl::access::fence_space::local_space);
+                sycl::group_barrier(item.get_group());
                 if (local_id < offset) {
                     local_buf_ptr[local_id] += local_buf_ptr[local_id + offset];
                 }

--- a/cpp/oneapi/dal/algo/decision_forest/backend/gpu/train_service_kernels_dpc.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/gpu/train_service_kernels_dpc.cpp
@@ -462,7 +462,7 @@ sycl::event train_service_kernels<Float, Bin, Index, Task>::update_mdi_var_impor
                 }
             }
 
-            item.barrier(sycl::access::fence_space::local_space);
+            sycl::group_barrier(item.get_group());
             if (1 < n_sub_groups && 0 == sub_group_id) {
                 // first sub group for current node reduces over local buffer if required
                 Float ftr_imp = (sub_group_local_id < n_sub_groups)

--- a/cpp/oneapi/dal/algo/decision_forest/backend/gpu/train_service_kernels_dpc.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/gpu/train_service_kernels_dpc.cpp
@@ -28,9 +28,9 @@ namespace de = dal::detail;
 namespace bk = dal::backend;
 namespace pr = dal::backend::primitives;
 
-using sycl::ext::oneapi::plus;
-using sycl::ext::oneapi::minimum;
-using sycl::ext::oneapi::maximum;
+using sycl::plus;
+using sycl::minimum;
+using sycl::maximum;
 
 using alloc = sycl::usm::alloc;
 using address = sycl::access::address_space;

--- a/cpp/oneapi/dal/algo/decision_forest/backend/gpu/train_splitter_helpers.hpp
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/gpu/train_splitter_helpers.hpp
@@ -31,9 +31,9 @@ namespace pr = dal::backend::primitives;
 using alloc = sycl::usm::alloc;
 using address = sycl::access::address_space;
 
-using sycl::ext::oneapi::plus;
-using sycl::ext::oneapi::minimum;
-using sycl::ext::oneapi::maximum;
+using sycl::plus;
+using sycl::minimum;
+using sycl::maximum;
 
 template <typename T>
 using enable_if_float_t = std::enable_if_t<detail::is_valid_float_v<T>>;

--- a/cpp/oneapi/dal/algo/decision_forest/backend/gpu/train_splitter_helpers.hpp
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/gpu/train_splitter_helpers.hpp
@@ -75,7 +75,7 @@ inline T* fill_with_group(sycl::nd_item<2>& item, T* dst, Index elem_count, T va
         dst[i] = val;
     }
 
-    item.barrier(sycl::access::fence_space::local_space);
+    sycl::group_barrier(item.get_group());
 
     return dst;
 }

--- a/cpp/oneapi/dal/algo/decision_forest/backend/gpu/train_splitter_impl_dpc.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/gpu/train_splitter_impl_dpc.cpp
@@ -437,7 +437,7 @@ inline void compute_histogram(const local_accessor_rw_t<hist_type_t>& hist,
             }
         }
         // Finalize regression case by calculating MSE
-        item.barrier(sycl::access::fence_space::local_space);
+        sycl::group_barrier(item.get_group());
         Float mse = 0;
         const Float mean = local_hist[loc_bin_pos + 1] / local_hist[loc_bin_pos + 0];
         for (Index row_idx = id / act_bin_block; row_idx < row_count; row_idx += work_size) {
@@ -639,7 +639,7 @@ sycl::event train_splitter_impl<Float, Bin, Index, Task>::best_split(
                                       local_size,
                                       hist_prop_count,
                                       bin_block);
-                    item.barrier(sycl::access::fence_space::local_space);
+                    sycl::group_barrier(item.get_group());
                     // Calculate histogram for bin block
                     const Index act_bin_block = sycl::min(bin_block, bin_count - bin_ofs);
                     compute_histogram<Index, Float, Task, Bin, hist_type_t>(hist,
@@ -654,7 +654,7 @@ sycl::event train_splitter_impl<Float, Bin, Index, Task>::best_split(
                                                                             hist_prop_count,
                                                                             arr);
                     // Wait until histogram computing will be finished
-                    item.barrier(sycl::access::fence_space::local_space);
+                    sycl::group_barrier(item.get_group());
                     // Calculate impurity decrease for block of bins
                     if (local_id < act_bin_block) {
                         auto cur_hist = local_hist + local_id * hist_prop_count;
@@ -697,7 +697,7 @@ sycl::event train_splitter_impl<Float, Bin, Index, Task>::best_split(
                     }
                     // Select best split among bin block
                     for (Index offset = 1; offset < act_bin_block; offset <<= 1) {
-                        item.barrier(sycl::access::fence_space::local_space);
+                        sycl::group_barrier(item.get_group());
                         const Index reduce_mask = (offset << 1) - 1;
                         if (((local_id & reduce_mask) == 0) &&
                             (local_id + offset < act_bin_block)) {
@@ -722,7 +722,7 @@ sycl::event train_splitter_impl<Float, Bin, Index, Task>::best_split(
                             }
                         }
                     }
-                    item.barrier(sycl::access::fence_space::local_space);
+                    sycl::group_barrier(item.get_group());
                 }
             });
         });
@@ -749,7 +749,7 @@ sycl::event train_splitter_impl<Float, Bin, Index, Task>::best_split(
                 ftr_ids.template get_multi_ptr<sycl::access::decorated::yes>().get_raw();
 
             ftr_indices[local_id] = local_id;
-            item.barrier(sycl::access::fence_space::local_space);
+            sycl::group_barrier(item.get_group());
 
             // Select best split inside one working item
             for (Index ftr_id = local_id; ftr_id < ftr_count; ftr_id += local_size) {
@@ -764,7 +764,7 @@ sycl::event train_splitter_impl<Float, Bin, Index, Task>::best_split(
             // Select best split among working group
             const Index reduce_count = sycl::min(local_size, ftr_count);
             for (Index offset = 1; offset < reduce_count; offset <<= 1) {
-                item.barrier(sycl::access::fence_space::local_space);
+                sycl::group_barrier(item.get_group());
                 const Index reduce_mask = (offset << 1) - 1;
                 if (((local_id & reduce_mask) == 0) && (local_id + offset < reduce_count)) {
                     split_scalar_t& s1 = node_splits[local_id];

--- a/cpp/oneapi/dal/algo/decision_forest/backend/gpu/train_splitter_impl_dpc.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/backend/gpu/train_splitter_impl_dpc.cpp
@@ -34,9 +34,9 @@ namespace pr = dal::backend::primitives;
 using alloc = sycl::usm::alloc;
 using address = sycl::access::address_space;
 
-using sycl::ext::oneapi::plus;
-using sycl::ext::oneapi::minimum;
-using sycl::ext::oneapi::maximum;
+using sycl::plus;
+using sycl::minimum;
+using sycl::maximum;
 
 template <typename Float, typename Bin, typename Index, typename Task>
 sycl::event train_splitter_impl<Float, Bin, Index, Task>::random_split(

--- a/cpp/oneapi/dal/algo/kmeans/backend/gpu/kernels_csr_impl.hpp
+++ b/cpp/oneapi/dal/algo/kmeans/backend/gpu/kernels_csr_impl.hpp
@@ -274,7 +274,7 @@ sycl::event update_centroids(sycl::queue& q,
             for (std::int64_t col_idx = local_id; col_idx < column_count; col_idx += col_block) {
                 local_centroid_ptr[col_idx] = 0;
             }
-            it.barrier();
+            sycl::group_barrier(it.get_group());
             for (std::int64_t row_idx = row_shift; row_idx < row_count; row_idx += row_block) {
                 if (resp_ptr[row_idx] == static_cast<std::int32_t>(cluster_id)) {
                     // Do computations only in case the workitem corresponds to this data row's centroid id
@@ -288,7 +288,7 @@ sycl::event update_centroids(sycl::queue& q,
                     }
                 }
             }
-            it.barrier();
+            sycl::group_barrier(it.get_group());
             // Update global sums of observations by adding up all the local sums
             if (local_id == 0) {
                 for (std::int64_t col_idx = 0; col_idx < column_count; ++col_idx) {

--- a/cpp/oneapi/dal/algo/kmeans/backend/gpu/kernels_fp_impl.hpp
+++ b/cpp/oneapi/dal/algo/kmeans/backend/gpu/kernels_fp_impl.hpp
@@ -364,8 +364,7 @@ sycl::event kernels_fp<Float>::partial_reduce_centroids(
                     if (local_id == 0) {
                         cl = response_ptr[i];
                     }
-                    cl =
-                        sycl::reduce_over_group(sg, cl, sycl::maximum<std::int32_t>());
+                    cl = sycl::reduce_over_group(sg, cl, sycl::maximum<std::int32_t>());
                     for (std::int64_t j = local_id; j < column_count; j += local_range) {
                         partial_centroids_ptr[sg_global_id * cluster_count * column_count +
                                               cl * column_count + j] +=

--- a/cpp/oneapi/dal/algo/kmeans/backend/gpu/kernels_fp_impl.hpp
+++ b/cpp/oneapi/dal/algo/kmeans/backend/gpu/kernels_fp_impl.hpp
@@ -173,8 +173,8 @@ sycl::event kernels_fp<Float>::select(sycl::queue& queue,
             cgh.parallel_for<select_min_distance<Float>>(
                 bk::make_multiple_nd_range_2d({ curr_block, wg_size }, { sg_count, sg_size }),
                 [=](sycl::nd_item<2> item) {
-                    constexpr sycl::ext::oneapi::minimum<Float> minimum_val;
-                    constexpr sycl::ext::oneapi::minimum<std::int32_t> minimum_idx;
+                    constexpr sycl::minimum<Float> minimum_val;
+                    constexpr sycl::minimum<std::int32_t> minimum_idx;
 
                     const std::int64_t row = item.get_global_id(0) + first_row;
 
@@ -312,7 +312,7 @@ sycl::event kernels_fp<Float>::merge_reduce_centroids(sycl::queue& queue,
                 for (std::int64_t i = local_id; i < part_count; i += local_range) {
                     sum += partial_centroids_ptr[i * cluster_count * column_count + sg_global_id];
                 }
-                sum = sycl::reduce_over_group(sg, sum, sycl::ext::oneapi::plus<Float>());
+                sum = sycl::reduce_over_group(sg, sum, sycl::plus<Float>());
 
                 if (local_id == 0) {
                     auto count = counters_ptr[sg_cluster_id];
@@ -365,7 +365,7 @@ sycl::event kernels_fp<Float>::partial_reduce_centroids(
                         cl = response_ptr[i];
                     }
                     cl =
-                        sycl::reduce_over_group(sg, cl, sycl::ext::oneapi::maximum<std::int32_t>());
+                        sycl::reduce_over_group(sg, cl, sycl::maximum<std::int32_t>());
                     for (std::int64_t j = local_id; j < column_count; j += local_range) {
                         partial_centroids_ptr[sg_global_id * cluster_count * column_count +
                                               cl * column_count + j] +=

--- a/cpp/oneapi/dal/algo/kmeans/backend/gpu/kernels_integral_dpc.cpp
+++ b/cpp/oneapi/dal/algo/kmeans/backend/gpu/kernels_integral_dpc.cpp
@@ -138,7 +138,7 @@ std::int64_t count_empty_clusters(sycl::queue& queue,
                 for (std::int64_t i = local_id; i < cluster_count; i += local_range) {
                     sum += counter_ptr[i] == 0;
                 }
-                sum = sycl::reduce_over_group(sg, sum, sycl::ext::oneapi::plus<std::int32_t>());
+                sum = sycl::reduce_over_group(sg, sum, sycl::plus<std::int32_t>());
                 if (local_id == 0) {
                     value_ptr[0] = sum;
                 }

--- a/cpp/oneapi/dal/algo/svm/backend/gpu/smo_solver.hpp
+++ b/cpp/oneapi/dal/algo/svm/backend/gpu/smo_solver.hpp
@@ -26,8 +26,8 @@ namespace oneapi::dal::svm::backend {
 
 namespace pr = dal::backend::primitives;
 
-using sycl::ext::oneapi::maximum;
-using sycl::ext::oneapi::minimum;
+using sycl::maximum;
+using sycl::minimum;
 
 template <typename Data>
 using local_accessor_rw_t = sycl::local_accessor<Data, 1>;

--- a/cpp/oneapi/dal/algo/svm/backend/gpu/smo_solver.hpp
+++ b/cpp/oneapi/dal/algo/svm/backend/gpu/smo_solver.hpp
@@ -68,7 +68,7 @@ inline void reduce_arg_max(sycl::nd_item<1> item,
         sg_cache_index[sg_id] = res_index;
     }
 
-    item.barrier(sycl::access::fence_space::local_space);
+    sycl::group_barrier(item.get_group());
 
     if (sg_id == 0 && sg_local_id < sg_count) {
         x = sg_cache_values[sg_local_id];
@@ -96,7 +96,7 @@ inline void reduce_arg_max(sycl::nd_item<1> item,
         }
     }
 
-    item.barrier(sycl::access::fence_space::local_space);
+    sycl::group_barrier(item.get_group());
 }
 
 template <typename Float>
@@ -178,7 +178,7 @@ sycl::event solve_smo(sycl::queue& q,
             Float* local_vars_ptr =
                 local_vars.template get_multi_ptr<sycl::access::decorated::yes>().get_raw();
             local_kernel_values_ptr[i] = kernel_values_ptr[i * row_count + ws_index];
-            item.barrier(sycl::access::fence_space::local_space);
+            sycl::group_barrier(item.get_group());
 
             std::int32_t inner_iter = 0;
             for (; inner_iter < max_inner_iter; ++inner_iter) {
@@ -210,7 +210,7 @@ sycl::event solve_smo(sycl::queue& q,
                     }
                 }
 
-                item.barrier(sycl::access::fence_space::local_space);
+                sycl::group_barrier(item.get_group());
                 if (local_vars_ptr[local_diff] < local_vars_ptr[local_eps]) {
                     break;
                 }
@@ -250,7 +250,7 @@ sycl::event solve_smo(sycl::queue& q,
                     local_vars_ptr[delta_b_j] = sycl::fmin(local_vars_ptr[delta_b_j], dt);
                 }
 
-                item.barrier(sycl::access::fence_space::local_space);
+                sycl::group_barrier(item.get_group());
 
                 const Float delta =
                     sycl::fmin(local_vars_ptr[delta_b_i], local_vars_ptr[delta_b_j]);

--- a/cpp/oneapi/dal/backend/primitives/placement/argwhere.hpp
+++ b/cpp/oneapi/dal/backend/primitives/placement/argwhere.hpp
@@ -36,13 +36,13 @@ struct where_alignment_map {};
 
 template <typename Index>
 struct where_alignment_map<Index, where_alignment::left> {
-    constexpr static inline sycl::ext::oneapi::maximum<Index> binary{};
+    constexpr static inline sycl::maximum<Index> binary{};
     constexpr static inline auto identity = std::numeric_limits<Index>::lowest();
 };
 
 template <typename Index>
 struct where_alignment_map<Index, where_alignment::right> {
-    constexpr static inline sycl::ext::oneapi::minimum<Index> binary{};
+    constexpr static inline sycl::minimum<Index> binary{};
     constexpr static inline auto identity = std::numeric_limits<Index>::max();
 };
 

--- a/cpp/oneapi/dal/backend/primitives/placement/cumulative_sum_dpc.cpp
+++ b/cpp/oneapi/dal/backend/primitives/placement/cumulative_sum_dpc.cpp
@@ -135,7 +135,7 @@ sycl::event block_cumsum(sycl::queue& queue,
 
         h.parallel_for(range, [=](sycl::nd_item<1> item) {
             constexpr Type zero = 0;
-            constexpr sycl::ext::oneapi::plus<Type> plus{};
+            constexpr sycl::plus<Type> plus{};
 
             auto group = item.get_group();
             const std::int64_t lid = item.get_local_linear_id();

--- a/cpp/oneapi/dal/backend/primitives/reduction/functors.hpp
+++ b/cpp/oneapi/dal/backend/primitives/reduction/functors.hpp
@@ -82,7 +82,7 @@ struct sum {
     using tag_t = reduce_binary_op_tag;
     constexpr static inline T init_value = 0;
 #ifdef ONEDAL_DATA_PARALLEL
-    constexpr static inline sycl::ext::oneapi::plus<T> native{};
+    constexpr static inline sycl::plus<T> native{};
 #else
     constexpr static inline std::plus<T> native{};
 #endif
@@ -96,7 +96,7 @@ struct max {
     using tag_t = reduce_binary_op_tag;
     constexpr static inline T init_value = std::numeric_limits<T>::lowest();
 #ifdef ONEDAL_DATA_PARALLEL
-    constexpr static inline sycl::ext::oneapi::maximum<T> native{};
+    constexpr static inline sycl::maximum<T> native{};
 #else
     constexpr static inline auto native = [](const T& a, const T& b) {
         return std::max(a, b);
@@ -112,7 +112,7 @@ struct min {
     using tag_t = reduce_binary_op_tag;
     constexpr static inline T init_value = std::numeric_limits<T>::max();
 #ifdef ONEDAL_DATA_PARALLEL
-    constexpr static inline sycl::ext::oneapi::minimum<T> native{};
+    constexpr static inline sycl::minimum<T> native{};
 #else
     constexpr static inline auto native = [](const T& a, const T& b) {
         return std::min(a, b);

--- a/cpp/oneapi/dal/backend/primitives/selection/kselect_by_rows_heap_dpc.cpp
+++ b/cpp/oneapi/dal/backend/primitives/selection/kselect_by_rows_heap_dpc.cpp
@@ -157,7 +157,7 @@ class kernel_select_heap {
     constexpr static inline idx_t idx_default = dal::detail::limits<idx_t>::min();
     constexpr static inline dst_t dst_default = dal::detail::limits<dst_t>::max();
 
-    constexpr static inline sycl::ext::oneapi::maximum<std::int32_t> max_func{};
+    constexpr static inline sycl::maximum<std::int32_t> max_func{};
 
     using acc_t = sycl::local_accessor<sel_t, 1>;
 

--- a/cpp/oneapi/dal/backend/primitives/selection/kselect_by_rows_quick.hpp
+++ b/cpp/oneapi/dal/backend/primitives/selection/kselect_by_rows_quick.hpp
@@ -218,12 +218,12 @@ private:
         for (std::int32_t step = 0; step < remainder; step++) {
             Float min_val = sycl::reduce_over_group(sg,
                                                     pos < 0 ? val : max_float,
-                                                    sycl::ext::oneapi::minimum<Float>());
+                                                    sycl::minimum<Float>());
             bool is_mine = min_val == val && pos == undefined_index;
             std::int32_t min_id =
                 sycl::reduce_over_group(sg,
                                         is_mine ? local_id : local_size,
-                                        sycl::ext::oneapi::minimum<std::int32_t>());
+                                        sycl::minimum<std::int32_t>());
             pos = min_id == local_id ? step : pos;
         }
         if (pos > undefined_index) {

--- a/cpp/oneapi/dal/backend/primitives/selection/kselect_by_rows_quick.hpp
+++ b/cpp/oneapi/dal/backend/primitives/selection/kselect_by_rows_quick.hpp
@@ -216,14 +216,12 @@ private:
         std::int32_t ind = is_used ? indices[offset] : undefined_index;
         std::int32_t pos = undefined_index;
         for (std::int32_t step = 0; step < remainder; step++) {
-            Float min_val = sycl::reduce_over_group(sg,
-                                                    pos < 0 ? val : max_float,
-                                                    sycl::minimum<Float>());
+            Float min_val =
+                sycl::reduce_over_group(sg, pos < 0 ? val : max_float, sycl::minimum<Float>());
             bool is_mine = min_val == val && pos == undefined_index;
-            std::int32_t min_id =
-                sycl::reduce_over_group(sg,
-                                        is_mine ? local_id : local_size,
-                                        sycl::minimum<std::int32_t>());
+            std::int32_t min_id = sycl::reduce_over_group(sg,
+                                                          is_mine ? local_id : local_size,
+                                                          sycl::minimum<std::int32_t>());
             pos = min_id == local_id ? step : pos;
         }
         if (pos > undefined_index) {

--- a/cpp/oneapi/dal/backend/primitives/selection/kselect_by_rows_simd.hpp
+++ b/cpp/oneapi/dal/backend/primitives/selection/kselect_by_rows_simd.hpp
@@ -141,85 +141,84 @@ private:
 
         auto event = queue.submit([&](sycl::handler& cgh) {
             cgh.depends_on(deps);
-            cgh.parallel_for(make_multiple_nd_range_2d({ wg_size, row_count }, { wg_size, 1 }),
-                             [=](sycl::nd_item<2> item) {
-                                 auto sg = item.get_sub_group();
-                                 const std::uint32_t sg_id = sg.get_group_id()[0];
-                                 const std::uint32_t wg_id = item.get_global_id(1);
-                                 const std::uint32_t sg_num = sg.get_group_range()[0];
+            cgh.parallel_for(
+                make_multiple_nd_range_2d({ wg_size, row_count }, { wg_size, 1 }),
+                [=](sycl::nd_item<2> item) {
+                    auto sg = item.get_sub_group();
+                    const std::uint32_t sg_id = sg.get_group_id()[0];
+                    const std::uint32_t wg_id = item.get_global_id(1);
+                    const std::uint32_t sg_num = sg.get_group_range()[0];
 
-                                 const std::uint32_t sg_global_id = wg_id * sg_num + sg_id;
-                                 if (sg_global_id >= row_count)
-                                     return;
+                    const std::uint32_t sg_global_id = wg_id * sg_num + sg_id;
+                    if (sg_global_id >= row_count)
+                        return;
 
-                                 [[maybe_unused]] const std::int32_t offset_ids_out =
-                                     sg_global_id * out_ids_stride;
-                                 [[maybe_unused]] const std::int32_t offset_dst_out =
-                                     sg_global_id * out_dst_stride;
+                    [[maybe_unused]] const std::int32_t offset_ids_out =
+                        sg_global_id * out_ids_stride;
+                    [[maybe_unused]] const std::int32_t offset_dst_out =
+                        sg_global_id * out_dst_stride;
 
-                                 const std::uint32_t local_id = sg.get_local_id()[0];
-                                 const std::uint32_t local_range = sg.get_local_range()[0];
+                    const std::uint32_t local_id = sg.get_local_id()[0];
+                    const std::uint32_t local_range = sg.get_local_range()[0];
 
-                                 Float values[simd_width];
-                                 std::int32_t private_indices[simd_width];
+                    Float values[simd_width];
+                    std::int32_t private_indices[simd_width];
 
-                                 for (std::uint32_t i = 0; i < simd_width; i++) {
-                                     values[i] = fp_max;
-                                     private_indices[i] = -1;
-                                 }
-                                 for (std::uint32_t i = local_id; i < col_count; i += local_range) {
-                                     const Float cur_val = dp.at(sg_global_id, i);
-                                     std::int32_t index = i;
-                                     std::int32_t pos = -1;
+                    for (std::uint32_t i = 0; i < simd_width; i++) {
+                        values[i] = fp_max;
+                        private_indices[i] = -1;
+                    }
+                    for (std::uint32_t i = local_id; i < col_count; i += local_range) {
+                        const Float cur_val = dp.at(sg_global_id, i);
+                        std::int32_t index = i;
+                        std::int32_t pos = -1;
 
-                                     pos = values[k - 1] > cur_val ? k - 1 : pos;
-                                     for (std::int32_t j = k - 2; j >= 0; j--) {
-                                         const bool do_shift = values[j] > cur_val;
-                                         pos = do_shift ? j : pos;
-                                         values[j + 1] = do_shift ? values[j] : values[j + 1];
-                                         private_indices[j + 1] =
-                                             do_shift ? private_indices[j] : private_indices[j + 1];
-                                     }
+                        pos = values[k - 1] > cur_val ? k - 1 : pos;
+                        for (std::int32_t j = k - 2; j >= 0; j--) {
+                            const bool do_shift = values[j] > cur_val;
+                            pos = do_shift ? j : pos;
+                            values[j + 1] = do_shift ? values[j] : values[j + 1];
+                            private_indices[j + 1] =
+                                do_shift ? private_indices[j] : private_indices[j + 1];
+                        }
 
-                                     if (pos != -1) {
-                                         values[pos] = cur_val;
-                                         private_indices[pos] = index;
-                                     }
-                                 }
-                                 sycl::group_barrier(sg);
+                        if (pos != -1) {
+                            values[pos] = cur_val;
+                            private_indices[pos] = index;
+                        }
+                    }
+                    sycl::group_barrier(sg);
 
-                                 std::int32_t bias = 0;
-                                 Float final_values[simd_width];
-                                 std::int32_t final_indices[simd_width];
-                                 for (std::uint32_t i = 0; i < k; i++) {
-                                     const Float min_val = sycl::reduce_over_group(
-                                         sg,
-                                         values[bias],
-                                         sycl::minimum<Float>());
-                                     const bool present = (min_val == values[bias]);
-                                     const std::int32_t pos = sycl::exclusive_scan_over_group(
-                                         sg,
-                                         present ? 1 : 0,
-                                         sycl::plus<std::int32_t>());
-                                     const bool owner = present && pos == 0;
-                                     final_indices[i] = -sycl::reduce_over_group(
-                                         sg,
-                                         owner ? -private_indices[bias] : 1,
-                                         sycl::minimum<std::int32_t>());
-                                     final_values[i] = min_val;
-                                     bias += owner ? 1 : 0;
-                                 }
-                                 if constexpr (indices_out) {
-                                     for (std::uint32_t i = local_id; i < k; i += local_range) {
-                                         indices_ptr[offset_ids_out + i] = final_indices[i];
-                                     }
-                                 }
-                                 if constexpr (selection_out) {
-                                     for (std::uint32_t i = local_id; i < k; i += local_range) {
-                                         selection_ptr[offset_dst_out + i] = final_values[i];
-                                     }
-                                 }
-                             });
+                    std::int32_t bias = 0;
+                    Float final_values[simd_width];
+                    std::int32_t final_indices[simd_width];
+                    for (std::uint32_t i = 0; i < k; i++) {
+                        const Float min_val =
+                            sycl::reduce_over_group(sg, values[bias], sycl::minimum<Float>());
+                        const bool present = (min_val == values[bias]);
+                        const std::int32_t pos =
+                            sycl::exclusive_scan_over_group(sg,
+                                                            present ? 1 : 0,
+                                                            sycl::plus<std::int32_t>());
+                        const bool owner = present && pos == 0;
+                        final_indices[i] =
+                            -sycl::reduce_over_group(sg,
+                                                     owner ? -private_indices[bias] : 1,
+                                                     sycl::minimum<std::int32_t>());
+                        final_values[i] = min_val;
+                        bias += owner ? 1 : 0;
+                    }
+                    if constexpr (indices_out) {
+                        for (std::uint32_t i = local_id; i < k; i += local_range) {
+                            indices_ptr[offset_ids_out + i] = final_indices[i];
+                        }
+                    }
+                    if constexpr (selection_out) {
+                        for (std::uint32_t i = local_id; i < k; i += local_range) {
+                            selection_ptr[offset_dst_out + i] = final_values[i];
+                        }
+                    }
+                });
         });
         return event;
     }

--- a/cpp/oneapi/dal/backend/primitives/selection/kselect_by_rows_simd.hpp
+++ b/cpp/oneapi/dal/backend/primitives/selection/kselect_by_rows_simd.hpp
@@ -195,17 +195,17 @@ private:
                                      const Float min_val = sycl::reduce_over_group(
                                          sg,
                                          values[bias],
-                                         sycl::ext::oneapi::minimum<Float>());
+                                         sycl::minimum<Float>());
                                      const bool present = (min_val == values[bias]);
                                      const std::int32_t pos = sycl::exclusive_scan_over_group(
                                          sg,
                                          present ? 1 : 0,
-                                         sycl::ext::oneapi::plus<std::int32_t>());
+                                         sycl::plus<std::int32_t>());
                                      const bool owner = present && pos == 0;
                                      final_indices[i] = -sycl::reduce_over_group(
                                          sg,
                                          owner ? -private_indices[bias] : 1,
-                                         sycl::ext::oneapi::minimum<std::int32_t>());
+                                         sycl::minimum<std::int32_t>());
                                      final_values[i] = min_val;
                                      bias += owner ? 1 : 0;
                                  }

--- a/cpp/oneapi/dal/backend/primitives/selection/kselect_by_rows_single_col.hpp
+++ b/cpp/oneapi/dal/backend/primitives/selection/kselect_by_rows_single_col.hpp
@@ -171,17 +171,17 @@ private:
                     sycl::group_barrier(sg);
 
                     const Float final_value =
-                        sycl::reduce_over_group(sg, value, sycl::ext::oneapi::minimum<Float>());
+                        sycl::reduce_over_group(sg, value, sycl::minimum<Float>());
                     const bool present = (final_value == value);
                     const std::int32_t pos =
                         sycl::exclusive_scan_over_group(sg,
                                                         present ? 1 : 0,
-                                                        sycl::ext::oneapi::plus<std::int32_t>());
+                                                        sycl::plus<std::int32_t>());
                     const bool owner = present && pos == 0;
                     const std::int32_t final_index =
                         -sycl::reduce_over_group(sg,
                                                  owner ? -index : 1,
-                                                 sycl::ext::oneapi::minimum<std::int32_t>());
+                                                 sycl::minimum<std::int32_t>());
 
                     if (local_id == 0) {
                         if constexpr (indices_out) {

--- a/cpp/oneapi/dal/backend/primitives/selection/kselect_by_rows_single_col.hpp
+++ b/cpp/oneapi/dal/backend/primitives/selection/kselect_by_rows_single_col.hpp
@@ -139,59 +139,58 @@ private:
 
         auto event = queue.submit([&](sycl::handler& cgh) {
             cgh.depends_on(deps);
-            cgh.parallel_for(
-                make_multiple_nd_range_2d({ wg_size, row_count }, { wg_size, 1 }),
-                [=](sycl::nd_item<2> item) {
-                    auto sg = item.get_sub_group();
-                    const std::uint32_t sg_id = sg.get_group_id()[0];
-                    const std::uint32_t wg_id = item.get_global_id(1);
-                    const std::uint32_t sg_num = sg.get_group_range()[0];
+            cgh.parallel_for(make_multiple_nd_range_2d({ wg_size, row_count }, { wg_size, 1 }),
+                             [=](sycl::nd_item<2> item) {
+                                 auto sg = item.get_sub_group();
+                                 const std::uint32_t sg_id = sg.get_group_id()[0];
+                                 const std::uint32_t wg_id = item.get_global_id(1);
+                                 const std::uint32_t sg_num = sg.get_group_range()[0];
 
-                    const std::uint32_t sg_global_id = wg_id * sg_num + sg_id;
-                    if (sg_global_id >= row_count)
-                        return;
+                                 const std::uint32_t sg_global_id = wg_id * sg_num + sg_id;
+                                 if (sg_global_id >= row_count)
+                                     return;
 
-                    [[maybe_unused]] const std::int32_t offset_ids_out =
-                        sg_global_id * out_ids_stride;
-                    [[maybe_unused]] const std::int32_t offset_dst_out =
-                        sg_global_id * out_dst_stride;
+                                 [[maybe_unused]] const std::int32_t offset_ids_out =
+                                     sg_global_id * out_ids_stride;
+                                 [[maybe_unused]] const std::int32_t offset_dst_out =
+                                     sg_global_id * out_dst_stride;
 
-                    const std::uint32_t local_id = sg.get_local_id()[0];
-                    const std::uint32_t local_range = sg.get_local_range()[0];
+                                 const std::uint32_t local_id = sg.get_local_id()[0];
+                                 const std::uint32_t local_range = sg.get_local_range()[0];
 
-                    std::int32_t index = -1;
-                    Float value = fp_max;
-                    for (std::uint32_t i = local_id; i < col_count; i += local_range) {
-                        const auto& cur_val = dp.at(sg_global_id, i);
-                        const bool handle = cur_val < value;
-                        index = handle ? i : index;
-                        value = handle ? cur_val : value;
-                    }
+                                 std::int32_t index = -1;
+                                 Float value = fp_max;
+                                 for (std::uint32_t i = local_id; i < col_count; i += local_range) {
+                                     const auto& cur_val = dp.at(sg_global_id, i);
+                                     const bool handle = cur_val < value;
+                                     index = handle ? i : index;
+                                     value = handle ? cur_val : value;
+                                 }
 
-                    sycl::group_barrier(sg);
+                                 sycl::group_barrier(sg);
 
-                    const Float final_value =
-                        sycl::reduce_over_group(sg, value, sycl::minimum<Float>());
-                    const bool present = (final_value == value);
-                    const std::int32_t pos =
-                        sycl::exclusive_scan_over_group(sg,
-                                                        present ? 1 : 0,
-                                                        sycl::plus<std::int32_t>());
-                    const bool owner = present && pos == 0;
-                    const std::int32_t final_index =
-                        -sycl::reduce_over_group(sg,
-                                                 owner ? -index : 1,
-                                                 sycl::minimum<std::int32_t>());
+                                 const Float final_value =
+                                     sycl::reduce_over_group(sg, value, sycl::minimum<Float>());
+                                 const bool present = (final_value == value);
+                                 const std::int32_t pos =
+                                     sycl::exclusive_scan_over_group(sg,
+                                                                     present ? 1 : 0,
+                                                                     sycl::plus<std::int32_t>());
+                                 const bool owner = present && pos == 0;
+                                 const std::int32_t final_index =
+                                     -sycl::reduce_over_group(sg,
+                                                              owner ? -index : 1,
+                                                              sycl::minimum<std::int32_t>());
 
-                    if (local_id == 0) {
-                        if constexpr (indices_out) {
-                            indices_ptr[offset_ids_out] = final_index;
-                        }
-                        if constexpr (selection_out) {
-                            selection_ptr[offset_dst_out] = final_value;
-                        }
-                    }
-                });
+                                 if (local_id == 0) {
+                                     if constexpr (indices_out) {
+                                         indices_ptr[offset_ids_out] = final_index;
+                                     }
+                                     if constexpr (selection_out) {
+                                         selection_ptr[offset_dst_out] = final_value;
+                                     }
+                                 }
+                             });
         });
         return event;
     }

--- a/cpp/oneapi/dal/backend/primitives/selection/row_partitioning_kernel.hpp
+++ b/cpp/oneapi/dal/backend/primitives/selection/row_partitioning_kernel.hpp
@@ -59,13 +59,10 @@ inline std::int32_t row_partitioning_kernel(sycl::nd_item<2> item,
         std::int32_t min_ind = sycl::reduce_over_group(sg, i, sycl::minimum<int>());
         if (num_of_small > 0) {
             const std::int32_t pos_in_group_small =
-                sycl::exclusive_scan_over_group(sg,
-                                                is_small && inside ? 1 : 0,
-                                                sycl::plus<int>());
+                sycl::exclusive_scan_over_group(sg, is_small && inside ? 1 : 0, sycl::plus<int>());
             const std::int32_t pos_in_group_great =
-                num_of_small + sycl::exclusive_scan_over_group(sg,
-                                                               is_small || !inside ? 0 : 1,
-                                                               sycl::plus<int>());
+                num_of_small +
+                sycl::exclusive_scan_over_group(sg, is_small || !inside ? 0 : 1, sycl::plus<int>());
             const std::int32_t pos_small = partition_start + split_index + pos_in_group_small;
             const std::int32_t pos_great = min_ind + pos_in_group_great;
             const std::int32_t pos = is_small ? pos_small : pos_great;
@@ -86,8 +83,7 @@ inline std::int32_t row_partitioning_kernel(sycl::nd_item<2> item,
         }
         split_index += num_of_small;
     }
-    split_index =
-        -sycl::reduce_over_group(sg, -split_index, sycl::minimum<std::int32_t>());
+    split_index = -sycl::reduce_over_group(sg, -split_index, sycl::minimum<std::int32_t>());
     return split_index + partition_start;
 }
 

--- a/cpp/oneapi/dal/backend/primitives/selection/row_partitioning_kernel.hpp
+++ b/cpp/oneapi/dal/backend/primitives/selection/row_partitioning_kernel.hpp
@@ -55,17 +55,17 @@ inline std::int32_t row_partitioning_kernel(sycl::nd_item<2> item,
         std::int32_t cur_index = i < partition_end ? indices[i] : -1;
         std::int32_t is_small = cur_value < pivot ? 1 : 0;
         const std::int32_t num_of_small =
-            sycl::reduce_over_group(sg, is_small && inside ? 1 : 0, sycl::ext::oneapi::plus<int>());
-        std::int32_t min_ind = sycl::reduce_over_group(sg, i, sycl::ext::oneapi::minimum<int>());
+            sycl::reduce_over_group(sg, is_small && inside ? 1 : 0, sycl::plus<int>());
+        std::int32_t min_ind = sycl::reduce_over_group(sg, i, sycl::minimum<int>());
         if (num_of_small > 0) {
             const std::int32_t pos_in_group_small =
                 sycl::exclusive_scan_over_group(sg,
                                                 is_small && inside ? 1 : 0,
-                                                sycl::ext::oneapi::plus<int>());
+                                                sycl::plus<int>());
             const std::int32_t pos_in_group_great =
                 num_of_small + sycl::exclusive_scan_over_group(sg,
                                                                is_small || !inside ? 0 : 1,
-                                                               sycl::ext::oneapi::plus<int>());
+                                                               sycl::plus<int>());
             const std::int32_t pos_small = partition_start + split_index + pos_in_group_small;
             const std::int32_t pos_great = min_ind + pos_in_group_great;
             const std::int32_t pos = is_small ? pos_small : pos_great;
@@ -87,7 +87,7 @@ inline std::int32_t row_partitioning_kernel(sycl::nd_item<2> item,
         split_index += num_of_small;
     }
     split_index =
-        -sycl::reduce_over_group(sg, -split_index, sycl::ext::oneapi::minimum<std::int32_t>());
+        -sycl::reduce_over_group(sg, -split_index, sycl::minimum<std::int32_t>());
     return split_index + partition_start;
 }
 

--- a/cpp/oneapi/dal/backend/primitives/selection/select_flagged_dpc.cpp
+++ b/cpp/oneapi/dal/backend/primitives/selection/select_flagged_dpc.cpp
@@ -22,7 +22,7 @@ namespace oneapi::dal::backend::primitives {
 
 namespace de = dal::detail;
 
-using sycl::ext::oneapi::plus;
+using sycl::plus;
 
 template <typename Data, typename Flag>
 sycl::event select_flagged_base<Data, Flag>::scan(sycl::queue& queue,

--- a/cpp/oneapi/dal/backend/primitives/sort/sort_dpc.cpp
+++ b/cpp/oneapi/dal/backend/primitives/sort/sort_dpc.cpp
@@ -55,7 +55,7 @@ inline std::uint64_t inv_bits(std::uint64_t x) {
     return x ^ (-(x >> 63) | 0x8000000000000000ul);
 }
 
-using sycl::ext::oneapi::plus;
+using sycl::plus;
 
 template <typename Float, typename Index>
 sycl::event radix_sort_indices_inplace<Float, Index>::radix_scan(sycl::queue& queue,

--- a/cpp/oneapi/dal/table/backend/csr_kernels.cpp
+++ b/cpp/oneapi/dal/table/backend/csr_kernels.cpp
@@ -424,7 +424,7 @@ bool is_sorted(sycl::queue& queue,
         .submit([&](sycl::handler& cgh) {
             cgh.depends_on(dependencies);
             auto count_descending_reduction =
-                sycl::reduction(count_buf, cgh, sycl::ext::oneapi::plus<std::int64_t>());
+                sycl::reduction(count_buf, cgh, sycl::plus<std::int64_t>());
 
             cgh.parallel_for(sycl::nd_range<1>{ wg_count * wg_size, wg_size },
                              count_descending_reduction,
@@ -499,9 +499,9 @@ out_of_bound_type check_bounds(const array<T>& arr,
         .submit([&](sycl::handler& cgh) {
             cgh.depends_on(dependencies);
             auto count_lt_reduction =
-                sycl::reduction(count_lt_buf, cgh, sycl::ext::oneapi::plus<std::int64_t>());
+                sycl::reduction(count_lt_buf, cgh, sycl::plus<std::int64_t>());
             auto count_gt_reduction =
-                sycl::reduction(count_gt_buf, cgh, sycl::ext::oneapi::plus<std::int64_t>());
+                sycl::reduction(count_gt_buf, cgh, sycl::plus<std::int64_t>());
 
             cgh.parallel_for(sycl::range<1>{ dal::detail::integral_cast<std::size_t>(count) },
                              count_lt_reduction,


### PR DESCRIPTION
## Description

Resolves build failures in CEV/CEV-MKL jobs. Replacements suggested via claude
CEV-MKL: http://intel-ci.intel.com/f1809784-c2c5-f178-8ac4-d4f5ef20c6a0
CEV: http://intel-ci.intel.com/f1809782-4dcd-f1c0-afc2-d4f5ef20c6a0

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [ ] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [ ] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.
- [ ] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [ ] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least a summary table with measured data, if performance change is expected.
- [ ] I have provided justification why performance and/or quality metrics have changed or why changes are not expected.
- [ ] I have extended the benchmarking suite and provided a corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.

</details>
