### PR TITLE
Add get_alloc_kind() method into table_metadata class

### DIFF
--- a/cpp/oneapi/dal/array.hpp
+++ b/cpp/oneapi/dal/array.hpp
@@ -676,6 +676,10 @@ public:
         update_data(impl_.get());
     }
 
+    alloc_kind get_alloc_kind() const {
+        return impl_->get_alloc_kind();
+    }
+
 private:
     static void swap(array<T>& a, array<T>& b) {
         std::swap(a.impl_, b.impl_);

--- a/cpp/oneapi/dal/array.hpp
+++ b/cpp/oneapi/dal/array.hpp
@@ -676,6 +676,7 @@ public:
         update_data(impl_.get());
     }
 
+    /// Returns the kind of memory allocation for the array's data.
     alloc_kind get_alloc_kind() const {
         return impl_->get_alloc_kind();
     }

--- a/cpp/oneapi/dal/common.hpp
+++ b/cpp/oneapi/dal/common.hpp
@@ -127,12 +127,23 @@ public:
     std::int64_t end_idx;
 };
 
+enum class alloc_kind : std::uint8_t {
+    non_usm /// Non-USM pointer allocated on host
+#ifdef ONEDAL_DATA_PARALLEL
+    ,
+    usm_host, /// USM pointer allocated by sycl::alloc_host
+    usm_device, /// USM pointer allocated by sycl::alloc_device
+    usm_shared /// USM pointer allocated by sycl::alloc_shared
+#endif
+};
+
 } // namespace v1
 
 using v1::byte_t;
 using v1::base;
 using v1::data_type;
 using v1::range;
+using v1::alloc_kind;
 
 } // namespace oneapi::dal
 

--- a/cpp/oneapi/dal/common.hpp
+++ b/cpp/oneapi/dal/common.hpp
@@ -127,6 +127,7 @@ public:
     std::int64_t end_idx;
 };
 
+/// Specifies the kind of memory allocation for a pointer.
 enum class alloc_kind : std::uint8_t {
     non_usm /// Non-USM pointer allocated on host
 #ifdef ONEDAL_DATA_PARALLEL

--- a/cpp/oneapi/dal/detail/array_impl.hpp
+++ b/cpp/oneapi/dal/detail/array_impl.hpp
@@ -383,6 +383,15 @@ public:
         return policy_var_t{ host_policy };
     }
 
