### PR TITLE
conda-recipe linux(clangxx-20) fix

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -16,7 +16,6 @@
 
 # Note: fetching tags from https://github.com/uxlfoundation/oneDAL
 # is required for the proper versioning of the package using GIT_DESCRIBE_TAG
-# ci-trigger: temporary marker to run the conda-recipe workflow on this PR (revert before merge)
 {% set version = environ.get('GIT_DESCRIBE_TAG', '0.0.0') %}
 {% set git_hash = environ.get('GIT_FULL_HASH', 'unknown')[:7] %}
 {% set buildnumber = 0 %}

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -16,6 +16,7 @@
 
 # Note: fetching tags from https://github.com/uxlfoundation/oneDAL
 # is required for the proper versioning of the package using GIT_DESCRIBE_TAG
+# ci-trigger: temporary marker to run the conda-recipe workflow on this PR (revert before merge)
 {% set version = environ.get('GIT_DESCRIBE_TAG', '0.0.0') %}
 {% set git_hash = environ.get('GIT_FULL_HASH', 'unknown')[:7] %}
 {% set buildnumber = 0 %}

--- a/cpp/daal/src/algorithms/dtrees/forest/df_train_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/df_train_dense_default_impl.i
@@ -66,12 +66,10 @@ services::SharedPtr<NumericTable> normalizeWeights(const NumericTable * weights,
     const algorithmFPType * src = srcBlock.get();
 
     algorithmFPType maxWeight = 0;
-#ifndef __clang__ // TODO: Temporary workaround. Clang fails to vectoize this simple loop
     PRAGMA_OMP_SIMD_ARGS(reduction(max : maxWeight))
-#endif
     for (size_t i = 0; i < nRows; ++i)
     {
-        if (src[i] > maxWeight) maxWeight = src[i];
+        maxWeight = src[i] > maxWeight ? src[i] : maxWeight;
     }
     if (!(maxWeight > 0)) return empty;
 
@@ -318,12 +316,14 @@ void TreeThreadCtxBase<algorithmFPType, cpu>::finalizeVarImp(training::VariableI
         }
         if (!isPositive<algorithmFPType, cpu>(maxVal)) return;
         const algorithmFPType div = 1. / maxVal;
-        for (size_t i = 0; i < nVars; varImp[i++] *= div);
+        for (size_t i = 0; i < nVars; varImp[i++] *= div)
+            ;
     }
     else
     {
         sum = 1. / sum;
-        for (size_t i = 0; i < nVars; varImp[i++] *= sum);
+        for (size_t i = 0; i < nVars; varImp[i++] *= sum)
+            ;
     }
 #endif
 }
