### PR TITLE
Bazel: document Windows PowerShell helpers

### DIFF
--- a/.ci/env/bazelisk.ps1
+++ b/.ci/env/bazelisk.ps1
@@ -14,6 +14,21 @@
 # limitations under the License.
 #===============================================================================
 
+<#
+.SYNOPSIS
+Installs the pinned Windows Bazelisk executable for CI.
+
+.DESCRIPTION
+This is the PowerShell counterpart of `.ci/env/bazelisk.sh`. The Windows
+nightly job cannot use that POSIX-shell helper, so this script downloads the
+Windows asset, verifies the SHA256 digest published in the GitHub release, and
+makes `bazel.exe` available to later workflow steps.
+
+When GitHub Actions provides `GITHUB_PATH`, the installation directory is
+appended there for subsequent steps. Otherwise, the current process `PATH` is
+updated, which also makes the script convenient for local CI reproduction.
+#>
+
 $ErrorActionPreference = "Stop"
 
 $bazeliskVersion = "v1.29.0"
@@ -27,6 +42,7 @@ $headers = @{
 }
 
 if ($env:GITHUB_TOKEN) {
+    # Authentication is optional, but avoids GitHub API rate limits in CI.
     $headers.Authorization = "Bearer $env:GITHUB_TOKEN"
 }
 
@@ -43,6 +59,7 @@ New-Item -ItemType Directory -Force -Path $installDir | Out-Null
 Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $bazelPath
 
 if (-not $asset.digest.StartsWith("sha256:")) {
+    # Do not install an asset that cannot be checked against release metadata.
     throw "Unexpected Bazelisk digest format: $($asset.digest)"
 }
 

--- a/.ci/scripts/compare_windows_release.ps1
+++ b/.ci/scripts/compare_windows_release.ps1
@@ -14,6 +14,36 @@
 # limitations under the License.
 #===============================================================================
 
