### PR TITLE
Extend decision forest row sampling to the values greater than 1.0

### DIFF
--- a/cpp/daal/include/algorithms/decision_forest/decision_forest_training_parameter.h
+++ b/cpp/daal/include/algorithms/decision_forest/decision_forest_training_parameter.h
@@ -129,7 +129,7 @@ public:
     Parameter();
 
     size_t nTrees;                         /*!< Number of trees in the forest. Default is 10 */
-    double observationsPerTreeFraction;    /*!< Fraction of observations used for a training of one tree, 0 to 1.
+    double observationsPerTreeFraction;    /*!< Fraction of observations used for a training of one tree, greater than 0.
                                                   Default is 1 (sampling with replacement) */
     size_t featuresPerNode;                /*!< Number of features tried as possible splits per node.
                                                   If 0 then sqrt(p) for classification, p/3 for regression,

--- a/cpp/oneapi/dal/algo/decision_forest/common.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/common.cpp
@@ -196,8 +196,7 @@ engine_type descriptor_base<Task>::get_engine_type() const {
 
 template <typename Task>
 void descriptor_base<Task>::set_observations_per_tree_fraction_impl(double value) {
-    check_domain_cond((value > 0.0 && value <= 1.0),
-                      "observations_per_tree_fraction should be > 0.0 and <= 1.0");
+    check_domain_cond((value > 0.0), "observations_per_tree_fraction should be > 0.0");
     impl_->observations_per_tree_fraction = value;
 }
 

--- a/cpp/oneapi/dal/algo/decision_forest/common.hpp
+++ b/cpp/oneapi/dal/algo/decision_forest/common.hpp
@@ -355,7 +355,6 @@ public:
 
     /// The fraction of observations per tree
     /// @invariant :expr:`observations_per_tree_fraction > 0.0`
-    /// @invariant :expr:`observations_per_tree_fraction <= 1.0`
     /// @remark default = 1.0
     double get_observations_per_tree_fraction() const {
         return base_t::get_observations_per_tree_fraction();

--- a/cpp/oneapi/dal/algo/decision_forest/test/badarg.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/test/badarg.cpp
@@ -168,8 +168,6 @@ DF_BADARG_TEST("throws if observations_per_tree_fraction is outside of (0.0, 1.0
     SKIP_IF(this->not_available_on_device());
     REQUIRE_THROWS_AS(this->get_default_descriptor().set_observations_per_tree_fraction(0.0),
                       domain_error);
-    REQUIRE_THROWS_AS(this->get_default_descriptor().set_observations_per_tree_fraction(1.1),
-                      domain_error);
     REQUIRE_THROWS_AS(this->get_default_descriptor().set_observations_per_tree_fraction(-0.5),
                       domain_error);
 }

--- a/cpp/oneapi/dal/algo/decision_forest/test/batch.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/test/batch.cpp
@@ -281,7 +281,10 @@ DF_BATCH_CLS_TEST_NIGHTLY_EXT("df cls oob per observation flow") {
     const auto error_metric_mode_val =
         error_metric_mode::out_of_bag_error | error_metric_mode::out_of_bag_error_per_observation;
     const std::int64_t features_per_node_val = GENERATE_COPY(0, 4);
-    const double observations_per_tree_fraction_val = GENERATE_COPY(1.0, 0.5);
+    const double observations_per_tree_fraction_val = GENERATE_COPY(1.0, 0.5, 1.2);
+
+    std::cout << "observation per tree fraction: " << observations_per_tree_fraction_val
+              << std::endl;
 
     auto desc = this->get_default_descriptor();
 
@@ -322,9 +325,12 @@ DF_BATCH_CLS_TEST("df cls base check with default params and train weights") {
     const auto [data, data_test, class_count, checker_list] =
         this->get_cls_dataframe_weighted_base();
 
+    const double observations_per_tree_fraction_val = GENERATE_COPY(1.0, 0.5, 1.2);
+
     auto desc = this->get_default_descriptor();
 
     desc.set_class_count(class_count);
+    desc.set_observations_per_tree_fraction(observations_per_tree_fraction_val);
 
     const auto train_result =
         this->train_weighted_base_checks(desc, data, this->get_homogen_table_id());

--- a/cpp/oneapi/dal/algo/decision_forest/test/spmd.cpp
+++ b/cpp/oneapi/dal/algo/decision_forest/test/spmd.cpp
@@ -362,7 +362,7 @@ DF_SPMD_CLS_TEST_NIGHTLY_EXT("df cls oob per observation flow") {
     const auto error_metric_mode_val =
         error_metric_mode::out_of_bag_error | error_metric_mode::out_of_bag_error_per_observation;
     const std::int64_t features_per_node_val = GENERATE_COPY(0, 4);
-    const double observations_per_tree_fraction_val = GENERATE_COPY(1.0, 0.5);
+    const double observations_per_tree_fraction_val = GENERATE_COPY(1.0, 0.5, 1.2);
 
     auto desc = this->get_default_descriptor();
 


### PR DESCRIPTION
## Description

Scikit-learn has changed how they sample observations with weights in random forests when they do subsampling or bootstrapping:

https://github.com/scikit-learn/scikit-learn/pull/31529

In the new methodology, observations are sampled according to their weights (meaning that rows with higher weight should be more likely to be sampled), and they have equal weights in the resamples.

Aim of this PR is to switch oneDAL to the new methodology in both CPU and GPU so that sample weights can continue being supported.

Internal CI: http://intel-ci.intel.com/f18b28a2-7bef-f1da-8010-d4f5ef20c6a0

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [x] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [x] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [x] I have run it locally and tested the changes extensively.
- [x] All CI jobs are green or I have provided justification why they aren't.
The issue in LinuxMakeGNU_MKL_Conda job is not related to the changes in this PR.
- [x] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

n/a

</details>