+    alloc_kind get_alloc_kind() const {
+#ifdef ONEDAL_DATA_PARALLEL
+        if (dp_policy_.has_value()) {
+            return dal::detail::get_alloc_kind(dp_policy_.value().get_queue(), get_data());
+        }
+#endif
+        return alloc_kind::non_usm;
+    }
+
 private:
     void reset_policy() {
 #ifdef ONEDAL_DATA_PARALLEL

--- a/cpp/oneapi/dal/detail/chunked_array_impl.cpp
+++ b/cpp/oneapi/dal/detail/chunked_array_impl.cpp
@@ -277,6 +277,38 @@ std::int64_t chunked_array_base::get_chunk_count() const noexcept {
     return detail::integral_cast_debug<std::int64_t>(res);
 }
 
+alloc_kind chunked_array_base::get_alloc_kind() const {
+    // All populated chunks share the same allocation kind, this invariant is
+    // enforced when chunks are inserted (see check_same_alloc_kind), so it is
+    // enough to inspect the first populated chunk.
+    const auto chunk_count = this->get_chunk_count();
+    for (std::int64_t c = 0l; c < chunk_count; ++c) {
+        const auto& chunk = this->get_chunk_impl(c);
+        if (chunk.get_data() != nullptr) {
+            return chunk.get_alloc_kind();
+        }
+    }
+
+    return alloc_kind::non_usm;
+}
+
+void chunked_array_base::check_same_alloc_kind(const array_impl_t& incoming) const {
+    if (incoming.get_data() == nullptr) {
+        return;
+    }
+
+    // When the array holds no data yet, get_alloc_kind() returns non_usm by
+    // convention. There is no existing allocation kind to match against in that
+    // case, so the incoming chunk is accepted unconditionally.
+    if (this->get_size_in_bytes() == 0l) {
+        return;
+    }
+
+    if (this->get_alloc_kind() != incoming.get_alloc_kind()) {
+        throw invalid_argument{ error_messages::alloc_kinds_of_chunks_do_not_match() };
+    }
+}
+
 const array_impl<byte_t>& chunked_array_base::get_chunk_impl(std::int64_t i) const {
     const auto cbegin = impl_->immutable_access().get_chunks().cbegin();
     using diff_t = typename decltype(cbegin)::difference_type;
@@ -296,6 +328,8 @@ array_impl<byte_t>& chunked_array_base::get_mut_chunk_impl(std::int64_t i) const
 }
 
 void chunked_array_base::set_chunk_impl(std::int64_t i, array_impl_t array) {
+    this->check_same_alloc_kind(array);
+
     auto accessor = impl_->mutable_access();
     const auto begin = accessor.get_chunks().begin();
 
@@ -317,6 +351,8 @@ void chunked_array_base::set_chunk_impl(std::int64_t i, array_impl_t array) {
 }
 
 void chunked_array_base::append_impl(array_impl_t arr) const {
+    this->check_same_alloc_kind(arr);
+
     auto accessor = impl_->mutable_access();
     accessor.get_chunks().emplace_back(std::move(arr));
 }

--- a/cpp/oneapi/dal/detail/chunked_array_impl.hpp
+++ b/cpp/oneapi/dal/detail/chunked_array_impl.hpp
@@ -52,6 +52,12 @@ public:
     std::int64_t get_size_in_bytes() const;
     std::int64_t get_chunk_count() const noexcept;
 
+    /// Returns the allocation kind shared by the populated chunks. All chunks
+    /// are guaranteed to have the same allocation kind, this invariant is
+    /// enforced when chunks are inserted. Returns non_usm when there are no
+    /// populated chunks.
+    alloc_kind get_alloc_kind() const;
+
     chunked_array_base(impl_ptr_t&& impl) : impl_{ std::forward<impl_ptr_t>(impl) } {}
 
     chunked_array_base(const impl_ptr_t& impl) : impl_{ impl } {}
@@ -198,6 +204,11 @@ private:
         const auto& internals = acc.get_pimpl(arr);
         return array_impl_t::reinterpret(*internals);
     }
+
+    /// Throws if the allocation kind of `incoming` differs from the allocation
+    /// kind already established by the populated chunks. Empty `incoming` chunks
+    /// and the case when the array holds no data yet are accepted unconditionally.
+    void check_same_alloc_kind(const array_impl_t& incoming) const;
 
     static impl_ptr_t make_array_impl(std::int64_t chunk_count);
 

--- a/cpp/oneapi/dal/detail/common.hpp
+++ b/cpp/oneapi/dal/detail/common.hpp
@@ -381,7 +381,7 @@ inline Out integral_cast_debug(const In& value) {
 }
 
 #ifdef ONEDAL_DATA_PARALLEL
-inline alloc_kind get_alloc_kind(sycl::queue& queue, const void * ptr) {
+inline alloc_kind get_alloc_kind(sycl::queue& queue, const void* ptr) {
     const auto alloc_kind = sycl::get_pointer_type(ptr, queue.get_context());
     if (alloc_kind == sycl::usm::alloc::host) {
         return alloc_kind::usm_host;

--- a/cpp/oneapi/dal/detail/common.hpp
+++ b/cpp/oneapi/dal/detail/common.hpp
@@ -382,18 +382,12 @@ inline Out integral_cast_debug(const In& value) {
 
 #ifdef ONEDAL_DATA_PARALLEL
 inline alloc_kind get_alloc_kind(sycl::queue& queue, const void* ptr) {
-    const auto alloc = sycl::get_pointer_type(ptr, queue.get_context());
-    if (alloc == sycl::usm::alloc::host) {
-        return alloc_kind::usm_host;
-    }
-    else if (alloc == sycl::usm::alloc::device) {
-        return alloc_kind::usm_device;
-    }
-    else if (alloc == sycl::usm::alloc::shared) {
-        return alloc_kind::usm_shared;
-    }
-    else {
-        return alloc_kind::non_usm;
+    const sycl::usm::alloc alloc = sycl::get_pointer_type(ptr, queue.get_context());
+    switch (alloc) {
+        case sycl::usm::alloc::host: return alloc_kind::usm_host;
+        case sycl::usm::alloc::device: return alloc_kind::usm_device;
+        case sycl::usm::alloc::shared: return alloc_kind::usm_shared;
+        case sycl::usm::alloc::unknown: return alloc_kind::non_usm;
     }
 }
 #endif

--- a/cpp/oneapi/dal/detail/common.hpp
+++ b/cpp/oneapi/dal/detail/common.hpp
@@ -380,6 +380,24 @@ inline Out integral_cast_debug(const In& value) {
     return static_cast<Out>(value);
 }
 
+#ifdef ONEDAL_DATA_PARALLEL
+inline alloc_kind get_alloc_kind(sycl::queue& queue, const void * ptr) {
+    const auto alloc_kind = sycl::get_pointer_type(ptr, queue.get_context());
+    if (alloc_kind == sycl::usm::alloc::host) {
+        return alloc_kind::usm_host;
+    }
+    else if (alloc_kind == sycl::usm::alloc::device) {
+        return alloc_kind::usm_device;
+    }
+    else if (alloc_kind == sycl::usm::alloc::shared) {
+        return alloc_kind::usm_shared;
+    }
+    else {
+        return alloc_kind::non_usm;
+    }
+}
+#endif
+
 } // namespace v1
 
 namespace v2 {
@@ -447,6 +465,10 @@ using v2::is_safe_sum;
 using v2::is_safe_mul;
 using v1::integral_cast;
 using v1::integral_cast_debug;
+
+#ifdef ONEDAL_DATA_PARALLEL
+using v1::get_alloc_kind;
+#endif
 
 } // namespace oneapi::dal::detail
 

--- a/cpp/oneapi/dal/detail/common.hpp
+++ b/cpp/oneapi/dal/detail/common.hpp
@@ -388,6 +388,8 @@ inline alloc_kind get_alloc_kind(sycl::queue& queue, const void* ptr) {
         case sycl::usm::alloc::device: return alloc_kind::usm_device;
         case sycl::usm::alloc::shared: return alloc_kind::usm_shared;
         case sycl::usm::alloc::unknown: return alloc_kind::non_usm;
+        /// Should never come here, because get_pointer_type returns unknown for non-USM pointers
+        default: throw unimplemented{ dal::detail::error_messages::unsupported_usm_alloc() };
     }
 }
 #endif

--- a/cpp/oneapi/dal/detail/common.hpp
+++ b/cpp/oneapi/dal/detail/common.hpp
@@ -382,14 +382,14 @@ inline Out integral_cast_debug(const In& value) {
 
 #ifdef ONEDAL_DATA_PARALLEL
 inline alloc_kind get_alloc_kind(sycl::queue& queue, const void* ptr) {
-    const auto alloc_kind = sycl::get_pointer_type(ptr, queue.get_context());
-    if (alloc_kind == sycl::usm::alloc::host) {
+    const auto alloc = sycl::get_pointer_type(ptr, queue.get_context());
+    if (alloc == sycl::usm::alloc::host) {
         return alloc_kind::usm_host;
     }
-    else if (alloc_kind == sycl::usm::alloc::device) {
+    else if (alloc == sycl::usm::alloc::device) {
         return alloc_kind::usm_device;
     }
-    else if (alloc_kind == sycl::usm::alloc::shared) {
+    else if (alloc == sycl::usm::alloc::shared) {
         return alloc_kind::usm_shared;
     }
     else {

--- a/cpp/oneapi/dal/detail/error_messages.cpp
+++ b/cpp/oneapi/dal/detail/error_messages.cpp
@@ -75,6 +75,10 @@ MSG(failed_to_compute_eigenvectors, "Failed to compute eigenvectors")
 MSG(failed_to_generate_random_numbers, "Failed to generate random numbers")
 
 /* Tables */
+MSG(alloc_kinds_of_chunks_do_not_match,
+    "Allocation kinds of the chunks in the chunked array do not match")
+MSG(alloc_kinds_of_arrays_do_not_match,
+    "Allocation kinds of the arrays the heterogeneous table is constructed from do not match")
 MSG(allocated_memory_size_is_not_enough_to_copy_data,
     "Allocated memory size is not enough to copy the data")
 MSG(cannot_get_data_type_from_empty_metadata, "Cannot get data type from empty metadata")

--- a/cpp/oneapi/dal/detail/error_messages.hpp
+++ b/cpp/oneapi/dal/detail/error_messages.hpp
@@ -103,6 +103,8 @@ public:
     MSG(failed_to_generate_random_numbers);
 
     /* Tables */
+    MSG(alloc_kinds_of_chunks_do_not_match);
+    MSG(alloc_kinds_of_arrays_do_not_match);
     MSG(allocated_memory_size_is_not_enough_to_copy_data);
     MSG(cannot_get_data_type_from_empty_metadata);
     MSG(cannot_get_feature_type_from_empty_metadata);

--- a/cpp/oneapi/dal/table/backend/common_kernels.hpp
+++ b/cpp/oneapi/dal/table/backend/common_kernels.hpp
@@ -139,7 +139,7 @@ inline table_metadata create_metadata(std::int64_t feature_count, data_type dtyp
 
     auto dtypes = array<data_type>::full(feature_count, dtype);
     auto ftypes = array<feature_type>::full(feature_count, default_ftype);
-    return table_metadata{ dtypes, ftypes };
+    return table_metadata{ dtypes, ftypes, alloc_kind::non_usm };
 }
 
 inline table_metadata create_metadata(std::int64_t feature_count,

--- a/cpp/oneapi/dal/table/backend/common_kernels.hpp
+++ b/cpp/oneapi/dal/table/backend/common_kernels.hpp
@@ -142,7 +142,9 @@ inline table_metadata create_metadata(std::int64_t feature_count, data_type dtyp
     return table_metadata{ dtypes, ftypes };
 }
 
-inline table_metadata create_metadata(std::int64_t feature_count, data_type dtype, alloc_kind alloc) {
+inline table_metadata create_metadata(std::int64_t feature_count,
+                                      data_type dtype,
+                                      alloc_kind alloc) {
     auto default_ftype =
         detail::is_floating_point(dtype) ? feature_type::ratio : feature_type::ordinal;
 

--- a/cpp/oneapi/dal/table/backend/common_kernels.hpp
+++ b/cpp/oneapi/dal/table/backend/common_kernels.hpp
@@ -21,13 +21,6 @@
 
 namespace oneapi::dal::backend {
 
-enum class alloc_kind {
-    host, /// Non-USM pointer allocated on host
-    usm_host, /// USM pointer allocated by sycl::alloc_host
-    usm_device, /// USM pointer allocated by sycl::alloc_device
-    usm_shared /// USM pointer allocated by sycl::alloc_shared
-};
-
 #ifdef ONEDAL_DATA_PARALLEL
 inline alloc_kind alloc_kind_from_sycl(sycl::usm::alloc alloc) {
     using error_msg = dal::detail::error_messages;
@@ -61,15 +54,15 @@ inline bool alloc_kind_requires_copy(alloc_kind src_alloc_kind, alloc_kind dst_a
         // and access is requested on host.
         // This might result in slower performance for some cases but shared usm
         // is not recommended to use for performance critical code anyway
-        case alloc_kind::host: //
+        case alloc_kind::non_usm: //
             return (src_alloc_kind == alloc_kind::usm_device || //
                     (src_alloc_kind == alloc_kind::usm_shared));
         case alloc_kind::usm_host: //
-            return (src_alloc_kind == alloc_kind::host) || //
+            return (src_alloc_kind == alloc_kind::non_usm) || //
                    (src_alloc_kind == alloc_kind::usm_device) || //
                    (src_alloc_kind == alloc_kind::usm_shared);
         case alloc_kind::usm_device: //
-            return (src_alloc_kind == alloc_kind::host) || //
+            return (src_alloc_kind == alloc_kind::non_usm) || //
                    (src_alloc_kind == alloc_kind::usm_host);
         case alloc_kind::usm_shared: //
             return (src_alloc_kind != alloc_kind::usm_shared);
@@ -77,8 +70,8 @@ inline bool alloc_kind_requires_copy(alloc_kind src_alloc_kind, alloc_kind dst_a
             ONEDAL_ASSERT(!"Unsupported alloc_kind");
     }
 #else
-    ONEDAL_ASSERT(src_alloc_kind == alloc_kind::host);
-    ONEDAL_ASSERT(dst_alloc_kind == alloc_kind::host);
+    ONEDAL_ASSERT(src_alloc_kind == alloc_kind::non_usm);
+    ONEDAL_ASSERT(dst_alloc_kind == alloc_kind::non_usm);
     return false;
 #endif
 }
@@ -93,7 +86,7 @@ inline alloc_kind get_alloc_kind(const array<T>& array) {
         return alloc_kind_from_sycl(array_alloc);
     }
 #endif
-    return alloc_kind::host;
+    return alloc_kind::non_usm;
 }
 
 template <typename Policy, typename Data>
@@ -102,10 +95,10 @@ ONEDAL_FORCEINLINE void reset_array(const Policy& policy,
                                     std::int64_t count,
                                     const alloc_kind& kind) {
     if constexpr (std::is_same_v<Policy, detail::default_host_policy>) {
-        ONEDAL_ASSERT(kind == alloc_kind::host, "Incompatible policy and type of allocation");
+        ONEDAL_ASSERT(kind == alloc_kind::non_usm, "Incompatible policy and type of allocation");
     }
 #ifdef ONEDAL_DATA_PARALLEL
-    if (kind == alloc_kind::host) {
+    if (kind == alloc_kind::non_usm) {
         array.reset(count);
     }
     else {
@@ -147,6 +140,15 @@ inline table_metadata create_metadata(std::int64_t feature_count, data_type dtyp
     auto dtypes = array<data_type>::full(feature_count, dtype);
     auto ftypes = array<feature_type>::full(feature_count, default_ftype);
     return table_metadata{ dtypes, ftypes };
+}
+
+inline table_metadata create_metadata(std::int64_t feature_count, data_type dtype, alloc_kind alloc) {
+    auto default_ftype =
+        detail::is_floating_point(dtype) ? feature_type::ratio : feature_type::ordinal;
+
+    auto dtypes = array<data_type>::full(feature_count, dtype);
+    auto ftypes = array<feature_type>::full(feature_count, default_ftype);
+    return table_metadata{ dtypes, ftypes, alloc };
 }
 
 /// The function tries to select correct policy for pull/push implementation

--- a/cpp/oneapi/dal/table/backend/csr_table_builder_impl.hpp
+++ b/cpp/oneapi/dal/table/backend/csr_table_builder_impl.hpp
@@ -122,7 +122,7 @@ public:
                        data,
                        column_indices,
                        row_offsets,
-                       alloc_kind::host,
+                       alloc_kind::non_usm,
                        preserve_mutability);
     }
 

--- a/cpp/oneapi/dal/table/backend/csr_table_impl.hpp
+++ b/cpp/oneapi/dal/table/backend/csr_table_impl.hpp
@@ -39,7 +39,7 @@ public:
                    std::int64_t column_count,
                    data_type dtype,
                    sparse_indexing indexing)
-            : meta_(create_metadata(column_count, dtype)),
+            : meta_(create_metadata(column_count, dtype, data.get_alloc_kind())),
               data_(data),
               column_indices_(column_indices),
               row_offsets_(row_offsets),
@@ -84,7 +84,7 @@ public:
                    data_type dtype,
                    sparse_indexing indexing,
                    const std::vector<sycl::event>& dependencies)
-            : meta_(create_metadata(column_count, dtype)),
+            : meta_(create_metadata(column_count, dtype, data.get_alloc_kind())),
               data_(data),
               column_indices_(column_indices),
               row_offsets_(row_offsets),
@@ -198,7 +198,7 @@ public:
                        data,
                        column_indices,
                        row_offsets,
-                       alloc_kind::host);
+                       alloc_kind::non_usm);
     }
 
 #ifdef ONEDAL_DATA_PARALLEL

--- a/cpp/oneapi/dal/table/backend/csr_table_impl.hpp
+++ b/cpp/oneapi/dal/table/backend/csr_table_impl.hpp
@@ -240,6 +240,15 @@ public:
 
     void deserialize(detail::input_archive& ar) override {
         ar(meta_, data_, column_indices_, row_offsets_, col_count_, row_count_, layout_, indexing_);
+        // The allocation kind is not persisted in the archive; re-establish it
+        // from the deserialized data, which was materialized according to the
+        // deserialization context (queue/policy). The deserialized feature and
+        // data types are preserved as-is.
+        if (data_.get_count() > 0) {
+            meta_ = table_metadata{ meta_.get_data_types(),
+                                    meta_.get_feature_types(),
+                                    data_.get_alloc_kind() };
+        }
     }
 
 private:

--- a/cpp/oneapi/dal/table/backend/heterogen_table_impl.hpp
+++ b/cpp/oneapi/dal/table/backend/heterogen_table_impl.hpp
@@ -93,6 +93,17 @@ public:
 
             set_column(col, dt, std::move(raw));
         }
+
+        // The allocation kind is not persisted in the archive; re-establish it
+        // from the deserialized columns, which were materialized according to the
+        // deserialization context (queue/policy). All columns share one allocation
+        // kind (enforced on construction), so the first column is representative.
+        // The deserialized feature and data types are preserved as-is.
+        if (col_count > 0l) {
+            meta_ = table_metadata{ meta_.get_data_types(),
+                                    meta_.get_feature_types(),
+                                    data_[0l].get_alloc_kind() };
+        }
     }
 
     // virtual void set_column(std::int64_t, data_type, detail::chunked_array_base) = 0;

--- a/cpp/oneapi/dal/table/backend/heterogen_table_impl.hpp
+++ b/cpp/oneapi/dal/table/backend/heterogen_table_impl.hpp
@@ -157,7 +157,7 @@ public:
     void pull_rows_template(const detail::default_host_policy& policy,
                             array<T>& block,
                             const range& rows) const {
-        heterogen_pull_rows(policy, meta_, data_, block, rows, alloc_kind::host);
+        heterogen_pull_rows(policy, meta_, data_, block, rows, alloc_kind::non_usm);
     }
 
     template <typename T>
@@ -165,7 +165,7 @@ public:
                               array<T>& block,
                               std::int64_t column_index,
                               const range& rows) const {
-        heterogen_pull_column(policy, meta_, data_, block, column_index, rows, alloc_kind::host);
+        heterogen_pull_column(policy, meta_, data_, block, column_index, rows, alloc_kind::non_usm);
     }
 
 #ifdef ONEDAL_DATA_PARALLEL

--- a/cpp/oneapi/dal/table/backend/heterogen_table_impl.hpp
+++ b/cpp/oneapi/dal/table/backend/heterogen_table_impl.hpp
@@ -47,10 +47,10 @@ public:
 
     std::int64_t get_row_count() const override {
         ONEDAL_ASSERT(validate());
-        if (get_column_count() == 0l)
-            return 0l;
-        auto dt = get_metadata().get_data_type(0l);
-        return detail::get_element_count(dt, data_[0l]);
+        if (get_column_count() == 0)
+            return 0;
+        auto dt = get_metadata().get_data_type(0);
+        return detail::get_element_count(dt, data_[0]);
     }
 
     std::int64_t get_column_count() const override {
@@ -72,7 +72,7 @@ public:
     void serialize(detail::output_archive& ar) const override {
         ar(this->meta_);
         const std::int64_t col_count = get_column_count();
-        for (std::int64_t col = 0l; col < col_count; ++col) {
+        for (std::int64_t col = 0; col < col_count; ++col) {
             const auto& raw = get_column(col);
             raw.serialize_impl(ar);
         }
@@ -86,7 +86,7 @@ public:
         }
 
         const std::int64_t col_count = get_column_count();
-        for (std::int64_t col = 0l; col < col_count; ++col) {
+        for (std::int64_t col = 0; col < col_count; ++col) {
             auto dt = get_metadata().get_data_type(col);
             detail::chunked_array_base raw;
             raw.deserialize_impl(dt, ar);
@@ -99,10 +99,10 @@ public:
         // deserialization context (queue/policy). All columns share one allocation
         // kind (enforced on construction), so the first column is representative.
         // The deserialized feature and data types are preserved as-is.
-        if (col_count > 0l) {
+        if (col_count > 0) {
             meta_ = table_metadata{ meta_.get_data_types(),
                                     meta_.get_feature_types(),
-                                    data_[0l].get_alloc_kind() };
+                                    data_[0].get_alloc_kind() };
         }
     }
 
@@ -135,8 +135,8 @@ public:
             return true;
         }
 
-        const auto dt = get_metadata().get_data_type(0l);
-        const auto row_count = detail::get_element_count(dt, data_[0l]);
+        const auto dt = get_metadata().get_data_type(0);
+        const auto row_count = detail::get_element_count(dt, data_[0]);
 
         for (std::int64_t c = 1l; c < col_count; ++c) {
             const auto dt_col = get_metadata().get_data_type(c);
@@ -152,7 +152,7 @@ public:
 
     void reset_with_metadata(const table_metadata& meta) {
         const auto col_count = meta.get_feature_count();
-        if (std::int64_t{ 0l } < col_count) {
+        if (std::int64_t{ 0 } < col_count) {
             const detail::chunked_array_base empty;
             auto new_data = data_t::full(col_count, empty);
             auto raw_ptr = new_data.get_mutable_data();

--- a/cpp/oneapi/dal/table/backend/homogen_table_builder_impl.hpp
+++ b/cpp/oneapi/dal/table/backend/homogen_table_builder_impl.hpp
@@ -175,7 +175,7 @@ public:
                           data_,
                           block,
                           rows,
-                          alloc_kind::host,
+                          alloc_kind::non_usm,
                           preserve_mutability);
     }
 
@@ -191,7 +191,7 @@ public:
                             block,
                             column_index,
                             rows,
-                            alloc_kind::host,
+                            alloc_kind::non_usm,
                             preserve_mutability);
     }
 

--- a/cpp/oneapi/dal/table/backend/homogen_table_impl.hpp
+++ b/cpp/oneapi/dal/table/backend/homogen_table_impl.hpp
@@ -33,7 +33,7 @@ public:
                        const array<byte_t>& data,
                        data_type dtype,
                        data_layout layout)
-            : meta_(create_metadata(column_count, dtype)),
+            : meta_(create_metadata(column_count, dtype, data.get_alloc_kind())),
               data_(data),
               row_count_(row_count),
               col_count_(column_count),
@@ -89,7 +89,7 @@ public:
     void pull_rows_template(const detail::default_host_policy& policy,
                             array<T>& block,
                             const range& rows) const {
-        homogen_pull_rows(policy, get_info(), data_, block, rows, alloc_kind::host);
+        homogen_pull_rows(policy, get_info(), data_, block, rows, alloc_kind::non_usm);
     }
 
     template <typename T>
@@ -97,7 +97,7 @@ public:
                               array<T>& block,
                               std::int64_t column_index,
                               const range& rows) const {
-        homogen_pull_column(policy, get_info(), data_, block, column_index, rows, alloc_kind::host);
+        homogen_pull_column(policy, get_info(), data_, block, column_index, rows, alloc_kind::non_usm);
     }
 
 #ifdef ONEDAL_DATA_PARALLEL

--- a/cpp/oneapi/dal/table/backend/homogen_table_impl.hpp
+++ b/cpp/oneapi/dal/table/backend/homogen_table_impl.hpp
@@ -139,6 +139,15 @@ public:
 
     void deserialize(detail::input_archive& ar) override {
         ar(meta_, data_, row_count_, col_count_, layout_);
+        // The allocation kind is not persisted in the archive; re-establish it
+        // from the deserialized data, which was materialized according to the
+        // deserialization context (queue/policy). The deserialized feature and
+        // data types are preserved as-is.
+        if (data_.get_count() > 0) {
+            meta_ = table_metadata{ meta_.get_data_types(),
+                                    meta_.get_feature_types(),
+                                    data_.get_alloc_kind() };
+        }
     }
 
 private:

--- a/cpp/oneapi/dal/table/backend/homogen_table_impl.hpp
+++ b/cpp/oneapi/dal/table/backend/homogen_table_impl.hpp
@@ -97,7 +97,13 @@ public:
                               array<T>& block,
                               std::int64_t column_index,
                               const range& rows) const {
-        homogen_pull_column(policy, get_info(), data_, block, column_index, rows, alloc_kind::non_usm);
+        homogen_pull_column(policy,
+                            get_info(),
+                            data_,
+                            block,
+                            column_index,
+                            rows,
+                            alloc_kind::non_usm);
     }
 
 #ifdef ONEDAL_DATA_PARALLEL

--- a/cpp/oneapi/dal/table/common.cpp
+++ b/cpp/oneapi/dal/table/common.cpp
@@ -131,11 +131,19 @@ public:
     }
 
     void serialize(detail::output_archive& ar) const override {
-        ar(dtypes_, ftypes_, kind_);
+        // kind_ is intentionally NOT serialized: it describes where the data
+        // currently resides in memory, which is a runtime property re-established
+        // when the data array is deserialized (see array_impl::deserialize, which
+        // materializes the buffer according to the deserialization context's
+        // policy/queue). Persisting it would both break the archive format (an
+        // extra field under the same serialization id) and record a value that is
+        // stale as soon as the table is deserialized on a different device.
+        ar(dtypes_, ftypes_);
     }
 
     void deserialize(detail::input_archive& ar) override {
-        ar(dtypes_, ftypes_, kind_);
+        ar(dtypes_, ftypes_);
+        // kind_ keeps its default (non_usm); see the note in serialize().
     }
 
 private:

--- a/cpp/oneapi/dal/table/common.cpp
+++ b/cpp/oneapi/dal/table/common.cpp
@@ -145,7 +145,7 @@ private:
 
     dal::array<data_type> dtypes_;
     dal::array<feature_type> ftypes_;
-    alloc_kind kind_;
+    alloc_kind kind_ = alloc_kind::non_usm; // Default allocation kind is non-USM
 };
 
 __ONEDAL_REGISTER_SERIALIZABLE__(simple_metadata_impl)
@@ -181,11 +181,9 @@ const dal::array<data_type>& table_metadata::get_data_types() const {
     return impl_->get_data_types();
 }
 
-#ifdef ONEDAL_DATA_PARALLEL
 alloc_kind table_metadata::get_alloc_kind() const {
     return impl_->get_alloc_kind();
 }
-#endif
 
 void table_metadata::serialize(detail::output_archive& ar) const {
     detail::serialize_polymorphic_shared(impl_, ar);

--- a/cpp/oneapi/dal/table/common.cpp
+++ b/cpp/oneapi/dal/table/common.cpp
@@ -131,11 +131,11 @@ public:
     }
 
     void serialize(detail::output_archive& ar) const override {
-        ar(dtypes_, ftypes_);
+        ar(dtypes_, ftypes_, kind_);
     }
 
     void deserialize(detail::input_archive& ar) override {
-        ar(dtypes_, ftypes_);
+        ar(dtypes_, ftypes_, kind_);
     }
 
 private:

--- a/cpp/oneapi/dal/table/common.cpp
+++ b/cpp/oneapi/dal/table/common.cpp
@@ -31,6 +31,7 @@ public:
     virtual const data_type& get_data_type(std::int64_t index) const = 0;
     virtual const dal::array<feature_type>& get_feature_types() const = 0;
     virtual const dal::array<data_type>& get_data_types() const = 0;
+    virtual alloc_kind get_alloc_kind() const = 0;
 };
 
 } // namespace v1
@@ -66,6 +67,10 @@ public:
         throw domain_error(dal::detail::error_messages::cannot_get_data_type_from_empty_metadata());
     }
 
+    alloc_kind get_alloc_kind() const override {
+        return alloc_kind::non_usm;
+    }
+
     void serialize(detail::output_archive& ar) const override {
         // Nothing to serialize
     }
@@ -82,9 +87,11 @@ public:
     simple_metadata_impl() = default;
 
     simple_metadata_impl(const dal::array<data_type>& dtypes,
-                         const dal::array<feature_type>& ftypes)
+                         const dal::array<feature_type>& ftypes,
+                         const alloc_kind kind)
             : dtypes_(dtypes),
