### PR TITLE
remove static designation on CEV broken functions

### DIFF
--- a/cpp/daal/src/algorithms/dtrees/dtrees_model_impl.h
+++ b/cpp/daal/src/algorithms/dtrees/dtrees_model_impl.h
@@ -356,10 +356,10 @@ void setProbabilities(const size_t treeId, const size_t nodeId, const size_t res
                       const double * const prob);
 
 template <typename ClassOrResponseType>
-static services::Status addLeafNodeInternal(const data_management::DataCollectionPtr & serializationData, const size_t treeId, const size_t parentId,
-                                            const size_t position, ClassOrResponseType response, double cover, size_t & res,
-                                            const data_management::DataCollectionPtr probTbl = data_management::DataCollectionPtr(),
-                                            const double * const prob = nullptr, const size_t nClasses = 0)
+services::Status addLeafNodeInternal(const data_management::DataCollectionPtr & serializationData, const size_t treeId, const size_t parentId,
+                                     const size_t position, ClassOrResponseType response, double cover, size_t & res,
+                                     const data_management::DataCollectionPtr probTbl = data_management::DataCollectionPtr(),
+                                     const double * const prob = nullptr, const size_t nClasses = 0)
 {
     const size_t noParent = static_cast<size_t>(-1);
     if (prob != nullptr)

--- a/cpp/daal/src/algorithms/dtrees/dtrees_model_impl_common.h
+++ b/cpp/daal/src/algorithms/dtrees/dtrees_model_impl_common.h
@@ -124,8 +124,8 @@ bool traverseNodeDF(size_t level, size_t iRowInTable, const DecisionTreeNode * a
 typedef services::Collection<size_t> NodeIdxArray;
 
 template <typename OnSplitFunctor, typename OnLeafFunctor>
-static bool traverseNodesBF(size_t level, NodeIdxArray & aCur, NodeIdxArray & aNext, const DecisionTreeNode * aNode, OnSplitFunctor & visitSplit,
-                            OnLeafFunctor & visitLeaf)
+bool traverseNodesBF(size_t level, NodeIdxArray & aCur, NodeIdxArray & aNext, const DecisionTreeNode * aNode, OnSplitFunctor & visitSplit,
+                     OnLeafFunctor & visitLeaf)
 {
     for (size_t i = 0; i < aCur.size(); ++i)
     {

--- a/cpp/oneapi/dal/backend/primitives/sort/sort_dpc.cpp
+++ b/cpp/oneapi/dal/backend/primitives/sort/sort_dpc.cpp
@@ -26,6 +26,7 @@
 #pragma clang diagnostic ignored "-Wunused-local-typedef"
 #pragma clang diagnostic ignored "-Wsign-compare"
 #pragma clang diagnostic ignored "-Wkeyword-macro"
+#pragma clang diagnostic ignored "-Wunused-template"
 
 // Workaround: some oneTBB versions annotate the override of
 // std::exception::what() with __TBB_EXPORTED_METHOD, which on Windows-x86


### PR DESCRIPTION
## Description

Resolves new failure in windows build for CEV (http://intel-ci.intel.com/f18af139-44fd-f1df-b2e8-d4f5ef20c6a0)
Run on this branch: http://intel-ci.intel.com/f18c4750-506a-f12c-874f-d4f5ef20c6a0

---

<!--
PR should start as a draft, then move to ready for review state
after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, a PR with docs update doesn't require checkboxes for performance
while a PR with any change in actual code should list checkboxes and
justify how this code change is expected to affect performance (or justification should be self-evident).
-->

<details>
<summary>Checklist:</summary>

**Completeness and readability**

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes or created a separate PR with updates and provided its number in the description, if necessary.
- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [ ] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [ ] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.
- [ ] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [ ] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least a summary table with measured data, if performance change is expected.
- [ ] I have provided justification why performance and/or quality metrics have changed or why changes are not expected.
- [ ] I have extended the benchmarking suite and provided a corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.

</details>
