### PR TITLE
Fix memory leaks for Logistic Regression

### DIFF
--- a/cpp/daal/include/algorithms/optimization_solver/objective_function/cross_entropy_loss_batch.h
+++ b/cpp/daal/include/algorithms/optimization_solver/objective_function/cross_entropy_loss_batch.h
@@ -77,7 +77,7 @@ public:
      */
     Batch(size_t nClasses, size_t numberOfTerms);
 
-    virtual ~Batch() {}
+    virtual ~Batch() { delete _par; }
 
     /**
      * Constructs an the Cross-entropy loss objective function algorithm by copying input objects and parameters

--- a/cpp/daal/include/algorithms/optimization_solver/objective_function/logistic_loss_batch.h
+++ b/cpp/daal/include/algorithms/optimization_solver/objective_function/logistic_loss_batch.h
@@ -76,7 +76,7 @@ public:
      */
     Batch(size_t numberOfTerms);
 
-    virtual ~Batch() {}
+    virtual ~Batch() { delete _par; }
 
     /**
      * Constructs an the Logistic loss objective function algorithm by copying input objects and parameters


### PR DESCRIPTION
## Description

If oneDAL is built using GNU compiler with sanitizers we had this memory leak

> Direct leak of 97920 byte(s) in 510 object(s) allocated from:
    #0 0x7fa4fe51b6eb in malloc ../../../../libsanitizer/asan/asan_malloc_linux.cpp:67
    #1 0x7ba0367e61d5 in mm_internal_malloc (/localdisk2/mkl/dcortes/repos/onedal-gcc-asan-o2/__release_lnx_gnu/daal/latest/lib/intel64/libonedal_core.so.3+0x21e61d5)
    #2 0x7ba037766806 in daal::algorithms::interface1::Parameter::operator new(unsigned long) __release_lnx_gnu/daal/latest/include/algorithms/algorithm_types.h:64
    #3 0x7ba037766806 in daal::algorithms::optimization_solver::logistic_loss::interface2::Batch<double, (daal::algorithms::optimization_solver::logistic_loss::Method)0>::Batch(unsigned long) cpp/daal/src/algorithms/objective_function/logistic_loss/logistic_loss_dense_default_batch_fpt_dispatcher.cpp:39
    #4 0x7ba0413b8203 in optimization_solver_logistic_loss_manager<double, (daal::algorithms::optimization_solver::logistic_loss::Method)0>::optimization_solver_logistic_loss_manager(unsigned long, bool, float, float, daal::services::interface1::SharedPtr<daal::data_management::interface1::NumericTable>&, unsigned long, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /localdisk2/mkl/dcortes/repos/sklex-gcc-asan-o2/build/daal4py_cpp.h:7663 


That happened because of missing delete in some of destructors. Similar fixes were already done here https://github.com/uxlfoundation/oneDAL/pull/3403 but these files were missed

---

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x ] I have commented my code, particularly in hard-to-understand areas.
- [ x] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [ x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [ x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [ x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
- [ x] I have extended testing suite if new functionality was introduced in this PR.


</details>