@@ -1356,7 +1356,8 @@ services::Status TrainBatchTaskBase<algorithmFPType, BinIndexType, DataHelper, H
         {
             TArray<IndexType, cpu> permutation(nOOB);
             DAAL_CHECK_MALLOC(permutation.get());
-            for (size_t i = 0; i < nOOB; permutation[i] = i, ++i);
+            for (size_t i = 0; i < nOOB; permutation[i] = i, ++i)
+                ;
             const size_t nTrees         = _threadCtx.nTrees;
             const intermSummFPType div1 = 1.0 / static_cast<intermSummFPType>(nTrees);
             for (size_t i = 0, n = nFeatures(); i < n; ++i)

--- a/cpp/daal/src/algorithms/dtrees/forest/df_train_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/df_train_dense_default_impl.i
@@ -66,7 +66,9 @@ services::SharedPtr<NumericTable> normalizeWeights(const NumericTable * weights,
     const algorithmFPType * src = srcBlock.get();
 
     algorithmFPType maxWeight = 0;
+#ifndef __clang__ // TODO: Temporary workaround. Clang fails to vectoize this simple loop
     PRAGMA_OMP_SIMD_ARGS(reduction(max : maxWeight))
+#endif
     for (size_t i = 0; i < nRows; ++i)
     {
         maxWeight = src[i] > maxWeight ? src[i] : maxWeight;

--- a/cpp/daal/src/algorithms/dtrees/forest/df_train_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/df_train_dense_default_impl.i
@@ -316,14 +316,12 @@ void TreeThreadCtxBase<algorithmFPType, cpu>::finalizeVarImp(training::VariableI
         }
         if (!isPositive<algorithmFPType, cpu>(maxVal)) return;
         const algorithmFPType div = 1. / maxVal;
-        for (size_t i = 0; i < nVars; varImp[i++] *= div)
-            ;
+        for (size_t i = 0; i < nVars; varImp[i++] *= div);
     }
     else
     {
         sum = 1. / sum;
-        for (size_t i = 0; i < nVars; varImp[i++] *= sum)
-            ;
+        for (size_t i = 0; i < nVars; varImp[i++] *= sum);
     }
 #endif
 }
@@ -1356,8 +1354,7 @@ services::Status TrainBatchTaskBase<algorithmFPType, BinIndexType, DataHelper, H
         {
             TArray<IndexType, cpu> permutation(nOOB);
             DAAL_CHECK_MALLOC(permutation.get());
-            for (size_t i = 0; i < nOOB; permutation[i] = i, ++i)
-                ;
+            for (size_t i = 0; i < nOOB; permutation[i] = i, ++i);
             const size_t nTrees         = _threadCtx.nTrees;
             const intermSummFPType div1 = 1.0 / static_cast<intermSummFPType>(nTrees);
             for (size_t i = 0, n = nFeatures(); i < n; ++i)

--- a/cpp/daal/src/algorithms/dtrees/forest/df_train_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/df_train_dense_default_impl.i
@@ -66,7 +66,9 @@ services::SharedPtr<NumericTable> normalizeWeights(const NumericTable * weights,
     const algorithmFPType * src = srcBlock.get();
 
     algorithmFPType maxWeight = 0;
+#ifndef __clang__ // TODO: Temporary workaround. Clang 18 fails to vectoize this simple loop
     PRAGMA_OMP_SIMD_ARGS(reduction(max : maxWeight))
+#endif
     for (size_t i = 0; i < nRows; ++i)
     {
         if (src[i] > maxWeight) maxWeight = src[i];

--- a/cpp/daal/src/algorithms/dtrees/forest/df_train_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/forest/df_train_dense_default_impl.i
@@ -66,7 +66,7 @@ services::SharedPtr<NumericTable> normalizeWeights(const NumericTable * weights,
     const algorithmFPType * src = srcBlock.get();
 
     algorithmFPType maxWeight = 0;
-#ifndef __clang__ // TODO: Temporary workaround. Clang 18 fails to vectoize this simple loop
+#ifndef __clang__ // TODO: Temporary workaround. Clang fails to vectoize this simple loop
     PRAGMA_OMP_SIMD_ARGS(reduction(max : maxWeight))
 #endif
     for (size_t i = 0; i < nRows; ++i)

--- a/cpp/daal/src/algorithms/dtrees/gbt/classification/gbt_classification_train_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/gbt/classification/gbt_classification_train_dense_default_impl.i
@@ -161,7 +161,9 @@ protected:
     {
         const algorithmFPType expThreshold = daal::internal::MathInst<algorithmFPType, cpu>::vExpThreshold();
         algorithmFPType maxArg             = arg[0];
+#ifndef __clang__ // TODO: Temporary workaround. Clang fails to vectoize this simple loop
         PRAGMA_OMP_SIMD_ARGS(reduction(max : maxArg))
+#endif
         for (size_t i = 1; i < _nClasses; ++i)
         {
             maxArg = arg[i] > maxArg ? arg[i] : maxArg;

--- a/cpp/daal/src/algorithms/dtrees/gbt/classification/gbt_classification_train_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/gbt/classification/gbt_classification_train_dense_default_impl.i
@@ -161,7 +161,7 @@ protected:
     {
         const algorithmFPType expThreshold = daal::internal::MathInst<algorithmFPType, cpu>::vExpThreshold();
         algorithmFPType maxArg             = arg[0];
-#ifndef __clang__ // TODO: Temporary workaround. Clang 18 fails to vectoize this simple loop
+#ifndef __clang__ // TODO: Temporary workaround. Clang fails to vectoize this simple loop
         PRAGMA_OMP_SIMD_ARGS(reduction(max : maxArg))
 #endif
         for (size_t i = 1; i < _nClasses; ++i)

--- a/cpp/daal/src/algorithms/dtrees/gbt/classification/gbt_classification_train_dense_default_impl.i
+++ b/cpp/daal/src/algorithms/dtrees/gbt/classification/gbt_classification_train_dense_default_impl.i
@@ -161,12 +161,10 @@ protected:
     {
         const algorithmFPType expThreshold = daal::internal::MathInst<algorithmFPType, cpu>::vExpThreshold();
         algorithmFPType maxArg             = arg[0];
-#ifndef __clang__ // TODO: Temporary workaround. Clang fails to vectoize this simple loop
         PRAGMA_OMP_SIMD_ARGS(reduction(max : maxArg))
-#endif
         for (size_t i = 1; i < _nClasses; ++i)
         {
-            maxArg = (maxArg < arg[i]) ? arg[i] : maxArg;
+            maxArg = arg[i] > maxArg ? arg[i] : maxArg;
         }
         PRAGMA_OMP_SIMD
         PRAGMA_VECTOR_ALWAYS

--- a/cpp/daal/src/algorithms/objective_function/cross_entropy_loss/cross_entropy_loss_dense_default_batch_impl.i
+++ b/cpp/daal/src/algorithms/objective_function/cross_entropy_loss/cross_entropy_loss_dense_default_batch_impl.i
@@ -96,12 +96,10 @@ void CrossEntropyLossKernel<algorithmFPType, method, cpu>::softmax(const algorit
         const algorithmFPType * const pArg = arg + iRow * nCols;
         algorithmFPType * const pRes       = res + iRow * nCols;
         algorithmFPType maxArg             = pArg[0];
-#ifndef __clang__ // TODO: Temporary workaround. Clang fails to vectoize this simple loop
         PRAGMA_OMP_SIMD_ARGS(reduction(max : maxArg))
-#endif
         for (size_t i = 1; i < nCols; ++i)
         {
-            maxArg = (pArg[i] > maxArg) ? pArg[i] : maxArg;
+            maxArg = pArg[i] > maxArg ? pArg[i] : maxArg;
         }
 
         PRAGMA_OMP_SIMD

--- a/cpp/daal/src/algorithms/objective_function/cross_entropy_loss/cross_entropy_loss_dense_default_batch_impl.i
+++ b/cpp/daal/src/algorithms/objective_function/cross_entropy_loss/cross_entropy_loss_dense_default_batch_impl.i
@@ -96,7 +96,9 @@ void CrossEntropyLossKernel<algorithmFPType, method, cpu>::softmax(const algorit
         const algorithmFPType * const pArg = arg + iRow * nCols;
         algorithmFPType * const pRes       = res + iRow * nCols;
         algorithmFPType maxArg             = pArg[0];
+#ifndef __clang__ // TODO: Temporary workaround. Clang fails to vectoize this simple loop
         PRAGMA_OMP_SIMD_ARGS(reduction(max : maxArg))
+#endif
         for (size_t i = 1; i < nCols; ++i)
         {
             maxArg = pArg[i] > maxArg ? pArg[i] : maxArg;

--- a/cpp/daal/src/algorithms/objective_function/cross_entropy_loss/cross_entropy_loss_dense_default_batch_impl.i
+++ b/cpp/daal/src/algorithms/objective_function/cross_entropy_loss/cross_entropy_loss_dense_default_batch_impl.i
@@ -96,7 +96,7 @@ void CrossEntropyLossKernel<algorithmFPType, method, cpu>::softmax(const algorit
         const algorithmFPType * const pArg = arg + iRow * nCols;
         algorithmFPType * const pRes       = res + iRow * nCols;
         algorithmFPType maxArg             = pArg[0];
-#ifndef __clang__ // TODO: Temporary workaround. Clang 18 fails to vectoize this simple loop
+#ifndef __clang__ // TODO: Temporary workaround. Clang fails to vectoize this simple loop
         PRAGMA_OMP_SIMD_ARGS(reduction(max : maxArg))
 #endif
         for (size_t i = 1; i < nCols; ++i)


### PR DESCRIPTION
## Summary

Guard the `PRAGMA_OMP_SIMD_ARGS(reduction(max : maxWeight))` directive in
`normalizeWeights()` with `#ifndef __clang__` so it is emitted only for
non-Clang compilers.

```cpp
algorithmFPType maxWeight = 0;
#ifndef __clang__ // TODO: Temporary workaround. Clang 18 fails to vectorize this simple loop
PRAGMA_OMP_SIMD_ARGS(reduction(max : maxWeight))
#endif
for (size_t i = 0; i < nRows; ++i)
{
    if (src[i] > maxWeight) maxWeight = src[i];
}
```

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least a summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance and/or quality metrics have changed or why changes are not expected.
- [x] I have extended the benchmarking suite and provided a corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.

</details>