+<#
+.SYNOPSIS
+Compares the file and binary surfaces of Make and Bazel Windows releases.
+
+.DESCRIPTION
+The nightly Windows job builds the existing Make `vc` release and a Bazel
+release under the same oneAPI and Visual Studio environment, then calls this
+adapter to run `dev/release_tests/compare_release_trees.py` with Windows
+semantics. Bazel normally auto-selects its ICX-based Windows toolchain, so this
+checks package and public binary-surface compatibility, not compiler
+equivalence or compiler-specific intermediate objects.
+
+All paths may be relative to the current working directory. The Python tool
+prints a bounded summary and exits nonzero when the selected check level finds
+a mismatch, which causes the calling CI step to fail.
+
+.PARAMETER MakeReleaseDir
+Path to the reference release produced by the Make-based Windows build.
+
+.PARAMETER BazelReleaseDir
+Path to the release produced by the Bazel `//:release` target.
+
+.PARAMETER CheckLevel
+Validation depth passed to `compare_release_trees.py`; level 4 includes the
+full manifest and binary-surface checks used by nightly CI.
+
+.PARAMETER MaxDiffLines
+Maximum number of difference lines printed in the summary.
+#>
+
 param(
     [string] $MakeReleaseDir = "__release_win_vc\daal\latest",
     [string] $BazelReleaseDir = "bazel-bin\release\daal\latest",
@@ -32,3 +62,7 @@ python $compareScript `
     --bazel $BazelReleaseDir `
     --check-level $CheckLevel `
     --summary-limit $MaxDiffLines
+
+# Windows PowerShell 5.1 does not turn native-command failures into terminating
+# errors, even when ErrorActionPreference is Stop.
+exit $LASTEXITCODE

--- a/.ci/scripts/test_bazel_release_cmake_example.ps1
+++ b/.ci/scripts/test_bazel_release_cmake_example.ps1
@@ -14,6 +14,36 @@
 # limitations under the License.
 #===============================================================================
 
+<#
+.SYNOPSIS
+Builds and runs a CMake example against the Bazel-produced Windows release.
+
+.DESCRIPTION
+This is a consumer smoke test for the packaged release, not another Bazel
+build. It points the examples' CMake project at the release through
+`CMAKE_PREFIX_PATH`, builds one dynamically linked target, and runs it. This
+checks that headers, CMake package metadata, import libraries, and runtime DLLs
+from `//:release` work together for a downstream CMake consumer.
+
+The script removes the examples' `Build` directory to prevent a cached CMake
+configuration from hiding packaging problems. It accepts either the oneAPI
+installation or CI-downloaded TBB layout and fails on configuration, build,
+missing-executable, or runtime errors.
+
+.PARAMETER ReleaseDir
+Root of the unpacked or freshly built oneDAL release package.
+
+.PARAMETER ExamplesDir
+Examples directory relative to the release root.
+
+.PARAMETER ExampleSource
+Reserved for selecting an example source; the current CMake flow selects the
+target through `ExampleTarget`.
+
+.PARAMETER ExampleTarget
+CMake example target to configure, build, locate, and run.
+#>
+
 param(
     [string]$ReleaseDir = ".\bazel-bin\release\daal\latest",
     [string]$ExamplesDir = "examples\oneapi\cpp",
@@ -28,6 +58,7 @@ $examplesPath = Join-Path $releasePath $ExamplesDir
 $buildPath = Join-Path $examplesPath "Build"
 
 if (Test-Path $buildPath) {
+    # A clean configure proves that the package is self-consistent.
     Remove-Item -Recurse -Force $buildPath
 }
 
@@ -37,6 +68,7 @@ $pathEntries = @(
 )
 
 $tbbDirCandidates = @(
+    # Developer installation first, then the dependency layout used in CI.
     ".\oneapi\tbb\latest\lib\cmake\tbb",
     ".\__deps\tbb\win\tbb\lib\cmake\tbb"
 )
@@ -69,11 +101,19 @@ foreach ($candidate in $tbbRedistCandidates) {
 
 $env:PATH = (($pathEntries | Where-Object { Test-Path $_ }) -join ";") + ";" + $env:PATH
 
+# Dynamic oneDAL examples need packaged oneDAL DLLs and a TBB runtime on PATH.
+
 Write-Host "Configuring CMake example from Bazel release: $examplesPath"
 cmake @cmakeArgs
+if ($LASTEXITCODE -ne 0) {
+    throw "CMake configuration failed with exit code $LASTEXITCODE"
+}
 
 Write-Host "Building CMake example target: $ExampleTarget"
 cmake --build $buildPath --config Release --target $ExampleTarget
+if ($LASTEXITCODE -ne 0) {
+    throw "CMake build failed with exit code $LASTEXITCODE"
+}
 
 $exampleExe = Get-ChildItem -Path @($buildPath, $examplesPath) -Recurse -Filter "$ExampleTarget.exe" -File |
     Select-Object -First 1

--- a/dev/bazel/README.md
+++ b/dev/bazel/README.md
@@ -293,51 +293,23 @@ The most used Bazel commands are `build`, `test` and `run`.
 
   The resulting release tree is under `bazel-bin/release/daal/latest`.
 
-### Windows release validation and helper scripts
+### Release validation and platform helpers
 
-The Windows nightly workflow validates more than whether `//:release` builds.
-It checks that the resulting directory is compatible with the established
-Make-produced package and that a downstream CMake project can consume it. The
-PowerShell helpers used by this flow are intentionally committed and kept
-small so developers can inspect and reproduce each CI step:
+Nightly CI builds Make and Bazel releases on both Linux and Windows, then uses
+`dev/release_tests/compare_release_trees.py` at check level 4 to compare their
+package trees, metadata, and exported symbols. Linux invokes the comparator
+directly; Windows uses `.ci/scripts/compare_windows_release.ps1`. Windows also
+runs `.ci/scripts/test_bazel_release_cmake_example.ps1` to verify that a CMake
+consumer can build and run against the Bazel package.
 
-- `.ci/env/bazelisk.ps1` is the Windows counterpart of
-  `.ci/env/bazelisk.sh`. It downloads the pinned Windows Bazelisk asset,
-  verifies its release SHA256 digest, and exposes it through `GITHUB_PATH` (or
-  the current process `PATH` outside GitHub Actions).
-- `.ci/scripts/compare_windows_release.ps1` invokes
-  `dev/release_tests/compare_release_trees.py` with Windows semantics. It
-  compares the package layout and public binary surface of a Make `vc` release
-  and a normally ICX-built Bazel release; it checks package compatibility, not
-  compiler equivalence or compiler-specific intermediate files.
-- `.ci/scripts/test_bazel_release_cmake_example.ps1` performs an independent
-  consumer test. It configures, builds, and runs a dynamically linked CMake
-  example using the Bazel release's headers, package metadata, import
-  libraries, and runtime DLLs.
-- `dev/bazel/toolchains/tools/dpc_link_win.ps1` is part of the generated
-  Windows DPC++ toolchain, not a standalone validation step. Its `.bat`
-  launcher is generated with the configured compiler path, while the committed
-  PowerShell implementation restructures large object-file response lists and
-  preserves the Intel compiler driver needed for SYCL device linking.
+Other Windows-specific helpers are `.ci/env/bazelisk.ps1`, the PowerShell
+counterpart of the Bazelisk installer, and
+`dev/bazel/toolchains/tools/dpc_link_win.ps1`, which keeps the Intel compiler
+driver in DPC++ link actions while moving large object lists to a response
+file. Each script contains detailed usage and maintenance comments.
 
-To reproduce the two package checks after building both releases from a shell
-with Python, CMake, oneAPI, and the Visual Studio environment initialized:
-
-```powershell
-.\.ci\scripts\compare_windows_release.ps1 `
-    -MakeReleaseDir .\__release_win_vc\daal\latest `
-    -BazelReleaseDir .\bazel-bin\release\daal\latest `
-    -CheckLevel 4
-
-.\.ci\scripts\test_bazel_release_cmake_example.ps1 `
-    -ReleaseDir .\bazel-bin\release\daal\latest
-```
-
-When changing the Windows release layout, update the Bazel packaging rules or
-the common Python comparator rather than hiding expected artifacts in the
-PowerShell adapter. When changing Windows DPC++ link behavior, keep the
-argument transformation in the committed `.ps1` file and the generated `.bat`
-launcher limited to substituting tool paths and forwarding arguments.
+When package contents change, update the Bazel packaging rules or the common
+comparator rather than hiding differences in a platform wrapper.
 
 ### Run oneAPI examples
 - To run all oneAPI C++ example use the following commands:

--- a/dev/bazel/README.md
+++ b/dev/bazel/README.md
@@ -293,6 +293,52 @@ The most used Bazel commands are `build`, `test` and `run`.
 
   The resulting release tree is under `bazel-bin/release/daal/latest`.
 
+### Windows release validation and helper scripts
+
+The Windows nightly workflow validates more than whether `//:release` builds.
+It checks that the resulting directory is compatible with the established
+Make-produced package and that a downstream CMake project can consume it. The
+PowerShell helpers used by this flow are intentionally committed and kept
+small so developers can inspect and reproduce each CI step:
+
+- `.ci/env/bazelisk.ps1` is the Windows counterpart of
+  `.ci/env/bazelisk.sh`. It downloads the pinned Windows Bazelisk asset,
+  verifies its release SHA256 digest, and exposes it through `GITHUB_PATH` (or
+  the current process `PATH` outside GitHub Actions).
+- `.ci/scripts/compare_windows_release.ps1` invokes
+  `dev/release_tests/compare_release_trees.py` with Windows semantics. It
+  compares the package layout and public binary surface of a Make `vc` release
+  and a normally ICX-built Bazel release; it checks package compatibility, not
+  compiler equivalence or compiler-specific intermediate files.
+- `.ci/scripts/test_bazel_release_cmake_example.ps1` performs an independent
+  consumer test. It configures, builds, and runs a dynamically linked CMake
+  example using the Bazel release's headers, package metadata, import
+  libraries, and runtime DLLs.
+- `dev/bazel/toolchains/tools/dpc_link_win.ps1` is part of the generated
+  Windows DPC++ toolchain, not a standalone validation step. Its `.bat`
+  launcher is generated with the configured compiler path, while the committed
+  PowerShell implementation restructures large object-file response lists and
+  preserves the Intel compiler driver needed for SYCL device linking.
+
+To reproduce the two package checks after building both releases from a shell
+with Python, CMake, oneAPI, and the Visual Studio environment initialized:
+
+```powershell
+.\.ci\scripts\compare_windows_release.ps1 `
+    -MakeReleaseDir .\__release_win_vc\daal\latest `
+    -BazelReleaseDir .\bazel-bin\release\daal\latest `
+    -CheckLevel 4
+
+.\.ci\scripts\test_bazel_release_cmake_example.ps1 `
+    -ReleaseDir .\bazel-bin\release\daal\latest
+```
+
+When changing the Windows release layout, update the Bazel packaging rules or
+the common Python comparator rather than hiding expected artifacts in the
+PowerShell adapter. When changing Windows DPC++ link behavior, keep the
+argument transformation in the committed `.ps1` file and the generated `.bat`
+launcher limited to substituting tool paths and forwarding arguments.
+
 ### Run oneAPI examples
 - To run all oneAPI C++ example use the following commands:
   ```sh

--- a/dev/bazel/toolchains/tools/dpc_link_win.ps1
+++ b/dev/bazel/toolchains/tools/dpc_link_win.ps1
@@ -14,6 +14,30 @@
 # limitations under the License.
 #===============================================================================
 
+<#
+.SYNOPSIS
+Adapts Bazel's Windows DPC++ link arguments for the Intel compiler driver.
+
+.DESCRIPTION
+The generated `dpc_link_win.bat` launcher invokes this committed script for
+DPC++ link actions. The Intel compiler driver must remain in the link path so
+it can add the SYCL device-code libraries, but very large Bazel link actions
+can exceed Windows response-file line limits when all object inputs are passed
+through the driver unchanged.
+
+The wrapper expands Bazel response files, moves `.obj` and `.res` inputs into
+a temporary response file with one argument per line, and inserts that file at
+the position of the first object input. Non-object arguments retain their
+original order. The compiler's exit code is propagated and the temporary file
+is removed even when linking fails.
+
+.PARAMETER Compiler
+Path to the Intel DPC++ compiler driver substituted by toolchain setup.
+
+.PARAMETER RawArgs
+The remaining arguments from the Bazel link action.
+#>
+
 param(
     [Parameter(Mandatory=$true)]
     [string]$Compiler,
@@ -24,6 +48,7 @@ param(
 $expandedArgs = New-Object System.Collections.Generic.List[string]
 foreach ($arg in $RawArgs) {
     if ($arg.StartsWith('@')) {
+        # Bazel writes one argument per line in these response files.
         $path = $arg.Substring(1)
         foreach ($line in [IO.File]::ReadLines($path)) {
             if ($line.Length -gt 0) {
@@ -55,6 +80,7 @@ foreach ($arg in $expandedArgs) {
 }
 
 try {
+    # An empty file is harmless for actions without object/resource inputs.
     [IO.File]::WriteAllLines($objectRsp, $objectArgs)
     & $Compiler @finalArgs
     exit $LASTEXITCODE


### PR DESCRIPTION
## Summary

- add comment-based help and targeted inline comments to the Windows PowerShell helpers introduced in #3670
- document the Windows Bazel release validation and DPC++ linker-wrapper flow in `dev/bazel/README.md`
- clarify that the release comparison checks package/public binary compatibility between the Make `vc` and normally ICX-built Bazel releases, not compiler equivalence
- propagate native command failures from the Python comparator and CMake configure/build steps under Windows PowerShell 5.1

## Context

Follow-up to #3670 and its review feedback requesting more explanation in the `.ps1` files. The added documentation covers each helper's purpose, inputs, outputs, CI/toolchain integration, and failure semantics.

## Testing

- `git diff --check`
- static validation of PowerShell comment-help/delimiter structure
- validation that every script path referenced by `dev/bazel/README.md` exists
- independent documentation review; all actionable findings addressed

`pwsh` is not installed in the local Linux workspace, so a native PowerShell parser check was not available locally. The changes are primarily documentation; the functional additions are explicit native-command exit-code propagation for existing CI steps.
