### PR TITLE
ci: remove debug for public ci jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,12 +46,6 @@ jobs:
     runs-on: ${{ matrix.runner }}
     name: LinuxMakeDPCPP(${{ matrix.ISA }})
     timeout-minutes: 360
-    # Force lld: stock GNU ld on ubuntu-24.04 (binutils 2.42) fails to build the
-    # .gdb_index emitted by the split-DWARF debug pipeline. The Makefiles
-    # detect LINKER=lld and skip GNU-ld-only flags (--no-keep-memory /
-    # --reduce-memory-overheads) that lld rejects with "unknown argument".
-    env:
-      LINKER: lld
 
     steps:
       - name: Checkout oneDAL

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,12 +64,12 @@ jobs:
           echo "NEOReadDebugKeys=1" >> "$GITHUB_ENV"
           echo "EnableRecoverablePageFaults=1" >> "$GITHUB_ENV"
           echo "GpuFaultCheckThreshold=0" >> "$GITHUB_ENV"
-      - name: Make daal debug
+      - name: Make daal
         run: |
           source /opt/intel/oneapi/setvars.sh
           .ci/scripts/build.sh --compiler icx  --optimizations ${{ matrix.ISA }} --target daal --jobs 20
           rm -rf __work
-      - name: Make onedal debug
+      - name: Make onedal
         id: onedal-dbg
         run: |
           source /opt/intel/oneapi/setvars.sh
@@ -100,10 +100,8 @@ jobs:
       - name: Make onedal
         if: matrix.runner != 'ubuntu-24.04'
         run: |
-          # generate new onedal portion for use in examples testing (due to issues with dpc debug build)
           source /opt/intel/oneapi/setvars.sh
           rm -rf __work
-          mv __work_daal __work
           .ci/scripts/build.sh --compiler icx  --optimizations ${{ matrix.ISA }} --target onedal --jobs 20
           rm -rf __work
       - name: daal/cpp examples
@@ -164,7 +162,7 @@ jobs:
           path: ./__release_lnx
       - name: Check ABI conformance
         run: |
-          echo "Note: This check uses abidiff to verify ABI compliance of an SSE/AVX512 debug oneDAL build."
+          echo "Note: This check uses abidiff to verify ABI compliance of an SSE/AVX512 oneDAL build."
           echo "It compares to the last completed main build, whose commit can be found in the 'Check Cache' step."
           echo "The ABI for other ISAs are assumed to match the SSE or AVX512 version, any ISA-specific exported "
           echo "information that is ISA unique must be manually checked. If no shared objects are found, then "

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
           source /opt/intel/oneapi/setvars.sh
           .ci/scripts/build.sh --compiler icx  --optimizations ${{ matrix.ISA }} --target oneapi_c --jobs 20
           rm -rf __work
-          .ci/scripts/build.sh --compiler icx  --optimizations ${{ matrix.ISA }} --target oneapi_dpc --jobs 8 --sycl-link-jobs 4
+          .ci/scripts/build.sh --compiler icx  --optimizations ${{ matrix.ISA }} --target oneapi_dpc --jobs 20
           # clean up build directory due to space limitations
           rm -rf __work
           echo "key=__release_lnx-$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,12 @@ jobs:
     runs-on: ${{ matrix.runner }}
     name: LinuxMakeDPCPP(${{ matrix.ISA }})
     timeout-minutes: 360
+    # Force lld: stock GNU ld on ubuntu-24.04 (binutils 2.42) fails to build the
+    # .gdb_index emitted by the split-DWARF debug pipeline. The Makefiles
+    # detect LINKER=lld and skip GNU-ld-only flags (--no-keep-memory /
+    # --reduce-memory-overheads) that lld rejects with "unknown argument".
+    env:
+      LINKER: lld
 
     steps:
       - name: Checkout oneDAL
@@ -67,15 +73,15 @@ jobs:
       - name: Make daal debug
         run: |
           source /opt/intel/oneapi/setvars.sh
-          .ci/scripts/build.sh --compiler icx  --optimizations ${{ matrix.ISA }} --target daal --debug symbols --jobs 20
-          if [[ ${{ matrix.runner }} != ubuntu-24.04 ]];then cp -r __work __work_daal;fi
+          .ci/scripts/build.sh --compiler icx  --optimizations ${{ matrix.ISA }} --target daal --jobs 20
+          rm -rf __work
       - name: Make onedal debug
         id: onedal-dbg
         run: |
           source /opt/intel/oneapi/setvars.sh
-          .ci/scripts/build.sh --compiler icx  --optimizations ${{ matrix.ISA }} --target oneapi_c --debug symbols --jobs 20
+          .ci/scripts/build.sh --compiler icx  --optimizations ${{ matrix.ISA }} --target oneapi_c --jobs 20
           rm -rf __work
-          .ci/scripts/build.sh --compiler icx  --optimizations ${{ matrix.ISA }} --target oneapi_dpc --debug symbols --jobs 20
+          .ci/scripts/build.sh --compiler icx  --optimizations ${{ matrix.ISA }} --target oneapi_dpc --jobs 8 --sycl-link-jobs 4
           # clean up build directory due to space limitations
           rm -rf __work
           echo "key=__release_lnx-$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Trims the public Linux CI build to a release-mode, disk-frugal configuration:
- Drop `--debug symbols` from all three `build.sh` invocations (`daal`, `oneapi_c`, `oneapi_dpc`).
- Delete the `cp -r __work __work_daal` step that previously preserved the DAAL intermediate build tree on non-`ubuntu-24.04` runners.
- Clean `__work` after the DAAL build step (previously only cleaned after the oneAPI steps).

Net effect on `LinuxMakeDPCPP` (job that produces the shared `__release_lnx` artifact):
- Smaller build artifacts (no `-g`).
- Lower peak disk usage between steps.
- Lower peak memory during icx/DPC++ compile — relevant because the SYCL TUs are the primary OOM risk on GitHub-hosted runners.

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [x] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least a summary table with measured data, if performance change is expected.
- [x] I have provided justification why performance and/or quality metrics have changed or why changes are not expected.
- [x] I have extended the benchmarking suite and provided a corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.

</details>