-              ftypes_(ftypes) {
+              ftypes_(ftypes),
+              kind_(kind) {
         if (dtypes_.get_count() != ftypes_.get_count()) {
             throw out_of_range{
                 dal::detail::error_messages::
@@ -119,6 +126,10 @@ public:
         return dtypes_[i];
     }
 
+    alloc_kind get_alloc_kind() const override {
+        return kind_;
+    }
+
     void serialize(detail::output_archive& ar) const override {
         ar(dtypes_, ftypes_);
     }
@@ -134,14 +145,21 @@ private:
 
     dal::array<data_type> dtypes_;
     dal::array<feature_type> ftypes_;
+    alloc_kind kind_;
 };
+
 __ONEDAL_REGISTER_SERIALIZABLE__(simple_metadata_impl)
 
 table_metadata::table_metadata() : impl_(new empty_metadata_impl()) {}
 
 table_metadata::table_metadata(const dal::array<data_type>& dtypes,
                                const dal::array<feature_type>& ftypes)
-        : impl_(new simple_metadata_impl(dtypes, ftypes)) {}
+        : impl_(new simple_metadata_impl(dtypes, ftypes, alloc_kind::non_usm)) {}
+
+table_metadata::table_metadata(const dal::array<data_type>& dtypes,
+                               const dal::array<feature_type>& ftypes,
+                               const alloc_kind kind)
+        : impl_(new simple_metadata_impl(dtypes, ftypes, kind)) {}
 
 int64_t table_metadata::get_feature_count() const {
     return impl_->get_feature_count();
@@ -162,6 +180,12 @@ const dal::array<feature_type>& table_metadata::get_feature_types() const {
 const dal::array<data_type>& table_metadata::get_data_types() const {
     return impl_->get_data_types();
 }
+
+#ifdef ONEDAL_DATA_PARALLEL
+alloc_kind table_metadata::get_alloc_kind() const {
+    return impl_->get_alloc_kind();
+}
+#endif
 
 void table_metadata::serialize(detail::output_archive& ar) const {
     detail::serialize_polymorphic_shared(impl_, ar);

--- a/cpp/oneapi/dal/table/common.hpp
+++ b/cpp/oneapi/dal/table/common.hpp
@@ -80,6 +80,7 @@ public:
     /// Get feature types in bulk
     const dal::array<feature_type>& get_feature_types() const;
 
+    /// Returns the kind of memory allocation for the table's data.
     alloc_kind get_alloc_kind() const;
 
 private:

--- a/cpp/oneapi/dal/table/common.hpp
+++ b/cpp/oneapi/dal/table/common.hpp
@@ -51,7 +51,15 @@ public:
     /// @param dtypes The data types of the features. Assigned into the :literal:`data_type` property.
     /// @param ftypes The feature types. Assigned into the :literal:`feature_type` property.
     /// @pre :expr:`dtypes.get_count() == ftypes.get_count()`
-    table_metadata(const dal::array<data_type>& dtypes, const dal::array<feature_type>& ftypes);
+    [[deprecated]] table_metadata(const dal::array<data_type>& dtypes, const dal::array<feature_type>& ftypes);
+
+    /// Creates the metadata instance from external information about the data types and the
+    /// feature types.
+    /// @param dtypes The data types of the features. Assigned into the :literal:`data_type` property.
+    /// @param ftypes The feature types. Assigned into the :literal:`feature_type` property.
+    /// @param kind The allocation kind for the table data.
+    /// @pre :expr:`dtypes.get_count() == ftypes.get_count()`
+    table_metadata(const dal::array<data_type>& dtypes, const dal::array<feature_type>& ftypes, const alloc_kind kind);
 
     /// The number of features that metadata contains information about
     /// @invariant :literal:`feature_count >= 0`
@@ -68,6 +76,8 @@ public:
 
     /// Get feature types in bulk
     const dal::array<feature_type>& get_feature_types() const;
+
+    alloc_kind get_alloc_kind() const;
 
 private:
     void serialize(detail::output_archive& ar) const;

--- a/cpp/oneapi/dal/table/common.hpp
+++ b/cpp/oneapi/dal/table/common.hpp
@@ -51,7 +51,8 @@ public:
     /// @param dtypes The data types of the features. Assigned into the :literal:`data_type` property.
     /// @param ftypes The feature types. Assigned into the :literal:`feature_type` property.
     /// @pre :expr:`dtypes.get_count() == ftypes.get_count()`
-    [[deprecated]] table_metadata(const dal::array<data_type>& dtypes, const dal::array<feature_type>& ftypes);
+    [[deprecated]] table_metadata(const dal::array<data_type>& dtypes,
+                                  const dal::array<feature_type>& ftypes);
 
     /// Creates the metadata instance from external information about the data types and the
     /// feature types.
@@ -59,7 +60,9 @@ public:
     /// @param ftypes The feature types. Assigned into the :literal:`feature_type` property.
     /// @param kind The allocation kind for the table data.
     /// @pre :expr:`dtypes.get_count() == ftypes.get_count()`
-    table_metadata(const dal::array<data_type>& dtypes, const dal::array<feature_type>& ftypes, const alloc_kind kind);
+    table_metadata(const dal::array<data_type>& dtypes,
+                   const dal::array<feature_type>& ftypes,
+                   const alloc_kind kind);
 
     /// The number of features that metadata contains information about
     /// @invariant :literal:`feature_count >= 0`

--- a/cpp/oneapi/dal/table/detail/metadata_utils.hpp
+++ b/cpp/oneapi/dal/table/detail/metadata_utils.hpp
@@ -73,15 +73,42 @@ inline dal::array<feature_type> find_array_ftypes() {
 }
 
 template <typename... Types>
-inline table_metadata make_default_metadata() {
+inline table_metadata make_default_metadata(const alloc_kind kind = alloc_kind::non_usm) {
     const auto dtypes = find_array_dtypes<Types...>();
     const auto ftypes = find_array_ftypes<Types...>();
-    return table_metadata(dtypes, ftypes);
+    return table_metadata(dtypes, ftypes, kind);
 }
 
-template <typename... Types>
-inline table_metadata make_default_metadata_from_arrays_impl(const std::tuple<Types...>* const) {
-    return make_default_metadata<Types...>();
+/// Deduces a single allocation kind shared by all the input arrays.
+/// The allocation kind of the first array is taken as the reference and all
+/// the remaining arrays are required to have the same allocation kind.
+/// @pre All arrays are allocated with the same allocation kind.
+template <typename... Arrays>
+inline alloc_kind deduce_common_alloc_kind(const Arrays&... arrays) {
+    if constexpr (sizeof...(Arrays) == 0ul) {
+        return alloc_kind::non_usm;
+    }
+    else {
+        bool first = true;
+        alloc_kind common = alloc_kind::non_usm;
+
+        detail::apply(
+            [&](const auto& array) -> void {
+                const auto current = array.get_alloc_kind();
+                if (first) {
+                    common = current;
+                    first = false;
+                }
+                else if (current != common) {
+                    throw invalid_argument{
+                        dal::detail::error_messages::alloc_kinds_of_arrays_do_not_match()
+                    };
+                }
+            },
+            arrays...);
+
+        return common;
+    }
 }
 
 template <typename Array>
@@ -106,9 +133,9 @@ template <typename Array, typename Raw = std::decay_t<Array>>
 using array_type_t = std::decay_t<typename array_type_map<Raw>::type>;
 
 template <typename... Arrays>
-inline table_metadata make_default_metadata_from_arrays() {
-    using type_seq_t = std::tuple<array_type_t<Arrays>...>;
-    return make_default_metadata_from_arrays_impl(reinterpret_cast<const type_seq_t*>(0ul));
+inline table_metadata make_default_metadata_from_arrays(const Arrays&... arrays) {
+    const alloc_kind kind = deduce_common_alloc_kind(arrays...);
+    return make_default_metadata<array_type_t<Arrays>...>(kind);
 }
 
 } // namespace v1

--- a/cpp/oneapi/dal/table/detail/test/metadata_utils.cpp
+++ b/cpp/oneapi/dal/table/detail/test/metadata_utils.cpp
@@ -58,13 +58,14 @@ TEST("can get correcty metadata from raw types") {
 }
 
 TEST("can get correcty metadata from array types") {
-    const auto meta = make_default_metadata_from_arrays<dal::array<std::int32_t>,
-                                                        dal::array<std::int64_t>,
-                                                        dal::array<float>,
-                                                        dal::array<double>>();
+    const auto meta = make_default_metadata_from_arrays(dal::array<std::int32_t>{},
+                                                        dal::array<std::int64_t>{},
+                                                        dal::array<float>{},
+                                                        dal::array<double>{});
 
     check_dtype_correctness(expected_dtypes, meta);
     check_ftype_correctness(expected_ftypes, meta);
+    REQUIRE(meta.get_alloc_kind() == alloc_kind::non_usm);
 }
 
 } // namespace oneapi::dal::detail

--- a/cpp/oneapi/dal/table/heterogen.hpp
+++ b/cpp/oneapi/dal/table/heterogen.hpp
@@ -48,7 +48,7 @@ public:
     static heterogen_table wrap(Arrays&&... arrays) {
         using detail::integral_cast;
 
-        auto meta = detail::make_default_metadata_from_arrays<Arrays...>();
+        auto meta = detail::make_default_metadata_from_arrays(arrays...);
         heterogen_table result = heterogen_table::empty(meta);
 
         [[maybe_unused]] const std::size_t ccount = sizeof...(Arrays);

--- a/cpp/oneapi/dal/table/test/csr.cpp
+++ b/cpp/oneapi/dal/table/test/csr.cpp
@@ -66,6 +66,7 @@ TEST("can construct CSR table from raw data pointers") {
         REQUIRE(meta.get_data_type(i) == data_type::float32);
         REQUIRE(meta.get_feature_type(i) == feature_type::ratio);
     }
+    REQUIRE(meta.get_alloc_kind() == alloc_kind::non_usm);
 
     REQUIRE(t.get_data<float>() == data);
     REQUIRE(t.get_column_indices() == column_indices);
@@ -105,6 +106,7 @@ TEST("can construct float64 table with zero-based indexing") {
         REQUIRE(meta.get_data_type(i) == data_type::float64);
         REQUIRE(meta.get_feature_type(i) == feature_type::ratio);
     }
+    REQUIRE(meta.get_alloc_kind() == alloc_kind::non_usm);
 
     REQUIRE(t.get_data<double>() == data);
     REQUIRE(t.get_column_indices() == column_indices);
@@ -152,7 +154,7 @@ TEST("can construct table reference") {
 
     REQUIRE(t1.get_indexing() == t2.get_indexing());
 
-    te::check_if_metadata_equal(m1, m2);
+    te::check_if_metadata_equal(m1, m2, true);
 }
 
 TEST("can construct table reference with a copy constructor") {
@@ -196,7 +198,7 @@ TEST("can construct table reference with a copy constructor") {
 
     REQUIRE(t1.get_indexing() == t2.get_indexing());
 
-    te::check_if_metadata_equal(m1, m2);
+    te::check_if_metadata_equal(m1, m2, true);
 }
 
 TEST("can construct table with move") {
@@ -233,6 +235,7 @@ TEST("can construct table with move") {
     for (std::int64_t i = 0; i < t2.get_column_count(); i++) {
         REQUIRE(m2.get_data_type(i) == data_type::float32);
     }
+    REQUIRE(m2.get_alloc_kind() == alloc_kind::non_usm);
     REQUIRE(t2.get_data<float>() == data);
     REQUIRE(t2.get_column_indices() == column_indices);
     REQUIRE(t2.get_row_offsets() == row_offsets);
@@ -281,7 +284,6 @@ TEST("can assign two table references") {
     REQUIRE(t1.get_row_count() == row_count2);
     REQUIRE(t1.get_column_count() == column_count2);
     REQUIRE(t1.get_non_zero_count() == element_count2);
-    REQUIRE(t1.get_metadata().get_data_type(0) == data_type::int32);
     REQUIRE(t1.get_data<std::int32_t>() == data2);
     REQUIRE(t1.get_column_indices() == column_indices2);
     REQUIRE(t1.get_row_offsets() == row_offsets2);
@@ -289,12 +291,11 @@ TEST("can assign two table references") {
     REQUIRE(t2.get_row_count() == row_count2);
     REQUIRE(t2.get_column_count() == column_count2);
     REQUIRE(t2.get_non_zero_count() == element_count2);
-    REQUIRE(t2.get_metadata().get_data_type(0) == data_type::int32);
     REQUIRE(t2.get_data<std::int32_t>() == data2);
     REQUIRE(t2.get_column_indices() == column_indices2);
     REQUIRE(t2.get_row_offsets() == row_offsets2);
 
-    te::check_if_metadata_equal(t1.get_metadata(), t2.get_metadata());
+    te::check_if_metadata_equal(t1.get_metadata(), t2.get_metadata(), true);
 }
 
 TEST("can move assigned table reference") {
@@ -334,6 +335,7 @@ TEST("can move assigned table reference") {
 
     t1 = std::move(t2);
 
+    REQUIRE(t1.get_metadata().get_alloc_kind() == alloc_kind::non_usm);
     REQUIRE(t1.has_data() == true);
     REQUIRE(t1.get_row_count() == row_count2);
     REQUIRE(t1.get_column_count() == column_count2);
@@ -369,6 +371,7 @@ TEST(
         REQUIRE(meta.get_data_type(i) == data_type::float32);
         REQUIRE(meta.get_feature_type(i) == feature_type::ratio);
     }
+    REQUIRE(meta.get_alloc_kind() == alloc_kind::non_usm);
 
     REQUIRE(t.get_data<float>() == data);
     REQUIRE(t.get_column_indices() == column_indices);
@@ -428,6 +431,7 @@ TEST((std::string("can construct table from data pointers allocated on the devic
         REQUIRE(meta.get_data_type(i) == data_type::float32);
         REQUIRE(meta.get_feature_type(i) == feature_type::ratio);
     }
+    REQUIRE(meta.get_alloc_kind() == alloc_kind::usm_shared);
 
     REQUIRE(t.get_data<float>() == data);
     REQUIRE(t.get_column_indices() == column_indices);
@@ -506,6 +510,7 @@ TEST((std::string("can construct table from arrays holding the data allocated on
     REQUIRE(t.get_row_count() == row_count);
     REQUIRE(t.get_column_count() == column_count);
     REQUIRE(t.get_non_zero_count() == element_count);
+    REQUIRE(t.get_metadata().get_alloc_kind() == alloc_kind::usm_device);
 
     sycl::free(data, q);
     sycl::free(column_indices, q);

--- a/cpp/oneapi/dal/table/test/heterogen.cpp
+++ b/cpp/oneapi/dal/table/test/heterogen.cpp
@@ -435,23 +435,6 @@ TEST("Can get column slice from heterogen to shared") {
     }
 }
 
-TEST("Cannot create heterogen table from columns with different alloc kinds") {
-    DECLARE_TEST_POLICY(policy);
-    auto& q = policy.get_queue();
-
-    constexpr auto device = sycl::usm::alloc::device;
-    constexpr auto shared = sycl::usm::alloc::shared;
-
-    auto arr0 = array<float>::empty(q, 8l, shared);
-    std::iota(begin(arr0), end(arr0), float(0));
-    chunked_array<float> chunked0(arr0);
-
-    auto arr1 = array<std::int32_t>::empty(q, 8l, device);
-    chunked_array<std::int32_t> chunked1(arr1);
-
-    REQUIRE_THROWS_AS(heterogen_table::wrap(chunked0, chunked1), invalid_argument);
-}
-
 TEST("Cannot build chunked array from chunks with different alloc kinds") {
     DECLARE_TEST_POLICY(policy);
     auto& q = policy.get_queue();

--- a/cpp/oneapi/dal/table/test/heterogen.cpp
+++ b/cpp/oneapi/dal/table/test/heterogen.cpp
@@ -336,7 +336,6 @@ TEST("Can get row slice from heterogen to shared") {
     DECLARE_TEST_POLICY(policy);
     auto& q = policy.get_queue();
 
-    constexpr auto host = sycl::usm::alloc::host;
     constexpr auto device = sycl::usm::alloc::device;
     constexpr auto shared = sycl::usm::alloc::shared;
 
@@ -350,15 +349,14 @@ TEST("Can get row slice from heterogen to shared") {
     std::iota(begin(arr3), end(arr3), std::int8_t(0));
     chunked_array<std::int8_t> chunked2(arr3);
 
-    auto arr4 = array<std::uint16_t>::empty(q, 20, host);
+    // All columns of a heterogen table must share the same allocation kind.
+    auto arr4 = array<std::uint16_t>::empty(q, 20, shared);
     std::iota(begin(arr4), end(arr4), std::uint16_t(0));
     chunked_array<std::uint16_t> chunked3(arr4);
 
-    auto arr5 = array<std::int32_t>::empty(q, 20, host);
+    auto arr5 = array<std::int32_t>::empty(q, 20, shared);
     std::iota(begin(arr5), end(arr5), std::int32_t(0l));
-    auto arr6 = array<std::int32_t>::empty(q, 20, device);
-    /* Copying to device */ detail::copy(arr6, arr5);
-    chunked_array<std::int32_t> chunked4(arr6);
+    chunked_array<std::int32_t> chunked4(arr5);
 
     auto table = heterogen_table::wrap( //
         chunked1,
@@ -384,7 +382,6 @@ TEST("Can get column slice from heterogen to shared") {
     DECLARE_TEST_POLICY(policy);
     auto& q = policy.get_queue();
 
-    constexpr auto host = sycl::usm::alloc::host;
     constexpr auto device = sycl::usm::alloc::device;
     constexpr auto shared = sycl::usm::alloc::shared;
 
@@ -398,15 +395,14 @@ TEST("Can get column slice from heterogen to shared") {
     std::iota(begin(arr1), end(arr1), std::int16_t(0));
     chunked_array<std::int16_t> chunked1(arr1);
 
-    auto arr2 = array<std::uint16_t>::empty(q, count, host);
+    // All columns of a heterogen table must share the same allocation kind.
+    auto arr2 = array<std::uint16_t>::empty(q, count, shared);
     std::iota(begin(arr2), end(arr2), std::uint16_t(0));
     chunked_array<std::uint16_t> chunked2(arr2);
 
-    auto arr3 = array<std::int32_t>::empty(q, count, host);
+    auto arr3 = array<std::int32_t>::empty(q, count, shared);
     std::iota(begin(arr3), end(arr3), std::int32_t(0l));
-    auto arr4 = array<std::int32_t>::empty(q, count, device);
-    /* Copying to device */ detail::copy(arr4, arr3);
-    chunked_array<std::int32_t> chunked3(arr4);
+    chunked_array<std::int32_t> chunked3(arr3);
 
     auto table = heterogen_table::wrap( //
         chunked0,
@@ -437,6 +433,39 @@ TEST("Can get column slice from heterogen to shared") {
 
         check_column(col, first, last, res);
     }
+}
+
+TEST("Cannot create heterogen table from columns with different alloc kinds") {
+    DECLARE_TEST_POLICY(policy);
+    auto& q = policy.get_queue();
+
+    constexpr auto device = sycl::usm::alloc::device;
+    constexpr auto shared = sycl::usm::alloc::shared;
+
+    auto arr0 = array<float>::empty(q, 8l, shared);
+    std::iota(begin(arr0), end(arr0), float(0));
+    chunked_array<float> chunked0(arr0);
+
+    auto arr1 = array<std::int32_t>::empty(q, 8l, device);
+    chunked_array<std::int32_t> chunked1(arr1);
+
+    REQUIRE_THROWS_AS(heterogen_table::wrap(chunked0, chunked1), invalid_argument);
+}
+
+TEST("Cannot build chunked array from chunks with different alloc kinds") {
+    DECLARE_TEST_POLICY(policy);
+    auto& q = policy.get_queue();
+
+    constexpr auto device = sycl::usm::alloc::device;
+    constexpr auto shared = sycl::usm::alloc::shared;
+
+    auto arr0 = array<float>::empty(q, 4l, shared);
+    std::iota(begin(arr0), end(arr0), float(0));
+    auto arr1 = array<float>::empty(q, 4l, device);
+
+    chunked_array<float> chunked(2);
+    chunked.set_chunk(0l, arr0);
+    REQUIRE_THROWS_AS(chunked.set_chunk(1l, arr1), invalid_argument);
 }
 
 #endif // ONEDAL_DATA_PARALLEL

--- a/cpp/oneapi/dal/table/test/heterogen_badargs.cpp
+++ b/cpp/oneapi/dal/table/test/heterogen_badargs.cpp
@@ -1,0 +1,43 @@
+/*******************************************************************************
+* Copyright contributors to the oneDAL project
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "oneapi/dal/array.hpp"
+#include "oneapi/dal/chunked_array.hpp"
+
+#include "oneapi/dal/table/heterogen.hpp"
+
+#include "oneapi/dal/test/engine/common.hpp"
+
+namespace oneapi::dal::test {
+
+TEST("Cannot create heterogen table from columns with different alloc kinds") {
+    DECLARE_TEST_POLICY(policy);
+    auto& q = policy.get_queue();
+
+    constexpr auto device = sycl::usm::alloc::device;
+    constexpr auto shared = sycl::usm::alloc::shared;
+
+    auto arr0 = array<float>::empty(q, 8l, shared);
+    std::iota(begin(arr0), end(arr0), float(0));
+    chunked_array<float> chunked0(arr0);
+
+    auto arr1 = array<std::int32_t>::empty(q, 8l, device);
+    chunked_array<std::int32_t> chunked1(arr1);
+
+    REQUIRE_THROWS_AS(heterogen_table::wrap(chunked0, chunked1), invalid_argument);
+}
+
+} // namespace oneapi::dal::test

--- a/cpp/oneapi/dal/table/test/homogen.cpp
+++ b/cpp/oneapi/dal/table/test/homogen.cpp
@@ -16,8 +16,11 @@
 
 #include "oneapi/dal/table/homogen.hpp"
 #include "oneapi/dal/test/engine/common.hpp"
+#include "oneapi/dal/test/engine/tables.hpp"
 
 namespace oneapi::dal::test {
+
+namespace te = dal::test::engine;
 
 TEST("can construct empty table") {
     homogen_table t;
@@ -46,6 +49,7 @@ TEST("can construct rowmajor table 3x2") {
         REQUIRE(meta.get_data_type(i) == data_type::float32);
         REQUIRE(meta.get_feature_type(i) == feature_type::ratio);
     }
+    REQUIRE(meta.get_alloc_kind() == alloc_kind::non_usm);
 
     REQUIRE(t.get_data<float>() == data);
     // TODO: now have no ctor to specify feature_type of the data
@@ -68,6 +72,7 @@ TEST("can construct colmajor float64 table") {
         REQUIRE(meta.get_data_type(i) == data_type::float64);
         REQUIRE(meta.get_feature_type(i) == feature_type::ratio);
     }
+    REQUIRE(meta.get_alloc_kind() == alloc_kind::non_usm);
 
     REQUIRE(t.get_data<double>() == data);
 }
@@ -93,11 +98,8 @@ TEST("can construct table reference") {
     const auto& m2 = t2.get_metadata();
 
     REQUIRE(t1.get_data_layout() == t2.get_data_layout());
-    // TODO: replace with metadata objects comparison
-    for (std::int64_t i = 0; i < t1.get_column_count(); i++) {
-        REQUIRE(m1.get_data_type(i) == m2.get_data_type(i));
-        REQUIRE(m1.get_feature_type(i) == m2.get_feature_type(i));
-    }
+
+    te::check_if_metadata_equal(m1, m2, true);
 }
 
 TEST("can construct table with move") {
@@ -119,6 +121,7 @@ TEST("can construct table with move") {
     REQUIRE(t2.get_data_layout() == data_layout::row_major);
     REQUIRE(m2.get_data_type(0) == data_type::float32);
     REQUIRE(m2.get_data_type(1) == data_type::float32);
+    REQUIRE(m2.get_alloc_kind() == alloc_kind::non_usm);
     REQUIRE(t2.get_data<float>() == data);
 }
 
@@ -139,13 +142,15 @@ TEST("can assign two table references") {
 
     REQUIRE(t1.get_row_count() == 4);
     REQUIRE(t1.get_column_count() == 3);
-    REQUIRE(t1.get_metadata().get_data_type(0) == data_type::int32);
     REQUIRE(t1.get_data<std::int32_t>() == data_int);
 
     REQUIRE(t2.get_row_count() == 4);
     REQUIRE(t2.get_column_count() == 3);
-    REQUIRE(t2.get_metadata().get_data_type(0) == data_type::int32);
     REQUIRE(t2.get_data<std::int32_t>() == data_int);
+
+    const auto& m1 = t1.get_metadata();
+    const auto& m2 = t2.get_metadata();
+    te::check_if_metadata_equal(m1, m2, true);
 }
 
 TEST("can move assigned table reference") {

--- a/cpp/oneapi/dal/table/test/homogen_serialization.cpp
+++ b/cpp/oneapi/dal/table/test/homogen_serialization.cpp
@@ -117,10 +117,15 @@ public:
 
     void compare_tables(const homogen_table& original, const table& deserialized) override {
         te::check_if_tables_equal<Data>(deserialized, original);
+        // The table is deserialized without a queue (see the serialization test
+        // engine), so its data is materialized on the host regardless of where
+        // the original resided. The allocation kind is therefore non_usm.
+        REQUIRE(deserialized.get_metadata().get_alloc_kind() == alloc_kind::non_usm);
     }
 
     void compare_tables(const homogen_table& original, const homogen_table& deserialized) override {
         te::check_if_tables_equal<Data>(deserialized, original);
+        REQUIRE(deserialized.get_metadata().get_alloc_kind() == alloc_kind::non_usm);
     }
 };
 

--- a/cpp/oneapi/dal/test/array.cpp
+++ b/cpp/oneapi/dal/test/array.cpp
@@ -33,6 +33,7 @@ TEST("can construct array of zeros") {
 
     REQUIRE(arr.get_count() == 5);
     REQUIRE(arr.has_mutable_data());
+    REQUIRE(arr.get_alloc_kind() == alloc_kind::non_usm);
 
     for (std::int32_t i = 0; i < arr.get_count(); i++) {
         REQUIRE(arr[i] == Approx(0.0f));
@@ -298,6 +299,7 @@ TEST("can construct device array with queue and without initialization") {
     REQUIRE(arr.get_count() == 10);
     REQUIRE(arr.has_mutable_data());
 
+    REQUIRE(arr.get_alloc_kind() == alloc_kind::usm_device);
     REQUIRE(sycl::get_pointer_type(arr.get_data(), q.get_context()) == sycl::usm::alloc::device);
 }
 
@@ -318,6 +320,7 @@ TEST("can construct array with queue and events") {
 
     REQUIRE(arr.get_count() == 10);
     REQUIRE(arr.has_mutable_data());
+    REQUIRE(arr.get_alloc_kind() == alloc_kind::usm_shared);
 
     for (std::int32_t i = 0; i < arr.get_count(); i++) {
         REQUIRE(arr[i] == Approx(float(i)));
@@ -333,6 +336,7 @@ TEST("can reset array with queue and bigger size") {
 
     REQUIRE(arr.get_count() == 10);
     REQUIRE(arr.has_mutable_data());
+    REQUIRE(arr.get_alloc_kind() == alloc_kind::usm_device);
 }
 
 TEST("can reset array with queue and smaller size") {
@@ -344,6 +348,7 @@ TEST("can reset array with queue and smaller size") {
 
     REQUIRE(arr.get_count() == 4);
     REQUIRE(arr.has_mutable_data());
+    REQUIRE(arr.get_alloc_kind() == alloc_kind::usm_device);
 }
 
 TEST("can reset array with queue and raw pointer") {
@@ -362,6 +367,7 @@ TEST("can reset array with queue and raw pointer") {
 
     arr.reset(data, count, detail::make_default_delete<float>(q));
 
+    REQUIRE(arr.get_alloc_kind() == alloc_kind::usm_shared);
     REQUIRE(arr.get_size() == count * sizeof(float));
     REQUIRE(arr.get_count() == count);
     REQUIRE(arr.has_mutable_data());
@@ -387,6 +393,7 @@ TEST("can wrap const data with queue, offset and deleter") {
     REQUIRE(arr.get_count() == 2);
     REQUIRE(arr.get_data() == cdata);
     REQUIRE(!arr.has_mutable_data());
+    REQUIRE(arr.get_alloc_kind() == alloc_kind::usm_shared);
 }
 #endif
 

--- a/cpp/oneapi/dal/test/array.cpp
+++ b/cpp/oneapi/dal/test/array.cpp
@@ -271,6 +271,7 @@ TEST("can construct array of zeros with queue") {
 
     REQUIRE(arr.get_count() == 5);
     REQUIRE(arr.has_mutable_data());
+    REQUIRE(arr.get_alloc_kind() == alloc_kind::usm_shared);
 
     for (std::int32_t i = 0; i < arr.get_count(); i++) {
         REQUIRE(arr[i] == Approx(0.0f));
@@ -284,6 +285,7 @@ TEST("can construct array of ones with queue") {
 
     REQUIRE(arr.get_count() == 5);
     REQUIRE(arr.has_mutable_data());
+    REQUIRE(arr.get_alloc_kind() == alloc_kind::usm_shared);
 
     for (std::int32_t i = 0; i < arr.get_count(); i++) {
         REQUIRE(arr[i] == Approx(1.0f));
@@ -336,7 +338,7 @@ TEST("can reset array with queue and bigger size") {
 
     REQUIRE(arr.get_count() == 10);
     REQUIRE(arr.has_mutable_data());
-    REQUIRE(arr.get_alloc_kind() == alloc_kind::usm_device);
+    REQUIRE(arr.get_alloc_kind() == alloc_kind::usm_shared);
 }
 
 TEST("can reset array with queue and smaller size") {
@@ -348,7 +350,7 @@ TEST("can reset array with queue and smaller size") {
 
     REQUIRE(arr.get_count() == 4);
     REQUIRE(arr.has_mutable_data());
-    REQUIRE(arr.get_alloc_kind() == alloc_kind::usm_device);
+    REQUIRE(arr.get_alloc_kind() == alloc_kind::usm_shared);
 }
 
 TEST("can reset array with queue and raw pointer") {

--- a/cpp/oneapi/dal/test/chunked_array.cpp
+++ b/cpp/oneapi/dal/test/chunked_array.cpp
@@ -316,51 +316,6 @@ TEST("can get slice of chunked_array on host") {
 
 #ifdef ONEDAL_DATA_PARALLEL
 
-TEST("can flatten array from different parts") {
-    DECLARE_TEST_POLICY(policy);
-    auto& q = policy.get_queue();
-    constexpr std::int64_t count = 3;
-
-    auto deleter = detail::make_default_delete<const float>(q);
-
-    auto* const data0 = sycl::malloc_shared<float>(count, q);
-    q.submit([&](sycl::handler& cgh) {
-         cgh.parallel_for(sycl::range<1>(count), [=](sycl::id<1> idx) {
-             data0[idx] = static_cast<float>(idx);
-         });
-     }).wait_and_throw();
-    auto arr0 = array<float>(q, data0, count, deleter);
-
-    auto* const data1 = sycl::malloc_device<float>(count, q);
-    q.submit([&](sycl::handler& cgh) {
-         cgh.parallel_for(sycl::range<1>(count), [=](sycl::id<1> idx) {
-             data1[idx] = static_cast<float>(idx);
-         });
-     }).wait_and_throw();
-    auto arr1 = array<float>(q, data1, count, deleter);
-
-    constexpr float data2[count] = { 0.f, 1.f, 2.f };
-    auto arr2 = array<float>::wrap(data2, count);
-
-    chunked_array<float> chunked;
-
-    chunked.append(arr0, arr1, arr2);
-
-    REQUIRE(!chunked.have_same_policies());
-
-    REQUIRE(chunked.get_count() == 3l * count);
-
-    auto host_arr = chunked.flatten();
-
-    for (std::int64_t i = 0l; i < (3l * count); ++i) {
-        const auto gtr = i % count;
-        const auto val = host_arr[i];
-
-        CAPTURE(i, gtr, val);
-        REQUIRE(gtr == val);
-    }
-}
-
 TEST("can flatten array on device") {
     DECLARE_TEST_POLICY(policy);
     auto& q = policy.get_queue();
@@ -376,14 +331,19 @@ TEST("can flatten array on device") {
      }).wait_and_throw();
     auto arr1 = array<float>(q, data1, count, deleter);
 
-    constexpr float data2[count] = { 0.f, 1.f, 2.f, 3.f };
-    auto arr2 = array<float>::wrap(data2, count);
+    auto* const data2 = sycl::malloc_device<float>(count, q);
+    q.submit([&](sycl::handler& cgh) {
+         cgh.parallel_for(sycl::range<1>(count), [=](sycl::id<1> idx) {
+             data2[idx] = static_cast<float>(idx);
+         });
+     }).wait_and_throw();
+    auto arr2 = array<float>(q, data2, count, deleter);
 
     chunked_array<float> chunked(arr1, arr2);
 
     chunked.append(arr1, arr2);
 
-    REQUIRE(!chunked.have_same_policies());
+    REQUIRE(chunked.have_same_policies());
     REQUIRE(chunked.get_count() == 4l * count);
 
     auto shared_arr = chunked.flatten(q, sycl::usm::alloc::shared);
@@ -412,12 +372,17 @@ TEST("can get data array on device") {
      }).wait_and_throw();
     auto arr1 = array<float>(q, data1, count, deleter);
 
-    constexpr float data2[count] = { 0.f, 1.f, 2.f, 3.f };
-    auto arr2 = array<float>::wrap(data2, count);
+    auto* const data2 = sycl::malloc_device<float>(count, q);
+    q.submit([&](sycl::handler& cgh) {
+         cgh.parallel_for(sycl::range<1>(count), [=](sycl::id<1> idx) {
+             data2[idx] = static_cast<float>(idx);
+         });
+     }).wait_and_throw();
+    auto arr2 = array<float>(q, data2, count, deleter);
 
     chunked_array<float> chunked(arr1, arr2);
 
-    REQUIRE(!chunked.have_same_policies());
+    REQUIRE(chunked.have_same_policies());
 
     auto data_host = chunked.get_data(q, sycl::usm::alloc::host);
 
@@ -433,21 +398,26 @@ TEST("can get data array on device") {
 TEST("can get slice of chunked_array on device") {
     DECLARE_TEST_POLICY(policy);
     auto& q = policy.get_queue();
-    constexpr std::int64_t host_count = 4;
-    constexpr std::int64_t device_count = 3;
+    constexpr std::int64_t arr2_count = 4;
+    constexpr std::int64_t arr1_count = 3;
 
     auto deleter = detail::make_default_delete<const float>(q);
 
-    auto* const data1 = sycl::malloc_device<float>(device_count, q);
+    auto* const data1 = sycl::malloc_device<float>(arr1_count, q);
     q.submit([&](sycl::handler& cgh) {
-         cgh.parallel_for(sycl::range<1>(device_count), [=](sycl::id<1> idx) {
+         cgh.parallel_for(sycl::range<1>(arr1_count), [=](sycl::id<1> idx) {
              data1[idx] = static_cast<float>(idx);
          });
      }).wait_and_throw();
-    auto arr1 = array<float>(q, data1, device_count, deleter);
+    auto arr1 = array<float>(q, data1, arr1_count, deleter);
 
-    constexpr float data2[host_count] = { 0.f, 1.f, 2.f, 3.f };
-    auto arr2 = array<float>::wrap(data2, host_count);
+    auto* const data2 = sycl::malloc_device<float>(arr2_count, q);
+    q.submit([&](sycl::handler& cgh) {
+         cgh.parallel_for(sycl::range<1>(arr2_count), [=](sycl::id<1> idx) {
+             data2[idx] = static_cast<float>(idx);
+         });
+     }).wait_and_throw();
+    auto arr2 = array<float>(q, data2, arr2_count, deleter);
 
     chunked_array<float> chunked(arr2, arr1, arr2);
     auto flattened = chunked.flatten();

--- a/cpp/oneapi/dal/test/chunked_array_badargs.cpp
+++ b/cpp/oneapi/dal/test/chunked_array_badargs.cpp
@@ -1,0 +1,49 @@
+/*******************************************************************************
+* Copyright contributors to the oneDAL project
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "oneapi/dal/chunked_array.hpp"
+#include "oneapi/dal/test/engine/common.hpp"
+
+namespace oneapi::dal::test {
+
+#ifdef ONEDAL_DATA_PARALLEL
+
+TEST("throw if allocation kinds of chunks are different") {
+    DECLARE_TEST_POLICY(policy);
+    auto& q = policy.get_queue();
+    constexpr std::int64_t count = 3;
+
+    auto deleter = detail::make_default_delete<const float>(q);
+
+    auto* const data0 = sycl::malloc_shared<float>(count, q);
+    q.submit([&](sycl::handler& cgh) {
+         cgh.parallel_for(sycl::range<1>(count), [=](sycl::id<1> idx) {
+             data0[idx] = static_cast<float>(idx);
+         });
+     }).wait_and_throw();
+    auto arr0 = array<float>(q, data0, count, deleter);
+
+    constexpr float data1[count] = { 0.f, 1.f, 2.f };
+    auto arr1 = array<float>::wrap(data1, count);
+
+    chunked_array<float> chunked;
+
+    REQUIRE_THROWS_AS(chunked.append(arr0, arr1), invalid_argument);
+}
+
+#endif
+
+} // namespace oneapi::dal::test

--- a/cpp/oneapi/dal/test/chunked_array_badargs.cpp
+++ b/cpp/oneapi/dal/test/chunked_array_badargs.cpp
@@ -46,4 +46,16 @@ TEST("throw if allocation kinds of chunks are different") {
 
 #endif
 
+TEST("do not throw if allocation kinds of chunks are same") {
+    constexpr float data0[] = { 0.f, 1.f, 2.f };
+    auto arr0 = array<float>::wrap(data0, 3l);
+
+    constexpr float data1[] = { 0.f, 1.f, 2.f };
+    auto arr1 = array<float>::wrap(data1, 3l);
+
+    chunked_array<float> chunked;
+
+    REQUIRE_NOTHROW(chunked.append(arr0, arr1));
+}
+
 } // namespace oneapi::dal::test

--- a/cpp/oneapi/dal/test/chunked_array_serialization.cpp
+++ b/cpp/oneapi/dal/test/chunked_array_serialization.cpp
@@ -102,21 +102,21 @@ TEMPLATE_LIST_TEST_M(chunked_array_serialization_test,
 
 #ifdef ONEDAL_DATA_PARALLEL
 TEMPLATE_LIST_TEST_M(chunked_array_serialization_test,
-                     "serialize/deserialize two hetero arrays",
-                     "[host][device]",
+                     "serialize/deserialize device arrays",
+                     "[device]",
                      array_types) {
-    const std::int64_t host_count = GENERATE(3, 7, 1027);
-    const std::int64_t device_count = GENERATE(5, 11, 1023);
-    array<TestType> host_array = this->get_host_backed_array(host_count, host_count);
-    array<TestType> device_array = this->get_device_backed_array(device_count, device_count);
+    const std::int64_t arr1_count = GENERATE(3, 7, 1027);
+    const std::int64_t arr2_count = GENERATE(5, 11, 1023);
+    array<TestType> arr1 = this->get_device_backed_array(arr1_count, arr1_count);
+    array<TestType> arr2 = this->get_device_backed_array(arr2_count, arr2_count);
 
-    chunked_array<TestType> hetero_chunked;
+    chunked_array<TestType> chunked;
 
-    hetero_chunked.append(device_array, host_array, device_array);
+    chunked.append(arr1, arr2, arr1);
 
-    const auto deserialized = te::serialize_deserialize(hetero_chunked);
+    const auto deserialized = te::serialize_deserialize(chunked);
 
-    this->compare_arrays(hetero_chunked, deserialized);
+    this->compare_arrays(chunked, deserialized);
 }
 #endif
 

--- a/cpp/oneapi/dal/test/engine/tables.hpp
+++ b/cpp/oneapi/dal/test/engine/tables.hpp
@@ -23,11 +23,23 @@
 
 namespace oneapi::dal::test::engine {
 
-inline void check_if_metadata_equal(const table_metadata& actual, const table_metadata& reference) {
+// NOTE: alloc_kind is compared only when check_alloc_kind is true, and is off by
+// default. Allocation kind is a runtime property of where the data currently
+// resides; it is not persisted in the archive and is re-established from the
+// deserialization context (see the table impls' deserialize methods). After a
+// context-agnostic round-trip the deserialized kind reflects the reading context,
+// which may differ from the original, so callers must opt in only when the
+// contexts are known to match.
+inline void check_if_metadata_equal(const table_metadata& actual,
+                                    const table_metadata& reference,
+                                    bool check_alloc_kind = false) {
     REQUIRE(actual.get_feature_count() == reference.get_feature_count());
     for (std::int64_t i = 0; i < reference.get_feature_count(); i++) {
         REQUIRE(actual.get_feature_type(i) == reference.get_feature_type(i));
         REQUIRE(actual.get_data_type(i) == reference.get_data_type(i));
+    }
+    if (check_alloc_kind) {
+        REQUIRE(actual.get_alloc_kind() == reference.get_alloc_kind());
     }
 }
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -345,6 +345,7 @@ nitpick_ignore = [
     ('cpp:identifier', 'data_layout::unknown'),
     ('cpp:identifier', 'feature_type'),
     ('cpp:identifier', 'data_type'),
+    ('cpp:identifier', 'alloc_kind'),
     ('cpp:identifier', 'table_metadata'),
     ('cpp:identifier', 'mutable_data'),
     ('cpp:identifier', 'data'),


### PR DESCRIPTION
## Description

In some situations it is beneficial to know the location of the data the table references.
This PR adds:

- `alloc_kind` enum which encodes `non_usm`, `usm_device`, `usm_host` and `usm_shared` kinds of data allocation supported by oneDAL;
- `table_metadata::get_alloc_kind()` method which allows to check the data allocation kind of the oneDAL table.

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

n/a

</details>
